### PR TITLE
Force kill after docker stop

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -24,6 +24,8 @@ cleanup_dind() {
         docker ps -aq | xargs -r docker rm -f || true
         echo "Waiting for docker to stop for 30 seconds"
         timeout 30 service docker stop || true
+        # force kill docker related processes
+        (cat /var/run/docker*.pid | xargs kill -9) || true
     fi
 }
 


### PR DESCRIPTION
Follow up to:
https://github.com/kubernetes/test-infra/pull/31534/files

the docker stop with timeout is still not enough :(  logs from [here](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-local-e2e/1838112895683006464/build-log.txt)
```
Cleaning up after docker in docker.
================================================================================
Waiting 30 seconds for pods stopped with terminationGracePeriod:30
Cleaning up after docker
Waiting for docker to stop for 30 seconds
Stopping Docker: dockerProgram process in pidfile '/var/run/docker-ssd.pid', 1 process(es), refused to die.
================================================================================
Done cleaning up after docker in docker.
```

So if the pid files are still there, then let's try to force a SIGKILL instead of the SIGTERM that is issues.