### PR TITLE
Add missing stage in pull-e2e-gci-gce-alpha-enabled-default

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -796,6 +796,7 @@ presubmits:
             - --ginkgo-parallel=30
             - --provider=gce
             - --runtime-config=api/all=true
+            - --stage=gs://kubernetes-release-pull/ci/pull-e2e-gci-gce-alpha-enabled-default
             - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0 --minStartupPods=8
             - --timeout=70m
           image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master


### PR DESCRIPTION
Fix as job is now failing with in [log](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/126577/pull-e2e-gci-gce-alpha-enabled-default/1821238865076162560/build-log.txt):

```
2024/08/07 17:51:38 process.go:155: Step 'bash -c . hack/lib/version.sh && KUBE_ROOT=. kube::version::get_version_vars && echo "${KUBE_GIT_VERSION-}"' finished in 1.422950165s
2024/08/07 17:51:38 main.go:326: Something went wrong: failed to acquire k8s binaries: open /home/prow/go/src/k8s.io/kubernetes/_output/gcs-stage: no such file or directory
Traceback (most recent call last):
  File "/workspace/scenarios/kubernetes_e2e.py", line 391, in <module>
    main(parse_args())
  File "/workspace/scenarios/kubernetes_e2e.py", line 307, in main
    mode.start(runner_args)
  File "/workspace/scenarios/kubernetes_e2e.py", line 136, in start
    check_env(env, self.command, *args)
  File "/workspace/scenarios/kubernetes_e2e.py", line 57, in check_env
    subprocess.check_call(cmd, env=env)
  File "/usr/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)

```