### PR TITLE
etcd: install gawk in website presubmit

### DIFF
--- a/config/jobs/etcd/etcd-website-presubmits.yaml
+++ b/config/jobs/etcd/etcd-website-presubmits.yaml
@@ -4,7 +4,8 @@ presubmits:
   - name: pull-website-lint
     cluster: eks-prow-build-cluster
     optional: true # remove this once the job is green
-    always_run: true
+    always_run: false
+    run_if_changed: '.*\.md$'
     branches:
     - main
     decorate: true
@@ -19,6 +20,7 @@ presubmits:
         args:
         - -c
         - |
+          apt-get update && apt-get install -y gawk
           npm install -g markdownlint-cli2
           make markdown-diff-lint
         resources:


### PR DESCRIPTION
Install gawk to run awk commands, as Node's base image has mawk, which is incompatible with the script's match syntax.

Part of etcd-io/website#857.

/cc @jmhbnz 