### PR TITLE
Update Kueue Release Branches for 1.31 and dropping 1.27.

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-8.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-8.yaml
@@ -58,44 +58,6 @@ presubmits:
           limits:
             cpu: "6"
             memory: "9Gi"
-  - name: pull-kueue-test-e2e-release-0-8-1-27
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^release-0.8
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-release-0-8-1-27
-      description: "Run kueue end to end tests for Kubernetes 1.27"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.27.13
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.22
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - kind-image-build
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "7"
-            memory: "10Gi"
-          limits:
-            cpu: "7"
-            memory: "10Gi"
   - name: pull-kueue-test-e2e-release-0-8-1-28
     cluster: eks-prow-build-cluster
     branches:
@@ -191,6 +153,44 @@ presubmits:
           env:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.22
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - name: pull-kueue-test-e2e-release-0-8-1-31
+    cluster: eks-prow-build-cluster
+    branches:
+      - ^release-0.8
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    decorate: true
+    path_alias: sigs.k8s.io/kueue
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-kueue-test-e2e-release-0-8-1-31
+      description: "Run kueue end to end tests for Kubernetes 1.31"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.31.0
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.22
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -116,52 +116,6 @@ periodics:
               cpu: "6"
               memory: "9Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-main-1-27
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-main-1-27
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue end to end tests for Kubernetes 1.27"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: main
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.27.13
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.22
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "7"
-              memory: "10Gi"
-            limits:
-              cpu: "7"
-              memory: "10Gi"
-  - interval: 12h
     name: periodic-kueue-test-e2e-main-1-28
     cluster: eks-prow-build-cluster
     annotations:
@@ -280,6 +234,52 @@ periodics:
           env:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.22
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-main-1-31
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-main-1-31
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue end to end tests for Kubernetes 1.31"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.31.0
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.22
           command:


### PR DESCRIPTION
- Drop 1.27 from release 0.8 presubmits.
- Add 1.31 to release 0.8 presubmit.
- Drop 1.27 from release 0.8 periodics
- Add 1.31 for release 0.8 periodics.