### PR TITLE
Ingress NGINX: Remove NGINX v1.21.

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -191,30 +191,6 @@ postsubmits:
               - --with-git-dir
               - images/nginx
 
-    # Ingress NGINX: NGINX v1.25
-    - name: post-ingress-nginx-nginx-1-25
-      annotations:
-        testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
-      branches:
-        - ^main$
-        - ^release-.+$
-      run_if_changed: ^images/nginx-1.25/
-      cluster: k8s-infra-prow-build-trusted
-      decorate: true
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/image-builder:v20240909-d870e42d3d
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-ingress-nginx
-              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
-              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
-              - --build-dir=.
-              - --with-git-dir
-              - images/nginx-1.25
-
     # Ingress NGINX: Test Runner
     - name: post-ingress-nginx-test-runner
       annotations:


### PR DESCRIPTION
The PR title might suggest removing NGINX v1.21. Actually we are renaming `nginx-1.25` to just `nginx` in the Ingress NGINX repository. As there already is a job config for `nginx`, which was used for NGINX v1.21 before, we effectively just remove the NGINX v1.25 config and re-use the NGINX v1.21 config.

Please consider also reviewing https://github.com/kubernetes/ingress-nginx/pull/12031 when reviewing this PR as they need to get merged/unhold shortly after each other.