### PR TITLE
delete hmac reconcile job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -32,51 +32,6 @@ postsubmits:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '1'
       description: deploys the configured version of prow by running prow/deploy.sh
-  - name: post-test-infra-reconcile-hmacs
-    cluster: test-infra-trusted
-    run_if_changed: 'config/prow/config.yaml'
-    decorate: true
-    branches:
-    - ^master$
-    max_concurrency: 1
-    spec:
-      containers:
-      - image: us-docker.pkg.dev/k8s-infra-prow/images/hmac:v20240802-66b115076
-        command:
-        - hmac
-        args:
-        - --config-path=config/prow/config.yaml
-        - --hook-url=https://prow.k8s.io/hook
-        - --hmac-token-secret-name=hmac-token
-        - --hmac-token-key=hmac
-        - --kubeconfig=/etc/kubeconfig/config
-        - --kubeconfig-context=prow-services
-        - --github-token-path=/etc/github/oauth
-        - --github-endpoint=http://ghproxy.default.svc.cluster.local
-        - --github-endpoint=https://api.github.com
-        - --dry-run=false
-        volumeMounts:
-        - name: kubeconfig
-          mountPath: /etc/kubeconfig
-          readOnly: true
-        - name: oauth
-          mountPath: /etc/github
-          readOnly: true
-      volumes:
-      - name: kubeconfig
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-prow-services
-      - name: oauth
-        secret:
-          defaultMode: 420
-          secretName: oauth-token
-    annotations:
-      testgrid-dashboards: sig-testing-prow
-      testgrid-tab-name: reconcile-hmacs
-      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-num-failures-to-alert: '1'
-      description: reconcile the hmac tokens and webhooks based on the managed_webhooks configuration in prow core config file
   - name: post-test-infra-gencred-refresh-kubeconfig
     cluster: test-infra-trusted
     run_if_changed: '^config/prow/gencred-config/'

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -190,28 +190,6 @@ prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug
 
-managed_webhooks:
-  # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.
-  respect_legacy_global_token: true
-  # Config for orgs and repos that have been onboarded to this Prow instance.
-  org_repo_config:
-    kubernetes:
-      token_created_after: 2020-08-12T00:00:00Z
-    kubernetes-client:
-      token_created_after: 2020-07-24T00:00:00Z
-    kubernetes-csi:
-      token_created_after: 2020-08-12T00:00:00Z
-    kubernetes-security:
-      token_created_after: 2021-05-19T00:00:00Z
-    kubernetes-sigs:
-      token_created_after: 2020-08-12T00:00:00Z
-    containerd/containerd:
-      token_created_after: 2020-09-17T00:00:00Z
-    kubernetes-sigs/apisnoop:
-      token_created_after: 2020-09-22T00:00:00Z
-    etcd-io:
-      token_created_after: 2023-11-13T00:00:00Z
-
 slack_reporter_configs:
   '*':
     job_types_to_report:

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -300,7 +300,6 @@ func TestCommunityJobs(t *testing.T) {
 		"ci-test-infra-gencred-refresh-kubeconfig",
 		"post-test-infra-deploy-prow",
 		"post-test-infra-gencred-refresh-kubeconfig",
-		"post-test-infra-reconcile-hmacs",
 		"ci-test-infra-autobump-prow",
 		"ci-test-infra-autobump-prow-for-auto-deploy",
 	)


### PR DESCRIPTION
@BenTheElder 

The webhooks for prow are now attached to the Kubernetes Github Enterprise which receives events from all the github orgs. This can't be accessed by prow anyway.