### PR TITLE
Drop perma-failing CI job - ci-fast-forward-website

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -367,41 +367,6 @@ periodics:
     testgrid-dashboards: sig-release-releng-blocking
     testgrid-tab-name: git-repo-kubernetes-fast-forward
 
-- interval: 6h
-  name: ci-fast-forward-website
-  cluster: k8s-infra-prow-build-trusted
-  decorate: true
-  spec:
-    serviceAccountName: gcb-builder
-    containers:
-    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
-      imagePullPolicy: Always
-      command:
-      - wrapper.sh
-      - /krel
-      - fast-forward
-      - --non-interactive
-      - --submit
-      - --github-org=kubernetes
-      - --github-repo=website
-      # TODO: enable no mock after a few runs to check
-      # - --nomock
-      resources:
-        requests:
-          cpu: 4
-          memory: "8Gi"
-        limits:
-          cpu: 4
-          memory: "8Gi"
-  rerun_auth_config:
-    github_team_slugs:
-      - org: kubernetes
-        slug: release-managers
-  annotations:
-    testgrid-alert-email: release-managers+alerts@kubernetes.io
-    testgrid-dashboards: sig-release-releng-informing
-    testgrid-tab-name: git-repo-kubernetes-website-fast-forward
-
 - name: periodic-release-verify-image-signatures
   cluster: k8s-infra-prow-build-trusted
   interval: 4h


### PR DESCRIPTION
slack thread: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1725476133589949

persistent failures: https://testgrid.k8s.io/sig-release-releng-informing#git-repo-kubernetes-website-fast-forward&width=20

We can always revive this if we find folks to staff the work etc.