### PR TITLE
migrate pull-kubernetes-e2e-gce-pull-through-cache off of gs://kubernetes-release-pull

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -363,7 +363,6 @@ presubmits:
             - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
             - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
             - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
-            - --extract=local
             - --gcp-master-image=ubuntu
             - --gcp-node-image=ubuntu
             - --gcp-zone=us-west1-b
@@ -374,7 +373,6 @@ presubmits:
             # Panic if data inconsistency is detected
             - --env=ENABLE_KUBE_LIST_FROM_CACHE_INCONSISTENCY_DETECTOR=true
             - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
-            - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-pull-through-cache
             - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
           image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master


### PR DESCRIPTION
This is a trial of migrating an optional, manually invoked presubmit for https://github.com/kubernetes/test-infra/issues/18789

If this pattern works as expected, I will bulk migrate more jobs in subsequent PRs and aim to eliminate this google.com bucket entirely.

It shouldn't be necessary, and I've recently confirmed this with the old `-no-stage` job, but I want to confirm with migrating one current job first.