### PR TITLE
Enable nvidia device plugin for EC2 based GPU tests

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -283,6 +283,7 @@ presubmits:
               kubetest2 ec2 \
                --build \
                --instance-type=g4dn.xlarge \
+               --device-plugin-nvidia true \
                --worker-image="$AMI_ID" \
                --region us-east-1 \
                --target-build-arch linux/amd64 \

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -40,6 +40,7 @@ periodics:
              --stage https://dl.k8s.io/ci/fast/ \
              --version $VERSION \
              --instance-type=g4dn.xlarge \
+             --device-plugin-nvidia true \
              --worker-image="$AMI_ID" \
              --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \
              --up \


### PR DESCRIPTION
We should use the CLI param in kubetest2 ec2 to install the device plugin for nvidia for these 2 jobs