### PR TITLE
Ingress NGINX: Bump `e2e-test-runner` to v20241004-114a6abb.

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-nginx/ingress-nginx-presubmit.yaml
@@ -14,7 +14,7 @@ presubmits:
       path_alias: k8s.io/ingress-nginx
       spec:
         containers:
-          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20240829-2c421762@sha256:5b7809bfe9cbd9cd6bcb8033ca27576ca704f05ce729fe4dcb574810f7a25785
+          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20241004-114a6abb@sha256:1389ec0589abbf5c431c9290c4c307437c8396995c63dda5eac26abd70963dc8
             command:
               - hack/verify-boilerplate.sh
             resources:
@@ -39,7 +39,7 @@ presubmits:
       path_alias: k8s.io/ingress-nginx
       spec:
         containers:
-          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20240829-2c421762@sha256:5b7809bfe9cbd9cd6bcb8033ca27576ca704f05ce729fe4dcb574810f7a25785
+          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20241004-114a6abb@sha256:1389ec0589abbf5c431c9290c4c307437c8396995c63dda5eac26abd70963dc8
             command:
               - hack/verify-codegen.sh
             resources:
@@ -64,7 +64,7 @@ presubmits:
       path_alias: k8s.io/ingress-nginx
       spec:
         containers:
-          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20240829-2c421762@sha256:5b7809bfe9cbd9cd6bcb8033ca27576ca704f05ce729fe4dcb574810f7a25785
+          - image: registry.k8s.io/ingress-nginx/e2e-test-runner:v20241004-114a6abb@sha256:1389ec0589abbf5c431c9290c4c307437c8396995c63dda5eac26abd70963dc8
             command:
               - make
             args:


### PR DESCRIPTION
/cc @strongjz @rikatz @cpanato @tao12345666333