### PR TITLE
migrate cloud provider kind jobs to new regex

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-periodic.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-periodic.yaml
@@ -26,7 +26,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|ServiceCIDRs)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
+        value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv6|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
       command:
         - wrapper.sh
         - bash
@@ -80,7 +80,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: \[Feature:(Networking-IPv4|Example|Federation|PerformanceDNS|ServiceCIDRs)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|loadbalancer.source.ranges|Internet.connection.for.containers
+        value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv4|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|Internet.connection|loadbalancer.source.ranges
       command:
         - wrapper.sh
         - bash

--- a/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|ServiceCIDRs)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|should.handle.updates.to.ExternalTrafficPolicy.field
+          value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv6|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
         command:
         - wrapper.sh
         - bash
@@ -87,7 +87,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: \[Feature:(Networking-IPv4|Example|Federation|PerformanceDNS|ServiceCIDRs)\]|GCE|NetworkPolicy|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|loadbalancer.source.ranges|Internet.connection.for.containers|should.handle.updates.to.ExternalTrafficPolicy.field
+          value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv4|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|Internet.connection|loadbalancer.source.ranges
         command:
         - wrapper.sh
         - bash
@@ -139,7 +139,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS|ServiceCIDRs)\]|GCE|NetworkPolicy|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|should.handle.updates.to.ExternalTrafficPolicy.field
+          value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|Networking-IPv6|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
         - name: PARALLEL
           value: "true"
         - name: IP_FAMILY


### PR DESCRIPTION
These are the remaining jobs for kind networking, after migrating all the jobs in sig-network/kind

/assign @adrianmoisey @ameukam 