### PR TITLE
Move to g4dn.12xlarge which has 4 NVIDIA T4(s)

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -282,7 +282,7 @@ presubmits:
                      --query 'Parameters[0].[Value]' --output text)
               kubetest2 ec2 \
                --build \
-               --worker-instance-type=g4dn.16xlarge \
+               --worker-instance-type=g4dn.12xlarge \
                --device-plugin-nvidia true \
                --worker-image="$AMI_ID" \
                --region us-east-1 \

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -39,7 +39,7 @@ periodics:
             kubetest2 ec2 \
              --stage https://dl.k8s.io/ci/fast/ \
              --version $VERSION \
-             --worker-instance-type=g4dn.16xlarge \
+             --worker-instance-type=g4dn.12xlarge \
              --device-plugin-nvidia true \
              --worker-image="$AMI_ID" \
              --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \


### PR DESCRIPTION
I probably typo-ed this earlier! it's cheaper too compared to 16xlarge

![image](https://github.com/user-attachments/assets/d5c5d6e3-277a-49b5-80ef-d24c1f1c423a)
