### PR TITLE
publishing-bot-presubmits to use go 1.23

### DIFF
--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         command:
         - make
         resources:
@@ -27,7 +27,7 @@ presubmits:
     path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         command:
         - make
         - test
@@ -53,7 +53,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         env:
         - name: "GOWORK"
           value: "off"
@@ -158,7 +158,7 @@ presubmits:
       path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         env:
         - name: "GOWORK"
           value: "off"


### PR DESCRIPTION
1. we introduced this godebug in go.mod in this PR: https://github.com/kubernetes/kubernetes/commit/65ef53139012dee36c08f558604dea48af170e11 
2. per @liggitt this is a new syntax introduced from go 1.23 https://go.dev/doc/godebug#default 
3. while publishing-bot-presubmits still using go 1.22, doesn't know this new syntax, and failed all job: https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-publishing-bot-validate