### PR TITLE
Add cherrypicker plugin to K8s-sigs/karpenter.

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1936,3 +1936,8 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  kubernetes-sigs/karpenter:
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request


### PR DESCRIPTION

This patch enables the cherrypicker plugin to k8s-sigs/karpenter.

fixes https://github.com/kubernetes-sigs/karpenter/issues/1543


/cc @njtran @engedaam @jonathan-innis
for LGTM and approval of project :)

