### PR TITLE
register pull-cluster-autoscaler-e2e-azure-master for all branches

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -16,8 +16,6 @@ presubmits:
     decoration_config:
       timeout: 5h
     path_alias: k8s.io/autoscaler
-    branches:
-      - master
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure


### PR DESCRIPTION
This job is blocking PRs from merging on non-master autoscaler branches since it was scoped only to master in #33361. The job was always failing on release branches and removing the job seems to have put the job in a perma-failing state that used to be overcome by the job being optional, but that seems not to make a difference if the job no longer exists for the branch.

This PR restores the job for all branches so as not to block PRs from merging.