### PR TITLE
replicate ci-crio-cgroupv1-node-e2e-conformance using kubetest2

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -52,6 +52,61 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 
     description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v1"
+- name: ci-crio-cgroupv1-node-e2e-conformance-kubetest2
+  interval: 1h
+  cluster: k8s-infra-prow-build
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-pull-kubernetes-e2e: "true"
+    preset-pull-kubernetes-e2e-gce: "true"  
+  decorate: true
+  decoration_config:
+    timeout: 240m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240903-6a352c5344-master
+      command:
+      - runner.sh
+      args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-west1-b
+      - --parallelism=8
+      - --focus-regex=\[NodeConformance\]
+      - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
+      - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
+      env:
+        - name: KUBE_SSH_USER
+          value: core
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1" 
+      resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 4
+          memory: 6Gi
+  annotations:
+    testgrid-dashboards: sig-node-cri-o
+    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-conformance-kubetest2
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v1 using kubetest2"
 # TODO (https://github.com/kubernetes/test-infra/issues/26127) consider restoring once we will figure out the right set of alpha features. The tag NodeAlphaFeature is not being used any longer
 # - name: ci-crio-cgroupv1-node-e2e-alpha
 #   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -59,7 +59,7 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-pull-kubernetes-e2e: "true"
-    preset-pull-kubernetes-e2e-gce: "true"  
+    preset-pull-kubernetes-e2e-gce: "true"
   decorate: true
   decoration_config:
     timeout: 240m
@@ -94,7 +94,7 @@ periodics:
         - name: KUBE_SSH_USER
           value: core
         - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-          value: "1" 
+          value: "1"
       resources:
         limits:
           cpu: 4


### PR DESCRIPTION
This is part of an effort to start using kubetest2 for crio e2e node tests. Being tracked in #32567