### PR TITLE
descheduler: set new timeouts and bump existing

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -7,6 +7,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-verify-master
     decorate: true
+    decoration_config:
+      timeout: 10m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -32,6 +34,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-verify-build-master
     decorate: true
+    decoration_config:
+      timeout: 10m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -57,6 +61,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-unit-test-master
     decorate: true
+    decoration_config:
+      timeout: 10m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -84,7 +90,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.30
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 30m
     always_run: true
     labels:
       preset-dind-enabled: "true"
@@ -122,7 +128,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.29
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 30m
     always_run: true
     labels:
       preset-dind-enabled: "true"
@@ -160,7 +166,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.28
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 30m
     always_run: true
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Addition of e2e in
https://github.com/kubernetes-sigs/descheduler/pull/1466 extends the running time of e2e suite. 20 minutes is no longer enough. Bumping the timeout to 30 minutes.

Also, sometimes it happens pull-descheduler-verify-master runs longer than 10 minutes. Which is a faulty behavior.