### PR TITLE
add with-git-dir args to post-vsphere-csi-driver-push-images job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-csi-vsphere.yaml
+++ b/config/jobs/image-pushing/k8s-staging-csi-vsphere.yaml
@@ -27,4 +27,5 @@ postsubmits:
               - --project=k8s-staging-images
               - --scratch-bucket=gs://k8s-staging-images-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
               - .


### PR DESCRIPTION
 post-vsphere-csi-driver-push-images job Job failed - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-vsphere-csi-driver-push-images/1829609226897461248

with `fatal: not a git repository (or any parent up to mount point /)`

vSphere CSI Image builder gets tag using git command

- `--with-git-dir`: If true, upload the .git directory to GCB, so we can e.g. get the git log and tag.


cc: @xing-yang @chethanv28 @upodroid


