### PR TITLE
add cluster-autoscaler Azure e2e jobs for older release branches

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -26,6 +26,47 @@ presubmits:
       serviceAccountName: azure
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-1.29
+        # This job is being phased out in favor of pull-cluster-autoscaler-e2e-azure-master. It always
+        # passes in order not to block PRs where the previous version of this job failed. This job can
+        # be removed when it is passing on all open PRs.
+        command:
+          - runner.sh
+          - "true"
+        resources:
+          requests:
+            cpu: 1
+            memory: "1Gi"
+          limits:
+            cpu: 1
+            memory: "1Gi"
+  - name: pull-cluster-autoscaler-e2e-azure-master
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+      testgrid-tab-name: cloudprovider-azure-master
+    always_run: false
+    optional: true
+    run_if_changed: 'cluster-autoscaler\/cloudprovider\/azure'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: k8s.io/autoscaler
+    branches:
+      - master
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.16
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
         command:
           - runner.sh
           - ./scripts/ci-entrypoint.sh
@@ -33,8 +74,6 @@ presubmits:
           - bash
           - -c
           - |
-            export REGISTRY=capzcicommunity.azurecr.io
-            hack/ensure-acr-login.sh
             cd ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test
             make test-e2e TAG=$(git rev-parse --short HEAD)
         env:
@@ -42,7 +81,7 @@ presubmits:
           - name: ADDITIONAL_ASO_CRDS
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
-            value: v1.29.4
+            value: "1.30" # latest available in AKS
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode
@@ -98,6 +137,171 @@ presubmits:
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
             value: "1.30"
+          - name: CLUSTER_TEMPLATE
+            value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 4
+            memory: "9Gi"
+          limits:
+            cpu: 4
+            memory: "9Gi"
+  - name: pull-cluster-autoscaler-e2e-azure-1-29
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+      testgrid-tab-name: cloudprovider-azure-1.29
+    always_run: false
+    optional: true
+    run_if_changed: 'cluster-autoscaler\/cloudprovider\/azure'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: k8s.io/autoscaler
+    branches:
+      - cluster-autoscaler-release-1.29
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.16
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-1.29
+        command:
+          - runner.sh
+          - ./scripts/ci-entrypoint.sh
+        args:
+          - bash
+          - -c
+          - |
+            cd ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test
+            make test-e2e TAG=$(git rev-parse --short HEAD)
+        env:
+          # CAPZ config
+          - name: ADDITIONAL_ASO_CRDS
+            value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
+          - name: KUBERNETES_VERSION
+            value: "1.29"
+          - name: CLUSTER_TEMPLATE
+            value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 4
+            memory: "9Gi"
+          limits:
+            cpu: 4
+            memory: "9Gi"
+  - name: pull-cluster-autoscaler-e2e-azure-1-28
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+      testgrid-tab-name: cloudprovider-azure-1.28
+    always_run: false
+    optional: true
+    run_if_changed: 'cluster-autoscaler\/cloudprovider\/azure'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: k8s.io/autoscaler
+    branches:
+      - cluster-autoscaler-release-1.28
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.16
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-1.28
+        command:
+          - runner.sh
+          - ./scripts/ci-entrypoint.sh
+        args:
+          - bash
+          - -c
+          - |
+            cd ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test
+            make test-e2e TAG=$(git rev-parse --short HEAD)
+        env:
+          # CAPZ config
+          - name: ADDITIONAL_ASO_CRDS
+            value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
+          - name: KUBERNETES_VERSION
+            value: "1.28"
+          - name: CLUSTER_TEMPLATE
+            value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 4
+            memory: "9Gi"
+          limits:
+            cpu: 4
+            memory: "9Gi"
+  - name: pull-cluster-autoscaler-e2e-azure-1-27
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+      testgrid-tab-name: cloudprovider-azure-1.27
+    always_run: false
+    optional: true
+    run_if_changed: 'cluster-autoscaler\/cloudprovider\/azure'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: k8s.io/autoscaler
+    branches:
+      - cluster-autoscaler-release-1.27
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.16
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-1.27
+        command:
+          - runner.sh
+          - ./scripts/ci-entrypoint.sh
+        args:
+          - bash
+          - -c
+          - |
+            cd ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test
+            make test-e2e TAG=$(git rev-parse --short HEAD)
+        env:
+          # CAPZ config
+          - name: ADDITIONAL_ASO_CRDS
+            value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
+          - name: KUBERNETES_VERSION
+            value: "1.27"
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
Follow-up from #33361 to add Azure e2e tests for the 1.27, 1.28, and 1.29 branches of cluster-autoscaler.

For the master branch, this requires some changes made by https://github.com/kubernetes/autoscaler/pull/7214:

/hold