### PR TITLE
Fix CRI-O swap fedora config

### DIFF
--- a/jobs/e2e_node/swap/image-config-swap-fedora.yaml
+++ b/jobs/e2e_node/swap/image-config-swap-fedora.yaml
@@ -6,4 +6,4 @@ images:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     machine: n1-standard-2
-    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupsv2_swap1g.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupv2_swap1g.ign"


### PR DESCRIPTION
Fixing the image config name.

Follow-up on https://github.com/kubernetes/test-infra/pull/33374

cc @kubernetes/sig-node-cri-o-test-maintainers 

Should make https://testgrid.k8s.io/sig-node-cri-o#kubelet-gce-e2e-swap-fedora green again.