### PR TITLE
chore: update owners & reviewers for capa jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
@@ -6,11 +6,13 @@ reviewers:
 - nrb
 - faiq
 - fiunchinho
+- damdo
 approvers:
 - richardcase
 - Ankitasw
 - dlipovetsky
-- vincepri
+- nrb
+- AndiDog
 emeritus_approvers:
 - chuckha
 - detiber
@@ -18,3 +20,4 @@ emeritus_approvers:
 - randomvariable
 - rudoi
 - Skarlso
+- vincepri


### PR DESCRIPTION
This updates the maintainers and owners for the standard capa jobs (not including image promotion).

Relates: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5119
Relates: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5082
Relates: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5081