### PR TITLE
Exclude Alpha|Beta features from pull-kubernetes-e2e-gce-network-policies

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -112,7 +112,8 @@ presubmits:
         - --provider=gce
         # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
         # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)
-        - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|SCTPConnectivity)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP --ginkgo.label-filter='!Feature: containsAny {Alpha, Beta}'
+        - >
+          --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|SCTPConnectivity)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP --ginkgo.label-filter='!Feature: containsAny {Alpha, Beta}'
         - --timeout=100m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
         resources:

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -113,7 +113,7 @@ presubmits:
         # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
         # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)
         - >
-          --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|SCTPConnectivity)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP --ginkgo.label-filter='!Feature: containsAny {Alpha, Beta}'
+          --test_args=--ginkgo.skip=GCE|Disruptive|Serial|SNAT --ginkgo.label-filter='(sig-network || Conformance || Feature:NetworkPolicy || Feature:NetworkPolicyEndPort) && !Feature: containsAny {Alpha, Beta, Example, Federation, IPv6DualStack, LoadBalancer, Networking-IPv6, PerformanceDNS, SCTPConnectivity, KubeProxyDaemonSetMigration}'
         - --timeout=100m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
         resources:

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -112,7 +112,7 @@ presubmits:
         - --provider=gce
         # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
         # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)
-        - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Alpha|Beta|Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|SCTPConnectivity)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP
+        - --test_args=--ginkgo.focus=\[sig-network\]|\[Conformance\]|\[Feature:NetworkPolicy\]|\[Feature:NetworkPolicyEndPort\] --ginkgo.skip=\[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|KubeProxyDaemonSetMigration|SCTPConnectivity)\]|DualStack|GCE|Disruptive|Serial|SNAT|LoadBalancer|ESIPP --ginkgo.label-filter='!Feature: containsAny {Alpha, Beta}'
         - --timeout=100m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
         resources:

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -113,7 +113,7 @@ presubmits:
         # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
         # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)
         - >
-          --test_args=--ginkgo.skip=GCE|Disruptive|Serial|SNAT --ginkgo.label-filter='(sig-network || Conformance || Feature:NetworkPolicy || Feature:NetworkPolicyEndPort) && !Feature: containsAny {Alpha, Beta, Example, Federation, IPv6DualStack, LoadBalancer, Networking-IPv6, PerformanceDNS, SCTPConnectivity, KubeProxyDaemonSetMigration}'
+          --test_args=--ginkgo.skip=GCE|Disruptive|Serial|SNAT --ginkgo.label-filter='(sig-network || Conformance || Feature: containsAny {NetworkPolicy, NetworkPolicyEndPort} ) && !Feature: containsAny {Alpha, Beta, Example, Federation, IPv6DualStack, LoadBalancer, Networking-IPv6, PerformanceDNS, SCTPConnectivity, KubeProxyDaemonSetMigration}'
         - --timeout=100m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
         resources:


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/test-infra/pull/33450

This test still ran, despite excluding Alpha/Beta:
```
[sig-network] [Feature:ServiceCIDRs] [FeatureGate:MultiCIDRServiceAllocator] [Beta] [It] should create Services and serve on different Service CIDRs [sig-network, Feature:ServiceCIDRs, FeatureGate:MultiCIDRServiceAllocator, Feature:Beta]
```

I think the tags before and after the description are different, but I'm not sure why.

Testing this locally seems to work, that one test is now excluded. I'm a little worried about the special characters in the command line, but unsure how to test those here.