### PR TITLE
fix: explicitly disable --short in scheduler-perf jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -755,6 +755,8 @@ periodics:
       # even on very powerful machines
       - name: BENCHTIME
         value: 1ns
+      - name: SHORT
+        value: --short=false
       # We need to constraint compute resources so all the tests
       # finish approximately at the same time. More compute power
       # can increase scheduling throughput and make consequent results

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -718,6 +718,8 @@ periodics:
           cpu: 1
           memory: "2Gi"
 
+# Note: we have a presubmit job "pull-scheduler-perf",
+# which you likely want to change when you change parameters in this test.
 - name: ci-benchmark-scheduler-perf-master
   cluster: k8s-infra-prow-build
   tags:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -757,6 +757,8 @@ periodics:
       # even on very powerful machines
       - name: BENCHTIME
         value: 1ns
+      # We distinguish which test cases to run with --short, and we want to run longer test cases in this job.
+      # We have to explicitly disable --short flag because the script enables by default.
       - name: SHORT
         value: --short=false
       # We need to constraint compute resources so all the tests

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -764,12 +764,17 @@ presubmits:
         env:
         - name: KUBE_TIMEOUT
           value: --timeout=2h25m
+        # Keep the unprocessed `go test` JSON output for debugging.
+        - name: KUBE_KEEP_VERBOSE_TEST_OUTPUT
+          value: "y"
         - name: TEST_PREFIX
           value: BenchmarkPerfScheduling
         # Set the benchtime to a very low value so every test is ran at most once
         # even on very powerful machines
         - name: BENCHTIME
           value: 1ns
+        - name: SHORT
+          value: --short=false
         # We need to constraint compute resources so all the tests
         # finish approximately at the same time. More compute power
         # can increase scheduling throughput and make consequent results

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -773,6 +773,8 @@ presubmits:
         # even on very powerful machines
         - name: BENCHTIME
           value: 1ns
+        # We distinguish which test cases to run with --short, and we want to run longer test cases in this job.
+        # We have to explicitly disable --short flag because the script enables by default.
         - name: SHORT
           value: --short=false
         # We need to constraint compute resources so all the tests


### PR DESCRIPTION
explicitly disable --short in scheduler-perf jobs otherwise the default is `--short=true`, which will run a fewer tests after https://github.com/kubernetes/kubernetes/pull/127269.

/cc @macsko 