### PR TITLE
Migrate etcd arm64 robustness jobs to prow

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -1,4 +1,6 @@
+---
 periodics:
+
 - name: ci-etcd-e2e-arm64
   interval: 4h
   cluster: k8s-infra-prow-build
@@ -145,6 +147,53 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
 
+- name: ci-etcd-robustness-arm64
+  interval: 24h
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 210m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-create-test-group: 'true'
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        result=0
+        apt-get -o APT::Update::Error-Mode=any update && apt-get --yes install cmake libfuse3-dev libfuse3-3 fuse3
+        sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+        make install-lazyfs
+        set -euo pipefail
+        GO_TEST_FLAGS="-v --count 120 --timeout '200m' --run TestRobustnessExploratory"
+        make gofail-enable
+        make build
+        VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/data/results make test-robustness || result=$?
+        if [ -d /data/results ]; then
+          zip -r ${ARTIFACTS}/results.zip /data/results
+        fi
+        exit $result
+      resources:
+        requests:
+          cpu: "7"
+          memory: "14Gi"
+        limits:
+          cpu: "7"
+          memory: "14Gi"
+      # fuse needs privileged mode
+      securityContext:
+        privileged: true
+    nodeSelector:
+      kubernetes.io/arch: arm64
+
 - name: ci-etcd-robustness-main-amd64
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -189,6 +238,51 @@ periodics:
         privileged: true
     nodeSelector:
       kubernetes.io/arch: amd64
+
+- name: ci-etcd-robustness-main-arm64
+  interval: 24h
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 210m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-create-test-group: 'true'
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        result=0
+        apt update && apt-get --yes install cmake libfuse3-dev libfuse3-3 fuse3
+        sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+        make install-lazyfs
+        set -euo pipefail
+        GO_TEST_FLAGS="-v --count 120 --timeout '200m' --run TestRobustnessExploratory"
+        VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/data/results make test-robustness-main || result=$?
+        if [ -d /data/results ]; then
+          zip -r ${ARTIFACTS}/results.zip /data/results
+        fi
+        exit $result
+      resources:
+        requests:
+          cpu: "7"
+          memory: "14Gi"
+        limits:
+          cpu: "7"
+          memory: "14Gi"
+      # fuse needs privileged mode
+      securityContext:
+        privileged: true
+    nodeSelector:
+      kubernetes.io/arch: arm64
 
 - name: ci-etcd-robustness-release35-amd64
   interval: 24h
@@ -235,6 +329,51 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
 
+- name: ci-etcd-robustness-release35-arm64
+  interval: 24h
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 210m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-create-test-group: 'true'
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        result=0
+        apt update && apt-get --yes install cmake libfuse3-dev libfuse3-3 fuse3
+        sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+        make install-lazyfs
+        set -euo pipefail
+        GO_TEST_FLAGS="-v --count 120 --timeout '200m' --run TestRobustnessExploratory"
+        VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/data/results make test-robustness-release-3.5 || result=$?
+        if [ -d /data/results ]; then
+          zip -r ${ARTIFACTS}/results.zip /data/results
+        fi
+        exit $result
+      resources:
+        requests:
+          cpu: "7"
+          memory: "14Gi"
+        limits:
+          cpu: "7"
+          memory: "14Gi"
+      # fuse needs privileged mode
+      securityContext:
+        privileged: true
+    nodeSelector:
+      kubernetes.io/arch: arm64
+
 - name: ci-etcd-robustness-release34-amd64
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -279,6 +418,52 @@ periodics:
         privileged: true
     nodeSelector:
       kubernetes.io/arch: amd64
+
+- name: ci-etcd-robustness-release34-arm64
+  interval: 24h
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 210m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-create-test-group: 'true'
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        result=0
+        apt update && apt-get --yes install cmake libfuse3-dev libfuse3-3 fuse3
+        sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+        make install-lazyfs
+        set -euo pipefail
+        GO_TEST_FLAGS="-v --count 120 --timeout '200m' --run TestRobustnessExploratory"
+        VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/data/results make test-robustness-release-3.4 || result=$?
+        if [ -d /data/results ]; then
+          zip -r ${ARTIFACTS}/results.zip /data/results
+        fi
+        exit $result
+      resources:
+        requests:
+          cpu: "7"
+          memory: "14Gi"
+        limits:
+          cpu: "7"
+          memory: "14Gi"
+      # fuse needs privileged mode
+      securityContext:
+        privileged: true
+    nodeSelector:
+      kubernetes.io/arch: arm64
+
 - name: ci-etcd-performance-ratio-1-128-amd64
   interval: 24h
   cluster: eks-prow-build-cluster

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -1,3 +1,4 @@
+---
 presubmits:
   etcd-io/etcd:
   - name: pull-etcd-build
@@ -340,3 +341,52 @@ presubmits:
           # fuse needs privileged mode
           securityContext:
             privileged: true
+
+  - name: pull-etcd-robustness-arm64
+    cluster: k8s-infra-prow-build
+    optional: true # remove this once the job is green
+    always_run: true
+    branches:
+      - main
+    decorate: true
+    decoration_config:
+      timeout: 60m
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits, sig-etcd-robustness
+      testgrid-tab-name: pull-etcd-robustness-arm64
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              return_code=0
+              apt-get -o APT::Update::Error-Mode=any update && apt-get --yes install cmake libfuse3-dev libfuse3-3 fuse3
+              sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+              make install-lazyfs
+              set -euo pipefail
+              go clean -testcache
+              GO_TEST_FLAGS="-v --count 12 --timeout '30m' --run TestRobustness"
+              make gofail-enable
+              make build
+              make gofail-disable
+              VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/tmp/results make test-robustness || return_code=$?
+              if [ -d /tmp/results ]; then
+                zip -r ${ARTIFACTS}/results.zip /tmp/results
+              fi
+              exit $return_code
+          resources:
+            requests:
+              cpu: "7"
+              memory: "14Gi"
+            limits:
+              cpu: "7"
+              memory: "14Gi"
+          # fuse needs privileged mode
+          securityContext:
+            privileged: true
+      nodeSelector:
+        kubernetes.io/arch: arm64

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -30,6 +30,19 @@ dashboards:
           value: <test-url>
         - key: etcdVersion
           value: v3.6
+    - name: ci-etcd-robustness-arm64
+      test_group_name: ci-etcd-robustness-arm64
+      file_bug_template:
+        url: https://github.com/etcd-io/etcd/issues/new
+        options:
+        - key: template
+          value: bug-report.yml
+        - key: title
+          value: '[robustness tests] main-arm64: <test-name>'
+        - key: problem
+          value: <test-url>
+        - key: etcdVersion
+          value: v3.6
     - name: ci-etcd-robustness-main-amd64
       test_group_name: ci-etcd-robustness-main-amd64
       file_bug_template:
@@ -39,6 +52,19 @@ dashboards:
           value: bug-report.yml
         - key: title
           value: '[robustness tests] main-amd64: <test-name>'
+        - key: problem
+          value: <test-url>
+        - key: etcdVersion
+          value: v3.6
+    - name: ci-etcd-robustness-main-arm64
+      test_group_name: ci-etcd-robustness-main-arm64
+      file_bug_template:
+        url: https://github.com/etcd-io/etcd/issues/new
+        options:
+        - key: template
+          value: bug-report.yml
+        - key: title
+          value: '[robustness tests] main-arm64: <test-name>'
         - key: problem
           value: <test-url>
         - key: etcdVersion
@@ -56,6 +82,19 @@ dashboards:
           value: <test-url>
         - key: etcdVersion
           value: v3.5
+    - name: ci-etcd-robustness-release35-arm64
+      test_group_name: ci-etcd-robustness-release35-arm64
+      file_bug_template:
+        url: https://github.com/etcd-io/etcd/issues/new
+        options:
+        - key: template
+          value: bug-report.yml
+        - key: title
+          value: '[robustness tests] 3.5-arm64: <test-name>'
+        - key: problem
+          value: <test-url>
+        - key: etcdVersion
+          value: v3.5
     - name: ci-etcd-robustness-release34-amd64
       test_group_name: ci-etcd-robustness-release34-amd64
       file_bug_template:
@@ -65,6 +104,19 @@ dashboards:
           value: bug-report.yml
         - key: title
           value: '[robustness tests] 3.4-amd64: <test-name>'
+        - key: problem
+          value: <test-url>
+        - key: etcdVersion
+          value: v3.4
+    - name: ci-etcd-robustness-release34-arm64
+      test_group_name: ci-etcd-robustness-release34-arm64
+      file_bug_template:
+        url: https://github.com/etcd-io/etcd/issues/new
+        options:
+        - key: template
+          value: bug-report.yml
+        - key: title
+          value: '[robustness tests] 3.4-arm64: <test-name>'
         - key: problem
           value: <test-url>
         - key: etcdVersion


### PR DESCRIPTION
Following https://github.com/kubernetes/test-infra/pull/33224 we now have `arm64` nodes available in prow 🎉  so let's shift our `arm64` robustness jobs to prow so we can continue moving away from GitHub actions and making the most of k8s test infra features.

cc @serathius, @ahrtr, @ivanvc, @upodroid 