### PR TITLE
migrate periodic-cluster-api-provider-azure-coverage to eks cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -165,7 +165,7 @@ periodics:
     testgrid-tab-name: capz-periodic-apiversion-upgrade-main
     description: This job creates clusters using supported older api versions (v1alpha4), and verifies that the clusters continue to operate properly after the api version is upgraded to the latest (v1beta1).
 - name: periodic-cluster-api-provider-azure-coverage
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   interval: 12h
   decorate: true
   path_alias: "sigs.k8s.io/cluster-api-provider-azure"


### PR DESCRIPTION
This PR migrate `periodic-cluster-api-provider-azure-coverage` to use `eks prow build cluster`.

- This is coming from the conversation https://kubernetes.slack.com/archives/C7J9RP96G/p1722532161618239 
- TL;DR: 8 cores is probably max on GKE clusters, if using higher resources, use EKS atm. 