### PR TITLE
Configure prow plugins for the new etcd-manager repo

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -548,6 +548,13 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        etcd-manager:
+          required_status_checks:
+            contexts:
+            - build
+            - test
+            - test-backuprestore
+            - test-upgradedowngrade
         external-dns:
           branches:
             gh-pages:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -74,6 +74,7 @@ approve:
   - kubernetes/cloud-provider-aws
   - kubernetes/kops
   - kubernetes/website
+  - kubernetes-sigs/etcd-manager
   - kubernetes-sigs/external-dns
   - kubernetes-sigs/cluster-api-provider-openstack
   require_self_approval: true
@@ -234,6 +235,7 @@ lgtm:
   - kubernetes-sigs/downloadkubernetes
   - kubernetes-sigs/e2e-framework
   - kubernetes-sigs/external-dns
+  - kubernetes-sigs/etcd-manager
   - kubernetes-sigs/promo-tools
   - kubernetes-sigs/k8s-gsm-tools
   - kubernetes-sigs/kind
@@ -1414,6 +1416,11 @@ plugins:
     - mergecommitblocker
     - override
     - branchcleaner
+
+  kubernetes-sigs/etcd-manager:
+    plugins:
+    - mergecommitblocker
+    - override
 
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
     plugins:


### PR DESCRIPTION
I'm largely reusing Kops' prow plugin configuration since the repos have the same maintainers. No `milestone` plugin because we aren't using release branches for etcd-manager (yet).