### PR TITLE
bump label_sync to v20241009-8bb28ed95b

### DIFF
--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-staging-test-infra/label_sync:v20240801-a5d9345e59
+              image: gcr.io/k8s-staging-test-infra/label_sync:v20241009-8bb28ed95b
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never  # https://github.com/kubernetes/kubernetes/issues/54870
       containers:
       - name: label-sync
-        image: gcr.io/k8s-staging-test-infra/label_sync:v20240801-a5d9345e59
+        image: gcr.io/k8s-staging-test-infra/label_sync:v20241009-8bb28ed95b
         args:
         - --config=/etc/config/labels.yaml
         - --confirm=true


### PR DESCRIPTION
https://kubernetes.slack.com/archives/C1TU9EB9S/p1728358394071729  

After https://github.com/kubernetes/test-infra/pull/33601 was merged, update the label sync image to latest.


This will help to fix https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-test-infra-label-sync.
