### PR TITLE
Increase the throttle limit for branchprotector

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-branchprotector.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-branchprotector.yaml
@@ -24,6 +24,7 @@ periodics:
       - --confirm
       - --github-endpoint=http://ghproxy.default.svc.cluster.local
       - --github-endpoint=https://api.github.com
+      - --github-hourly-tokens=1000 # Up the rate limit from default (300) to 1000
       volumeMounts:
       - name: github
         mountPath: /etc/github


### PR DESCRIPTION
Right now it's timing out because it's getting throttled too much. There is some long term changes we should look at, such as how we are reconciling these as well as moving to a GH app token, but this should hopefully help.