### PR TITLE
Switch e2e-ci-kubernetes-e2e-al2023-aws-disruptive-canary from kubenet to amazonvpc

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1206,7 +1206,7 @@ def generate_misc():
         build_test(name_override="ci-kubernetes-e2e-al2023-aws-disruptive-canary",
                    cloud="aws",
                    distro="al2023",
-                   networking="kubenet",
+                   networking="amazonvpc",
                    k8s_version="ci",
                    kops_version=marker_updown_green("master"),
                    kops_channel="alpha",

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -3106,7 +3106,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: ci-kubernetes-e2e-cos-gce-reboot-canary
 
-# {"cloud": "aws", "distro": "al2023", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "amazonvpc"}
 - name: e2e-ci-kubernetes-e2e-al2023-aws-disruptive-canary
   cron: '57 6-23/8 * * *'
   labels:
@@ -3136,7 +3136,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.5.20240730.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='137112412989/al2023-ami-2023.5.20240730.0-kernel-6.1-x86_64' --channel=alpha --networking=amazonvpc --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -3169,7 +3169,7 @@ periodics:
     test.kops.k8s.io/k8s_version: ci
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: kubenet
+    test.kops.k8s.io/networking: amazonvpc
     testgrid-dashboards: amazon-ec2-kops, kops-distro-al2023, kops-k8s-ci, kops-latest, sig-cluster-lifecycle-kops, sig-cluster-lifecycle-kubeup-to-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: ci-kubernetes-e2e-al2023-aws-disruptive-canary


### PR DESCRIPTION
The CI job has has persistent failures for a long time, something networking related, let's quickly try another alternative:
https://testgrid.k8s.io/sig-cluster-lifecycle-kops#ci-kubernetes-e2e-al2023-aws-disruptive-canary&width=20

