### PR TITLE
Self-nominate Kevin Hannon (kannon92) as an approver for sig-node jobs

### DIFF
--- a/config/jobs/containerd/containerd/OWNERS
+++ b/config/jobs/containerd/containerd/OWNERS
@@ -18,6 +18,7 @@ approvers:
   - klueska
   - SergeyKanzhelev
   - endocrimes
+  - kannon92
 emeritus_approvers:
   - dashpole
   - ehashman

--- a/config/jobs/kubernetes/sig-node/OWNERS
+++ b/config/jobs/kubernetes/sig-node/OWNERS
@@ -19,6 +19,7 @@ approvers:
   - klueska
   - SergeyKanzhelev
   - endocrimes
+  - kannon92
 emeritus_approvers:
   - dashpole
   - ehashman

--- a/config/testgrids/kubernetes/sig-node/OWNERS
+++ b/config/testgrids/kubernetes/sig-node/OWNERS
@@ -18,6 +18,7 @@ approvers:
   - klueska
   - SergeyKanzhelev
   - endocrimes
+  - kannon92
 emeritus_approvers:
   - dashpole
   - ehashman

--- a/jobs/e2e_node/OWNERS
+++ b/jobs/e2e_node/OWNERS
@@ -25,6 +25,7 @@ approvers:
 - mrunalp
 - SergeyKanzhelev
 - endocrimes
+- kannon92
 emeritus_approvers:
 - yguo0905
 - dashpole


### PR DESCRIPTION
I would like to self nominate to be an approver for sig-node configs in test-infra.

I am an active member of the sig-node community (reviewer of kubelet, maintainer for crio related tests) and I also support general CI infrastructure around sig-node.

I have good familiarity with e2e_node and I have worked for many months on fixing test failures in sig-node.

Relevant PRs authored/merged:
- https://github.com/kubernetes/test-infra/pulls?q=is%3Apr+author%3Akannon92+is%3Aclosed+sig%2Fnode
- 53 PRs merged

I aided in porting the crio jobs to use the new prow cluster and I have helped/aided authors in adding test jobs to support their features. Main ones I worked on were Swap and split-filesystem.

I have worked on promoting crio jobs to be informing jobs for the release and I am working on making these jobs blocking for a release.

 