### PR TITLE
containerd: use correct env for presubmit jobs

### DIFF
--- a/jobs/e2e_node/containerd/containerd-release-1.7-presubmit/image-config-presubmit.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.7-presubmit/image-config-presubmit.yaml
@@ -2,4 +2,4 @@ images:
   cos-stable:
     image_family: cos-beta
     project: cos-cloud
-    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main-presubmit/env,gci-update-strategy=update_disabled"
+    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.7-presubmit/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-release-1.7-sandboxed-presubmit/image-config-presubmit.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.7-sandboxed-presubmit/image-config-presubmit.yaml
@@ -2,4 +2,4 @@ images:
   cos-stable:
     image_family: cos-beta
     project: cos-cloud
-    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main-presubmit/env,gci-update-strategy=update_disabled"
+    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.7-sandboxed-presubmit/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
This is effectively no change for containerd-release-1.7-presubmit as the env file is identical between that job and containerd-main-presubmit, but there is a difference for containerd-release-1.7-sandboxed-presubmit.