### PR TITLE
update cni plugins from 0.7.5 to 1.0.1 for ubuntu huge pages and swap.

### DIFF
--- a/jobs/e2e_node/containerd/ubuntu-init-hugepages-1G-allocation.yaml
+++ b/jobs/e2e_node/containerd/ubuntu-init-hugepages-1G-allocation.yaml
@@ -9,6 +9,6 @@ runcmd:
   - mkdir -p /etc/containerd
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/config.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-config'
-  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz -L https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz'
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
   - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
   - systemctl restart containerd

--- a/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml
+++ b/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml
@@ -8,7 +8,7 @@ runcmd:
   - mkdir -p /etc/containerd
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/config.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-config'
-  - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz -L https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz'
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
   - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
   - systemctl restart containerd
   - 'echo current swappiness: $(sysctl vm.swappiness)'


### PR DESCRIPTION
Potential fix for https://github.com/kubernetes/kubernetes/issues/126856 and  https://github.com/kubernetes/kubernetes/issues/126857.

I noticed that containerd jobs that are working are using a much more updated CNI plugin. The one these two jobs use is older and that seems to have caused problem.
