### PR TITLE
Temporarily reduce CAPZ load test nodes to 80

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -818,7 +818,7 @@ presubmits:
         - name: WINDOWS_WORKER_MACHINE_COUNT
           value: "0" # Don't create windows workers
         - name: WORKER_MACHINE_COUNT
-          value: "100"
+          value: "80"
         # clusterloader2 variables
         - name: ENABLE_PROMETHEUS_SERVER
           value: "true"


### PR DESCRIPTION
Since this 100 nodes is reaching the quota limit