### PR TITLE
etcd: Add etcd-website lint presubmit job

### DIFF
--- a/config/jobs/etcd/etcd-website-presubmits.yaml
+++ b/config/jobs/etcd/etcd-website-presubmits.yaml
@@ -1,0 +1,30 @@
+---
+presubmits:
+  etcd-io/website:
+  - name: pull-website-lint
+    cluster: eks-prow-build-cluster
+    optional: true # remove this once the job is green
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-website-presubmits
+      testgrid-tab-name: pull-website-lint
+    spec:
+      containers:
+      - image: public.ecr.aws/docker/library/node:20
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |
+          npm install -g markdownlint-cli2
+          make markdown-diff-lint
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+          limits:
+            cpu: "2"
+            memory: "4Gi"

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -8,6 +8,7 @@ dashboard_groups:
   - sig-etcd-postsubmits
   - sig-etcd-robustness
   - sig-etcd-etcd-manager
+  - sig-etcd-website-presubmits
 
 dashboards:
   - name: sig-etcd-amd64
@@ -122,3 +123,4 @@ dashboards:
         - key: etcdVersion
           value: v3.4
   - name: sig-etcd-etcd-manager
+  - name: sig-etcd-website-presubmits


### PR DESCRIPTION
Add a website job to link Markdown files using a NodeJS image and `markdownlint-cli2`.

Part of etcd-io/website#857