### PR TITLE
Increase resource available for periodic CAPZ main jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -39,10 +39,10 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
         requests:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
@@ -87,10 +87,10 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
         requests:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
@@ -135,10 +135,10 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
         requests:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -26,10 +26,10 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
           limits:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
@@ -72,10 +72,10 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
           limits:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
@@ -114,10 +114,10 @@ periodics:
         privileged: true
       resources:
           requests:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
           limits:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
@@ -155,10 +155,10 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
           limits:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
@@ -275,10 +275,10 @@ periodics:
           value: ""
       resources:
         limits:
-          cpu: 2
+          cpu: 6
           memory: "9Gi"
         requests:
-          cpu: 2
+          cpu: 6
           memory: "9Gi"
       # docker-in-docker needs privileged mode
       securityContext:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: periodic-cluster-api-provider-azure-conformance-main
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
@@ -37,7 +37,7 @@ periodics:
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
     description: Runs conformance & node conformance tests on a stable k8s version with latest cluster-api-provider-azure
 - name: periodic-cluster-api-provider-azure-conformance-with-ci-artifacts-main
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
@@ -247,7 +247,7 @@ periodics:
     testgrid-tab-name: capz-periodic-e2e-main
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
 - name: periodic-cluster-api-provider-azure-e2e-aks-main
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.15.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.15.yaml
@@ -28,10 +28,10 @@ periodics:
           value: "\\[K8s-Upgrade\\]|API Version Upgrade"
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
         requests:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
       # docker-in-docker needs privileged mode
       securityContext:
@@ -69,10 +69,10 @@ periodics:
           value: \[Managed Kubernetes\]
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
         requests:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
       # docker-in-docker needs privileged mode
       securityContext:
@@ -110,10 +110,10 @@ periodics:
           value: ""
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
         requests:
-          cpu: 2
+          cpu: 4
           memory: 4Gi
       # docker-in-docker needs privileged mode
       securityContext:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.16.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.16.yaml
@@ -26,10 +26,10 @@ periodics:
           privileged: true
         resources:
           limits:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
           requests:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
@@ -72,10 +72,10 @@ periodics:
           privileged: true
         resources:
           limits:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
           requests:
-            cpu: 2
+            cpu: 6
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
@@ -111,10 +111,10 @@ periodics:
           value: "\\[K8s-Upgrade\\]|API Version Upgrade"
       resources:
         limits:
-          cpu: 2
+          cpu: 6
           memory: "9Gi"
         requests:
-          cpu: 2
+          cpu: 6
           memory: "9Gi"
       # docker-in-docker needs privileged mode
       securityContext:
@@ -152,10 +152,10 @@ periodics:
           value: \[Managed Kubernetes\]
       resources:
         limits:
-          cpu: 2
+          cpu: 6
           memory: "9Gi"
         requests:
-          cpu: 2
+          cpu: 6
           memory: "9Gi"
       # docker-in-docker needs privileged mode
       securityContext:
@@ -193,10 +193,10 @@ periodics:
           value: ""
       resources:
         limits:
-          cpu: 2
+          cpu: 6
           memory: "9Gi"
         requests:
-          cpu: 2
+          cpu: 6
           memory: "9Gi"
       # docker-in-docker needs privileged mode
       securityContext:


### PR DESCRIPTION
- This PR increases the `resource.limits.cpu` and `resource.requests.cpu` for CAPZ periodic main jobs. 
  - We have been seeing context deadline exceeded on some of the CAPZ jobs. Also noticed that the test jobs are slow on CI when `cpu` is limited to `2`.
  - The jobs with `cpu:2, memory: 4Gi` were upgraded to `cpu: 4` and the ones with `cpu:2, memory : 9Gi` to `cpu:6`.
- Also moving CAPZ periodic main jobs to `eks-prow-build-cluster` to track resource consumption at https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?var-org=kubernetes-sigs&var-repo=cluster-api-provider-azure&orgId=1&refresh=30s