### PR TITLE
Fix label filter regex for ci-kubernetes-e2e-gce-cos-k8sbeta-serial

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -184,7 +184,7 @@ periodics:
       - --extract-ci-bucket=k8s-release-dev
       - --timeout=660m
       - --ginkgo-parallel=1
-      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]\[sig-cloud-provider-gcp\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\] --minStartupPods=8
       env:
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
       resources:

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -53,7 +53,7 @@ jobs:
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sbeta-serial:
     args:
-    - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]\[sig-cloud-provider-gcp\] --minStartupPods=8  
+    - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\] --minStartupPods=8  
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true


### PR DESCRIPTION
Adds missing `|` for label filter in https://github.com/kubernetes/test-infra/pull/33222