### PR TITLE
Change to kubekins image for COSI API CI

### DIFF
--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-api.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-api.yaml
@@ -11,9 +11,10 @@ presubmits:
       description: Build test in container-object-storage-interface-api repo.
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.18.4
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240611-597c402033-master
         command:
-        # Plain make runs also verify
+        - runner.sh
+        args:
         - make
         resources:
           limits:
@@ -34,10 +35,11 @@ presubmits:
       description: Unit tests in container-object-storage-interface-api repo.
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.18.4
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240611-597c402033-master
         command:
-        - make
+        - runner.sh
         args:
+        - make
         - test
         resources:
           limits:


### PR DESCRIPTION
Change to the gcr.io/k8s-staging-test-infra/kubekins-e2e image for COSI's API CI. This image has a near-latest version of golang that the project needs for keeping tests running. Because this image is periodically updated by bots, this choice should be useful for a long time to come.