### PR TITLE
Fix broken ci job ci kubernetes e2e gce cos k8sstable2 alphafeatures

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -458,7 +458,7 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8


### PR DESCRIPTION
This is TEST fix. if this works, then we need to go back and fix the config files that generate this CI job.

slack discussion:
https://kubernetes.slack.com/archives/CJH2GBF7Y/p1723657992636629?thread_ts=1723656088.321359&cid=CJH2GBF7Y

See failed job apiserver log here:
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable2-alphafeatures/1819778715274448896/artifacts/test-a8a0b221b9-master/kube-apiserver.log