### PR TITLE
Scale k8s-prow components to 0.

### DIFF
--- a/config/prow/cluster/build/grandmatriarch.yaml
+++ b/config/prow/cluster/build/grandmatriarch.yaml
@@ -44,7 +44,7 @@ metadata:
   labels:
     app: grandmatriarch
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: grandmatriarch

--- a/config/prow/cluster/cherrypicker_deployment.yaml
+++ b/config/prow/cluster/cherrypicker_deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app: cherrypicker
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app: crier
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: crier

--- a/config/prow/cluster/ghproxy.yaml
+++ b/config/prow/cluster/ghproxy.yaml
@@ -45,7 +45,7 @@ spec:
   selector:
     matchLabels:
       app: ghproxy
-  replicas: 1  # TODO(fejta): this should be HA
+  replicas: 0  # TODO(fejta): this should be HA
   template:
     metadata:
       labels:

--- a/config/prow/cluster/halogen.yaml
+++ b/config/prow/cluster/halogen.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: halogen
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: halogen

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app: hook
 spec:
-  replicas: 4
+  replicas: 0
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app: horologium
 spec:
-  replicas: 1 # Do not scale up.
+  replicas: 0 # Do not scale up.
   strategy:
     type: Recreate
   selector:

--- a/config/prow/cluster/kube-state-metrics_deployment.yaml
+++ b/config/prow/cluster/kube-state-metrics_deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   name: kube-state-metrics
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: kube-state-metrics

--- a/config/prow/cluster/kubernetes-external-secrets_deployment.yaml
+++ b/config/prow/cluster/kubernetes-external-secrets_deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-external-secrets
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: kubernetes-external-secrets

--- a/config/prow/cluster/needs-rebase_deployment.yaml
+++ b/config/prow/cluster/needs-rebase_deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app: needs-rebase
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: needs-rebase

--- a/config/prow/cluster/pipeline_deployment.yaml
+++ b/config/prow/cluster/pipeline_deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prow-pipeline
   namespace: default
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:

--- a/config/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/config/prow/cluster/prow_controller_manager_deployment.yaml
@@ -21,7 +21,7 @@ metadata:
     app: prow-controller-manager
 spec:
   # Mutually exclusive with plank. Only one of them may have more than zero replicas.
-  replicas: 1
+  replicas: 0
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/config/prow/cluster/pushgateway_deployment.yaml
+++ b/config/prow/cluster/pushgateway_deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: pushgateway
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: pushgateway
@@ -73,7 +73,7 @@ metadata:
   labels:
     app: pushgateway-proxy
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: pushgateway-proxy

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: sinker
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: sinker

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app: statusreconciler
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: statusreconciler

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app: tide
 spec:
-  replicas: 1 # Do not scale up.
+  replicas: 0 # Do not scale up.
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
Scale all components to 0 replicas, except Deck, which will be handled separately. (Leaving Deck up during the migration while we swap the component over).

Apply manually with:
```
cd test-infra/config/prow
make deploy-prow
```

/hold

Ref https://github.com/kubernetes/test-infra/issues/33350