### PR TITLE
kOps: Use v1.29 for the addons test

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1798,8 +1798,8 @@ def generate_presubmits_network_plugins():
             k8s_version = 'ci'
             optional = True
         if plugin == 'amazonvpc':
-            master_size = "r5d.xlarge"
-            node_size = "r5d.xlarge"
+            master_size = "r6g.xlarge"
+            node_size = "r6g.xlarge"
         results.append(
             presubmit_test(
                 distro='u2404arm64',

--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -2196,7 +2196,7 @@ def generate_presubmits_e2e():
             }
         ),
         presubmit_test(
-            name="pull-kops-e2e-aws-upgrade-k127-ko127-to-klatest-kolatest-many-addons",
+            name="pull-kops-e2e-aws-upgrade-k129-ko129-to-klatest-kolatest-many-addons",
             optional=True,
             distro='u2204',
             networking='cilium',
@@ -2206,8 +2206,8 @@ def generate_presubmits_e2e():
             run_if_changed=r'^upup\/(models\/cloudup\/resources\/addons\/|pkg\/fi\/cloudup\/bootstrapchannelbuilder\/)',
             scenario='upgrade-ab',
             env={
-                'KOPS_VERSION_A': "1.28",
-                'K8S_VERSION_A': "v1.28.0",
+                'KOPS_VERSION_A': "1.29",
+                'K8S_VERSION_A': "v1.29.0",
                 'KOPS_VERSION_B': "latest",
                 'K8S_VERSION_B': "latest",
                 'KOPS_SKIP_E2E': '1',

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -2202,7 +2202,7 @@ presubmits:
       testgrid-tab-name: pull-kops-e2e-aws-upgrade-k125-kolatest-to-k126-kolatest
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
-  - name: pull-kops-e2e-aws-upgrade-k127-ko127-to-klatest-kolatest-many-addons
+  - name: pull-kops-e2e-aws-upgrade-k129-ko129-to-klatest-kolatest-many-addons
     cluster: k8s-infra-kops-prow-build
     branches:
     - master
@@ -2238,9 +2238,9 @@ presubmits:
         - name: GOPATH
           value: /home/prow/go
         - name: KOPS_VERSION_A
-          value: "1.28"
+          value: "1.29"
         - name: K8S_VERSION_A
-          value: "v1.28.0"
+          value: "v1.29.0"
         - name: KOPS_VERSION_B
           value: "latest"
         - name: K8S_VERSION_B
@@ -2254,7 +2254,7 @@ presubmits:
         - name: CLOUD_PROVIDER
           value: "aws"
         - name: CLUSTER_NAME
-          value: "e2e-4c2eafaad8-50be8.test-cncf-aws.k8s.io"
+          value: "e2e-4d8d7f076f-d2dcf.test-cncf-aws.k8s.io"
         - name: KOPS_STATE_STORE
           value: "s3://k8s-kops-prow"
         - name: KOPS_IRSA
@@ -2271,7 +2271,7 @@ presubmits:
       test.kops.k8s.io/networking: cilium
       testgrid-dashboards: kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
-      testgrid-tab-name: pull-kops-e2e-aws-upgrade-k127-ko127-to-klatest-kolatest-many-addons
+      testgrid-tab-name: pull-kops-e2e-aws-upgrade-k129-ko129-to-klatest-kolatest-many-addons
 
 # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--instance-manager=karpenter --master-size=c6g.xlarge", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-aws-upgrade-k127-ko127-to-k128-kolatest-karpenter

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -3,7 +3,7 @@
 presubmits:
   kubernetes/kops:
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--master-size=r5d.xlarge --node-size=r5d.xlarge --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--master-size=r6g.xlarge --node-size=r6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
   - name: pull-kops-e2e-cni-amazonvpc
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -36,7 +36,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20240906' --channel=alpha --networking=amazonvpc --master-size=r5d.xlarge --node-size=r5d.xlarge --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20240906' --channel=alpha --networking=amazonvpc --master-size=r6g.xlarge --node-size=r6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -63,7 +63,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2404arm64
-      test.kops.k8s.io/extra_flags: --master-size=r5d.xlarge --node-size=r5d.xlarge --discovery-store=s3://k8s-kops-prow/discovery
+      test.kops.k8s.io/extra_flags: --master-size=r6g.xlarge --node-size=r6g.xlarge --discovery-store=s3://k8s-kops-prow/discovery
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: amazonvpc


### PR DESCRIPTION
The 1.28 marker is gone. Time to move on to 1.29.

/cc @rifelpet @justinsb @dims 