### PR TITLE
add azure-community preset to cloud-provider-azure-master-capz-main job

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -1104,8 +1104,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred-wi: "true"
-    preset-azure-anonymous-pull: "true"
+    preset-azure-community: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure


### PR DESCRIPTION
I noticed the [cloud-provider-azure-master-capz-main](https://testgrid.k8s.io/provider-azure-cloud-provider-azure#cloud-provider-azure-master-capz-main) job has been failing recently with this error when trying to `az login`:

```
ERROR: AADSTS700211: No matching federated identity record found for presented assertion issuer 'https://oidc.eks.us-east-2.amazonaws.com/id/F8B73554FE6FBAF9B19569183FB39762'. Please note that the matching is done using a case-sensitive comparison. Please check your federated identity credential Subject, Audience and Issuer against the presented assertion. https://learn.microsoft.com/entra/workload-id/workload-identity-federation Trace ID: ff8b285d-1f0a-4144-97b4-435e3f6fcc00 Correlation ID: 2daa0779-6d5b-4a02-9b32-0b8cb44039ec Timestamp: 2024-09-26 16:01:56Z
```

This PR updates the job to use the `preset-azure-community` label like the other jobs which configures the job for the new community infra.