### PR TITLE
Kops - Request more resources for digitalocean jobs

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -43,11 +43,11 @@ periodics:
           --parallel 15 \
       resources:
         limits:
-          memory: "3Gi"
-          cpu: "2"
+          cpu: "4"
+          memory: 6Gi
         requests:
-          cpu: "2"
-          memory: "3Gi"
+          cpu: "4"
+          memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: digitalocean
     test.kops.k8s.io/k8s_version: 'stable'
@@ -101,11 +101,11 @@ periodics:
         --parallel 15 \
       resources:
         limits:
-          memory: "3Gi"
-          cpu: "2"
+          cpu: "4"
+          memory: 6Gi
         requests:
-          cpu: "2"
-          memory: "3Gi"
+          cpu: "4"
+          memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: digitalocean
     test.kops.k8s.io/k8s_version: 'stable'
@@ -160,11 +160,11 @@ periodics:
           --parallel 15 \
       resources:
         limits:
-          memory: "3Gi"
-          cpu: "2"
+          cpu: "4"
+          memory: 6Gi
         requests:
-          cpu: "2"
-          memory: "3Gi"
+          cpu: "4"
+          memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: digitalocean
     test.kops.k8s.io/k8s_version: 'stable'


### PR DESCRIPTION
These jobs have been getting killed recently:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-do-calico-gossip/1843394450789765120

```
 github.com/aws/aws-sdk-go-v2/service/ec2: /usr/local/go/pkg/tool/linux_amd64/compile: signal: killed 
```

This updates the resource requests and limits to match our other e2e periodic jobs:

https://github.com/kubernetes/test-infra/blob/25661331b77e58a69896a7a2af8140744535c566/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja#L108-L114

/cc @hakman