### PR TITLE
kubespray: allow to manage ci labels with /label

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -170,6 +170,10 @@ label:
     - team/katacoda
     # This label, for k/website, identifies PRs with large refactoring changes
     - refactor
+    # These labels are used by kubespray to test more stuff (or less for 'short') on some PRs
+    - ci-short
+    - ci-extended
+    - ci-full
 
   restricted_labels:
     kubernetes/kubernetes:


### PR DESCRIPTION
Follow-up to #33289, to enable the ci-* labels to be managed by org-members with /label commands

I'm not sure this is the correct way to enable label management for org members(kubernetes-sigs), if not, I'll update the PR.

@BenTheElder following the thread on slack in #sig-testing

/cc @yankay @ant31 @tico88612
