### PR TITLE
Use exactly the same number of GPUs in both ec2 and gce (4 NVIDIA T4 GPUs)

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -282,7 +282,7 @@ presubmits:
                      --query 'Parameters[0].[Value]' --output text)
               kubetest2 ec2 \
                --build \
-               --instance-type=g4dn.xlarge \
+               --instance-type=g4dn.16xlarge \
                --device-plugin-nvidia true \
                --worker-image="$AMI_ID" \
                --region us-east-1 \

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -3,7 +3,7 @@ presets:
     preset-pull-gce-device-plugin-gpu: "true"
   env:
   - name: NODE_ACCELERATORS
-    value: type=nvidia-tesla-t4,count=2
+    value: type=nvidia-tesla-t4,count=4
   - name: CREATE_CUSTOM_NETWORK
     value: "true"
   - name: NODE_SIZE

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -39,7 +39,7 @@ periodics:
             kubetest2 ec2 \
              --stage https://dl.k8s.io/ci/fast/ \
              --version $VERSION \
-             --instance-type=g4dn.xlarge \
+             --instance-type=g4dn.16xlarge \
              --device-plugin-nvidia true \
              --worker-image="$AMI_ID" \
              --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \


### PR DESCRIPTION
`g4dn.12xlarge` has 4 `NVIDIA T4` GPU(s) and there isn't any instance types with 2 T4 GPU(s) So let's switch to that.

https://aws.amazon.com/blogs/aws/now-available-ec2-instances-g4-with-nvidia-t4-tensor-core-gpus/

Also bump `preset-pull-gce-device-plugin-gpu` to match the same.

As we add more GPU based tests that end up running in the following CI jobs, we avoid flakiness in the jobs.
- pull-kubernetes-e2e-ec2-device-plugin-gpu / ci-kubernetes-e2e-ec2-device-plugin-gpu
- pull-kubernetes-e2e-gce-device-plugin-gpu / ci-kubernetes-e2e-gce-device-plugin-gpu

