### PR TITLE
chore: Switch cluster templates to use release-1.30 from master

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.27.yaml
@@ -1,524 +1,248 @@
+---
 presubmits:
   kubernetes-sigs/cloud-provider-azure:
-    - name: pull-cloud-provider-azure-check-1-27
-      cluster: eks-prow-build-cluster
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.27
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - make
-              - test-check
-            resources:
-              limits:
-                memory: "9Gi"
-                cpu: "2"
-              requests:
-                memory: "9Gi"
-                cpu: "2"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
-        testgrid-tab-name: pr-cloud-provider-azure-check-1-27
-        description: "Run lint check tests for cloud-provider-azure release-1.27."
-        testgrid-num-columns-recent: "30"
+  - name: pull-cloud-provider-azure-check-1-27
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.27
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-check
+        resources:
+          limits:
+            memory: "9Gi"
+            cpu: "2"
+          requests:
+            memory: "9Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+      testgrid-tab-name: pr-cloud-provider-azure-check-1-27
+      description: "Run lint check tests for cloud-provider-azure release-1.27."
+      testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-27
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-27
-      skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.27
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.27"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-27
-        description: "Runs Azure specific tests with cloud-provider-azure release-1.27 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    # pull-cloud-provider-azure-e2e-capz-1-27 runs kubernetes conformance tests.
-    - name: pull-cloud-provider-azure-e2e-capz-1-27
-      skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.27
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.27
-          path_alias: k8s.io/kubernetes
-          workdir: false
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-e2e-capz
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.27"
-              - name: GINKGO_ARGS # cloud-provider-azure config
-                value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
-                value: "30"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-27
-        description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.27 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    # pull-cloud-provider-azure-e2e-ccm-1-27
-    - name: pull-cloud-provider-azure-e2e-ccm-capz-1-27
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.27
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.27"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-27
-        description: "Runs Azure specific tests with cloud-provider-azure release-1.27 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    - name: pull-cloud-provider-azure-unit-1-27
-      cluster: eks-prow-build-cluster
-      skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.27
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - make
-              - test-unit
-            resources:
-              limits:
-                memory: "9Gi"
-                cpu: "2"
-              requests:
-                memory: "9Gi"
-                cpu: "2"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
-        testgrid-tab-name: pr-cloud-provider-azure-unit-1-27
-        description: "Run unit tests for cloud-provider-azure release-1.27."
-        testgrid-num-columns-recent: "30"
-    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-27
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.27
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            args:
-            - ./scripts/ci-entrypoint.sh
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.27"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-27-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-27
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.27
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            args:
-            - ./scripts/ci-entrypoint.sh
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.27"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-27-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-27
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.27
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-            args:
-            - bash
-            - -c
-            - >-
-              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e &&
-              popd
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.27"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-27-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-27
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.27
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-            args:
-            - bash
-            - -c
-            - >-
-              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e &&
-              popd
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.27"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-27-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-27 runs Azure specific e2e tests with cloud controller manager v1.27 and IP-based load balancer backend pools.
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-27
-      skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.27
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - ./scripts/ci-entrypoint.sh
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.27"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: ENABLE_MULTI_SLB # cloud-provider-azure config
-                value: "false"
-              - name: PUT_VMSS_VM_BATCH_SIZE # cloud-provider-azure config
-                value: "0"
-              - name: LB_BACKEND_POOL_CONFIG_TYPE # cloud-provider-azure config
-                value: "nodeIP"
-              - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
-                value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
-              - name: CCM_E2E_ARGS # cloud-provider-azure config
-                value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
-              - name: LABEL_FILTER # cloud-provider-azure config
-                value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
-                value: "false"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-27
-        description: "Runs Azure specific e2e tests with cloud controller manager v1.27 and IP-based load balancer backend pools."
-        testgrid-num-columns-recent: '30'
-periodics:
-- cron: '0 20 * * *'  # Run at 20:00 UTC everyday
-  name: cloud-provider-azure-master-ipv6-capz-1-27
-  decorate: true
-  decoration_config:
-    timeout: 5h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
-  extra_refs:
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-27
+    skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.27
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: release-1.15
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.27"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-27
+      description: "Runs Azure specific tests with cloud-provider-azure release-1.27 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-capz-1-27 runs kubernetes conformance tests.
+  - name: pull-cloud-provider-azure-e2e-capz-1-27
+    skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.27
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
     - org: kubernetes-sigs
-      repo: cloud-provider-azure
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes
+      repo: kubernetes
       base_ref: release-1.27
-      path_alias: sigs.k8s.io/cloud-provider-azure
+      path_alias: k8s.io/kubernetes
       workdir: false
-  spec:
-    containers:
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-e2e-capz
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.27"
+        - name: GINKGO_ARGS  # cloud-provider-azure config
+          value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: GINKGO_PARALLEL_NODES  # cloud-provider-azure config
+          value: "30"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-27
+      description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.27 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-ccm-1-27
+  - name: pull-cloud-provider-azure-e2e-ccm-capz-1-27
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.27
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.27"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-27
+      description: "Runs Azure specific tests with cloud-provider-azure release-1.27 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+  - name: pull-cloud-provider-azure-unit-1-27
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.27
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-unit
+        resources:
+          limits:
+            memory: "9Gi"
+            cpu: "2"
+          requests:
+            memory: "9Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+      testgrid-tab-name: pr-cloud-provider-azure-unit-1-27
+      description: "Run unit tests for cloud-provider-azure release-1.27."
+      testgrid-num-columns-recent: "30"
+  - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-27
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.27
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
         command:
         - runner.sh
@@ -532,18 +256,295 @@ periodics:
         securityContext:
           privileged: true
         env:
-        - name: TEST_CCM # CAPZ config
+        - name: TEST_CCM  # CAPZ config
           value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
+        - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.27"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-27-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-27
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.27
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.27"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-27-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-27
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.27
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e &&
+          popd
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.27"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
           value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-27-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-27
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.27
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e &&
+          popd
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.27"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-27-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-27 runs Azure specific e2e tests with cloud controller manager v1.27 and IP-based load balancer backend pools.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-27
+    skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.27
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.27"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: ENABLE_MULTI_SLB  # cloud-provider-azure config
+          value: "false"
+        - name: PUT_VMSS_VM_BATCH_SIZE  # cloud-provider-azure config
+          value: "0"
+        - name: LB_BACKEND_POOL_CONFIG_TYPE  # cloud-provider-azure config
+          value: "nodeIP"
+        - name: CUSTOM_CLOUD_PROVIDER_CONFIG  # CAPZ config
+          value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
+        - name: CCM_E2E_ARGS  # cloud-provider-azure config
+          value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
+        - name: LABEL_FILTER  # cloud-provider-azure config
+          value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config
+          value: "false"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-27
+      description: "Runs Azure specific e2e tests with cloud controller manager v1.27 and IP-based load balancer backend pools."
+      testgrid-num-columns-recent: '30'
+periodics:
+- cron: '0 20 * * *'  # Run at 20:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-capz-1-27
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.27
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.27"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
     testgrid-tab-name: cloud-provider-azure-master-ipv6-capz-1-27
@@ -561,43 +562,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.27
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.27
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.27"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.27"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
     testgrid-tab-name: cloud-provider-azure-master-ipv6-vmss-capz-1-27
@@ -615,43 +616,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.27
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.27
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.27"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.27"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
     testgrid-tab-name: cloud-provider-azure-master-dualstack-capz-1-27
@@ -669,43 +670,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.27
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.27
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.27"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.27"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-27
     testgrid-tab-name: cloud-provider-azure-master-dualstack-vmss-capz-1-27

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
@@ -1,589 +1,221 @@
+---
 presubmits:
   kubernetes-sigs/cloud-provider-azure:
-    - name: pull-cloud-provider-azure-check-1-28
-      cluster: eks-prow-build-cluster
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.28
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - make
-              - test-check
-            resources:
-              limits:
-                memory: "9Gi"
-                cpu: "2"
-              requests:
-                memory: "9Gi"
-                cpu: "2"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
-        testgrid-tab-name: pr-cloud-provider-azure-check-1-28
-        description: "Run lint check tests for cloud-provider-azure release-1.28."
-        testgrid-num-columns-recent: "30"
+  - name: pull-cloud-provider-azure-check-1-28
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-check
+        resources:
+          limits:
+            memory: "9Gi"
+            cpu: "2"
+          requests:
+            memory: "9Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-check-1-28
+      description: "Run lint check tests for cloud-provider-azure release-1.28."
+      testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-28
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-28
-      skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.28
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.28"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-28
-        description: "Runs Azure specific tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    # pull-cloud-provider-azure-e2e-capz-1-28 runs kubernetes conformance tests.
-    - name: pull-cloud-provider-azure-e2e-capz-1-28
-      skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.28
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.28
-          path_alias: k8s.io/kubernetes
-          workdir: false
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-e2e-capz
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.28"
-              - name: GINKGO_ARGS # cloud-provider-azure config
-                value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
-                value: "30"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-28
-        description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    # pull-cloud-provider-azure-e2e-ccm-1-28
-    - name: pull-cloud-provider-azure-e2e-ccm-capz-1-28
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.28
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.28"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-28
-        description: "Runs Azure specific tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    # pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-28 runs Azure specific e2e tests with cloud controller manager v1.28 and IP-based load balancer backend pools.
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-28
-      skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.28
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - ./scripts/ci-entrypoint.sh
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.28"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: ENABLE_MULTI_SLB # cloud-provider-azure config
-                value: "false"
-              - name: PUT_VMSS_VM_BATCH_SIZE # cloud-provider-azure config
-                value: "0"
-              - name: LB_BACKEND_POOL_CONFIG_TYPE # cloud-provider-azure config
-                value: "nodeIP"
-              - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
-                value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
-              - name: CCM_E2E_ARGS # cloud-provider-azure config
-                value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
-              - name: LABEL_FILTER # cloud-provider-azure config
-                value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
-                value: "false"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-28
-        description: "Runs Azure specific e2e tests with cloud controller manager v1.28 and IP-based load balancer backend pools."
-        testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-28 runs Azure specific e2e tests with cloud controller manager v1.28 and multiple standard load balancers.
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-28
-      skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.28
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - ./scripts/ci-entrypoint.sh
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.28"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
-                value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-multi-slb.json"
-              - name: CCM_E2E_ARGS # cloud-provider-azure config
-                value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
-              - name: LABEL_FILTER # cloud-provider-azure config
-                value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
-                value: "false"
-              - name: TEST_MULTI_SLB
-                value: "true"
-              - name: WINDOWS_WORKER_MACHINE_COUNT
-                value: "2"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-28
-        description: "Runs Azure specific e2e tests with cloud controller manager v1.28 and multiple standard load balancers."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-unit-1-28
-      cluster: eks-prow-build-cluster
-      skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.28
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - make
-              - test-unit
-            resources:
-              limits:
-                memory: "9Gi"
-                cpu: "2"
-              requests:
-                memory: "9Gi"
-                cpu: "2"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
-        testgrid-tab-name: pr-cloud-provider-azure-unit-1-28
-        description: "Run unit tests for cloud-provider-azure release-1.28."
-        testgrid-num-columns-recent: "30"
-    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-28
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.28
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            args:
-            - ./scripts/ci-entrypoint.sh
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.28"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-28-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-28
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.28
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            args:
-            - ./scripts/ci-entrypoint.sh
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.28"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-28-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-28
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.28
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-            args:
-            - bash
-            - -c
-            - >-
-              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e &&
-              popd
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.28"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-28-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-28
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.28
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-            args:
-            - bash
-            - -c
-            - >-
-              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e &&
-              popd
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.28"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-28-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-periodics:
-- cron: '0 22 * * *'  # Run at 22:00 UTC everyday
-  name: cloud-provider-azure-master-ipv6-capz-1-28
-  decorate: true
-  decoration_config:
-    timeout: 5h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
-  extra_refs:
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-28
+    skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: release-1.15
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-28
+      description: "Runs Azure specific tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-capz-1-28 runs kubernetes conformance tests.
+  - name: pull-cloud-provider-azure-e2e-capz-1-28
+    skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
     - org: kubernetes-sigs
-      repo: cloud-provider-azure
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes
+      repo: kubernetes
       base_ref: release-1.28
-      path_alias: sigs.k8s.io/cloud-provider-azure
+      path_alias: k8s.io/kubernetes
       workdir: false
-  spec:
-    containers:
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-e2e-capz
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: GINKGO_ARGS  # cloud-provider-azure config
+          value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: GINKGO_PARALLEL_NODES  # cloud-provider-azure config
+          value: "30"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-28
+      description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-ccm-1-28
+  - name: pull-cloud-provider-azure-e2e-ccm-capz-1-28
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-28
+      description: "Runs Azure specific tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-28 runs Azure specific e2e tests with cloud controller manager v1.28 and IP-based load balancer backend pools.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-28
+    skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
         command:
         - runner.sh
@@ -597,18 +229,387 @@ periodics:
         securityContext:
           privileged: true
         env:
-        - name: TEST_CCM # CAPZ config
+        - name: TEST_CCM  # CAPZ config
           value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
+        - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.28"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: ENABLE_MULTI_SLB  # cloud-provider-azure config
+          value: "false"
+        - name: PUT_VMSS_VM_BATCH_SIZE  # cloud-provider-azure config
+          value: "0"
+        - name: LB_BACKEND_POOL_CONFIG_TYPE  # cloud-provider-azure config
+          value: "nodeIP"
+        - name: CUSTOM_CLOUD_PROVIDER_CONFIG  # CAPZ config
+          value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
+        - name: CCM_E2E_ARGS  # cloud-provider-azure config
+          value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
+        - name: LABEL_FILTER  # cloud-provider-azure config
+          value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
+        - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config
+          value: "false"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-28
+      description: "Runs Azure specific e2e tests with cloud controller manager v1.28 and IP-based load balancer backend pools."
+      testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-28 runs Azure specific e2e tests with cloud controller manager v1.28 and multiple standard load balancers.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-28
+    skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CUSTOM_CLOUD_PROVIDER_CONFIG  # CAPZ config
+          value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-multi-slb.json"
+        - name: CCM_E2E_ARGS  # cloud-provider-azure config
+          value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
+        - name: LABEL_FILTER  # cloud-provider-azure config
+          value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config
+          value: "false"
+        - name: TEST_MULTI_SLB
+          value: "true"
+        - name: WINDOWS_WORKER_MACHINE_COUNT
+          value: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-28
+      description: "Runs Azure specific e2e tests with cloud controller manager v1.28 and multiple standard load balancers."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-unit-1-28
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-unit
+        resources:
+          limits:
+            memory: "9Gi"
+            cpu: "2"
+          requests:
+            memory: "9Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-unit-1-28
+      description: "Run unit tests for cloud-provider-azure release-1.28."
+      testgrid-num-columns-recent: "30"
+  - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-28
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-28-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-28
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-28-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-28
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e &&
+          popd
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
           value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-28-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-28
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e &&
+          popd
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-28-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+periodics:
+- cron: '0 22 * * *'  # Run at 22:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-capz-1-28
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.28
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.28"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
     testgrid-tab-name: cloud-provider-azure-master-ipv6-capz-1-28
@@ -626,43 +627,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.28
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.28
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.28"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.28"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
     testgrid-tab-name: cloud-provider-azure-master-ipv6-vmss-capz-1-28
@@ -680,43 +681,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.28
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.28
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.28"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.28"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
     testgrid-tab-name: cloud-provider-azure-master-dualstack-capz-1-28
@@ -734,43 +735,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.28
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.28
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.28"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.28"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
     testgrid-tab-name: cloud-provider-azure-master-dualstack-vmss-capz-1-28

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.29.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.29.yaml
@@ -1,589 +1,221 @@
+---
 presubmits:
   kubernetes-sigs/cloud-provider-azure:
-    - name: pull-cloud-provider-azure-check-1-29
-      cluster: eks-prow-build-cluster
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.29
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - make
-              - test-check
-            resources:
-              limits:
-                memory: "9Gi"
-                cpu: "2"
-              requests:
-                memory: "9Gi"
-                cpu: "2"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
-        testgrid-tab-name: pr-cloud-provider-azure-check-1-29
-        description: "Run lint check tests for cloud-provider-azure release-1.29."
-        testgrid-num-columns-recent: "30"
+  - name: pull-cloud-provider-azure-check-1-29
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.29
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-check
+        resources:
+          limits:
+            memory: "9Gi"
+            cpu: "2"
+          requests:
+            memory: "9Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+      testgrid-tab-name: pr-cloud-provider-azure-check-1-29
+      description: "Run lint check tests for cloud-provider-azure release-1.29."
+      testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-29
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-29
-      skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.29
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.29"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-29
-        description: "Runs Azure specific tests with cloud-provider-azure release-1.29 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    # pull-cloud-provider-azure-e2e-capz-1-29 runs kubernetes conformance tests.
-    - name: pull-cloud-provider-azure-e2e-capz-1-29
-      skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.29
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.29
-          path_alias: k8s.io/kubernetes
-          workdir: false
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-e2e-capz
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.29"
-              - name: GINKGO_ARGS # cloud-provider-azure config
-                value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
-                value: "30"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-29
-        description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.29 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    # pull-cloud-provider-azure-e2e-ccm-1-29
-    - name: pull-cloud-provider-azure-e2e-ccm-capz-1-29
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.29
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.29"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-29
-        description: "Runs Azure specific tests with cloud-provider-azure release-1.29 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    # pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-29 runs Azure specific e2e tests with cloud controller manager v1.29 and IP-based load balancer backend pools.
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-29
-      skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.29
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - ./scripts/ci-entrypoint.sh
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.29"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: ENABLE_MULTI_SLB # cloud-provider-azure config
-                value: "false"
-              - name: PUT_VMSS_VM_BATCH_SIZE # cloud-provider-azure config
-                value: "0"
-              - name: LB_BACKEND_POOL_CONFIG_TYPE # cloud-provider-azure config
-                value: "nodeIP"
-              - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
-                value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
-              - name: CCM_E2E_ARGS # cloud-provider-azure config
-                value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
-              - name: LABEL_FILTER # cloud-provider-azure config
-                value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
-                value: "false"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-29
-        description: "Runs Azure specific e2e tests with cloud controller manager v1.29 and IP-based load balancer backend pools."
-        testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-29 runs Azure specific e2e tests with cloud controller manager v1.29 and multiple standard load balancers.
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-29
-      skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.29
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - ./scripts/ci-entrypoint.sh
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.29"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
-                value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-multi-slb.json"
-              - name: CCM_E2E_ARGS # cloud-provider-azure config
-                value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
-              - name: LABEL_FILTER # cloud-provider-azure config
-                value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
-                value: "false"
-              - name: TEST_MULTI_SLB
-                value: "true"
-              - name: WINDOWS_WORKER_MACHINE_COUNT
-                value: "2"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-29
-        description: "Runs Azure specific e2e tests with cloud controller manager v1.29 and multiple standard load balancers."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-unit-1-29
-      cluster: eks-prow-build-cluster
-      skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.29
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - make
-              - test-unit
-            resources:
-              limits:
-                memory: "9Gi"
-                cpu: "2"
-              requests:
-                memory: "9Gi"
-                cpu: "2"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
-        testgrid-tab-name: pr-cloud-provider-azure-unit-1-29
-        description: "Run unit tests for cloud-provider-azure release-1.29."
-        testgrid-num-columns-recent: "30"
-    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-29
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.29
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            args:
-            - ./scripts/ci-entrypoint.sh
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.29"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-29-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-29
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.29
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            args:
-            - ./scripts/ci-entrypoint.sh
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.29"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-29-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-29
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.29
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-            args:
-            - bash
-            - -c
-            - >-
-              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e &&
-              popd
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.29"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-29-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-29
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.29
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-            args:
-            - bash
-            - -c
-            - >-
-              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e &&
-              popd
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.29"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-29-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-periodics:
-- cron: '0 23 * * *'  # Run at 23:00 UTC everyday
-  name: cloud-provider-azure-master-ipv6-capz-1-29
-  decorate: true
-  decoration_config:
-    timeout: 5h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
-  extra_refs:
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-29
+    skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.29
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: release-1.15
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.29"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-29
+      description: "Runs Azure specific tests with cloud-provider-azure release-1.29 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-capz-1-29 runs kubernetes conformance tests.
+  - name: pull-cloud-provider-azure-e2e-capz-1-29
+    skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.29
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
     - org: kubernetes-sigs
-      repo: cloud-provider-azure
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes
+      repo: kubernetes
       base_ref: release-1.29
-      path_alias: sigs.k8s.io/cloud-provider-azure
+      path_alias: k8s.io/kubernetes
       workdir: false
-  spec:
-    containers:
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-e2e-capz
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.29"
+        - name: GINKGO_ARGS  # cloud-provider-azure config
+          value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: GINKGO_PARALLEL_NODES  # cloud-provider-azure config
+          value: "30"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-29
+      description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.29 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-ccm-1-29
+  - name: pull-cloud-provider-azure-e2e-ccm-capz-1-29
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.29
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.29"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-29
+      description: "Runs Azure specific tests with cloud-provider-azure release-1.29 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-29 runs Azure specific e2e tests with cloud controller manager v1.29 and IP-based load balancer backend pools.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-29
+    skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.29
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
         command:
         - runner.sh
@@ -597,18 +229,387 @@ periodics:
         securityContext:
           privileged: true
         env:
-        - name: TEST_CCM # CAPZ config
+        - name: TEST_CCM  # CAPZ config
           value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
+        - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.29"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: ENABLE_MULTI_SLB  # cloud-provider-azure config
+          value: "false"
+        - name: PUT_VMSS_VM_BATCH_SIZE  # cloud-provider-azure config
+          value: "0"
+        - name: LB_BACKEND_POOL_CONFIG_TYPE  # cloud-provider-azure config
+          value: "nodeIP"
+        - name: CUSTOM_CLOUD_PROVIDER_CONFIG  # CAPZ config
+          value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
+        - name: CCM_E2E_ARGS  # cloud-provider-azure config
+          value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
+        - name: LABEL_FILTER  # cloud-provider-azure config
+          value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
+        - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config
+          value: "false"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-29
+      description: "Runs Azure specific e2e tests with cloud controller manager v1.29 and IP-based load balancer backend pools."
+      testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-29 runs Azure specific e2e tests with cloud controller manager v1.29 and multiple standard load balancers.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-29
+    skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.29
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.29"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CUSTOM_CLOUD_PROVIDER_CONFIG  # CAPZ config
+          value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-multi-slb.json"
+        - name: CCM_E2E_ARGS  # cloud-provider-azure config
+          value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
+        - name: LABEL_FILTER  # cloud-provider-azure config
+          value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config
+          value: "false"
+        - name: TEST_MULTI_SLB
+          value: "true"
+        - name: WINDOWS_WORKER_MACHINE_COUNT
+          value: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-29
+      description: "Runs Azure specific e2e tests with cloud controller manager v1.29 and multiple standard load balancers."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-unit-1-29
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.29
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-unit
+        resources:
+          limits:
+            memory: "9Gi"
+            cpu: "2"
+          requests:
+            memory: "9Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+      testgrid-tab-name: pr-cloud-provider-azure-unit-1-29
+      description: "Run unit tests for cloud-provider-azure release-1.29."
+      testgrid-num-columns-recent: "30"
+  - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-29
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.29
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.29"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-29-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-29
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.29
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.29"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-29-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-29
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.29
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e &&
+          popd
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.29"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
           value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-29-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-29
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.29
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e &&
+          popd
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.29"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-29-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+periodics:
+- cron: '0 23 * * *'  # Run at 23:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-capz-1-29
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.29
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.29"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
     testgrid-tab-name: cloud-provider-azure-master-ipv6-capz-1-29
@@ -626,43 +627,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.29
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.29
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.29"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.29"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
     testgrid-tab-name: cloud-provider-azure-master-ipv6-vmss-capz-1-29
@@ -680,43 +681,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.29
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.29
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.29"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.29"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
     testgrid-tab-name: cloud-provider-azure-master-dualstack-capz-1-29
@@ -734,43 +735,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.29
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.29
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.29"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.29"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-29
     testgrid-tab-name: cloud-provider-azure-master-dualstack-vmss-capz-1-29

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.30.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.30.yaml
@@ -1,589 +1,221 @@
+---
 presubmits:
   kubernetes-sigs/cloud-provider-azure:
-    - name: pull-cloud-provider-azure-check-1-30
-      cluster: eks-prow-build-cluster
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.30
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - make
-              - test-check
-            resources:
-              limits:
-                memory: "9Gi"
-                cpu: "2"
-              requests:
-                memory: "9Gi"
-                cpu: "2"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
-        testgrid-tab-name: pr-cloud-provider-azure-check-1-30
-        description: "Run lint check tests for cloud-provider-azure release-1.30."
-        testgrid-num-columns-recent: "30"
+  - name: pull-cloud-provider-azure-check-1-30
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.30
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-check
+        resources:
+          limits:
+            memory: "9Gi"
+            cpu: "2"
+          requests:
+            memory: "9Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
+      testgrid-tab-name: pr-cloud-provider-azure-check-1-30
+      description: "Run lint check tests for cloud-provider-azure release-1.30."
+      testgrid-num-columns-recent: "30"
     # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-30
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-30
-      skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.30
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.30"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-30
-        description: "Runs Azure specific tests with cloud-provider-azure release-1.30 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    # pull-cloud-provider-azure-e2e-capz-1-30 runs kubernetes conformance tests.
-    - name: pull-cloud-provider-azure-e2e-capz-1-30
-      skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.30
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-        - org: kubernetes
-          repo: kubernetes
-          base_ref: release-1.30
-          path_alias: k8s.io/kubernetes
-          workdir: false
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-e2e-capz
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.30"
-              - name: GINKGO_ARGS # cloud-provider-azure config
-                value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: GINKGO_PARALLEL_NODES # cloud-provider-azure config
-                value: "30"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-30
-        description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.30 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    # pull-cloud-provider-azure-e2e-ccm-1-30
-    - name: pull-cloud-provider-azure-e2e-ccm-capz-1-30
-      skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.30
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-              - ./scripts/ci-entrypoint.sh
-            args:
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.30"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-30
-        description: "Runs Azure specific tests with cloud-provider-azure release-1.30 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: "30"
-    # pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-30 runs Azure specific e2e tests with cloud controller manager v1.30 and IP-based load balancer backend pools.
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-30
-      skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.30
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - ./scripts/ci-entrypoint.sh
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.30"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: ENABLE_MULTI_SLB # cloud-provider-azure config
-                value: "false"
-              - name: PUT_VMSS_VM_BATCH_SIZE # cloud-provider-azure config
-                value: "0"
-              - name: LB_BACKEND_POOL_CONFIG_TYPE # cloud-provider-azure config
-                value: "nodeIP"
-              - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
-                value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
-              - name: CCM_E2E_ARGS # cloud-provider-azure config
-                value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
-              - name: LABEL_FILTER # cloud-provider-azure config
-                value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
-                value: "false"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-30
-        description: "Runs Azure specific e2e tests with cloud controller manager v1.30 and IP-based load balancer backend pools."
-        testgrid-num-columns-recent: '30'
-    # pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-30 runs Azure specific e2e tests with cloud controller manager v1.30 and multiple standard load balancers.
-    - name: pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-30
-      skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.30
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-        preset-azure-capz-sa-cred: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - ./scripts/ci-entrypoint.sh
-              - bash
-              - -c
-              - >-
-                cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-                make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.30"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CUSTOM_CLOUD_PROVIDER_CONFIG # CAPZ config
-                value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-multi-slb.json"
-              - name: CCM_E2E_ARGS # cloud-provider-azure config
-                value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
-              - name: LABEL_FILTER # cloud-provider-azure config
-                value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: ENABLE_VMSS_FLEX # cloud-provider-azure config
-                value: "false"
-              - name: TEST_MULTI_SLB
-                value: "true"
-              - name: WINDOWS_WORKER_MACHINE_COUNT
-                value: "2"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-30
-        description: "Runs Azure specific e2e tests with cloud controller manager v1.30 and multiple standard load balancers."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-unit-1-30
-      cluster: eks-prow-build-cluster
-      skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
-      decorate: true
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.30
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-              - runner.sh
-            args:
-              - make
-              - test-unit
-            resources:
-              limits:
-                memory: "9Gi"
-                cpu: "2"
-              requests:
-                memory: "9Gi"
-                cpu: "2"
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
-        testgrid-tab-name: pr-cloud-provider-azure-unit-1-30
-        description: "Run unit tests for cloud-provider-azure release-1.30."
-        testgrid-num-columns-recent: "30"
-    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-30
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.30
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            args:
-            - ./scripts/ci-entrypoint.sh
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.30"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-30-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-30
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.30
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            args:
-            - ./scripts/ci-entrypoint.sh
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.30"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "Standard"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-30-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-30
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.30
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-            args:
-            - bash
-            - -c
-            - >-
-              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e &&
-              popd
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.30"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-30-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-    - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-30
-      always_run: false
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      branches:
-        - release-1.30
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-azure-cred-only: "true"
-        preset-azure-anonymous-pull: "true"
-      extra_refs:
-        - org: kubernetes-sigs
-          repo: cluster-api-provider-azure
-          base_ref: release-1.15
-          path_alias: sigs.k8s.io/cluster-api-provider-azure
-          workdir: true
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-            command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-            args:
-            - bash
-            - -c
-            - >-
-              pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-              make test-ccm-e2e &&
-              popd
-            securityContext:
-              privileged: true
-            env:
-              - name: TEST_CCM # CAPZ config
-                value: "true"
-              - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-                value: "standard"
-              - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-                value: "1"
-              - name: KUBERNETES_VERSION # CAPZ config
-                value: "latest-1.30"
-              - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-                value: "capz"
-              - name: CLUSTER_TEMPLATE # CAPZ config
-                value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
-      annotations:
-        testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
-        testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-30-presubmit
-        description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
-        testgrid-num-columns-recent: '30'
-periodics:
-- cron: '0 23 * * *'  # Run at 23:00 UTC everyday
-  name: cloud-provider-azure-master-ipv6-capz-1-30
-  decorate: true
-  decoration_config:
-    timeout: 5h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-cred-only: "true"
-    preset-azure-anonymous-pull: "true"
-    preset-azure-capz-sa-cred: "true"
-  extra_refs:
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-30
+    skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.30
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
       base_ref: release-1.15
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.30"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-30
+      description: "Runs Azure specific tests with cloud-provider-azure release-1.30 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-capz-1-30 runs kubernetes conformance tests.
+  - name: pull-cloud-provider-azure-e2e-capz-1-30
+    skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.30
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
     - org: kubernetes-sigs
-      repo: cloud-provider-azure
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes
+      repo: kubernetes
       base_ref: release-1.30
-      path_alias: sigs.k8s.io/cloud-provider-azure
+      path_alias: k8s.io/kubernetes
       workdir: false
-  spec:
-    containers:
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-e2e-capz
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.30"
+        - name: GINKGO_ARGS  # cloud-provider-azure config
+          value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: GINKGO_PARALLEL_NODES  # cloud-provider-azure config
+          value: "30"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-30
+      description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.30 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-ccm-1-30
+  - name: pull-cloud-provider-azure-e2e-ccm-capz-1-30
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.30
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.30"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-30
+      description: "Runs Azure specific tests with cloud-provider-azure release-1.30 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-30 runs Azure specific e2e tests with cloud controller manager v1.30 and IP-based load balancer backend pools.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-30
+    skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.30
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
         command:
         - runner.sh
@@ -597,18 +229,387 @@ periodics:
         securityContext:
           privileged: true
         env:
-        - name: TEST_CCM # CAPZ config
+        - name: TEST_CCM  # CAPZ config
           value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
+        - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.30"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: ENABLE_MULTI_SLB  # cloud-provider-azure config
+          value: "false"
+        - name: PUT_VMSS_VM_BATCH_SIZE  # cloud-provider-azure config
+          value: "0"
+        - name: LB_BACKEND_POOL_CONFIG_TYPE  # cloud-provider-azure config
+          value: "nodeIP"
+        - name: CUSTOM_CLOUD_PROVIDER_CONFIG  # CAPZ config
+          value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
+        - name: CCM_E2E_ARGS  # cloud-provider-azure config
+          value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
+        - name: LABEL_FILTER  # cloud-provider-azure config
+          value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
+        - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config
+          value: "false"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-30
+      description: "Runs Azure specific e2e tests with cloud controller manager v1.30 and IP-based load balancer backend pools."
+      testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-30 runs Azure specific e2e tests with cloud controller manager v1.30 and multiple standard load balancers.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-30
+    skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.30
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+      preset-azure-capz-sa-cred: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.30"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CUSTOM_CLOUD_PROVIDER_CONFIG  # CAPZ config
+          value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-multi-slb.json"
+        - name: CCM_E2E_ARGS  # cloud-provider-azure config
+          value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
+        - name: LABEL_FILTER  # cloud-provider-azure config
+          value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config
+          value: "false"
+        - name: TEST_MULTI_SLB
+          value: "true"
+        - name: WINDOWS_WORKER_MACHINE_COUNT
+          value: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-30
+      description: "Runs Azure specific e2e tests with cloud controller manager v1.30 and multiple standard load balancers."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-unit-1-30
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.30
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-unit
+        resources:
+          limits:
+            memory: "9Gi"
+            cpu: "2"
+          requests:
+            memory: "9Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
+      testgrid-tab-name: pr-cloud-provider-azure-unit-1-30
+      description: "Run unit tests for cloud-provider-azure release-1.30."
+      testgrid-num-columns-recent: "30"
+  - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-30
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.30
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.30"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-30-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-30
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.30
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.30"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-30-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-30
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.30
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e &&
+          popd
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.30"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
           value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-30-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-30
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.30
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.15
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e &&
+          popd
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.30"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-30-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+periodics:
+- cron: '0 23 * * *'  # Run at 23:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-capz-1-30
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
+    preset-azure-capz-sa-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.30
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.30"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
     testgrid-tab-name: cloud-provider-azure-master-ipv6-capz-1-30
@@ -626,43 +627,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.30
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.30
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.30"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.30"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
     testgrid-tab-name: cloud-provider-azure-master-ipv6-vmss-capz-1-30
@@ -680,43 +681,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.30
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.30
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.30"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.30"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.15/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
     testgrid-tab-name: cloud-provider-azure-master-dualstack-capz-1-30
@@ -734,43 +735,43 @@ periodics:
     preset-azure-anonymous-pull: "true"
     preset-azure-capz-sa-cred: "true"
   extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.15
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    - org: kubernetes-sigs
-      repo: cloud-provider-azure
-      base_ref: release-1.30
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      workdir: false
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.15
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.30
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
-        command:
-        - runner.sh
-        args:
-        - ./scripts/ci-entrypoint.sh
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-        securityContext:
-          privileged: true
-        env:
-        - name: TEST_CCM # CAPZ config
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU # cloud-provider-azure config
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT # CAPZ config
-          value: "1"
-        - name: KUBERNETES_VERSION # CAPZ config
-          value: "latest-1.30"
-        - name: CLUSTER_PROVISIONING_TOOL # cloud-provider-azure config
-          value: "capz"
-        - name: CLUSTER_TEMPLATE # CAPZ config
-          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.30"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/release-1.30/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure-1-30
     testgrid-tab-name: cloud-provider-azure-master-dualstack-vmss-capz-1-30


### PR DESCRIPTION
chore: Switch cluster templates to use release-1.30 from master

/kind failing-test
/area provider/azure