### PR TITLE
CAPI: Bump CoreDNS version of 1.32 tests to 1.11.3

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-upgrades.yaml
@@ -323,7 +323,7 @@ periodics:
       - name: ETCD_VERSION_UPGRADE_TO
         value: "3.5.15-0"
       - name: COREDNS_VERSION_UPGRADE_TO
-        value: "v1.11.1"
+        value: "v1.11.3"
       - name: GINKGO_FOCUS
         value: "\\[Conformance\\] \\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -314,7 +314,7 @@ presubmits:
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.5.15-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "v1.11.1"
+            value: "v1.11.3"
           - name: GINKGO_FOCUS
             value: "\\[Conformance\\] \\[K8s-Upgrade\\]"
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-prowjob-gen.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-prowjob-gen.yaml
@@ -158,5 +158,5 @@ prow_ignored:
       k8sRelease: "stable-1.31"
     "1.32":
       etcd: "3.5.15-0"
-      coreDNS: "v1.11.1"
+      coreDNS: "v1.11.3"
       k8sRelease: "ci/latest-1.32"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com