### PR TITLE
Skip sig-cloud-provider-gcp labelled tests after in-tree cloud provider removal

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -183,8 +183,8 @@ periodics:
       - --extract=ci/latest-1.31
       - --extract-ci-bucket=k8s-release-dev
       - --timeout=660m
-      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
+      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]\[sig-cloud-provider-gcp\] --minStartupPods=8
       env:
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240725-1d8ea3e909-master
       resources:

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -52,6 +52,8 @@ jobs:
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sbeta-serial:
+    args:
+    - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]\[sig-cloud-provider-gcp\] --minStartupPods=8  
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true


### PR DESCRIPTION
Fixes https://testgrid.k8s.io/sig-release-1.31-informing#gce-cos-k8sbeta-serial failure.

In-tree cloud provider extensions were removed. https://github.com/kubernetes/kubernetes/pull/124519
These tests haven't been fixed yet and should be skipped.

k/k master branch issue: https://github.com/kubernetes/kubernetes/issues/124748