### PR TITLE
New locations for bazel container images

### DIFF
--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -14,7 +14,7 @@
 
 # Includes git, gcloud, and bazel.
 ARG OLD_BAZEL_VERSION
-FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
+FROM gcr.io/bazel-public/bazel:${OLD_BAZEL_VERSION} as old
 FROM ubuntu:18.04
 
 # add env we can debug with the image name:tag

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -16,7 +16,7 @@
 # unit and integration tests
 
 ARG OLD_BAZEL_VERSION
-FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
+FROM gcr.io/bazel-public/bazel:${OLD_BAZEL_VERSION} as old
 FROM gcr.io/k8s-staging-test-infra/bootstrap:v20240923-eef969af11
 
 # hint to kubetest that it is in CI


### PR DESCRIPTION
failure from [log](https://storage.googleapis.com/kubernetes-jenkins/logs/post-test-infra-push-kubekins-e2e/1838236891271401472/build-log.txt)
```
Step #1: Step 1/37 : ARG OLD_BAZEL_VERSION
Step #1: Step 2/37 : FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
Step #1: Head "https://launcher.gcr.io/v2/google/bazel/manifests/3.1.0": denied: Unauthenticated request. Unauthenticated requests do not have permission "artifactregistry.repositories.downloadArtifacts" on resource "projects/cloud-marketplace-containers/locations/us/repositories/gcr.io" (or it may not exist)
Finished Step #1
```

Looks like the new locations are under `gcr.io/bazel-public/bazel`:
- https://explore.ggcr.dev/?image=gcr.io%2Fbazel-public%2Fbazel:3.1.0
- https://explore.ggcr.dev/?image=gcr.io%2Fbazel-public%2Fbazel:2.2.0