### PR TITLE
etcd: make website markdown linting presubmit blocking

### DIFF
--- a/config/jobs/etcd/etcd-website-presubmits.yaml
+++ b/config/jobs/etcd/etcd-website-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
   etcd-io/website:
   - name: pull-website-lint
     cluster: eks-prow-build-cluster
-    optional: true # remove this once the job is green
     always_run: false
     run_if_changed: '.*\.md$'
     branches:


### PR DESCRIPTION
Mark the website linting presubmit job as blocking.

Fixes etcd-io/website#857.

/cc @jmhbnz 