### PR TITLE
remove halogen from config

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -69,10 +69,6 @@ deck:
     - lens:
         name: buildlog
         config:
-          highlighter:
-            endpoint: http://halogen.default.svc.cluster.local
-            pin: true
-            auto: false
           highlight_regexes:
           - Automatic merge failed
           - cannot convert.+to type


### PR DESCRIPTION
TODO: drop it from the cluster

we're rarely seeing this highlight anything, one less component to manage