### PR TITLE
scheduler-perf: keep `go test` JSON output for debugging

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -746,6 +746,9 @@ periodics:
       env:
       - name: KUBE_TIMEOUT
         value: --timeout=2h25m
+      # Keep the unprocessed `go test` JSON output for debugging.
+      - name: KUBE_KEEP_VERBOSE_TEST_OUTPUT
+        value: "y"
       - name: TEST_PREFIX
         value: BenchmarkPerfScheduling
       # Set the benchtime to a very low value so every test is ran at most once


### PR DESCRIPTION
There are issues with gotestsum processing the JSON output of benchmarks. Collecting the original output may help with debugging this.

If the files are not too large, then it may be worthwhile to keep this enabled even after fixing the current
issue (https://github.com/kubernetes/kubernetes/issues/127245).

/assign @macsko 