### PR TITLE
Ingress NGINX: Rework image pushing configuration.

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -5,8 +5,7 @@ postsubmits:
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
-        - ^main$
-        - ^release-.*$
+        - ^release-.+$
       run_if_changed: 'TAG'
       cluster: k8s-infra-prow-build-trusted
       decorate: true
@@ -30,7 +29,7 @@ postsubmits:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^main$
-        - ^release-.*$
+        - ^release-.+$
       run_if_changed: 'images/nginx/.*'
       cluster: k8s-infra-prow-build-trusted
       decorate: true
@@ -54,7 +53,7 @@ postsubmits:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^main$
-        - ^release-.*$
+        - ^release-.+$
       run_if_changed: 'images/nginx-1.25/.*'
       cluster: k8s-infra-prow-build-trusted
       decorate: true
@@ -78,7 +77,7 @@ postsubmits:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^main$
-        - ^release-.*$
+        - ^release-.+$
       run_if_changed: 'images/opentelemetry/.*'
       cluster: k8s-infra-prow-build-trusted
       decorate: true
@@ -102,7 +101,7 @@ postsubmits:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^main$
-        - ^release-.*$
+        - ^release-.+$
       run_if_changed: 'images/test-runner/.*|NGINX_BASE'
       cluster: k8s-infra-prow-build-trusted
       decorate: true
@@ -126,6 +125,7 @@ postsubmits:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^main$
+        - ^release-.+$
       run_if_changed: 'images/cfssl/.*'
       cluster: k8s-infra-prow-build-trusted
       decorate: true
@@ -149,6 +149,7 @@ postsubmits:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^main$
+        - ^release-.+$
       run_if_changed: 'images/echo/.*|NGINX_BASE'
       cluster: k8s-infra-prow-build-trusted
       decorate: true
@@ -172,6 +173,7 @@ postsubmits:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^main$
+        - ^release-.+$
       run_if_changed: 'images/fastcgi-helloserver/.*'
       cluster: k8s-infra-prow-build-trusted
       decorate: true
@@ -195,6 +197,7 @@ postsubmits:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^main$
+        - ^release-.+$
       run_if_changed: 'images/httpbun/.*'
       cluster: k8s-infra-prow-build-trusted
       decorate: true
@@ -218,6 +221,7 @@ postsubmits:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^main$
+        - ^release-.+$
       run_if_changed: 'images/kube-webhook-certgen/.*'
       cluster: k8s-infra-prow-build-trusted
       decorate: true
@@ -241,6 +245,7 @@ postsubmits:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^main$
+        - ^release-.+$
       run_if_changed: 'images/custom-error-pages/.*'
       cluster: k8s-infra-prow-build-trusted
       decorate: true

--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -23,102 +23,6 @@ postsubmits:
               - --with-git-dir
               - .
 
-    # Ingress NGINX: NGINX
-    - name: post-ingress-nginx-nginx
-      annotations:
-        testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      branches:
-        - ^main$
-        - ^release-.+$
-      run_if_changed: ^images/nginx/
-      cluster: k8s-infra-prow-build-trusted
-      decorate: true
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/image-builder:v20240725-9fc4a08b13
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-ingress-nginx
-              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
-              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
-              - --build-dir=.
-              - --with-git-dir
-              - images/nginx
-
-    # Ingress NGINX: NGINX v1.25
-    - name: post-ingress-nginx-nginx-1-25
-      annotations:
-        testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      branches:
-        - ^main$
-        - ^release-.+$
-      run_if_changed: ^images/nginx-1.25/
-      cluster: k8s-infra-prow-build-trusted
-      decorate: true
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/image-builder:v20240725-9fc4a08b13
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-ingress-nginx
-              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
-              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
-              - --build-dir=.
-              - --with-git-dir
-              - images/nginx-1.25
-
-    # Ingress NGINX: OpenTelemetry
-    - name: post-ingress-nginx-opentelemetry
-      annotations:
-        testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      branches:
-        - ^main$
-        - ^release-.+$
-      run_if_changed: ^images/opentelemetry/
-      cluster: k8s-infra-prow-build-trusted
-      decorate: true
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/image-builder:v20240725-9fc4a08b13
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-ingress-nginx
-              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
-              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
-              - --build-dir=.
-              - --with-git-dir
-              - images/opentelemetry
-
-    # Ingress NGINX: Test Runner
-    - name: post-ingress-nginx-test-runner
-      annotations:
-        testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      branches:
-        - ^main$
-        - ^release-.+$
-      run_if_changed: ^images/test-runner/
-      cluster: k8s-infra-prow-build-trusted
-      decorate: true
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/image-builder:v20240725-9fc4a08b13
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-ingress-nginx
-              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
-              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
-              - --build-dir=.
-              - --with-git-dir
-              - images/test-runner
-
     # Ingress NGINX: CFSSL
     - name: post-ingress-nginx-cfssl
       annotations:
@@ -142,6 +46,30 @@ postsubmits:
               - --build-dir=.
               - --with-git-dir
               - images/cfssl
+
+    # Ingress NGINX: Custom Error Pages
+    - name: post-ingress-nginx-custom-error-pages
+      annotations:
+        testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
+      branches:
+        - ^main$
+        - ^release-.+$
+      run_if_changed: ^images/custom-error-pages/
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20240725-9fc4a08b13
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-ingress-nginx
+              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
+              - --build-dir=.
+              - --with-git-dir
+              - images/custom-error-pages
 
     # Ingress NGINX: E2E Test Echo
     - name: post-ingress-nginx-e2e-test-echo
@@ -239,14 +167,14 @@ postsubmits:
               - --with-git-dir
               - images/kube-webhook-certgen
 
-    # Ingress NGINX: Custom Error Pages
-    - name: post-ingress-nginx-custom-error-pages
+    # Ingress NGINX: NGINX
+    - name: post-ingress-nginx-nginx
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^main$
         - ^release-.+$
-      run_if_changed: ^images/custom-error-pages/
+      run_if_changed: ^images/nginx/
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:
@@ -261,4 +189,76 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
               - --build-dir=.
               - --with-git-dir
-              - images/custom-error-pages
+              - images/nginx
+
+    # Ingress NGINX: NGINX v1.25
+    - name: post-ingress-nginx-nginx-1-25
+      annotations:
+        testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
+      branches:
+        - ^main$
+        - ^release-.+$
+      run_if_changed: ^images/nginx-1.25/
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20240725-9fc4a08b13
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-ingress-nginx
+              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
+              - --build-dir=.
+              - --with-git-dir
+              - images/nginx-1.25
+
+    # Ingress NGINX: OpenTelemetry
+    - name: post-ingress-nginx-opentelemetry
+      annotations:
+        testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
+      branches:
+        - ^main$
+        - ^release-.+$
+      run_if_changed: ^images/opentelemetry/
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20240725-9fc4a08b13
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-ingress-nginx
+              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
+              - --build-dir=.
+              - --with-git-dir
+              - images/opentelemetry
+
+    # Ingress NGINX: Test Runner
+    - name: post-ingress-nginx-test-runner
+      annotations:
+        testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
+      branches:
+        - ^main$
+        - ^release-.+$
+      run_if_changed: ^images/test-runner/
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20240725-9fc4a08b13
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-ingress-nginx
+              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
+              - --build-dir=.
+              - --with-git-dir
+              - images/test-runner

--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -6,7 +6,7 @@ postsubmits:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
         - ^release-.+$
-      run_if_changed: 'TAG'
+      run_if_changed: ^TAG$
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:
@@ -30,7 +30,7 @@ postsubmits:
       branches:
         - ^main$
         - ^release-.+$
-      run_if_changed: 'images/nginx/.*'
+      run_if_changed: ^images/nginx/
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:
@@ -54,7 +54,7 @@ postsubmits:
       branches:
         - ^main$
         - ^release-.+$
-      run_if_changed: 'images/nginx-1.25/.*'
+      run_if_changed: ^images/nginx-1.25/
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:
@@ -78,7 +78,7 @@ postsubmits:
       branches:
         - ^main$
         - ^release-.+$
-      run_if_changed: 'images/opentelemetry/.*'
+      run_if_changed: ^images/opentelemetry/
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:
@@ -102,7 +102,7 @@ postsubmits:
       branches:
         - ^main$
         - ^release-.+$
-      run_if_changed: 'images/test-runner/.*|NGINX_BASE'
+      run_if_changed: ^images/test-runner/
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:
@@ -126,7 +126,7 @@ postsubmits:
       branches:
         - ^main$
         - ^release-.+$
-      run_if_changed: 'images/cfssl/.*'
+      run_if_changed: ^images/cfssl/
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:
@@ -150,7 +150,7 @@ postsubmits:
       branches:
         - ^main$
         - ^release-.+$
-      run_if_changed: 'images/echo/.*|NGINX_BASE'
+      run_if_changed: ^images/e2e-test-echo/
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:
@@ -174,7 +174,7 @@ postsubmits:
       branches:
         - ^main$
         - ^release-.+$
-      run_if_changed: 'images/fastcgi-helloserver/.*'
+      run_if_changed: ^images/fastcgi-helloserver/
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:
@@ -198,7 +198,7 @@ postsubmits:
       branches:
         - ^main$
         - ^release-.+$
-      run_if_changed: 'images/httpbun/.*'
+      run_if_changed: ^images/httpbun/
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:
@@ -222,7 +222,7 @@ postsubmits:
       branches:
         - ^main$
         - ^release-.+$
-      run_if_changed: 'images/kube-webhook-certgen/.*'
+      run_if_changed: ^images/kube-webhook-certgen/
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:
@@ -246,7 +246,7 @@ postsubmits:
       branches:
         - ^main$
         - ^release-.+$
-      run_if_changed: 'images/custom-error-pages/.*'
+      run_if_changed: ^images/custom-error-pages/
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       spec:

--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -1,7 +1,7 @@
 postsubmits:
   kubernetes/ingress-nginx:
-
-    - name: post-ingress-nginx-push-images
+    # Ingress NGINX: Controller
+    - name: post-ingress-nginx-controller
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
@@ -24,7 +24,8 @@ postsubmits:
               - --build-dir=.
               - .
 
-    - name: post-ingress-nginx-build-nginx-image
+    # Ingress NGINX: NGINX
+    - name: post-ingress-nginx-nginx
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
@@ -47,7 +48,8 @@ postsubmits:
               - --with-git-dir
               - images/nginx
 
-    - name: post-ingress-nginx-build-nginx-1-25-image
+    # Ingress NGINX: NGINX v1.25
+    - name: post-ingress-nginx-nginx-1-25
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
@@ -70,7 +72,8 @@ postsubmits:
               - --with-git-dir
               - images/nginx-1.25
 
-    - name: post-ingress-nginx-build-opentelemetry
+    # Ingress NGINX: OpenTelemetry
+    - name: post-ingress-nginx-opentelemetry
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
@@ -93,7 +96,8 @@ postsubmits:
               - --with-git-dir
               - images/opentelemetry
 
-    - name: post-ingress-nginx-build-e2e-image
+    # Ingress NGINX: Test Runner
+    - name: post-ingress-nginx-test-runner
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
@@ -116,7 +120,8 @@ postsubmits:
               - --with-git-dir
               - images/test-runner
 
-    - name: post-ingress-nginx-build-cfssl-image
+    # Ingress NGINX: CFSSL
+    - name: post-ingress-nginx-cfssl
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
@@ -138,7 +143,8 @@ postsubmits:
               - --with-git-dir
               - images/cfssl
 
-    - name: post-ingress-nginx-build-echo-image
+    # Ingress NGINX: E2E Test Echo
+    - name: post-ingress-nginx-e2e-test-echo
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
@@ -160,7 +166,8 @@ postsubmits:
               - --with-git-dir
               - images/echo
 
-    - name: post-ingress-nginx-build-fastcgi-helloserver-image
+    # Ingress NGINX: FastCGI HelloServer
+    - name: post-ingress-nginx-fastcgi-helloserver
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
@@ -182,7 +189,8 @@ postsubmits:
               - --with-git-dir
               - images/fastcgi-helloserver
 
-    - name: post-ingress-nginx-build-httpbun-image
+    # Ingress NGINX: HTTPBun
+    - name: post-ingress-nginx-httpbun
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
@@ -204,7 +212,8 @@ postsubmits:
               - --with-git-dir
               - images/httpbun
 
-    - name: post-ingress-nginx-build-webhook-certgen-image
+    # Ingress NGINX: Kube Webhook CertGen
+    - name: post-ingress-nginx-kube-webhook-certgen
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
@@ -226,7 +235,8 @@ postsubmits:
               - --with-git-dir
               - images/kube-webhook-certgen
 
-    - name: post-ingress-nginx-build-custom-error-pages-image
+    # Ingress NGINX: Custom Error Pages
+    - name: post-ingress-nginx-custom-error-pages
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb

--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -1,5 +1,6 @@
 postsubmits:
   kubernetes/ingress-nginx:
+
     - name: post-ingress-nginx-push-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -22,6 +23,7 @@ postsubmits:
               - --with-git-dir
               - --build-dir=.
               - .
+
     - name: post-ingress-nginx-build-nginx-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -44,6 +46,7 @@ postsubmits:
               - --build-dir=.
               - --with-git-dir
               - images/nginx
+
     - name: post-ingress-nginx-build-nginx-1-25-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -66,6 +69,7 @@ postsubmits:
               - --build-dir=.
               - --with-git-dir
               - images/nginx-1.25
+
     - name: post-ingress-nginx-build-opentelemetry
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -88,6 +92,7 @@ postsubmits:
               - --build-dir=.
               - --with-git-dir
               - images/opentelemetry
+
     - name: post-ingress-nginx-build-e2e-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -110,6 +115,7 @@ postsubmits:
               - --build-dir=.
               - --with-git-dir
               - images/test-runner
+
     - name: post-ingress-nginx-build-cfssl-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -131,6 +137,7 @@ postsubmits:
               - --build-dir=.
               - --with-git-dir
               - images/cfssl
+
     - name: post-ingress-nginx-build-echo-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -152,6 +159,7 @@ postsubmits:
               - --build-dir=.
               - --with-git-dir
               - images/echo
+
     - name: post-ingress-nginx-build-fastcgi-helloserver-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -173,6 +181,7 @@ postsubmits:
               - --build-dir=.
               - --with-git-dir
               - images/fastcgi-helloserver
+
     - name: post-ingress-nginx-build-httpbun-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -194,6 +203,7 @@ postsubmits:
               - --build-dir=.
               - --with-git-dir
               - images/httpbun
+
     - name: post-ingress-nginx-build-webhook-certgen-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -215,6 +225,7 @@ postsubmits:
               - --build-dir=.
               - --with-git-dir
               - images/kube-webhook-certgen
+
     - name: post-ingress-nginx-build-custom-error-pages-image
       cluster: k8s-infra-prow-build-trusted
       annotations:

--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -2,14 +2,14 @@ postsubmits:
   kubernetes/ingress-nginx:
     # Ingress NGINX: Controller
     - name: post-ingress-nginx-controller
-      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      decorate: true
-      run_if_changed: 'TAG'
       branches:
         - ^main$
         - ^release-.*$
+      run_if_changed: 'TAG'
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -20,20 +20,20 @@ postsubmits:
               - --project=k8s-staging-ingress-nginx
               - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
               - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
-              - --with-git-dir
               - --build-dir=.
+              - --with-git-dir
               - .
 
     # Ingress NGINX: NGINX
     - name: post-ingress-nginx-nginx
-      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      decorate: true
-      run_if_changed: 'images/nginx/.*'
       branches:
         - ^main$
         - ^release-.*$
+      run_if_changed: 'images/nginx/.*'
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -50,14 +50,14 @@ postsubmits:
 
     # Ingress NGINX: NGINX v1.25
     - name: post-ingress-nginx-nginx-1-25
-      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      decorate: true
-      run_if_changed: 'images/nginx-1.25/.*'
       branches:
         - ^main$
         - ^release-.*$
+      run_if_changed: 'images/nginx-1.25/.*'
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -74,14 +74,14 @@ postsubmits:
 
     # Ingress NGINX: OpenTelemetry
     - name: post-ingress-nginx-opentelemetry
-      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      decorate: true
-      run_if_changed: 'images/opentelemetry/.*'
       branches:
         - ^main$
         - ^release-.*$
+      run_if_changed: 'images/opentelemetry/.*'
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -98,14 +98,14 @@ postsubmits:
 
     # Ingress NGINX: Test Runner
     - name: post-ingress-nginx-test-runner
-      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      decorate: true
-      run_if_changed: 'images/test-runner/.*|NGINX_BASE'
       branches:
         - ^main$
         - ^release-.*$
+      run_if_changed: 'images/test-runner/.*|NGINX_BASE'
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -122,13 +122,13 @@ postsubmits:
 
     # Ingress NGINX: CFSSL
     - name: post-ingress-nginx-cfssl
-      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      decorate: true
-      run_if_changed: 'images/cfssl/.*'
       branches:
         - ^main$
+      run_if_changed: 'images/cfssl/.*'
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -145,13 +145,13 @@ postsubmits:
 
     # Ingress NGINX: E2E Test Echo
     - name: post-ingress-nginx-e2e-test-echo
-      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      decorate: true
-      run_if_changed: 'images/echo/.*|NGINX_BASE'
       branches:
         - ^main$
+      run_if_changed: 'images/echo/.*|NGINX_BASE'
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -168,13 +168,13 @@ postsubmits:
 
     # Ingress NGINX: FastCGI HelloServer
     - name: post-ingress-nginx-fastcgi-helloserver
-      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      decorate: true
-      run_if_changed: 'images/fastcgi-helloserver/.*'
       branches:
         - ^main$
+      run_if_changed: 'images/fastcgi-helloserver/.*'
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -191,13 +191,13 @@ postsubmits:
 
     # Ingress NGINX: HTTPBun
     - name: post-ingress-nginx-httpbun
-      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      decorate: true
-      run_if_changed: 'images/httpbun/.*'
       branches:
         - ^main$
+      run_if_changed: 'images/httpbun/.*'
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -214,13 +214,13 @@ postsubmits:
 
     # Ingress NGINX: Kube Webhook CertGen
     - name: post-ingress-nginx-kube-webhook-certgen
-      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      decorate: true
-      run_if_changed: 'images/kube-webhook-certgen/.*'
       branches:
         - ^main$
+      run_if_changed: 'images/kube-webhook-certgen/.*'
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -237,13 +237,13 @@ postsubmits:
 
     # Ingress NGINX: Custom Error Pages
     - name: post-ingress-nginx-custom-error-pages
-      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      decorate: true
-      run_if_changed: 'images/custom-error-pages/.*'
       branches:
         - ^main$
+      run_if_changed: 'images/custom-error-pages/.*'
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
       spec:
         serviceAccountName: gcb-builder
         containers:

--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -165,7 +165,7 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
               - --build-dir=.
               - --with-git-dir
-              - images/echo
+              - images/e2e-test-echo
 
     # Ingress NGINX: FastCGI HelloServer
     - name: post-ingress-nginx-fastcgi-helloserver


### PR DESCRIPTION
This PR reworks the current image pushing configuration for the Ingress NGINX project. It harmonizes the single jobs and makes them match our actual needs. See the single commits for easier review.