### PR TITLE
drop legacy service account rotation job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -199,35 +199,3 @@ periodics:
     testgrid-tab-name: gencred-refresh-kubeconfig
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     description: Runs gencred to refresh generated kubeconfigs.
-# Legacy job for rotating the default sa json key used for legacy prowjobs that
-# can't migrate to use workload identity yet. This json key expires every 90
-# days, so rotating every 15 days should be safe as it allows 5 failures.
-# GCP only allows up to 9 keys for a sa, so deleting old ones on the fly as well.
-- cron: "30 1 1,15 * *"  # At 01:30 on day-of-month 1 and 15.
-  name: ci-test-infra-rotate-legacy-default-build-sa-json-key
-  cluster: test-infra-trusted
-  decorate: true
-  spec:
-    serviceAccountName: legacy-sa-json-key-rotator
-    containers:
-    - name: gcloud
-      image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20230111-cd1b3caf9c
-      command:
-      - /bin/bash
-      args:
-      - -c
-      - |
-        set -euo pipefail
-
-        temp_file="$(mktemp)"
-        gcloud iam service-accounts keys create "${temp_file}" --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com --key-file-type=json
-        gcloud secrets versions add default-k8s-build-cluster-service-account-key --data-file="${temp_file}" --project=k8s-prow-builds
-        for key_id in $(gcloud iam service-accounts keys list --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com --managed-by=user --created-before=$(date +%Y-%m-%d -d "90 days ago") --format="value(KEY_ID)"); do
-          gcloud iam service-accounts keys delete "${key_id}" -q --iam-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
-        done
-  annotations:
-    testgrid-num-failures-to-alert: '3'
-    testgrid-dashboards: sig-testing-misc
-    testgrid-tab-name: rotate-legacy-default-build-sa-json-key
-    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    description: Rotate legacy build cluster service account json key.

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -298,7 +298,6 @@ func TestCommunityJobs(t *testing.T) {
 	// DO NOT ADD ANY MORE JOBS HERE
 	knownBadJobs := sets.NewString(
 		"ci-test-infra-gencred-refresh-kubeconfig",
-		"ci-test-infra-rotate-legacy-default-build-sa-json-key",
 		"post-test-infra-deploy-prow",
 		"post-test-infra-gencred-refresh-kubeconfig",
 		"post-test-infra-reconcile-hmacs",


### PR DESCRIPTION
we have spun down the default cluster and expect to have prow migrated within the next 90d anyhow

this job last ran on july 31st

following https://github.com/kubernetes/test-infra/pull/33272