### PR TITLE
chore(deps): bump client-go to use golang 1.22

### DIFF
--- a/config/jobs/kubernetes/client-go/client-go-presubmits.yaml
+++ b/config/jobs/kubernetes/client-go/client-go-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: k8s.io/client-go
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.21
+      - image: public.ecr.aws/docker/library/golang:1.22
         env:
         - name: GO111MODULE
           value: "on"


### PR DESCRIPTION
The pull-client-go-build prow jobs fail at the moment because `go.mod requires go >= 1.22.0`

xref: https://github.com/kubernetes/client-go/pull/1354 