### PR TITLE
Switch `ci-crio-cgroupv2-node-e2e-conformance` to use crun

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -503,7 +503,7 @@ periodics:
     testgrid-tab-name: node-kubelet-crio-cgroupv2-performance-test
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
-- name: ci-crio-cgroupv2-node-e2e-conformance
+- name: ci-crio-cgroupv2-crun-node-e2e-conformance
   cluster: k8s-infra-prow-build
   interval: 1h
   labels:
@@ -537,7 +537,7 @@ periodics:
       - --provider=gce
       - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
       - --timeout=180m
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv2.yaml
+      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgrpv2-crun.yaml
       env:
       - name: GOPATH
         value: /go
@@ -552,9 +552,9 @@ periodics:
           memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o, sig-release-master-informing, sig-node-release-blocking
-    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-conformance
+    testgrid-tab-name: ci-crio-cgroupv2-crun-node-e2e-conformance
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v2"
+    description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v2 using crun"
 - name: ci-crio-cgroupv1-node-e2e-resource-managers
   cluster: k8s-infra-prow-build
   interval: 4h

--- a/jobs/e2e_node/crio/crio_cgroupsv2_crun.ign
+++ b/jobs/e2e_node/crio/crio_cgroupsv2_crun.ign
@@ -1,0 +1,90 @@
+{
+  "ignition": {
+    "version": "3.3.0"
+  },
+  "kernelArguments": {
+    "shouldNotExist": [
+      "mitigations=auto,nosmt"
+    ]
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/zincati/config.d/90-disable-auto-updates.toml",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bupdates%5D%0Aenabled%20%3D%20false%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/root/kubelet-e2e.te",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/6RRy07DMBC8+ytG4gwCjkT9lsp1BrTKxjbOWhWK+u+ItiFpE07scWcf83B9aqsSXT1QaY98JV6enhvnCj+rFGJ0uJZ9ZUKy+YNy2FtzC4SPkmpetevAsrd+DUgUWx9J0bzEn5UZCeqHAa0UjJAUTBEKvREpM+JYxIjT/fi7KDHC58zYTguaQofe58tmoW9RGH1P1KgSu/nYybmH3bKufHHT3Dmvmo4TNmt9++f7++cLX7YZLAcWNC6mbdq10vcb7B8aZ3yK+nz+nEjjvgMAAP//f1Vw5EkCAAA="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/20-crio.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/7SP0UrFMAyG7/MUY/duT3CeREbp6bIukiYjTUXfXuomgoII4lVp+P98Xx6TkU5UYsYFKmWJ3gzDoUzpdbgN44ye5h6az9n0VFVGgLNoTZwKLsCaA+Mzcu+seG95hNX0CCSbxZDchtuwRa4IK26xsYer2wvWJH3d+fHWKVmTBa5vOKLv72Kt2sx0xxe8BHtuhKJCrvZTTqV8v+GT121+wzut/85zrP6wR1kZ7T+4bwEAAP//V7kNseQBAAA="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/sysctl.d/99-e2e-sysctl.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/2SQvU7DQBCEez/FSG7BduKf4Eh0NBR06dH6bo1P8d1F3r3EvD2KCJFQqpW+LWbmy/EezMIkjCMvgefi5OynpxUU7B/SaWGy8nzFGuFpdT75AofJCZwgMFu2GOOS5Tg5Cz47oy4GKIvKEwY2lIQh36LsLS5uniGsoBvCxVnGG4+UZj2QHOWD1izHQMIWMcA7n0LyiCN0YmGcaU4sRZZjXXjcY1I9yb4sv5xOaShM9OUt7X5N9N5pWVM1Vp1pNrTth11XjdyZ2tKu3fZmbPuW25eaqOqyHIeJYX9L3QJBC0NjxBwv18HXNo+Ti+y/zNdm0zd11WSPQu+vnwAAAP//xE8bG4oBAAA="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/ssh-key-secret/ssh-public",
+        "contents": {
+          "source": "data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA=="
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/99-crun.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Adefault_runtime%20%3D%20%22crun%22%0A"
+        },
+        "mode": 420
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "contents": "[Unit]\nDescription=Configure required sysctls.\n\n[Service]\nType=oneshot\nExecStart=/usr/lib/systemd/systemd-sysctl\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "configure-sysctl.service"
+      },
+      {
+        "contents": "[Unit]\nDescription=Download and install required tools.\nBefore=crio-install.service\nAfter=NetworkManager-wait-online.service\n\n[Service]\nType=oneshot\nExecStart=rpm-ostree install \\\n  -y \\\n  --apply-live \\\n  --allow-inactive \\\n  dbus-tools \\\n  checkpolicy\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "tools-install.service"
+      },
+      {
+        "contents": "[Unit]\nDescription=Setup SELinux policy\nAfter=tools-install.service\n\n[Service]\nType=oneshot\nExecStartPre=setenforce 1\nExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te\nExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod\nExecStartPre=semodule -i /root/kubelet-e2e.pp\nExecStartPre=mkdir -p /var/lib/kubelet\nExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "selinux-install.service"
+      },
+      {
+        "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=selinux-install.service\n\n[Service]\nType=oneshot\nEnvironment=\"SCRIPT_COMMIT=52aa3c2a31ccc9623962e9e338b6585267d6f3f4\"\nEnvironment=\"CRIO_COMMIT=1c04ca9768e535cf22017da6e6cee620bb3a6431\"\n\nExecStartPre=mount /tmp /tmp -o remount,exec,suid\nExecStartPre=mount -o remount,rw /dev/sda4 /usr\nExecStartPre=bash -c '\\\n  curl --fail --retry 5 --retry-delay 3 --silent --show-error \\\n    https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\\\n      bash -s -- -t $CRIO_COMMIT'\nExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist\nExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf\nExecStart=systemctl enable --now crio.service\nRestart=on-failure\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "crio-install.service"
+      },
+      {
+        "contents": "[Unit]\nDescription=Copy authorized keys\nBefore=crio-install.service\nAfter=NetworkManager-wait-online.service\n\n[Service]\nType=oneshot\nExecStart=/bin/sh -c '\\\n  /usr/bin/mkdir -m 0700 -p /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/cat /etc/ssh-key-secret/ssh-public \\\n    \u003e\u003e /home/core/.ssh/authorized_keys \u0026\u0026 \\\n  /usr/bin/chown -R core:core /home/core/.ssh \u0026\u0026 \\\n  /usr/bin/chmod 0600 /home/core/.ssh/authorized_keys'\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "authorized-key.service"
+      }
+    ]
+  }
+}

--- a/jobs/e2e_node/crio/latest/image-config-cgrpv2-crun.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgrpv2-crun.yaml
@@ -1,0 +1,5 @@
+images:
+  fedora:
+    image_family: fedora-coreos-stable
+    project: fedora-coreos-cloud
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupsv2_crun.ign"

--- a/jobs/e2e_node/crio/templates/crio_cgroupsv2_crun.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupsv2_crun.yaml
@@ -1,0 +1,132 @@
+---
+variant: fcos
+version: 1.4.0
+kernel_arguments:
+  should_not_exist:
+    - mitigations=auto,nosmt
+storage:
+  files:
+    - path: /etc/zincati/config.d/90-disable-auto-updates.toml
+      contents:
+        local: 90-disable-auto-updates.toml
+      mode: 0644
+    - path: /root/kubelet-e2e.te
+      contents:
+        local: kubelet-e2e.te
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/20-crio.conf
+      contents:
+        local: 20-crio.conf
+      mode: 0644
+    - path: /etc/sysctl.d/99-e2e-sysctl.conf
+      contents:
+        local: 99-e2e-sysctl.conf
+      mode: 0644
+    - path: /etc/ssh-key-secret/ssh-public
+      contents:
+        # base64 encoded "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
+        source: data:text/plain;base64,R0NFX1NTSF9QVUJMSUNfS0VZX0ZJTEVfQ09OVEVOVA==
+      mode: 0644
+    - path: /etc/crio/crio.conf.d/99-crun.conf
+      # Note: This also assumes the crun handler is enabled in the base crio.conf,
+      # crun is installed, and the version of crun supports the `crun features` command.
+      # All of this is true at the time of writing.
+      # TODO(haircommander): This can be removed when runc 1.2.0 is released
+      contents:
+        local: 99-crun.conf
+      mode: 0644
+systemd:
+  units:
+    - name: configure-sysctl.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Configure required sysctls.
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/lib/systemd/systemd-sysctl
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: tools-install.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Download and install required tools.
+        Before=crio-install.service
+        After=NetworkManager-wait-online.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=rpm-ostree install \
+          -y \
+          --apply-live \
+          --allow-inactive \
+          dbus-tools \
+          checkpolicy
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: selinux-install.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Setup SELinux policy
+        After=tools-install.service
+
+        [Service]
+        Type=oneshot
+        ExecStartPre=setenforce 1
+        ExecStartPre=checkmodule -M -m -o /root/kubelet-e2e.mod /root/kubelet-e2e.te
+        ExecStartPre=semodule_package -o /root/kubelet-e2e.pp -m /root/kubelet-e2e.mod
+        ExecStartPre=semodule -i /root/kubelet-e2e.pp
+        ExecStartPre=mkdir -p /var/lib/kubelet
+        ExecStart=chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: crio-install.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Download and install crio binaries and configurations.
+        After=selinux-install.service
+
+        [Service]
+        Type=oneshot
+        Environment="SCRIPT_COMMIT=52aa3c2a31ccc9623962e9e338b6585267d6f3f4"
+        Environment="CRIO_COMMIT=1c04ca9768e535cf22017da6e6cee620bb3a6431"
+
+        ExecStartPre=mount /tmp /tmp -o remount,exec,suid
+        ExecStartPre=mount -o remount,rw /dev/sda4 /usr
+        ExecStartPre=bash -c '\
+          curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+            https://raw.githubusercontent.com/cri-o/packaging/$SCRIPT_COMMIT/get |\
+              bash -s -- -t $CRIO_COMMIT'
+        ExecStartPre=rm -f /etc/cni/net.d/87-podman-bridge.conflist
+        ExecStartPre=rm -f /etc/crio/crio.conf.d/10-crio.conf
+        ExecStart=systemctl enable --now crio.service
+        Restart=on-failure
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: authorized-key.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Copy authorized keys
+        Before=crio-install.service
+        After=NetworkManager-wait-online.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/sh -c '\
+          /usr/bin/mkdir -m 0700 -p /home/core/.ssh && \
+          /usr/bin/cat /etc/ssh-key-secret/ssh-public \
+            >> /home/core/.ssh/authorized_keys && \
+          /usr/bin/chown -R core:core /home/core/.ssh && \
+          /usr/bin/chmod 0600 /home/core/.ssh/authorized_keys'
+
+        [Install]
+        WantedBy=multi-user.target

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -29,6 +29,7 @@ declare -A CONFIGURATIONS=(
     ["crio_cgroupsv1_eventedpleg"]="root cgroups-v1 eventedpleg"
     ["crio_cgroupsv1_hugepages"]="root cgroups-v1 hugepages"
     ["crio_cgroupsv2"]="root"
+    ["crio_cgroupsv2_crun"]="root crun-enabled"
     ["crio_cgroupsv2_swap1g"]="root swap-1G"
     ["crio_cgroupsv2_imagefs"]="root imagefs"
     ["crio_cgroupsv2_splitfs"]="root splitfs"


### PR DESCRIPTION
The test is part of the SIG Release informing dashboards and the de-factor standard suite using CRI-O. The corresponding cgroups v1 test is still using runc.

/hold
for discussion

