### PR TITLE
Fix node-kubelet-cgroupv1-serial-cri-o job by dropping extra quote

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -186,7 +186,7 @@ periodics:
           - --provider=gce
           # *Manager jobs are skipped because they have corresponding test lanes with the right image
           # These jobs in serial get partially skipped and are long jobs.
-          - --test_args=--nodes=1 --timeout=5h --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[NodeFeature:NodeSwap]""
+          - --test_args=--nodes=1 --timeout=5h --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[NodeFeature:NodeSwap]"
           - --timeout=300m
       env:
       - name: GOPATH


### PR DESCRIPTION
Fix https://testgrid.k8s.io/sig-node-cri-o#node-kubelet-cgroupv1-serial-crio for real this time.

We have an extra quote at the end of the SKIP section. 