### PR TITLE
[ci-kubernetes-e2e-gce-cos-k8sbeta-alphafeatures] Drop unused/removed feature gates

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -25,7 +25,7 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
       - --env=ENABLE_AUTH_PROVIDER_GCP=true
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true


### PR DESCRIPTION
Fix for failing test: https://testgrid.k8s.io/sig-release-1.31-blocking#gce-cos-k8sbeta-alphafeatures&width=20

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/79601e11-ffb9-416a-a181-c2a9a861c1ae">

You can see the logs where kubelet refuses to come up here:
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sbeta-alphafeatures/1820251593476411392/artifacts/test-eef92b583b-master/kubelet.log

```
Aug 05 00:18:51.424084 test-eef92b583b-master kubelet[2650]: W0805 00:18:51.423981    2650 feature_gate.go:354] Setting GA feature gate DisableCloudProviders=true. It will be removed in a future release.
Aug 05 00:18:51.424084 test-eef92b583b-master kubelet[2650]: W0805 00:18:51.424050    2650 feature_gate.go:354] Setting GA feature gate DisableKubeletCloudCredentialProviders=true. It will be removed in a future release.
Aug 05 00:18:51.424295 test-eef92b583b-master kubelet[2650]: E0805 00:18:51.424109    2650 run.go:72] "command failed" err="failed to set feature gates from initial flags-based config: unrecognized feature gate: InTreePluginGCEUnregister"
Aug 05 00:18:51.426810 test-eef92b583b-master systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE
```