### PR TITLE
Test the upcoming containerd 2.0.0 (rc5)

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -852,7 +852,7 @@ periodics:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --check-leaked-resources
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.20
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0-rc.5
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.13
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -903,7 +903,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0-rc.4
+      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0-rc.5
       - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.1.13
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false
       - --env=KUBE_PROXY_DAEMONSET=true


### PR DESCRIPTION
Switching over 2 CI jobs to use the RC5 for containerd 2.0.0

xref: https://github.com/containerd/containerd/pull/10752
xref: https://github.com/containerd/containerd/releases/tag/v2.0.0-rc.5
