### PR TITLE
Bump ci-kubernetes-e2e-gci-gce-alpha-enabled-default to containerd v2.0.0-rc.4

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -903,7 +903,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v1.7.20
+      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0-rc.4
       - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.1.13
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false
       - --env=KUBE_PROXY_DAEMONSET=true


### PR DESCRIPTION
Chasing this error, want to see if it exists in newer containerd code base as well:
https://storage.googleapis.com/k8s-triage/index.html?job=ci-kubernetes-e2e-gci-gce-alpha-enabled-default&test=should%20run%20without%20error

```
[FAILED] an error on the server ("Internal Error: failed to list pod stats: rpc error: code = Unknown desc = 1 error occurred:\n\t* failed to decode sandbox container metrics for sandbox \"7576f2a4814b019b6c84faad30e1509f4d86086e76877545238be0366849754e\": ttrpc: closed: unknown") has prevented the request from succeeding (get nodes bootstrap-e2e-minion-group-272j:10250)
In [It] at: k8s.io/kubernetes/test/e2e/node/node_problem_detector.go:381 @ 09/15/24 02:05:51.753
```

```
[FAILED] an error on the server ("Internal Error: failed to list pod stats: rpc error: code = Unknown desc = 1 error occurred:\n\t* failed to decode sandbox container metrics for sandbox \"b9c95c4fff0fb91f5cac96d61dcea66c7420fa19b16e729c3468d5f4058c8476\": runc did not terminate successfully: exit status 1: container does not exist\n: unknown") has prevented the request from succeeding (get nodes bootstrap-e2e-minion-group-95dx:10250)
In [It] at: k8s.io/kubernetes/test/e2e/node/node_problem_detector.go:381 @ 09/15/24 00:36:46.272
```