### PR TITLE
Setup release-0.14 branch jobs for CAPI Operator

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-14.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-14.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-operator-test-release-0-13
+- name: periodic-cluster-api-operator-test-release-0-14
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
@@ -8,7 +8,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-operator
-    base_ref: release-0.13
+    base_ref: release-0.14
     path_alias: sigs.k8s.io/cluster-api-operator
   spec:
     containers:
@@ -23,11 +23,11 @@ periodics:
           cpu: "1"
           memory: "2Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.13
-    testgrid-tab-name: capi-operator-test-release-0-13
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.14
+    testgrid-tab-name: capi-operator-test-release-0-14
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-operator-e2e-release-0-13
+- name: periodic-cluster-api-operator-e2e-release-0-14
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
@@ -39,7 +39,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-operator
-    base_ref: release-0.13
+    base_ref: release-0.14
     path_alias: sigs.k8s.io/cluster-api-operator
   spec:
     containers:
@@ -58,7 +58,7 @@ periodics:
           cpu: "1"
           memory: "2Gi"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.13
-    testgrid-tab-name: capi-operator-e2e-release-0-13
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.14
+    testgrid-tab-name: capi-operator-e2e-release-0-14
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-14.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-14.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes-sigs/cluster-api-operator:
-  - name: pull-cluster-api-operator-build-release-0-13
+  - name: pull-cluster-api-operator-build-release-0-14
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -9,7 +9,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.13$
+    - ^release-0.14$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240923-c8645c1a17-1.27
@@ -24,9 +24,9 @@ presubmits:
             cpu: "1"
             memory: "2Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.13
-      testgrid-tab-name: capi-operator-pr-build-release-0-13
-  - name: pull-cluster-api-operator-make-release-0-13
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.14
+      testgrid-tab-name: capi-operator-pr-build-release-0-14
+  - name: pull-cluster-api-operator-make-release-0-14
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -36,7 +36,7 @@ presubmits:
       preset-dind-enabled: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.13$
+    - ^release-0.14$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240923-c8645c1a17-1.27
@@ -54,9 +54,9 @@ presubmits:
             cpu: "4"
             memory: "8Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.13
-      testgrid-tab-name: capi-operator-pr-make-release-0-13
-  - name: pull-cluster-api-operator-apidiff-release-0-13
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.14
+      testgrid-tab-name: capi-operator-pr-make-release-0-14
+  - name: pull-cluster-api-operator-apidiff-release-0-14
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -65,7 +65,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.13$
+    - ^release-0.14$
     run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
@@ -81,9 +81,9 @@ presubmits:
             cpu: "1"
             memory: "2Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.13
-      testgrid-tab-name: capi-operator-pr-apidiff-release-0-13
-  - name: pull-cluster-api-operator-verify-release-0-13
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.14
+      testgrid-tab-name: capi-operator-pr-apidiff-release-0-14
+  - name: pull-cluster-api-operator-verify-release-0-14
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -92,7 +92,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.13$
+    - ^release-0.14$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240923-c8645c1a17-1.27
@@ -107,9 +107,9 @@ presubmits:
             cpu: "1"
             memory: "2Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.13
-      testgrid-tab-name: capi-operator-pr-verify-release-0-13
-  - name: pull-cluster-api-operator-test-release-0-13
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.14
+      testgrid-tab-name: capi-operator-pr-verify-release-0-14
+  - name: pull-cluster-api-operator-test-release-0-14
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -117,7 +117,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.13$
+    - ^release-0.14$
     run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
@@ -133,9 +133,9 @@ presubmits:
             cpu: "1"
             memory: "2Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.13
-      testgrid-tab-name: capi-operator-pr-test-release-0-13
-  - name: pull-cluster-api-operator-e2e-release-0-13
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.14
+      testgrid-tab-name: capi-operator-pr-test-release-0-14
+  - name: pull-cluster-api-operator-e2e-release-0-14
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
@@ -146,7 +146,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - ^release-0.13$
+    - ^release-0.14$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240923-c8645c1a17-1.27
@@ -165,5 +165,5 @@ presubmits:
             cpu: "4"
             memory: "8Gi"
     annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.13
-      testgrid-tab-name: capi-operator-pr-e2e-release-0-13
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator-0.14
+      testgrid-tab-name: capi-operator-pr-e2e-release-0-14

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -19,7 +19,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-cluster-api-provider-openstack
     - sig-cluster-lifecycle-cluster-api-provider-cloudstack
     - sig-cluster-lifecycle-cluster-api-provider-nested
-    - sig-cluster-lifecycle-cluster-api-operator-0.13
+    - sig-cluster-lifecycle-cluster-api-operator-0.14
     - sig-cluster-lifecycle-cluster-api-operator
     - sig-cluster-lifecycle-kops
     - sig-cluster-lifecycle-image-pushes
@@ -62,7 +62,7 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
 - name: sig-cluster-lifecycle-cluster-api-provider-cloudstack
 - name: sig-cluster-lifecycle-cluster-api-provider-nested
-- name: sig-cluster-lifecycle-cluster-api-operator-0.13
+- name: sig-cluster-lifecycle-cluster-api-operator-0.14
 - name: sig-cluster-lifecycle-cluster-api-operator
 - name: sig-cluster-lifecycle-kops
 - name: sig-cluster-lifecycle-image-pushes


### PR DESCRIPTION
Bump release branch jobs to track the [release-0.14](https://github.com/kubernetes-sigs/cluster-api-operator/tree/release-0.14), the latest operator branch.