### PR TITLE
Fix broken ci job for k/examples images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-examples.yaml
+++ b/config/jobs/image-pushing/k8s-staging-examples.yaml
@@ -22,4 +22,6 @@ postsubmits:
               - --project=k8s-staging-examples
               - --scratch-bucket=gs://k8s-staging-examples-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
+              - --gcb-config=dev/cloudbuild/cloudbuild.yaml
               - .


### PR DESCRIPTION
CI job is failing:
https://storage.googleapis.com/kubernetes-jenkins/logs/examples-push-images/1835965233173106688/build-log.txt

Looks like it has not run in a long while. trying to resurrect it.