### PR TITLE
Update clusterloader2 provider to azure

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/soak-tests.yaml
@@ -34,7 +34,7 @@ presubmits:
               cd ${GOPATH}/src/k8s.io/perf-tests/ &&
               ./run-e2e.sh cluster-loader2
               --testconfig=testing/windows-tests/config.yaml
-              --provider=aks
+              --provider=azure
               --report-dir=${ARTIFACTS}
               --v=2
           securityContext:
@@ -125,7 +125,7 @@ periodics:
               ./run-e2e.sh cluster-loader2
               --kubeconfig ${GOPATH}/src/k8s.io/perf-tests/kubeconfig
               --testconfig=testing/windows-tests/config.yaml
-              --provider=aks
+              --provider=azure
               --report-dir=${ARTIFACTS}
               --v=2
           env:
@@ -310,7 +310,7 @@ periodics:
               cd ${GOPATH}/src/k8s.io/perf-tests/ &&
               ./run-e2e.sh cluster-loader2
               --testconfig=testing/windows-tests/config.yaml
-              --provider=aks
+              --provider=azure
               --report-dir=${ARTIFACTS}
               --v=2
           securityContext:


### PR DESCRIPTION
Changes the `cluster-loader2` command-line flag to `--provider=azure` (from `--provider=aks`) to match the perf-tests PR that renames it: kubernetes/perf-tests#2864