### PR TITLE
Update presubmit SELinux job

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -231,14 +231,15 @@ presubmits:
     skip_branches:
       - release-\d+\.\d+ # per-release image
     annotations:
-      testgrid-dashboards: presubmits-kubernetes-nonblocking
-      testgrid-tab-name: pull-kubernetes-e2e-aws-storage-selinux
-      testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
       description: Run tests with [Feature:SELinux] on a cluster with SELinux enabled.
+      fork-per-release: "true"
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: presubmits-kubernetes-nonblocking
+      testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+      testgrid-num-failures-to-alert: "10"
     labels:
-      preset-service-account: "true"
-      preset-aws-ssh: "true"
-      preset-aws-credential: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 150m
@@ -258,25 +259,18 @@ presubmits:
             - -xc
             - |
               make -C $GOPATH/src/k8s.io/kops test-e2e-install
-              kubetest2 kops -v=6 --cloud-provider=aws --up --down --build \
+              kubetest2 kops -v=6 --cloud-provider=gce --up --down --build --env=KOPS_FEATURE_FLAGS=SELinuxMount \
                 --build-kubernetes=true --target-build-arch=linux/amd64 \
                 --admin-access=0.0.0.0/0 \
                 --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
-                --create-args "--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium --set=cluster.spec.containerd.selinuxEnabled=true --discovery-store=s3://k8s-kops-prow/discovery" \
-                --env=KOPS_FEATURE_FLAGS=SELinuxMount \
+                --create-args "--image='rhel-cloud/rhel-9-v20240815' --channel=alpha --networking=cilium --set=cluster.spec.containerd.selinuxEnabled=true --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
                 --test=kops \
                 -- \
                 --ginkgo-args="--debug" \
                 --timeout=120m \
-                --focus-regex="\[Feature:SELinux\]" \
-                --skip-regex="\[Feature:Volumes\]|\[Driver:.nfs\]|\[Driver:.local\]|\[FeatureGate:SELinuxMount\]" \
+                --skip-regex="\[Feature:SELinux\]" \
                 --use-built-binaries=true \
-                --parallel=1
-          env:
-          - name: KUBE_SSH_KEY_PATH
-            value: /etc/aws-ssh/aws-ssh-private
-          - name: KUBE_SSH_USER
-            value: ec2-user
+                --parallel=1 # [Feature:SELinux] tests include serial ones
           image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
           resources:
             limits:
@@ -285,6 +279,8 @@ presubmits:
             requests:
               cpu: 4
               memory: "14Gi"
+          securityContext:
+            privileged: true
 periodics:
 - interval: 24h
   name: ci-kubernetes-e2e-gce-iscsi-serial


### PR DESCRIPTION
Update the presubmit job to run on GCE.

Copies pull-kubernetes-e2e-gce-canary, adding just RHEL image + SELinux feature gates.

kOps on GCE can now use RHEL: https://github.com/kubernetes/kops/pull/16705/