### PR TITLE
add periodic DRA test job to CAPZ

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -84,6 +84,59 @@ periodics:
     testgrid-tab-name: capz-periodic-conformance-k8s-ci-main
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs conformance & node conformance tests on latest kubernetes master with cluster-api-provider-azure
+- name: periodic-cluster-api-provider-azure-conformance-with-ci-artifacts-dra-main
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 12h # TODO: increase this to 48h when we're confident it's stable
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: main
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: master
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-1.29
+        command:
+          - runner.sh
+        args:
+          - ./scripts/ci-conformance.sh
+        env:
+        - name: E2E_ARGS
+          value: "-kubetest.use-ci-artifacts"
+        - name: CONFORMANCE_FLAVOR
+          value: conformance-ci-artifacts-dra
+        - name: KUBETEST_CONF_PATH
+          value: ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/test/e2e/data/kubetest/conformance-dra-ginkgo-v2.yaml
+        - name: KUBERNETES_VERSION
+          value: latest
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 6
+            memory: "9Gi"
+          limits:
+            cpu: 6
+            memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-conformance-k8s-ci-dra-main
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Runs conformance & node DRA tests on latest kubernetes master with cluster-api-provider-azure
 - name: periodic-cluster-api-provider-azure-capi-e2e-main
   cluster: eks-prow-build-cluster
   decorate: true


### PR DESCRIPTION
This PR adds a new periodic job to the CAPZ bucket that runs the DRA e2e tests from k/k.