### PR TITLE
Replace use of old misc images with new ones.

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -10,7 +10,7 @@ periodics:
     testgrid-tab-name: api-review-help
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -58,7 +58,7 @@ periodics:
     testgrid-tab-name: stable-metrics-help
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -97,7 +97,7 @@ periodics:
     testgrid-tab-name: cla
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -140,7 +140,7 @@ periodics:
     testgrid-tab-name: close-issues
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -201,7 +201,7 @@ periodics:
     testgrid-tab-name: close-prs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -258,7 +258,7 @@ periodics:
     description: Automatically /retest for approved PRs that are failing tests
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -326,7 +326,7 @@ periodics:
     testgrid-tab-name: rotten-issues
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -387,7 +387,7 @@ periodics:
     testgrid-tab-name: rotten-prs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -445,7 +445,7 @@ periodics:
     testgrid-tab-name: stale-issues
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -506,7 +506,7 @@ periodics:
     testgrid-tab-name: stale-prs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -564,7 +564,7 @@ periodics:
     testgrid-tab-name: thaw-prs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -612,7 +612,7 @@ periodics:
     testgrid-tab-name: re-triage
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -661,7 +661,7 @@ periodics:
     testgrid-tab-name: re-triage-important
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -711,7 +711,7 @@ periodics:
     testgrid-tab-name: re-triage-critical
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
       command:
       - commenter
       args:
@@ -762,7 +762,7 @@ periodics:
     description: Creates github issues based on data from various 'IssueSource's.
   spec:
     containers:
-    - image: gcr.io/k8s-prow/issue-creator:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/issue-creator:v20240801-a5d9345e59
       command:
       - issue-creator
       args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -37,8 +37,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-testgrid-config-updater
       containers:
-      # TODO: Switch this to use the k8s-staging-infra-tools/k8s-infra image instead.
-      - image: gcr.io/k8s-prow/configurator:v20240731-a5d9345e59
+      - image: gcr.io/k8s-staging-test-infra/configurator:v20240801-a5d9345e59
         command:
         - configurator
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-label-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-label-sync.yaml
@@ -8,7 +8,7 @@ periodics:
   spec:
     containers:
     - name: label-sync
-      image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
+      image: gcr.io/k8s-staging-test-infra/label_sync:v20240801-a5d9345e59
       command:
       - label_sync
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -128,7 +128,7 @@ postsubmits:
       serviceAccountName: gencred-refresher
       containers:
       - name: gencred
-        image: gcr.io/k8s-prow/gencred:v20240731-a5d9345e59
+        image: gcr.io/k8s-staging-test-infra/gencred:v20240801-a5d9345e59
         command:
         - gencred
         args:
@@ -228,7 +228,7 @@ periodics:
     serviceAccountName: gencred-refresher
     containers:
     - name: gencred
-      image: gcr.io/k8s-prow/gencred:v20240731-a5d9345e59
+      image: gcr.io/k8s-staging-test-infra/gencred:v20240801-a5d9345e59
       command:
       - gencred
       args:

--- a/config/prow/cluster/halogen.yaml
+++ b/config/prow/cluster/halogen.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: halogen
       containers:
       - name: halogen
-        image: gcr.io/k8s-prow/analyze:v20240731-a5d9345e59
+        image: gcr.io/k8s-staging-test-infra/analyze:v20240801-a5d9345e59
         args:
         - --project=k8s-prow
         - --region=us-central1

--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
+              image: gcr.io/k8s-staging-test-infra/label_sync:v20240801-a5d9345e59
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never  # https://github.com/kubernetes/kubernetes/issues/54870
       containers:
       - name: label-sync
-        image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
+        image: gcr.io/k8s-staging-test-infra/label_sync:v20240801-a5d9345e59
         args:
         - --config=/etc/config/labels.yaml
         - --confirm=true

--- a/testgrid/config-merger-prowjob-example.yaml
+++ b/testgrid/config-merger-prowjob-example.yaml
@@ -9,7 +9,7 @@ presubmits:
       testgrid-create-test-group: "false"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/configurator
+      - image: gcr.io/k8s-staging-test-infra/configurator
         command:
         - /app/testgrid/cmd/configurator/app.binary
         args: # TODO: Replace These (See Configurator Readme)
@@ -43,7 +43,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-config-updater # TODO: Add a service account that can write to your cloud storage
       containers:
-      - image: gcr.io/k8s-prow/configurator
+      - image: gcr.io/k8s-staging-test-infra/configurator
         command:
         - /app/testgrid/cmd/configurator/app.binary
         args: # TODO: Replace These (See Configurator Readme)


### PR DESCRIPTION
Current uses of the old images uploaded by the misc-image push job are at
https://cs.k8s.io/?q=gcr.io%2Fk8s-prow%2F(label_sync%7Ccommenter%7Cpr-creator%7Cissue-creator%7Cconfigurator%7Cgcsweb%7Cgencred%7Canalyze)&i=nope&files=&excludeFiles=&repos=. Replacing these references with the newly-built images from the k8s-staging-test-infra location instead. (This should cover all the existing references, the last one is in Announcements under the k8s-sigs/prow site and can remain there).

Ref https://github.com/kubernetes/test-infra/issues/32432