### PR TITLE
Add mimowo to owners for kueue

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/OWNERS
+++ b/config/jobs/kubernetes-sigs/kueue/OWNERS
@@ -3,8 +3,10 @@
 approvers:
 - ahg-g
 - alculquicondor
+- mimowo
 - tenzen-y
 reviewers:
 - ahg-g
 - alculquicondor
+- mimowo
 - tenzen-y


### PR DESCRIPTION
As mimowo is a top-level approver Kueue: https://github.com/kubernetes-sigs/kueue/blob/main/OWNERS.

/cc @alculquicondor @tenzen-y 