### PR TITLE
Update CSI tests to run on k8s 1.30/1.31

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -2,204 +2,10 @@
 
 presubmits:
   kubernetes-csi/csi-driver-host-path:
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-27-on-kubernetes-1-27
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-27-on-kubernetes-1-27
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.27 on Kubernetes 1.27
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.27.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.27"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-27-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-27-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.27 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-28-on-kubernetes-1-28
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.28 on Kubernetes 1.28
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-28-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-28-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.28 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-29-on-kubernetes-1-29
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: []
@@ -232,7 +38,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS
@@ -276,7 +82,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "latest"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -293,10 +99,10 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-28-on-kubernetes-1-28
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: []
@@ -306,8 +112,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: alpha-1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.28 on Kubernetes 1.28
+      testgrid-tab-name: 1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.30 on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,211 +129,211 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.30.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
+          value: "1.30"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-30-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: 1-30-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.30 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: 1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-31-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: 1-31-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.31 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-30-on-kubernetes-1-30
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.30 on Kubernetes 1.30
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.30.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.30"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS
           value: "serial-alpha parallel-alpha"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-27-test-on-kubernetes-1-27
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-27-test-on-kubernetes-1-27
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.27-test on Kubernetes 1.27
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.27.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.27"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: "-test"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-27-test-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-27-test-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.27-test on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: "-test"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-28-test-on-kubernetes-1-28
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-28-test-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.28-test on Kubernetes 1.28
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: "-test"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-28-test-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-28-test-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.28-test on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: "-test"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -574,7 +380,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS
@@ -618,7 +424,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "latest"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -635,9 +441,9 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-28-test-on-kubernetes-1-28
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-30-test-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -648,8 +454,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: alpha-1-28-test-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.28-test on Kubernetes 1.28
+      testgrid-tab-name: 1-30-test-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.30-test on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -665,13 +471,207 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.30.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
+          value: "1.30"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-30-test-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: 1-30-test-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.30-test on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: "-test"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-31-test-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: 1-31-test-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.31-test on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: "-test"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-31-test-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: 1-31-test-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.31-test on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: "-test"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-30-test-on-kubernetes-1-30
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: alpha-1-30-test-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.30-test on Kubernetes 1.30
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.30.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.30"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: "-test"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS
@@ -724,342 +724,6 @@ presubmits:
 
 periodics:
 - interval: 6h
-  name: ci-kubernetes-csi-1-27-on-kubernetes-1-27
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.27-on-1.27
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.27 on Kubernetes 1.27
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.27"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.27"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-27-on-kubernetes-1-28
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.27-on-1.28
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.27 on Kubernetes 1.28
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.28"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.27"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-27-on-kubernetes-1-29
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.27-on-1.29
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.27 on Kubernetes 1.29
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.29"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.27"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-27-on-kubernetes-master
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.27-on-master
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.27 on Kubernetes master
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "latest"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "master"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.27"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-28-on-kubernetes-1-28
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.28-on-1.28
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.28 on Kubernetes 1.28
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.28"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.28"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-28-on-kubernetes-1-29
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.28-on-1.29
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.28 on Kubernetes 1.29
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.29"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.28"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-28-on-kubernetes-master
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.28-on-master
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.28 on Kubernetes master
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "latest"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "master"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.28"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
   name: ci-kubernetes-csi-1-29-on-kubernetes-1-29
   cluster: k8s-infra-prow-build
   decorate: true
@@ -1087,6 +751,102 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.29"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.29"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: ""
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-1-29-on-kubernetes-1-30
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.29-on-1.30
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29 on Kubernetes 1.30
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.30"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.29"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: ""
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-1-29-on-kubernetes-1-31
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.29-on-1.31
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29 on Kubernetes 1.31
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.31"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v6.1.0"
       - name: CSI_PROW_BUILD_JOB
@@ -1156,7 +916,7 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-1-27-test-on-kubernetes-1-27
+  name: ci-kubernetes-csi-1-30-on-kubernetes-1-30
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
@@ -1169,9 +929,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.27-test-on-1.27
+    testgrid-tab-name: 1.30-on-1.30
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.27-test on Kubernetes 1.27
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.30 on Kubernetes 1.30
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1182,15 +942,15 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.27"
+        value: "release-1.30"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v6.1.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.27"
+        value: "kubernetes-1.30"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
+        value: ""
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1204,7 +964,7 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-1-27-test-on-kubernetes-1-28
+  name: ci-kubernetes-csi-1-30-on-kubernetes-1-31
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
@@ -1217,9 +977,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.27-test-on-1.28
+    testgrid-tab-name: 1.30-on-1.31
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.27-test on Kubernetes 1.28
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.30 on Kubernetes 1.31
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1230,15 +990,15 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.28"
+        value: "release-1.31"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v6.1.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.27"
+        value: "kubernetes-1.30"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
+        value: ""
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1252,7 +1012,7 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-1-27-test-on-kubernetes-1-29
+  name: ci-kubernetes-csi-1-30-on-kubernetes-master
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
@@ -1265,57 +1025,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.27-test-on-1.29
+    testgrid-tab-name: 1.30-on-master
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.27-test on Kubernetes 1.29
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.29"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.27"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-27-test-on-kubernetes-master
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.27-test-on-master
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.27-test on Kubernetes master
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.30 on Kubernetes master
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1332,9 +1044,9 @@ periodics:
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.27"
+        value: "kubernetes-1.30"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
+        value: ""
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1348,7 +1060,7 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-1-28-test-on-kubernetes-1-28
+  name: ci-kubernetes-csi-1-31-on-kubernetes-1-31
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
@@ -1361,9 +1073,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.28-test-on-1.28
+    testgrid-tab-name: 1.31-on-1.31
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.28-test on Kubernetes 1.28
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.31 on Kubernetes 1.31
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1374,15 +1086,15 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.28"
+        value: "release-1.31"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v6.1.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.28"
+        value: "kubernetes-1.31"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
+        value: ""
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1396,7 +1108,7 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-1-28-test-on-kubernetes-1-29
+  name: ci-kubernetes-csi-1-31-on-kubernetes-master
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
@@ -1409,57 +1121,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.28-test-on-1.29
+    testgrid-tab-name: 1.31-on-master
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.28-test on Kubernetes 1.29
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.29"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.28"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-28-test-on-kubernetes-master
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.28-test-on-master
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.28-test on Kubernetes master
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.31 on Kubernetes master
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1476,9 +1140,9 @@ periodics:
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.28"
+        value: "kubernetes-1.31"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
+        value: ""
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1519,6 +1183,102 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.29"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.29"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-1-29-test-on-kubernetes-1-30
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.29-test-on-1.30
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29-test on Kubernetes 1.30
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.30"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.29"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-1-29-test-on-kubernetes-1-31
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.29-test-on-1.31
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29-test on Kubernetes 1.31
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.31"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v6.1.0"
       - name: CSI_PROW_BUILD_JOB
@@ -1588,8 +1348,8 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-canary-on-kubernetes-1-27
-  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-csi-1-30-test-on-kubernetes-1-30
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1601,9 +1361,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: canary-on-1.27
+    testgrid-tab-name: 1.30-test-on-1.30
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary on Kubernetes 1.27
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.30-test on Kubernetes 1.30
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1614,21 +1374,15 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "1.27.0"
+        value: "release-1.30"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
-      # Replace images....
-      - name: CSI_PROW_HOSTPATH_CANARY
-        value: "canary"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.30"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "master"
-      # ... but the RBAC rules only when testing on master.
-      # The other jobs test against the unmodified deployment for
-      # that Kubernetes version, i.e. with the original RBAC rules.
-      - name: UPDATE_RBAC_RULES
-        value: "false"
+        value: "-test"
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1642,8 +1396,8 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-canary-on-kubernetes-1-28
-  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-csi-1-30-test-on-kubernetes-1-31
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1655,9 +1409,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: canary-on-1.28
+    testgrid-tab-name: 1.30-test-on-1.31
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary on Kubernetes 1.28
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.30-test on Kubernetes 1.31
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1668,21 +1422,159 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "1.28.0"
+        value: "release-1.31"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
-      # Replace images....
-      - name: CSI_PROW_HOSTPATH_CANARY
-        value: "canary"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.30"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
+        value: "-test"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-1-30-test-on-kubernetes-master
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.30-test-on-master
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.30-test on Kubernetes master
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "latest"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "master"
-      # ... but the RBAC rules only when testing on master.
-      # The other jobs test against the unmodified deployment for
-      # that Kubernetes version, i.e. with the original RBAC rules.
-      - name: UPDATE_RBAC_RULES
+      - name: CSI_PROW_BUILD_JOB
         value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.30"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-1-31-test-on-kubernetes-1-31
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.31-test-on-1.31
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.31-test on Kubernetes 1.31
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.31"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.31"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-1-31-test-on-kubernetes-master
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.31-test-on-master
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.31-test on Kubernetes master
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "latest"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "master"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.31"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1723,6 +1615,114 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "1.29.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      # Replace images....
+      - name: CSI_PROW_HOSTPATH_CANARY
+        value: "canary"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: ""
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "master"
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
+      - name: UPDATE_RBAC_RULES
+        value: "false"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-canary-on-kubernetes-1-30
+  cluster: eks-prow-build-cluster
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: canary-on-1.30
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary on Kubernetes 1.30
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "1.30.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      # Replace images....
+      - name: CSI_PROW_HOSTPATH_CANARY
+        value: "canary"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: ""
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "master"
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
+      - name: UPDATE_RBAC_RULES
+        value: "false"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-canary-on-kubernetes-1-31
+  cluster: eks-prow-build-cluster
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: canary-on-1.31
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary on Kubernetes 1.31
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "1.31.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       # Replace images....
@@ -1858,114 +1858,6 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-canary-test-on-kubernetes-1-27
-  cluster: eks-prow-build-cluster
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: canary-test-on-1.27
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary-test on Kubernetes 1.27
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "1.27.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      # Replace images....
-      - name: CSI_PROW_HOSTPATH_CANARY
-        value: "canary"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "master"
-      # ... but the RBAC rules only when testing on master.
-      # The other jobs test against the unmodified deployment for
-      # that Kubernetes version, i.e. with the original RBAC rules.
-      - name: UPDATE_RBAC_RULES
-        value: "false"
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-canary-test-on-kubernetes-1-28
-  cluster: eks-prow-build-cluster
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: canary-test-on-1.28
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary-test on Kubernetes 1.28
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "1.28.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      # Replace images....
-      - name: CSI_PROW_HOSTPATH_CANARY
-        value: "canary"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "master"
-      # ... but the RBAC rules only when testing on master.
-      # The other jobs test against the unmodified deployment for
-      # that Kubernetes version, i.e. with the original RBAC rules.
-      - name: UPDATE_RBAC_RULES
-        value: "false"
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-29
   cluster: eks-prow-build-cluster
   decorate: true
@@ -1993,6 +1885,114 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "1.29.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      # Replace images....
+      - name: CSI_PROW_HOSTPATH_CANARY
+        value: "canary"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "master"
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
+      - name: UPDATE_RBAC_RULES
+        value: "false"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-canary-test-on-kubernetes-1-30
+  cluster: eks-prow-build-cluster
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: canary-test-on-1.30
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary-test on Kubernetes 1.30
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "1.30.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      # Replace images....
+      - name: CSI_PROW_HOSTPATH_CANARY
+        value: "canary"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "master"
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
+      - name: UPDATE_RBAC_RULES
+        value: "false"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-canary-test-on-kubernetes-1-31
+  cluster: eks-prow-build-cluster
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: canary-test-on-1.31
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary-test on Kubernetes 1.31
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "1.31.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       # Replace images....

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -53,7 +53,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-csi-test
-      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-test, using deployment 1.28 on Kubernetes 1.28
+      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-test, using deployment 1.30 on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -94,7 +94,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-external-provisioner
-      description: Kubernetes-CSI pull job in repo csi-release-tools for external-provisioner, using deployment 1.28 on Kubernetes 1.28
+      description: Kubernetes-CSI pull job in repo csi-release-tools for external-provisioner, using deployment 1.30 on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -117,11 +117,11 @@ presubmits:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/external-provisioner
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.30.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
+          value: "1.30"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_PROW_TESTS
           value: "unit sanity parallel"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -145,7 +145,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-external-snapshotter
-      description: Kubernetes-CSI pull job in repo csi-release-tools for external-snapshotter, using deployment 1.28 on Kubernetes 1.28
+      description: Kubernetes-CSI pull job in repo csi-release-tools for external-snapshotter, using deployment 1.30 on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -168,11 +168,11 @@ presubmits:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.30.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
+          value: "1.30"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_PROW_TESTS
           value: "unit sanity parallel"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -196,7 +196,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-csi-driver-host-path
-      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-driver-host-path, using deployment 1.28 on Kubernetes 1.28
+      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-driver-host-path, using deployment 1.30 on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -219,11 +219,11 @@ presubmits:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/csi-driver-host-path
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.30.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
+          value: "1.30"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_PROW_TESTS
           value: "unit sanity parallel"
         - name: CSI_SNAPSHOTTER_VERSION

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -2,204 +2,10 @@
 
 presubmits:
   kubernetes-csi/external-attacher:
-  - name: pull-kubernetes-csi-external-attacher-1-27-on-kubernetes-1-27
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-attacher
-      testgrid-tab-name: 1-27-on-kubernetes-1-27
-      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.27 on Kubernetes 1.27
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.27.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.27"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-attacher-1-27-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-attacher
-      testgrid-tab-name: 1-27-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.27 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-attacher-1-28-on-kubernetes-1-28
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-attacher
-      testgrid-tab-name: 1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.28 on Kubernetes 1.28
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-attacher-1-28-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-attacher
-      testgrid-tab-name: 1-28-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.28 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-external-attacher-1-29-on-kubernetes-1-29
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
@@ -232,7 +38,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS
@@ -276,7 +82,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "latest"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -293,10 +99,10 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-external-attacher-alpha-1-28-on-kubernetes-1-28
+  - name: pull-kubernetes-csi-external-attacher-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
@@ -306,8 +112,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-attacher
-      testgrid-tab-name: alpha-1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo external-attacher for alpha tests, using deployment 1.28 on Kubernetes 1.28
+      testgrid-tab-name: 1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.30 on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,13 +129,207 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.30.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
+          value: "1.30"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-attacher-1-30-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-attacher
+      testgrid-tab-name: 1-30-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.30 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-attacher-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-attacher
+      testgrid-tab-name: 1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-attacher-1-31-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-attacher
+      testgrid-tab-name: 1-31-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.31 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-attacher-alpha-1-30-on-kubernetes-1-30
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-attacher
+      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo external-attacher for alpha tests, using deployment 1.30 on Kubernetes 1.30
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.30.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.30"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -2,204 +2,10 @@
 
 presubmits:
   kubernetes-csi/external-provisioner:
-  - name: pull-kubernetes-csi-external-provisioner-1-27-on-kubernetes-1-27
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: 1-27-on-kubernetes-1-27
-      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.27 on Kubernetes 1.27
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.27.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.27"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-provisioner-1-27-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: 1-27-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.27 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-provisioner-1-28-on-kubernetes-1-28
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: 1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.28 on Kubernetes 1.28
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-provisioner-1-28-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: 1-28-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.28 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-1-29-on-kubernetes-1-29
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
@@ -232,7 +38,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS
@@ -276,7 +82,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "latest"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -293,10 +99,10 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-external-provisioner-alpha-1-28-on-kubernetes-1-28
+  - name: pull-kubernetes-csi-external-provisioner-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
@@ -306,8 +112,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: alpha-1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo external-provisioner for alpha tests, using deployment 1.28 on Kubernetes 1.28
+      testgrid-tab-name: 1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.30 on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,13 +129,207 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.30.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
+          value: "1.30"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-provisioner-1-30-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-provisioner
+      testgrid-tab-name: 1-30-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.30 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-provisioner-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-provisioner
+      testgrid-tab-name: 1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-provisioner-1-31-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-provisioner
+      testgrid-tab-name: 1-31-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.31 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-provisioner-alpha-1-30-on-kubernetes-1-30
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-provisioner
+      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo external-provisioner for alpha tests, using deployment 1.30 on Kubernetes 1.30
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.30.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.30"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -2,204 +2,10 @@
 
 presubmits:
   kubernetes-csi/external-resizer:
-  - name: pull-kubernetes-csi-external-resizer-1-27-on-kubernetes-1-27
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-resizer
-      testgrid-tab-name: 1-27-on-kubernetes-1-27
-      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.27 on Kubernetes 1.27
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.27.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.27"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-resizer-1-27-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-resizer
-      testgrid-tab-name: 1-27-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.27 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-resizer-1-28-on-kubernetes-1-28
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-resizer
-      testgrid-tab-name: 1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.28 on Kubernetes 1.28
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-resizer-1-28-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-resizer
-      testgrid-tab-name: 1-28-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.28 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-external-resizer-1-29-on-kubernetes-1-29
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: []
@@ -232,7 +38,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS
@@ -276,7 +82,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "latest"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -293,10 +99,10 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-external-resizer-alpha-1-28-on-kubernetes-1-28
+  - name: pull-kubernetes-csi-external-resizer-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: []
@@ -306,8 +112,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-resizer
-      testgrid-tab-name: alpha-1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo external-resizer for alpha tests, using deployment 1.28 on Kubernetes 1.28
+      testgrid-tab-name: 1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.30 on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,13 +129,207 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.30.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
+          value: "1.30"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-resizer-1-30-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-resizer
+      testgrid-tab-name: 1-30-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.30 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-resizer-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-resizer
+      testgrid-tab-name: 1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-resizer-1-31-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-resizer
+      testgrid-tab-name: 1-31-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.31 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-resizer-alpha-1-30-on-kubernetes-1-30
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-resizer
+      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo external-resizer for alpha tests, using deployment 1.30 on Kubernetes 1.30
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.30.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.30"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -2,204 +2,10 @@
 
 presubmits:
   kubernetes-csi/external-snapshotter:
-  - name: pull-kubernetes-csi-external-snapshotter-1-27-on-kubernetes-1-27
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-snapshotter
-      testgrid-tab-name: 1-27-on-kubernetes-1-27
-      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.27 on Kubernetes 1.27
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.27.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.27"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-snapshotter-1-27-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-snapshotter
-      testgrid-tab-name: 1-27-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.27 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-snapshotter-1-28-on-kubernetes-1-28
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-snapshotter
-      testgrid-tab-name: 1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.28 on Kubernetes 1.28
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-snapshotter-1-28-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-snapshotter
-      testgrid-tab-name: 1-28-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.28 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-1-29-on-kubernetes-1-29
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
@@ -232,7 +38,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS
@@ -276,7 +82,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "latest"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -293,10 +99,10 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-external-snapshotter-alpha-1-28-on-kubernetes-1-28
+  - name: pull-kubernetes-csi-external-snapshotter-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
@@ -306,8 +112,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-snapshotter
-      testgrid-tab-name: alpha-1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo external-snapshotter for alpha tests, using deployment 1.28 on Kubernetes 1.28
+      testgrid-tab-name: 1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.30 on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,13 +129,207 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.30.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
+          value: "1.30"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-snapshotter-1-30-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-snapshotter
+      testgrid-tab-name: 1-30-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.30 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-snapshotter-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-snapshotter
+      testgrid-tab-name: 1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-snapshotter-1-31-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-snapshotter
+      testgrid-tab-name: 1-31-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.31 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-snapshotter-alpha-1-30-on-kubernetes-1-30
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-snapshotter
+      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo external-snapshotter for alpha tests, using deployment 1.30 on Kubernetes 1.30
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.30.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.30"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -24,7 +24,6 @@ base="$(dirname $0)"
 # irrelevant because the prow.sh script will pick a suitable KinD
 # image or build from source.
 k8s_versions="
-1.28
 1.29
 1.30
 1.31
@@ -32,20 +31,19 @@ k8s_versions="
 
 # All the deployment versions we're testing.
 deployment_versions="
-1.28
 1.29
 1.30
 1.31
 "
 
 # The experimental version for which jobs are optional.
-experimental_k8s_version="1.30"
+experimental_k8s_version="1.31"
 
 # The latest stable Kubernetes version for testing alpha jobs
-latest_stable_k8s_version="1.31"
+latest_stable_k8s_version="1.30"
 
 # Tag of the hostpath driver we should use for sidecar pull jobs
-hostpath_driver_version="v1.14.1"
+hostpath_driver_version="v1.15.0"
 
 # We need this image because it has Docker in Docker and go.
 dind_image="gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master"

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -24,26 +24,28 @@ base="$(dirname $0)"
 # irrelevant because the prow.sh script will pick a suitable KinD
 # image or build from source.
 k8s_versions="
-1.27
 1.28
 1.29
+1.30
+1.31
 "
 
 # All the deployment versions we're testing.
 deployment_versions="
-1.27
 1.28
 1.29
+1.30
+1.31
 "
 
 # The experimental version for which jobs are optional.
-experimental_k8s_version="1.29"
+experimental_k8s_version="1.30"
 
 # The latest stable Kubernetes version for testing alpha jobs
-latest_stable_k8s_version="1.28"
+latest_stable_k8s_version="1.31"
 
 # Tag of the hostpath driver we should use for sidecar pull jobs
-hostpath_driver_version="v1.12.1"
+hostpath_driver_version="v1.14.1"
 
 # We need this image because it has Docker in Docker and go.
 dind_image="gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master"

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -2,204 +2,10 @@
 
 presubmits:
   kubernetes-csi/livenessprobe:
-  - name: pull-kubernetes-csi-livenessprobe-1-27-on-kubernetes-1-27
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.4|release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-livenessprobe
-      testgrid-tab-name: 1-27-on-kubernetes-1-27
-      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.27 on Kubernetes 1.27
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.27.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.27"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-livenessprobe-1-27-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-livenessprobe
-      testgrid-tab-name: 1-27-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.27 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-livenessprobe-1-28-on-kubernetes-1-28
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.4|release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-livenessprobe
-      testgrid-tab-name: 1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.28 on Kubernetes 1.28
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-livenessprobe-1-28-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-livenessprobe
-      testgrid-tab-name: 1-28-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.28 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-1-29-on-kubernetes-1-29
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.4|release-1.0)$"]
@@ -232,7 +38,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS
@@ -276,7 +82,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "latest"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -293,10 +99,10 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-livenessprobe-alpha-1-28-on-kubernetes-1-28
+  - name: pull-kubernetes-csi-livenessprobe-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.4|release-1.0)$"]
@@ -306,8 +112,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-livenessprobe
-      testgrid-tab-name: alpha-1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo livenessprobe for alpha tests, using deployment 1.28 on Kubernetes 1.28
+      testgrid-tab-name: 1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.30 on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,13 +129,207 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.30.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
+          value: "1.30"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-livenessprobe-1-30-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-livenessprobe
+      testgrid-tab-name: 1-30-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.30 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-livenessprobe-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.4|release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-livenessprobe
+      testgrid-tab-name: 1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-livenessprobe-1-31-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-livenessprobe
+      testgrid-tab-name: 1-31-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.31 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-livenessprobe-alpha-1-30-on-kubernetes-1-30
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.4|release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-livenessprobe
+      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo livenessprobe for alpha tests, using deployment 1.30 on Kubernetes 1.30
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.30.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.30"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -2,204 +2,10 @@
 
 presubmits:
   kubernetes-csi/node-driver-registrar:
-  - name: pull-kubernetes-csi-node-driver-registrar-1-27-on-kubernetes-1-27
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-node-driver-registrar
-      testgrid-tab-name: 1-27-on-kubernetes-1-27
-      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.27 on Kubernetes 1.27
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.27.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.27"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-node-driver-registrar-1-27-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-node-driver-registrar
-      testgrid-tab-name: 1-27-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.27 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-node-driver-registrar-1-28-on-kubernetes-1-28
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-node-driver-registrar
-      testgrid-tab-name: 1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.28 on Kubernetes 1.28
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-node-driver-registrar-1-28-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-node-driver-registrar
-      testgrid-tab-name: 1-28-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.28 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-1-29-on-kubernetes-1-29
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-1.0)$"]
@@ -232,7 +38,7 @@ presubmits:
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS
@@ -276,7 +82,7 @@ presubmits:
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "latest"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_SNAPSHOTTER_VERSION
@@ -293,10 +99,10 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-28-on-kubernetes-1-28
+  - name: pull-kubernetes-csi-node-driver-registrar-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-1.0)$"]
@@ -306,8 +112,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-node-driver-registrar
-      testgrid-tab-name: alpha-1-28-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo node-driver-registrar for alpha tests, using deployment 1.28 on Kubernetes 1.28
+      testgrid-tab-name: 1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.30 on Kubernetes 1.30
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,13 +129,207 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.30.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.28"
+          value: "1.30"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.12.1"
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-node-driver-registrar-1-30-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-node-driver-registrar
+      testgrid-tab-name: 1-30-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.30 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-node-driver-registrar-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-node-driver-registrar
+      testgrid-tab-name: 1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-node-driver-registrar-1-31-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-node-driver-registrar
+      testgrid-tab-name: 1-31-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.31 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-30-on-kubernetes-1-30
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-node-driver-registrar
+      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
+      description: Kubernetes-CSI pull job in repo node-driver-registrar for alpha tests, using deployment 1.30 on Kubernetes 1.30
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.30.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.30"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS


### PR DESCRIPTION
- Drop k8s 1.27 (end of life already!)
- Add 1.30 and 1.31 k8s versions
- update hostpath_driver_version to v1.14.1