### PR TITLE
Enable Nvidia device plugin via kube-up addon

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -47,6 +47,7 @@ presubmits:
         # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
         # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
         - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
+        - --env=KUBE_ENABLE_NVIDIA_GPU=true
         - --gcp-node-image=gci
         - --gcp-nodes=2
         - --gcp-project-type=gpu-project

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -47,6 +47,7 @@ periodics:
       # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
+      - --env=KUBE_ENABLE_NVIDIA_GPU=true
       - --gcp-node-image=gci
       - --gcp-nodes=1
       - --gcp-project-type=gpu-project


### PR DESCRIPTION
Needed to test https://github.com/kubernetes/kubernetes/pull/127442/

Will revert if this does not work. (no harm if PR above does not land)

You can see that the recently added nvidia sanity tests are being skipped as the GPUs are not available:
https://testgrid.k8s.io/sig-release-master-blocking#gce-device-plugin-gpu-master&width=20