### PR TITLE
etcd: add pull-etcd-integration-{1,2,4}-cpu-arm64 presubmit jobs

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -292,6 +292,39 @@ presubmits:
             cpu: "2"
             memory: "3Gi"
 
+  - name: pull-etcd-integration-1-cpu-arm64
+    optional: true # remove when stable
+    cluster: k8s-infra-prow-build
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-integration-1-cpu-arm64
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240903-6a352c5344-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          make gofail-enable
+          export JUNIT_REPORT_DIR=${ARTIFACTS}
+          GOOS=linux GOARCH=arm64 CPU=1 make test-integration
+        resources:
+          requests:
+            cpu: "2"
+            memory: "3Gi"
+          limits:
+            cpu: "2"
+            memory: "3Gi"
+      nodeSelector:
+        kubernetes.io/arch: arm64
+
   - name: pull-etcd-integration-2-cpu-amd64
     cluster: eks-prow-build-cluster
     always_run: true
@@ -322,6 +355,39 @@ presubmits:
             cpu: "3"
             memory: "3Gi"
 
+  - name: pull-etcd-integration-2-cpu-arm64
+    optional: true # remove when stable
+    cluster: k8s-infra-prow-build
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-integration-2-cpu-arm64
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240903-6a352c5344-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          make gofail-enable
+          export JUNIT_REPORT_DIR=${ARTIFACTS}
+          GOOS=linux GOARCH=arm64 CPU=2 make test-integration
+        resources:
+          requests:
+            cpu: "3"
+            memory: "3Gi"
+          limits:
+            cpu: "3"
+            memory: "3Gi"
+      nodeSelector:
+        kubernetes.io/arch: arm64
+
   - name: pull-etcd-integration-4-cpu-amd64
     cluster: eks-prow-build-cluster
     always_run: true
@@ -351,6 +417,39 @@ presubmits:
           limits:
             cpu: "6"
             memory: "3Gi"
+
+  - name: pull-etcd-integration-4-cpu-arm64
+    optional: true # remove when stable
+    cluster: k8s-infra-prow-build
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-integration-4-cpu-arm64
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240903-6a352c5344-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          make gofail-enable
+          export JUNIT_REPORT_DIR=${ARTIFACTS}
+          GOOS=linux GOARCH=arm64 CPU=4 make test-integration
+        resources:
+          requests:
+            cpu: "6"
+            memory: "3Gi"
+          limits:
+            cpu: "6"
+            memory: "3Gi"
+      nodeSelector:
+        kubernetes.io/arch: arm64
 
   - name: pull-etcd-robustness-amd64
     cluster: k8s-infra-prow-build


### PR DESCRIPTION
Import the integration tests ARM64 presubmit jobs.

Part of #32754, kubernetes/k8s.io#6102.