### PR TITLE
Ingress NGINX: Update `e2e-test-runner` to v20240829-2c421762.

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-presubmit.yaml
@@ -14,7 +14,7 @@ presubmits:
       path_alias: k8s.io/ingress-nginx
       spec:
         containers:
-          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20240812-3f0129aa@sha256:95c2aaf2a66e8cbbf7a7453046f3b024383c273a0988efab841cd96116afd1a9
+          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20240829-2c421762@sha256:5b7809bfe9cbd9cd6bcb8033ca27576ca704f05ce729fe4dcb574810f7a25785
             command:
               - hack/verify-boilerplate.sh
             resources:
@@ -39,7 +39,7 @@ presubmits:
       path_alias: k8s.io/ingress-nginx
       spec:
         containers:
-          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20240812-3f0129aa@sha256:95c2aaf2a66e8cbbf7a7453046f3b024383c273a0988efab841cd96116afd1a9
+          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20240829-2c421762@sha256:5b7809bfe9cbd9cd6bcb8033ca27576ca704f05ce729fe4dcb574810f7a25785
             command:
               - hack/verify-codegen.sh
             resources:
@@ -64,7 +64,7 @@ presubmits:
       path_alias: k8s.io/ingress-nginx
       spec:
         containers:
-          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20240812-3f0129aa@sha256:95c2aaf2a66e8cbbf7a7453046f3b024383c273a0988efab841cd96116afd1a9
+          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20240829-2c421762@sha256:5b7809bfe9cbd9cd6bcb8033ca27576ca704f05ce729fe4dcb574810f7a25785
             command:
               - make
             args:


### PR DESCRIPTION
Do not merge before https://github.com/kubernetes/k8s.io/pull/7236.

/cc @strongjz @tao12345666333 @rikatz @cpanato
/hold