### PR TITLE
replicate pull-crio-cgroupv2-node-e2e-eviction using kubetest2

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3086,6 +3086,62 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
       testgrid-tab-name: pr-crio-cgroupv2-node-e2e-eviction
+  - name: pull-crio-cgroupv2-node-e2e-eviction-kubetest2
+    cluster: k8s-infra-prow-build
+    # explicitly needs /test pull-crio-cgroupv2-node-e2e-eviction-kubetest2 to run
+    always_run: false
+    optional: true
+    max_concurrency: 12
+    skip_report: false
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    decorate: true
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    decoration_config:
+      timeout: 320m
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+    annotations:
+      testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
+      testgrid-tab-name: pr-crio-cgroupv2-node-e2e-eviction-kubetest2
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240923-c8645c1a17-master
+        command:
+        - runner.sh
+        args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-west1-b
+        - --parallelism=1
+        - --focus-regex=\[NodeFeature:Eviction\]
+        - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2.yaml
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+        env:
+          - name: GOPATH
+            value: /go
+          - name: KUBE_SSH_USER
+            value: core
+          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+            value: "1"
   - name: pull-crio-cgroupv2-imagefs-separatedisktest
     cluster: k8s-infra-prow-build
     skip_branches:


### PR DESCRIPTION
This is part of an effort to start using kubetest2 for crio e2e node tests. Being tracked in https://github.com/kubernetes/test-infra/issues/32567. starting with presubmits