### PR TITLE
secrets-store: make e2e jobs required for sync controller

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-sync-controller/secrets-store-sync-controller-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-sync-controller/secrets-store-sync-controller-config.yaml
@@ -110,7 +110,6 @@ presubmits:
     decoration_config:
       timeout: 10m
     always_run: true
-    optional: true
     path_alias: sigs.k8s.io/secrets-store-sync-controller
     branches:
     - ^main$
@@ -152,7 +151,6 @@ presubmits:
     decoration_config:
       timeout: 10m
     always_run: true
-    optional: true
     path_alias: sigs.k8s.io/secrets-store-sync-controller
     branches:
     - ^main$
@@ -194,7 +192,6 @@ presubmits:
     decoration_config:
       timeout: 10m
     always_run: true
-    optional: true
     path_alias: sigs.k8s.io/secrets-store-sync-controller
     branches:
     - ^main$
@@ -236,7 +233,6 @@ presubmits:
     decoration_config:
       timeout: 10m
     always_run: true
-    optional: true
     path_alias: sigs.k8s.io/secrets-store-sync-controller
     branches:
     - ^main$


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/secrets-store-sync-controller/issues/37