### PR TITLE
releng-ci: switch to go 1.23

### DIFF
--- a/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -61,7 +61,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       cluster: eks-prow-build-cluster
       spec:
         containers:
-          - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+          - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
             imagePullPolicy: Always
             command:
               - make
@@ -32,7 +32,7 @@ presubmits:
       cluster: eks-prow-build-cluster
       spec:
         containers:
-          - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+          - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
             imagePullPolicy: Always
             command:
               - make

--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -31,7 +31,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
+++ b/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
@@ -168,7 +168,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -67,7 +67,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/tejolote/tejolote-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/tejolote/tejolote-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - go

--- a/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -31,7 +31,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -55,7 +55,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - make

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -102,7 +102,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -128,7 +128,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -153,7 +153,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -178,7 +178,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
Update the jobs using the releng-ci image to use go 1.23.

cc @kubernetes/release-engineering 