### PR TITLE
kOps: drop canary jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -1,116 +1,29 @@
 periodics:
-- name: ci-k8s-infra-build-cluster-prow-build
-  cron: "*/5 * * * *" #Every 5 minutes
-  cluster: k8s-infra-prow-build
-  decorate: true
-  max_concurrency: 1
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-  annotations:
-    testgrid-dashboards: sig-k8s-infra-prow
-    testgrid-tab-name: gke-prow-build-heartbeat
-    testgrid-num-failures-to-alert: '6'
-    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, k8s-infra-prow-oncall@kubernetes.io
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
-      command:
-      - "echo"
-      args:
-      - "Everything is fine!"
-      resources:
-        limits:
-          cpu: 100m
-          memory: 512Mi
-        requests:
-          cpu: 100m
-          memory: 512Mi
-
-- name: ci-aws-kops-eks-sandbox
-  interval: 5m
-  cluster: k8s-infra-kops-prow-build
-  max_concurrency: 1
-  decorate: true
-  spec:
-    containers:
-      - command:
-        - curl
-        - -v
-        - -L
-        - https://dl.k8s.io/release/stable.txt
-        image: cgr.dev/chainguard/curl:latest
-        resources:
-          limits:
-            cpu: 2
-            memory: 2Gi
-          requests:
-            cpu: 2
-            memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-k8s-infra-canaries
-    testgrid-tab-name: ci-aws-kops-eks-sandbox
-    description: Uses to test scheduling on an EKS cluster and Boskos features development
-
-- name: ci-aws-kops-eks-pod-identity-sandbox
-  interval: 1h
-  cluster: k8s-infra-kops-prow-build
-  labels:
-    preset-aws-ssh: "true"
-  max_concurrency: 1
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    serviceAccountName: prowjob-default-sa
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20231013-1532' --channel=alpha --networking=cilium --discovery-store=s3://k8s-kops-ci-prow-sandbox/discovery" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable.txt \
-          --parallel=25
-      env:
-      - name: DISCOVERY_STORE
-        value: "s3://k8s-kops-ci-prow-sandbox"
-      - name: KOPS_DNS_DOMAIN
-        value: "tests-kops-aws.k8s.io"
-      - name: KOPS_STATE_STORE
-        value: "s3://k8s-kops-ci-prow-sandbox-state-store"
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-k8s-infra-canaries
-    testgrid-tab-name: ci-aws-kops-eks-pod-identity-sandbox
-    description: Uses to test EKS Pod Identity
+  - name: ci-k8s-infra-build-cluster-prow-build
+    cron: "*/5 * * * *" #Every 5 minutes
+    cluster: k8s-infra-prow-build
+    decorate: true
+    max_concurrency: 1
+    extra_refs:
+      - org: kubernetes
+        repo: test-infra
+        base_ref: master
+    annotations:
+      testgrid-dashboards: sig-k8s-infra-prow
+      testgrid-tab-name: gke-prow-build-heartbeat
+      testgrid-num-failures-to-alert: "6"
+      testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+          command:
+            - "echo"
+          args:
+            - "Everything is fine!"
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi


### PR DESCRIPTION
Drop jobs used to validate the EKS cluster used for kOps E2E tests.