### PR TITLE
descheduler: update presubmits for 1.31 release

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -83,6 +83,44 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
+  - name: pull-descheduler-test-e2e-k8s-master-1-31
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.31
+    decorate: true
+    decoration_config:
+      timeout: 30m
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        env:
+        - name: KUBERNETES_VERSION
+          value: "v1.31.0"
+        - name: KIND_E2E
+          value: "true"
+        args:
+        - make
+        - test-e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-30
     cluster: eks-prow-build-cluster
     annotations:
@@ -105,7 +143,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.30.0"
+          value: "v1.30.4"
         - name: KIND_E2E
           value: "true"
         args:
@@ -143,45 +181,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.29.4"
-        - name: KIND_E2E
-          value: "true"
-        args:
-        - make
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 4
-            memory: 4Gi
-          requests:
-            cpu: 4
-            memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-master-1-28
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.28
-    decorate: true
-    decoration_config:
-      timeout: 30m
-    always_run: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    branches:
-    - master
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        env:
-        - name: KUBERNETES_VERSION
-          value: "v1.28.9"
+          value: "v1.29.8"
         - name: KIND_E2E
           value: "true"
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.29.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.29.yaml
@@ -99,7 +99,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.29.0"
+          value: "v1.29.8"
         - name: KIND_E2E
           value: "true"
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.30.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.30.yaml
@@ -99,7 +99,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.30.0"
+          value: "v1.30.4"
         - name: KIND_E2E
           value: "true"
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.31.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.31.yaml
@@ -1,20 +1,20 @@
 # sigs.k8s.io/descheduler presubmits
 presubmits:
   kubernetes-sigs/descheduler:
-  - name: pull-descheduler-verify-release-1-28
+  - name: pull-descheduler-verify-release-1-31
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-verify-release-1.28
+      testgrid-tab-name: pull-descheduler-verify-release-1.31
     decorate: true
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.28$
+    - ^release-1.31$
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20.10
+      - image: public.ecr.aws/docker/library/golang:1.22.5
         command:
         - make
         args:
@@ -26,20 +26,20 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-verify-build-release-1-28
+  - name: pull-descheduler-verify-build-release-1-31
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-verify-build-release-1.28
+      testgrid-tab-name: pull-descheduler-verify-build-release-1.31
     decorate: true
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.28$
+    - ^release-1.31$
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20.10
+      - image: public.ecr.aws/docker/library/golang:1.22.5
         command:
         - make
         args:
@@ -51,21 +51,21 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-unit-test-release-1-28
+  - name: pull-descheduler-unit-test-release-1-31
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-unit-test-release-1.28
+      testgrid-tab-name: pull-descheduler-unit-test-release-1.31
     decorate: true
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.28$
+    - ^release-1.31$
     always_run: false
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.20.10
+      - image: public.ecr.aws/docker/library/golang:1.22.5
         command:
         - make
         args:
@@ -77,11 +77,11 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-release-1-28-1-28
+  - name: pull-descheduler-test-e2e-k8s-release-1-31-1-31
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-28-1.28
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-31-1.31
     decorate: true
     decoration_config:
       timeout: 20m
@@ -90,7 +90,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.28
+    - release-1.31
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
@@ -99,7 +99,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.28.0"
+          value: "v1.31.0"
         - name: KIND_E2E
           value: "true"
         args:
@@ -115,11 +115,11 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-release-1-28-1-27
+  - name: pull-descheduler-test-e2e-k8s-release-1-31-1-30
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-28-1.27
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-31-1.30
     decorate: true
     decoration_config:
       timeout: 20m
@@ -128,7 +128,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.28
+    - release-1.31
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
@@ -137,7 +137,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.27.3"
+          value: "v1.30.4"
         - name: KIND_E2E
           value: "true"
         args:
@@ -153,11 +153,11 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-release-1-28-1-26
+  - name: pull-descheduler-test-e2e-k8s-release-1-31-1-29
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-28-1.26
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-31-1.29
     decorate: true
     decoration_config:
       timeout: 20m
@@ -166,7 +166,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.28
+    - release-1.31
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
@@ -175,7 +175,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.26.6"
+          value: "v1.29.8"
         - name: KIND_E2E
           value: "true"
         args:


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/descheduler/issues/1488

Similar to https://github.com/kubernetes/test-infra/pull/32633