### PR TITLE
add kubernetes-sigs/mcs-api OWNERS

### DIFF
--- a/config/jobs/kubernetes-sigs/mcs-api/OWNERS
+++ b/config/jobs/kubernetes-sigs/mcs-api/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- JeremyOT
+- pmorie
+- lauralorenz
+- skitt
+- nojnhuh
+
+labels:
+- sig/multicluster


### PR DESCRIPTION
Adding the initial scaffolding to define jobs for https://github.com/kubernetes-sigs/mcs-api.

The listed OWNERS here match the owners listed for the repo at https://github.com/kubernetes-sigs/mcs-api/blob/master/OWNERS