### PR TITLE
etcd: adjust govulncheck memory limits

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -170,10 +170,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "1Gi"
+            memory: "4Gi"
           limits:
             cpu: "4"
-            memory: "1Gi"
+            memory: "4Gi"
 
   - name: pull-etcd-e2e-amd64
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
The job gets stuck when running the `govulncheck` command at the repository's root. Following Grafana, it seems to be reaching the memory limit.

Based on historical usage, I initially configured it to use at most 1Gi. However, usage seems to increase if there's a vulnerability in the code (right now, we should get a job failure because the main branch is still using Go 1.22.6).

Reference:
* https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?var-org=etcd-io&var-repo=etcd&var-job=pull-etcd-govulncheck&orgId=1&refresh=30s&from=now-24h&to=now&var-build=All
* https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-etcd-govulncheck