### PR TITLE
Update e2e test script and expand feature focus for volume group snapshots

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
@@ -193,3 +193,47 @@ periodics:
           limits:
             cpu: "2"
             memory: "6Gi"
+
+  - name: ci-kubernetes-e2e-storage-kind-volume-group-snapshots
+    interval: 12h
+    annotations:
+      testgrid-dashboards: sig-storage-kubernetes
+      testgrid-tab-name: storage-kind-volume-group-snapshots
+      testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+      description: Run storage tests volume group snapshots in a KIND cluster.
+    decorate: true
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    cluster: eks-prow-build-cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20240705-131cd74733-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/run_group_snapshot_e2e.sh
+        env:
+        - name: RUNTIME_CONFIG
+          value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
+        - name: FOCUS
+          value: \[Feature:volumegroupsnapshot\]
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "2"
+            memory: "6Gi"
+          limits:
+            cpu: "2"
+            memory: "6Gi"


### PR DESCRIPTION


Change the e2e test script in the sig-storage-kind.yaml to use 'run_group_snapshot_e2e.sh' the run_group_snapshot_e2e.sh script installs group snapshot CRD and then runs group snapshot e2e tests along with the existing alpha beta feature tests.

This update is part of ongoing efforts to enhance testing for volume group snapshot capabilities in Kubernetes SIG Storage.

PR in k/k: https://github.com/kubernetes/kubernetes/pull/126326