### PR TITLE
Replaced "repos" with "orgs"

### DIFF
--- a/config/prow/cluster/starter/starter-s3-kind.yaml
+++ b/config/prow/cluster/starter/starter-s3-kind.yaml
@@ -131,8 +131,8 @@ data:
         - do-not-merge/hold
         - do-not-merge/work-in-progress
         - do-not-merge/invalid-owners-file
-        repos:
-        - $GITHUB_REPO
+        orgs:
+        - $GITHUB_ORG
 
     decorate_all_jobs: true
     periodics:


### PR DESCRIPTION
This looks like a misconfiguration, every other example file are using `orgs`.

Using `repos` gives the following error in logs:

```
{"component":"tide","error":"query 0, err: Post \"http://ghproxy/graphql\": failed to get installation id for org git@github.com:hector-vido: the github app is not installed in organization git@github.com:hector-vido","file":"sigs.k8s.io/prow/cmd/tide/main.go:293","func":"main.sync","level":"error","msg":"Error syncing.","severity":"error","time":"2024-09-04T22:26:22Z"}
{"client":"github","component":"tide","file":"sigs.k8s.io/prow/pkg/github/client.go:800","func":"sigs.k8s.io/prow/pkg/github.(*client).log","level":"info","msg":"AppInstallation()","severity":"info","time":"2024-09-04T22:26:22Z"}
```