### PR TITLE
Fix for metrics-bigquery failures

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -14,7 +14,7 @@ query: |
   select /* find the most recent time each job passed (may not be this week) */
     job,
     max(started) latest_pass
-  from `k8s-gubernator.build.all`
+  from `kubernetes-public.k8s_infra_kettle.all`
   where
     result = 'SUCCESS'
   group by job

--- a/metrics/configs/build-stats.yaml
+++ b/metrics/configs/build-stats.yaml
@@ -13,7 +13,7 @@ query: |
     COUNT(started) invocations,
     countif(result = 'SUCCESS') passes
   FROM
-    `k8s-gubernator.build.all`
+    `kubernetes-public.k8s_infra_kettle.all`
   where
     started >= TIMESTAMP_SECONDS(<LAST_DATA_TIME>)
     and started < timestamp_trunc(current_timestamp(), day)

--- a/metrics/configs/failures-config.yaml
+++ b/metrics/configs/failures-config.yaml
@@ -13,7 +13,7 @@ query: |
     select /* filter to jobs that ran this week */
       job,
       count(1) weekly_builds
-    from `k8s-gubernator.build.all`
+    from `kubernetes-public.k8s_infra_kettle.all`
     where
       started > timestamp_sub(current_timestamp(), interval 7 day)
     group by job
@@ -24,7 +24,7 @@ query: |
       job,
       date(min(started)) first_run,
       date(max(started)) latest_run
-    from `k8s-gubernator.build.all`
+    from `kubernetes-public.k8s_infra_kettle.all`
     group by job
   ) runs
   on jobs.job = runs.job
@@ -32,7 +32,7 @@ query: |
     select /* find the most recent time each job passed (may not be this week) */
       job,
       max(started) latest_pass
-    from `k8s-gubernator.build.all`
+    from `kubernetes-public.k8s_infra_kettle.all`
     where
       result = 'SUCCESS'
     group by job

--- a/metrics/configs/flakes-config.yaml
+++ b/metrics/configs/flakes-config.yaml
@@ -67,7 +67,7 @@ query: |
             test  /* repeated tuple of tests */
           from (
                 select *,
-                       ifnull(b.repos, (select i.value from b.metadata i where i.key = 'repos')) repo from `k8s-gubernator.build.week` as b
+                       ifnull(b.repos, (select i.value from b.metadata i where i.key = 'repos')) repo from `kubernetes-public.k8s_infra_kettle.week` as b
           ) as t
           where
             datetime(started) > datetime_sub(current_datetime(), interval 7 DAY)

--- a/metrics/configs/flakes-daily-config.yaml
+++ b/metrics/configs/flakes-daily-config.yaml
@@ -67,7 +67,7 @@ query: |
             test  /* repeated tuple of tests */
           from (
                 select *,
-                       ifnull(b.repos, (select i.value from b.metadata i where i.key = 'repos')) repo from `k8s-gubernator.build.week` as b
+                       ifnull(b.repos, (select i.value from b.metadata i where i.key = 'repos')) repo from `kubernetes-public.k8s_infra_kettle.week` as b
           ) as t
           where
             datetime(started) > datetime_sub(current_datetime(), interval 1 DAY)

--- a/metrics/configs/job-health.yaml
+++ b/metrics/configs/job-health.yaml
@@ -40,7 +40,7 @@ query: |
         b.tests_failed tests_failed,
         b.passed passed
       from
-        `k8s-gubernator.build.all` AS b
+        `kubernetes-public.k8s_infra_kettle.all` AS b
       where
         b.started > timestamp_seconds(<LAST_DATA_TIME>)
         and started < timestamp_trunc(current_timestamp(), day)

--- a/metrics/configs/presubmit-health.yaml
+++ b/metrics/configs/presubmit-health.yaml
@@ -43,7 +43,7 @@ query: |
           elapsed,
           REGEXP_EXTRACT(path, "/(\\d+)/") pr
         FROM
-          `k8s-gubernator.build.all`
+          `kubernetes-public.k8s_infra_kettle.all`
         WHERE
           REGEXP_CONTAINS(job, '^pr:')
           AND started > TIMESTAMP_SECONDS(<LAST_DATA_TIME>)


### PR DESCRIPTION
When we updated big query data set project/dataset processing, we neglected to fix references causing failures:
https://github.com/kubernetes/test-infra/commit/cf9b9b3dc577ae4e3d419a8f96935a8a6bba3ce7

for example:
`k8s-gubernator.build.all` should be `kubernetes-public.k8s_infra_kettle.all`

kubernetes-public - is the new project
.k8s_infra_kettle - is the new data set

Direct link:
https://console.cloud.google.com/bigquery?ws=!1m5!1m4!4m3!1skubernetes-public!2sk8s_infra_kettle!3sall