### PR TITLE
Turn off branch protection for weekly shared dev branches in LWKD.

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -586,6 +586,9 @@ branch-protection:
               - Test Linux
               - Test MacOS
               - Test Windows
+        lwkd:
+          exclude:
+            - "^20\\d+" # don't protect weekly article dev branch
         metrics-server:
           branches:
             gh-pages:


### PR DESCRIPTION
Because we need to delete the weekly draft editions.