### PR TITLE
Cleanup ci-kubernetes-e2e-ec2-device-plugin-gpu CI job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -278,10 +278,8 @@ presubmits:
             - |
               GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
               AMI_ID=$(aws ssm get-parameters --names \
-                     /aws/service/eks/optimized-ami/1.29/amazon-linux-2-gpu/recommended/image_id \
+                     /aws/service/eks/optimized-ami/1.30/amazon-linux-2-gpu/recommended/image_id \
                      --query 'Parameters[0].[Value]' --output text)
-              export TEST_MAX_GPU_COUNT=1
-              export NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.14.5/nvidia-device-plugin.yml
               kubetest2 ec2 \
                --build \
                --instance-type=g4dn.xlarge \

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -33,11 +33,9 @@ periodics:
           - |
             GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
             AMI_ID=$(aws ssm get-parameters --names \
-                     /aws/service/eks/optimized-ami/1.29/amazon-linux-2-gpu/recommended/image_id \
+                     /aws/service/eks/optimized-ami/1.30/amazon-linux-2-gpu/recommended/image_id \
                      --query 'Parameters[0].[Value]' --output text)
             VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
-            export TEST_MAX_GPU_COUNT=1
-            export NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.14.5/nvidia-device-plugin.yml
             kubetest2 ec2 \
              --stage https://dl.k8s.io/ci/fast/ \
              --version $VERSION \


### PR DESCRIPTION
update to use newer EKS AMI (1.29->1.30). Drop unnecessary env variables.