### PR TITLE
Enable `cherrypicker` plugin for `cri-tools`

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1798,6 +1798,12 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/cri-tools:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   kubernetes-sigs/gateway-api:
   - name: cherrypicker
     events:


### PR DESCRIPTION
Enable the cherrypicker plugin for the cri-tools repo.

@kubernetes/sig-node-pr-reviews PTAL