### PR TITLE
Use latest bootstrap in kubekins-e2e

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG OLD_BAZEL_VERSION
 FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
-FROM gcr.io/k8s-staging-test-infra/bootstrap:v20240702-c547b1533e
+FROM gcr.io/k8s-staging-test-infra/bootstrap:v20240801-5d0231fada
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
It contains  https://github.com/Argh4k/test-infra/pull/new/kubekins-bump

Additionally this bumps Google Cloud SDK  from 483.0 to 486.0  