### PR TITLE
apidiff: fix controller-runtime branch

### DIFF
--- a/config/jobs/kubernetes/sig-testing/apidiff.yaml
+++ b/config/jobs/kubernetes/sig-testing/apidiff.yaml
@@ -26,7 +26,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: controller-runtime
-      base_ref: master
+      base_ref: main
       path_alias: sigs.k8s.io/controller-runtime
     spec:
       containers:


### PR DESCRIPTION
Development happens on "main", not "master".

/assign @aojea 