### PR TITLE
drop staging from all jobs using k8s-release-pull

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.27.yaml
@@ -910,7 +910,6 @@ presubmits:
       - args:
         - --build=quick
         - --cluster=
-        - --extract=local
         - --env=KUBE_NODE_OS_DISTRIBUTION=gci
         - --env=KUBE_GCE_NODE_IMAGE=cos-97-16919-189-5
         - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
@@ -920,7 +919,6 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
-        - --stage=gs://k8s-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
         command:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.28.yaml
@@ -910,14 +910,12 @@ presubmits:
       - args:
         - --build=quick
         - --cluster=
-        - --extract=local
         - --gcp-node-image=gci
         - --gcp-nodes=2
         - --gcp-project=k8s-jkns-pr-gce-gpus
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
-        - --stage=gs://k8s-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
         command:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -1017,7 +1017,6 @@ presubmits:
       - args:
         - --build=quick
         - --cluster=
-        - --extract=local
         - --env=KUBE_NODE_OS_DISTRIBUTION=gci
         - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
         - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
@@ -1028,7 +1027,6 @@ presubmits:
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
-        - --stage=gs://k8s-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --timeout=60m
         command:
         - runner.sh

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -41,12 +41,10 @@ presubmits:
         args:
         - --build=quick
         - --cluster=
-        - --extract=local
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
-        - --stage=gs://k8s-release-pull/ci/pull-kubernetes-e2e-gce-storage-slow
         - --test_args=--ginkgo.focus=\[sig-storage\].*\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=120m
         securityContext:

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -85,8 +85,6 @@ periodics:
         ../test-infra/scenarios/kubernetes_e2e.py \
           --build=quick \
           --dump-before-and-after \
-          --extract=local \
-          --stage=gs://k8s-release-dev/ci/ci-kubernetes-conformance-coverage \
           --gcp-zone=us-west1-b \
           --provider=gce \
           --timeout=300m \
@@ -154,8 +152,6 @@ periodics:
         ../test-infra/scenarios/kubernetes_e2e.py \
           --build=quick \
           --dump-before-and-after \
-          --extract=local \
-          --stage=gs://k8s-release-dev/ci/ci-kubernetes-coverage-e2e-gci-gce \
           --gcp-master-image=gci \
           --gcp-node-image=gci \
           --gcp-nodes=4 \


### PR DESCRIPTION
FYI @dims @ameukam @upodroid -- at some point we created this in k8s-infra as an alternative to `gs://kubernetes-release-pull`, but neither are actually needed.

see #18789 

these jobs are all optional and I've already tested this sort of change on a number of jobs now