### PR TITLE
fix: use bash instead of sh to resolve popd: not found issue in ci-kubernetes-e2e-kind-compatibility-versions

### DIFF
--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2024 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fixes related prow test failure for ci-kubernetes-e2e-kind-compatibility-versions job here:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kind-compatibility-versions/1843382918697717760