### PR TITLE
[ec2][gpu] Use larger instance type just for ec2 worker nodes

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -282,7 +282,7 @@ presubmits:
                      --query 'Parameters[0].[Value]' --output text)
               kubetest2 ec2 \
                --build \
-               --instance-type=g4dn.16xlarge \
+               --worker-instance-type=g4dn.16xlarge \
                --device-plugin-nvidia true \
                --worker-image="$AMI_ID" \
                --region us-east-1 \

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -39,7 +39,7 @@ periodics:
             kubetest2 ec2 \
              --stage https://dl.k8s.io/ci/fast/ \
              --version $VERSION \
-             --instance-type=g4dn.16xlarge \
+             --worker-instance-type=g4dn.16xlarge \
              --device-plugin-nvidia true \
              --worker-image="$AMI_ID" \
              --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \


### PR DESCRIPTION
Needs https://github.com/kubernetes-sigs/provider-aws-test-infra/pull/370 to land first.

We do not need a large instance of control plane node unnecessarily so have toggle for instance types for control plane and worker nodes and use appropriately (`kubetest2 ec2` harness!)