### PR TITLE
etcd: adjust e2e presubmit jobs

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -177,7 +177,6 @@ presubmits:
 
   - name: pull-etcd-e2e-amd64
     cluster: eks-prow-build-cluster
-    optional: true # remove this once the job is green
     always_run: true
     branches:
     - main
@@ -200,14 +199,13 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "8Gi"
+            memory: "4Gi"
           limits:
             cpu: "4"
-            memory: "8Gi"
+            memory: "4Gi"
 
   - name: pull-etcd-e2e-386
     cluster: eks-prow-build-cluster
-    optional: true # remove this once the job is green
     always_run: true
     branches:
     - main
@@ -229,14 +227,13 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "8Gi"
+            memory: "4Gi"
           limits:
             cpu: "4"
-            memory: "8Gi"
+            memory: "4Gi"
 
   - name: pull-etcd-e2e-arm64
     cluster: k8s-infra-prow-build
-    optional: true # remove this once the job is green
     always_run: true
     branches:
     - main


### PR DESCRIPTION
* Don't set them as optional, as the jobs have been stable, according to TestGrid.
* Set the RAM requests/limits to 4Gi, as based on the Grafana stats, ARM and AMD jobs have been using around 1Gi, so cutting the resources in half should be enough.

ARM resources are to be adjusted, as I need to confirm with sig-infra where we can find the stats for the cluster where the jobs run.

Part of #32754 / kubernetes/k8s.io#6102