### PR TITLE
Bump ci-kubernetes-e2e-gce-device-plugin-gpu to 2 nodes

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -48,7 +48,7 @@ periodics:
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
       - --gcp-node-image=gci
-      - --gcp-nodes=1
+      - --gcp-nodes=2
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b
       - --provider=gce


### PR DESCRIPTION
Presubmit has 2 nodes, bump the CI job to match
https://github.com/kubernetes/test-infra/blob/3dd2fb7e717251ea943683212a5331170321c0cf/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml#L51