### PR TITLE
Move local-e2e to k8s-infra-prow-build cluster

### DIFF
--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       timeout: 240m
@@ -59,7 +59,7 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
-  cluster: eks-prow-build-cluster
+  cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 240m


### PR DESCRIPTION
Trying to test a theory if bottlerocket based nodes could be involved in the test failures in:
https://testgrid.k8s.io/conformance-hack-local-up-cluster#local-up-cluster,%20master%20(dev)&width=20