### PR TITLE
containerd: pull-containerd-node-e2e-1-7-sandboxed

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -181,8 +181,6 @@ presubmits:
         env:
         - name: USE_TEST_INFRA_LOG_DUMPING
           value: "true"
-        - name: ENABLE_CRI_SANDBOXES
-          value: "true"
         command:
         - sh
         - -c
@@ -200,7 +198,7 @@ presubmits:
           --provider=gce
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
-          "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.7-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+          "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.7-sandboxed-presubmit/image-config-presubmit.yaml -node-env=PULL_REFS=$(PULL_REFS)"
         resources:
           limits:
             cpu: 4

--- a/jobs/e2e_node/containerd/containerd-release-1.7-sandboxed-presubmit/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.7-sandboxed-presubmit/env
@@ -1,0 +1,10 @@
+CONTAINERD_TEST: 'true'
+CONTAINERD_LOG_LEVEL: 'debug'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools'
+CONTAINERD_PKG_PREFIX: 'containerd-cni'
+
+CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'
+CONTAINERD_EXTRA_RUNTIME_OPTIONS: |
+  BinaryName = "/home/containerd/usr/local/sbin/runc"
+CONTAINERD_SYSTEMD_CGROUP: 'true'
+CONTAINERD_ENABLE_CRI_SANDBOXES: 'true'

--- a/jobs/e2e_node/containerd/containerd-release-1.7-sandboxed-presubmit/image-config-presubmit.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.7-sandboxed-presubmit/image-config-presubmit.yaml
@@ -1,0 +1,5 @@
+images:
+  cos-stable:
+    image_family: cos-beta
+    project: cos-cloud
+    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main-presubmit/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
This change will enable the pull-containerd-node-e2e-1-7-sandboxed job to pass down configuration enabling CRI sandboxes in containerd 1.7. This is an optional CRI backend in 1.7 and will be the new backend in containerd 2.0.

Corresponding containerd change: https://github.com/containerd/containerd/pull/10801