### PR TITLE
Update OWNERS

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/OWNERS
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/OWNERS
@@ -2,11 +2,13 @@
 
 reviewers:
   - cheftako
-  - mcrute
-  - anfernee
-  - andrewsykim
+  - ipochi
+  - jkh52
 approvers:
   - cheftako
-  - mcrute
-  - anfernee
+  - ipochi
+  - jkh52
+emeritus_approvers:
   - andrewsykim
+  - anfernee
+  - mcrute


### PR DESCRIPTION
Update OWNERS to match apiserver-network-proxy repo.

Split out from https://github.com/kubernetes/test-infra/pull/33578