### PR TITLE
Attempted fix for pull-kubernetes-e2e-gce-network-policies

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -113,7 +113,7 @@ presubmits:
         # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
         # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)
         - >
-          --test_args=--ginkgo.skip=GCE|Disruptive|Serial|SNAT --ginkgo.label-filter='(sig-network || Conformance || Feature: containsAny {NetworkPolicy, NetworkPolicyEndPort} ) && !Feature: containsAny {Alpha, Beta, Example, Federation, IPv6DualStack, LoadBalancer, Networking-IPv6, PerformanceDNS, SCTPConnectivity, KubeProxyDaemonSetMigration}'
+          --test_args=--ginkgo.skip=GCE|Disruptive|Serial|SNAT --ginkgo.label-filter=(sig-network || Conformance || Feature: containsAny {NetworkPolicy, NetworkPolicyEndPort} ) && !Feature: containsAny {Alpha, Beta, Example, Federation, IPv6DualStack, LoadBalancer, Networking-IPv6, PerformanceDNS, SCTPConnectivity, KubeProxyDaemonSetMigration}
         - --timeout=100m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240903-6a352c5344-master
         resources:


### PR DESCRIPTION
```
+ /home/prow/go/src/k8s.io/kubernetes/_output/dockerized/bin/linux/amd64/ginkgo --nodes=30 --poll-progress-after=60m --poll-progress-interval=5m --source-root=/home/prow/go/src/k8s.io/kubernetes --timeout=24h --flake-attempts=1 --silence-skips --force-newlines --no-color /home/prow/go/src/k8s.io/kubernetes/_output/dockerized/bin/linux/amd64/e2e.test -- --kubeconfig=/workspace/.kube/config --host=https://34.105.121.132 --provider=gce --gce-project=k8s-infra-e2e-boskos-126 --gce-zone=us-west1-b --gce-region=us-west1 --gce-multizone=false --gke-cluster=bootstrap-e2e --kube-master=bootstrap-e2e-master --cluster-tag= --cloud-config-file= --repo-root=/home/prow/go/src/k8s.io/kubernetes --node-instance-group=bootstrap-e2e-minion-group --prefix=bootstrap-e2e --network=bootstrap-e2e --node-tag=bootstrap-e2e-minion --master-tag=bootstrap-e2e-master --docker-config-file= --dns-domain=cluster.local --prepull-images=false --master-os-distro=gci --node-os-distro=gci --num-nodes=4 --report-complete-ginkgo --report-complete-junit '--ginkgo.skip=GCE|Disruptive|Serial|SNAT' '--ginkgo.label-filter='\''(sig-network' '||' Conformance '||' Feature: containsAny '{NetworkPolicy,' 'NetworkPolicyEndPort}' ')' '&&' '!Feature:' containsAny '{Alpha,' Beta, Example, Federation, IPv6DualStack, LoadBalancer, Networking-IPv6, PerformanceDNS, SCTPConnectivity, 'KubeProxyDaemonSetMigration}'\''' --report-dir=/logs/artifacts --disable-log-dump=true --cluster-ip-range=10.64.0.0/14
 Ginkgo timed out waiting for all parallel procs to report back
Test suite: e2e (./_output/dockerized/bin/linux/amd64)
 This occurs if a parallel process exits before it reports its results to the
Ginkgo CLI.  The CLI will now print out all the stdout/stderr output it's
collected from the running processes.  However you may not see anything useful
in these logs because the individual test processes usually intercept output to
stdout/stderr in order to capture it in the spec reports.
 You may want to try rerunning your test suite with
--output-interceptor-mode=none to see additional output here and debug your
suite.

Output from proc 1:
  unknown additional command line arguments: [|| Conformance || Feature: containsAny {NetworkPolicy, NetworkPolicyEndPort} ) && !Feature: containsAny {Alpha, Beta, Example, Federation, IPv6DualStack, LoadBalancer, Networking-IPv6, PerformanceDNS, SCTPConnectivity, KubeProxyDaemonSetMigration}' --report-dir=/logs/artifacts --disable-log-dump=true --cluster-ip-range=10.64.0.0/14]
```

I thiiiiink the single quotes is causing this issue, since the `--ginkgo.skip` parameter works without them.

It's also possible that the spaces will now break, but I'll follow up with a new change to escape them.