### PR TITLE
chore: remove apisnoop gh-pages branch protection

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -515,6 +515,10 @@ branch-protection:
         - "^dependabot/" # don't protect branches created by dependabot
         - "^greenkeeper/" # don't protect branches created by greenkeeper
       repos:
+        apisnoop:
+          branches:
+            gh-pages:
+              protect: false
         aws-ebs-csi-driver:
           branches:
             gh-pages:


### PR DESCRIPTION
allow for helm chart publishing