### PR TITLE
Periodic arm64 kind CI job that runs once a day

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -694,3 +694,52 @@ periodics:
           cpu: 2
   rerun_auth_config:
     allow_anyone: true
+- interval: 24h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-e2e-kind-arm64
+  annotations:
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: kind-master-arm64
+    description: Runs e2e tests against a latest kubernetes master created with sigs.k8s.io/kind using arm64
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com, davanum@gmail.com
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240705-131cd74733-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-arm64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+      - name: FOCUS
+        value: "."
+      - name: SKIP
+        value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
+      - name: PARALLEL
+        value: "true"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7
+    nodeSelector:
+      kubernetes.io/arch: arm64


### PR DESCRIPTION
Same set of tests as in `pull-kubernetes-e2e-kind`, but using the new arm64 based setup.