### PR TITLE
Create an initial set of arm64 etcd jobs

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -1,4 +1,38 @@
 periodics:
+- name: ci-etcd-e2e-arm64
+  interval: 4h
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-arm64
+    testgrid-tab-name: ci-etcd-e2e-armd64
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"
+    nodeSelector:
+      kubernetes.io/arch: arm64
+
 - name: ci-etcd-e2e-amd64
   interval: 4h
   cluster: eks-prow-build-cluster
@@ -10,11 +44,11 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-periodics
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-amd64
     testgrid-tab-name: ci-etcd-e2e-amd64
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
       command:
       - runner.sh
       args:
@@ -30,6 +64,9 @@ periodics:
         limits:
           cpu: "4"
           memory: "8Gi"
+    nodeSelector:
+      kubernetes.io/arch: amd64
+
 - name: ci-etcd-unit-test-amd64
   interval: 4h
   cluster: eks-prow-build-cluster
@@ -45,7 +82,7 @@ periodics:
     testgrid-tab-name: ci-etcd-unit-test-amd64
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
       command:
       - runner.sh
       args:
@@ -58,6 +95,9 @@ periodics:
         limits:
           cpu: "4"
           memory: "4Gi"
+    nodeSelector:
+      kubernetes.io/arch: amd64
+
 - name: ci-etcd-robustness-amd64
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -72,7 +112,7 @@ periodics:
     testgrid-create-test-group: 'true'
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
       command:
       - runner.sh
       args:
@@ -102,6 +142,9 @@ periodics:
       # fuse needs privileged mode
       securityContext:
         privileged: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+
 - name: ci-etcd-robustness-main-amd64
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -116,7 +159,7 @@ periodics:
     testgrid-create-test-group: 'true'
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
       command:
       - runner.sh
       args:
@@ -144,6 +187,9 @@ periodics:
       # fuse needs privileged mode
       securityContext:
         privileged: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+
 - name: ci-etcd-robustness-release35-amd64
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -158,7 +204,7 @@ periodics:
     testgrid-create-test-group: 'true'
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
       command:
       - runner.sh
       args:
@@ -186,6 +232,9 @@ periodics:
       # fuse needs privileged mode
       securityContext:
         privileged: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+
 - name: ci-etcd-robustness-release34-amd64
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -200,7 +249,7 @@ periodics:
     testgrid-create-test-group: 'true'
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
       command:
       - runner.sh
       args:
@@ -228,6 +277,8 @@ periodics:
       # fuse needs privileged mode
       securityContext:
         privileged: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
 - name: ci-etcd-performance-ratio-1-128-amd64
   interval: 24h
   cluster: eks-prow-build-cluster
@@ -243,7 +294,7 @@ periodics:
     testgrid-tab-name: ci-etcd-performance-ratio-1-128-amd64
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
       command:
       - runner.sh
       args:
@@ -261,6 +312,9 @@ periodics:
         limits:
           cpu: "7"
           memory: "4Gi"
+    nodeSelector:
+      kubernetes.io/arch: amd64
+
 - name: ci-etcd-performance-ratio-1-8-amd64
   interval: 24h
   cluster: eks-prow-build-cluster
@@ -276,7 +330,7 @@ periodics:
     testgrid-tab-name: ci-etcd-performance-ratio-1-8-amd64
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
       command:
       - runner.sh
       args:
@@ -294,6 +348,9 @@ periodics:
         limits:
           cpu: "7"
           memory: "8Gi"
+    nodeSelector:
+      kubernetes.io/arch: amd64
+
 - name: ci-etcd-performance-ratio-1-4-amd64
   interval: 24h
   cluster: eks-prow-build-cluster
@@ -309,7 +366,7 @@ periodics:
     testgrid-tab-name: ci-etcd-performance-ratio-1-4-amd64
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
       command:
       - runner.sh
       args:
@@ -327,6 +384,9 @@ periodics:
         limits:
           cpu: "7"
           memory: "8Gi"
+    nodeSelector:
+      kubernetes.io/arch: amd64
+
 - name: ci-etcd-performance-ratio-1-2-amd64
   interval: 24h
   cluster: eks-prow-build-cluster
@@ -342,7 +402,7 @@ periodics:
     testgrid-tab-name: ci-etcd-performance-ratio-1-2-amd64
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
       command:
       - runner.sh
       args:
@@ -360,6 +420,9 @@ periodics:
         limits:
           cpu: "7"
           memory: "10Gi"
+    nodeSelector:
+      kubernetes.io/arch: amd64
+
 - name: ci-etcd-performance-ratio-2-1-amd64
   interval: 24h
   cluster: eks-prow-build-cluster
@@ -375,7 +438,7 @@ periodics:
     testgrid-tab-name: ci-etcd-performance-ratio-2-1-amd64
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
       command:
       - runner.sh
       args:
@@ -393,3 +456,5 @@ periodics:
         limits:
           cpu: "7"
           memory: "10Gi"
+    nodeSelector:
+      kubernetes.io/arch: amd64

--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -10,7 +10,7 @@ postsubmits:
       testgrid-tab-name: post-etcd-build
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
         command:
         - runner.sh
         args:

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       testgrid-tab-name: pull-etcd-build
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
         command:
         - runner.sh
         args:
@@ -36,7 +36,7 @@ presubmits:
       testgrid-tab-name: pull-etcd-unit-test-amd64
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
         command:
         - runner.sh
         args:
@@ -53,6 +53,36 @@ presubmits:
             cpu: "4"
             memory: "2Gi"
 
+  - name: pull-etcd-unit-test-arm64
+    cluster: k8s-infra-prow-build
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-unit-test-arm64
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          export JUNIT_REPORT_DIR=${ARTIFACTS}
+          GOOS=linux GOARCH=arm64 CPU=4 GO_TEST_FLAGS='-p=2' make test-unit
+        resources:
+          requests:
+            cpu: "4"
+            memory: "2Gi"
+          limits:
+            cpu: "4"
+            memory: "2Gi"
+      nodeSelector:
+        kubernetes.io/arch: arm64
+
   - name: pull-etcd-unit-test-386
     cluster: eks-prow-build-cluster
     always_run: true
@@ -64,7 +94,7 @@ presubmits:
       testgrid-tab-name: pull-etcd-unit-test-386
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
         command:
         - runner.sh
         args:
@@ -92,7 +122,7 @@ presubmits:
       testgrid-tab-name: pull-etcd-verify
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
         command:
         - /bin/bash
         args:
@@ -128,7 +158,7 @@ presubmits:
       testgrid-tab-name: pull-etcd-govulncheck
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
         command:
         - runner.sh
         args:
@@ -156,7 +186,7 @@ presubmits:
       testgrid-tab-name: pull-etcd-e2e-amd64
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
         command:
         - runner.sh
         args:
@@ -185,7 +215,7 @@ presubmits:
       testgrid-tab-name: pull-etcd-integration-1-cpu-amd64
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
         command:
         - runner.sh
         args:
@@ -215,7 +245,7 @@ presubmits:
       testgrid-tab-name: pull-etcd-integration-2-cpu-amd64
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
         command:
         - runner.sh
         args:
@@ -245,7 +275,7 @@ presubmits:
       testgrid-tab-name: pull-etcd-integration-4-cpu-amd64
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
         command:
         - runner.sh
         args:
@@ -278,7 +308,7 @@ presubmits:
       testgrid-tab-name: pull-etcd-robustness-amd64
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
           command:
             - runner.sh
           args:

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -1,6 +1,8 @@
 dashboard_groups:
 - name: sig-etcd
   dashboard_names:
+  - sig-etcd-amd64
+  - sig-etcd-arm64
   - sig-etcd-presubmits
   - sig-etcd-periodics
   - sig-etcd-postsubmits
@@ -8,6 +10,8 @@ dashboard_groups:
   - sig-etcd-etcd-manager
 
 dashboards:
+  - name: sig-etcd-amd64
+  - name: sig-etcd-arm64
   - name: sig-etcd-presubmits
   - name: sig-etcd-periodics
   - name: sig-etcd-postsubmits


### PR DESCRIPTION
🎉 🎉 🎉  We have officially deployed our first arm64 nodes for prow. https://github.com/kubernetes/k8s.io/pull/7123

To use these nodes:
1. They are only available on k8s-infra-prow-build cluster(for now, we'll enable the eks-prow-build-cluster in the future).
2. You must use the `us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e` docker image, it is a multi-arch image.
3. You must specify a nodeSelector as shown on this PR. 

For etcd, if you have jobs that are architecture specific, please use the nodeSelector.

@jmhbnz @wenjiaswe 