### PR TITLE
Use new location for Prow images instead of old.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 REPO_ROOT:=${CURDIR}
 OUT_DIR=$(REPO_ROOT)/_output
 # image building and publishing config
-REGISTRY ?= gcr.io/k8s-prow
+REGISTRY ?= gcr.io/k8s-staging-test-infra
 PROW_IMAGE ?=
 ################################################################################
 # ================================= Testing ====================================
@@ -60,8 +60,7 @@ update-go-deps:
 verify-go-deps:
 	hack/make-rules/verify/go-deps.sh
 # ======================== Image Building/Publishing ===========================
-# Build and publish miscellaneous images that get pushed to "gcr.io/k8s-prow/".
-# These are not prow images, but published there for legacy reasons.
+# Build and publish miscellaneous images that get pushed to the specified REGISTRY.
 # The full set of images covered by these targets is configured in
 # .test-infra-misc-images.yaml.
 .PHONY: push-misc-images

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
@@ -127,7 +127,7 @@ periodics:
       slug: test-infra-admins
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240802-66b115076
       command:
       - generic-autobumper
       args:
@@ -166,7 +166,7 @@ periodics:
       slug: test-infra-admins
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240802-66b115076
       command:
       - generic-autobumper
       args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -157,7 +157,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240802-66b115076
       command:
       - generic-autobumper
       args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-branchprotector.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-branchprotector.yaml
@@ -14,7 +14,7 @@ periodics:
   spec:
     containers:
     - name: branchprotector
-      image: gcr.io/k8s-prow/branchprotector:v20240802-66b115076
+      image: us-docker.pkg.dev/k8s-infra-prow/images/branchprotector:v20240802-66b115076
       command:
       - branchprotector
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-checkconfig.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-checkconfig.yaml
@@ -12,7 +12,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20240802-66b115076
       command:
       - checkconfig
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
     run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20240802-66b115076
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20240802-66b115076
         command:
         - checkconfig
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -41,7 +41,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-prow/hmac:v20240802-66b115076
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/hmac:v20240802-66b115076
         command:
         - hmac
         args:
@@ -154,7 +154,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240802-66b115076
       command:
       - generic-autobumper
       args:
@@ -191,7 +191,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240802-66b115076
       command:
       - generic-autobumper
       args:

--- a/config/mkpj.sh
+++ b/config/mkpj.sh
@@ -32,11 +32,11 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 config="${root}/config/prow/config.yaml"
 job_config_path="${root}/config/jobs"
 
-docker pull gcr.io/k8s-prow/mkpj 1>&2 || true
+docker pull us-docker.pkg.dev/k8s-infra-prow/images/mkpj 1>&2 || true
 docker run \
        -i --rm \
        --user "$(id -u):$(id -g)" \
        -v "${root}:${root}" \
        --security-opt="label=disable" \
-       gcr.io/k8s-prow/mkpj \
+       us-docker.pkg.dev/k8s-infra-prow/images/mkpj \
        "--config-path=${config}" "--job-config-path=${job_config_path}" "$@"

--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -3,7 +3,7 @@ gitHubLogin: "k8s-ci-robot"
 gitHubToken: "/etc/github-token/oauth"
 gitName: "Kubernetes Prow Robot"
 gitEmail: "20407524+k8s-ci-robot@users.noreply.github.com"
-onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
+onCallAddress: "" # No oncall assigned to this at the moment.
 selfAssign: true # Commenting `/cc`, so that autobump PR is not assigned to anyone
 skipPullRequest: false
 gitHubOrg: "kubernetes"
@@ -13,26 +13,15 @@ upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master
 includedConfigPaths:
   - "."
 excludedConfigPaths:
-  - ".ko.yaml" # Contains gcr.io/k8s-prow/git, which is not pushed by prow
+  - ".ko.yaml" # Contains gcr.io/k8s-staging-test-infra/git, which is not pushed by prow
 targetVersion: "latest"
 prefixes:
   - name: "Prow"
-    prefix: "gcr.io/k8s-prow/"
+    prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
     refConfigFile: "config/prow/cluster/deck_deployment.yaml"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: true
     consistentImages: true
-    consistentImageExceptions:
-      - "gcr.io/k8s-prow/alpine"
-      - "gcr.io/k8s-prow/analyze"
-      - "gcr.io/k8s-prow/commenter"
-      - "gcr.io/k8s-prow/configurator"
-      - "gcr.io/k8s-prow/gcsweb"
-      - "gcr.io/k8s-prow/gencred"
-      - "gcr.io/k8s-prow/git"
-      - "gcr.io/k8s-prow/issue-creator"
-      - "gcr.io/k8s-prow/label_sync"
-      - "gcr.io/k8s-prow/pr-creator"
   - name: "Boskos"
     prefix: "gcr.io/k8s-staging-boskos/"
     refConfigFile: "config/prow/cluster/build/boskos.yaml"

--- a/config/prow/cluster/build/grandmatriarch.yaml
+++ b/config/prow/cluster/build/grandmatriarch.yaml
@@ -56,6 +56,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/grandmatriarch:v20240802-66b115076
         args:
         - http-cookiefile

--- a/config/prow/cluster/cherrypicker_deployment.yaml
+++ b/config/prow/cluster/cherrypicker_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/cherrypicker:v20240802-66b115076
         imagePullPolicy: Always
         args:
         - --github-token-path=/etc/github/token

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240802-66b115076
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20240802-66b115076
         imagePullPolicy: Always
         ports:
         - name: http

--- a/config/prow/cluster/ghproxy.yaml
+++ b/config/prow/cluster/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240802-66b115076
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240802-66b115076
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/needs-rebase_deployment.yaml
+++ b/config/prow/cluster/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/needs-rebase:v20240802-66b115076
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/pipeline_deployment.yaml
+++ b/config/prow/cluster/pipeline_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: prow-pipeline
       containers:
       - name: pipeline
-        image: gcr.io/k8s-prow/pipeline:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/pipeline:v20240802-66b115076
         args:
         - --all-contexts
         - --config=/etc/prow-config/config.yaml

--- a/config/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/config/prow/cluster/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20240802-66b115076
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -118,10 +118,10 @@ data:
             key: cert
           s3_credentials_secret: s3-credentials
           utility_images:
-            clonerefs: gcr.io/k8s-prow/clonerefs:v20240802-66b115076
-            entrypoint: gcr.io/k8s-prow/entrypoint:v20240802-66b115076
-            initupload: gcr.io/k8s-prow/initupload:v20240802-66b115076
-            sidecar: gcr.io/k8s-prow/sidecar:v20240802-66b115076
+            clonerefs: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20240802-66b115076
+            entrypoint: us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240802-66b115076
+            initupload: us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240802-66b115076
+            sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240802-66b115076
 
     tide:
       queries:
@@ -172,7 +172,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240802-66b115076
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -261,7 +261,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
@@ -300,7 +300,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --plugin-config=/etc/plugins/plugins.yaml
@@ -397,7 +397,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20240802-66b115076
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -432,7 +432,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20240802-66b115076
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -542,7 +542,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20240802-66b115076
         args:
         - --dry-run=false
         - --continue-on-error=true
@@ -934,7 +934,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240802-66b115076
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99
@@ -1003,7 +1003,7 @@ spec:
             secretKeyRef:
               name: github-token
               key: appid
-        image: gcr.io/k8s-prow/prow-controller-manager:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20240802-66b115076
         volumeMounts:
         - name: github-token
           mountPath: /etc/github
@@ -1139,7 +1139,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240802-66b115076
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/starter/starter-gcs.yaml
+++ b/config/prow/cluster/starter/starter-gcs.yaml
@@ -109,10 +109,10 @@ data:
             name: github-token
             key: cert
           utility_images:
-            clonerefs: gcr.io/k8s-prow/clonerefs:v20240802-66b115076
-            entrypoint: gcr.io/k8s-prow/entrypoint:v20240802-66b115076
-            initupload: gcr.io/k8s-prow/initupload:v20240802-66b115076
-            sidecar: gcr.io/k8s-prow/sidecar:v20240802-66b115076
+            clonerefs: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20240802-66b115076
+            entrypoint: us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240802-66b115076
+            initupload: us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240802-66b115076
+            sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240802-66b115076
 
     tide:
       queries:
@@ -163,7 +163,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240802-66b115076
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -253,7 +253,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
@@ -292,7 +292,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --plugin-config=/etc/plugins/plugins.yaml
@@ -389,7 +389,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20240802-66b115076
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -424,7 +424,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20240802-66b115076
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -535,7 +535,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20240802-66b115076
         args:
         - --dry-run=false
         - --continue-on-error=true
@@ -927,7 +927,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240802-66b115076
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99
@@ -996,7 +996,7 @@ spec:
             secretKeyRef:
               name: github-token
               key: appid
-        image: gcr.io/k8s-prow/prow-controller-manager:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20240802-66b115076
         volumeMounts:
         - name: github-token
           mountPath: /etc/github
@@ -1132,7 +1132,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240802-66b115076
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -116,10 +116,10 @@ data:
             key: cert
           s3_credentials_secret: s3-credentials
           utility_images:
-            clonerefs: gcr.io/k8s-prow/clonerefs:latest
-            entrypoint: gcr.io/k8s-prow/entrypoint:latest
-            initupload: gcr.io/k8s-prow/initupload:latest
-            sidecar: gcr.io/k8s-prow/sidecar:latest
+            clonerefs: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:latest
+            entrypoint: us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:latest
+            initupload: us-docker.pkg.dev/k8s-infra-prow/images/initupload:latest
+            sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:latest
 
     tide:
       queries:
@@ -187,7 +187,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:latest
+        image: us-docker.pkg.dev/k8s-infra-prow/images/hook:latest
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -290,7 +290,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:latest
+        image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:latest
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
@@ -336,7 +336,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:latest
+        image: us-docker.pkg.dev/k8s-infra-prow/images/deck:latest
         args:
         - --config-path=/etc/config/config.yaml
         - --plugin-config=/etc/plugins/plugins.yaml
@@ -446,7 +446,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:latest
+        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:latest
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -488,7 +488,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:latest
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:latest
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -570,7 +570,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:latest
+        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:latest
         args:
         - --dry-run=false
         - --continue-on-error=true
@@ -969,7 +969,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:latest
+        image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:latest
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=5
@@ -1039,7 +1039,7 @@ spec:
             secretKeyRef:
               name: github-token
               key: appid
-        image: gcr.io/k8s-prow/prow-controller-manager:latest
+        image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:latest
         volumeMounts:
         - name: github-token
           mountPath: /etc/github
@@ -1181,7 +1181,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:latest
+        image: us-docker.pkg.dev/k8s-infra-prow/images/crier:latest
         args:
         - --blob-storage-workers=2
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/starter/starter-s3.yaml
+++ b/config/prow/cluster/starter/starter-s3.yaml
@@ -119,10 +119,10 @@ data:
             key: cert
           s3_credentials_secret: s3-credentials
           utility_images:
-            clonerefs: gcr.io/k8s-prow/clonerefs:v20240802-66b115076
-            entrypoint: gcr.io/k8s-prow/entrypoint:v20240802-66b115076
-            initupload: gcr.io/k8s-prow/initupload:v20240802-66b115076
-            sidecar: gcr.io/k8s-prow/sidecar:v20240802-66b115076
+            clonerefs: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20240802-66b115076
+            entrypoint: us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240802-66b115076
+            initupload: us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240802-66b115076
+            sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240802-66b115076
 
     tide:
       queries:
@@ -173,7 +173,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240802-66b115076
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -262,7 +262,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
@@ -301,7 +301,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20240802-66b115076
         args:
         - --config-path=/etc/config/config.yaml
         - --plugin-config=/etc/plugins/plugins.yaml
@@ -398,7 +398,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20240802-66b115076
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -433,7 +433,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20240802-66b115076
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -543,7 +543,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20240802-66b115076
         args:
         - --dry-run=false
         - --continue-on-error=true
@@ -935,7 +935,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240802-66b115076
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99
@@ -1004,7 +1004,7 @@ spec:
             secretKeyRef:
               name: github-token
               key: appid
-        image: gcr.io/k8s-prow/prow-controller-manager:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20240802-66b115076
         volumeMounts:
         - name: github-token
           mountPath: /etc/github
@@ -1140,7 +1140,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240802-66b115076
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20240802-66b115076
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20240802-66b115076
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -13,10 +13,10 @@ plank:
       timeout: 2h
       grace_period: 15m
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20240802-66b115076"
-        initupload: "gcr.io/k8s-prow/initupload:v20240802-66b115076"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20240802-66b115076"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20240802-66b115076"
+        clonerefs: "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20240802-66b115076"
+        initupload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240802-66b115076"
+        entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240802-66b115076"
+        sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240802-66b115076"
       gcs_configuration:
         bucket: "kubernetes-jenkins"
         path_strategy: "legacy"

--- a/config/prow/experimental/controller_manager.yaml
+++ b/config/prow/experimental/controller_manager.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/prow-controller-manager:v20240802-66b115076
+        image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20240802-66b115076
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/README.md
+++ b/prow/README.md
@@ -6,8 +6,8 @@ The Prow source code that previously lived here was moved along with ghProxy to 
 
 ## How this impacts you and what to do:
 
-- If you just use Prow or maintain a Prow instance there is nothing you need to do. Container images will still be available at [gcr.io/k8s-prow/](http://gcr.io/k8s-prow/).
-- If you don't develop Prow itself, but you do rely on its go packages (via importing the k8s.io/test-infra go module), after April 9th you'll need to update import statements to be prefixed with 'sigs.k8s.io/prow' rather than 'k8s.io/test-infra'. Since the repo relative paths will remain the same, you can use a sed command like this one to fix any references: 
+- If you just use Prow or maintain a Prow instance there is nothing you need to do. Container images will still be available at [us-docker.pkg.dev/k8s-infra-prow/images/](http://us-docker.pkg.dev/k8s-infra-prow/images/).
+- If you don't develop Prow itself, but you do rely on its go packages (via importing the k8s.io/test-infra go module), after April 9th you'll need to update import statements to be prefixed with 'sigs.k8s.io/prow' rather than 'k8s.io/test-infra'. Since the repo relative paths will remain the same, you can use a sed command like this one to fix any references:
   `sed -i 's,k8s.io/test-infra/prow,sigs.k8s.io/prow/prow,g;s,k8s.io/test-infra/ghproxy,sigs.k8s.io/prow/ghproxy,g'`
   Don't forget to run `go mod tidy` afterwards.
 - If you do develop Prow you'll need to start targeting PRs against the [kubernetes-sigs/prow](https://github.com/kubernetes-sigs/prow) repo instead of this repo. You can transfer any open PRs to the new repo by using the `git format-patch` and `git am` commands. You'll also need to update package references as described in the previous bullet point.


### PR DESCRIPTION
Prow images have been published to a new location for a while now (us-docker.pkg.dev/k8s-infra-prow/images/). These should be the same images as published to the old location, so update images to pull from the new location instead.

Also updated a couple of spots that reference the old gcr.io/k8s-prow location (in the README.md and the Makefile).

Ref https://github.com/kubernetes/test-infra/issues/32432