### PR TITLE
pull-kubernetes-node-e2e-cri-proxy-serial is not updated to `test`

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -893,6 +893,10 @@ periodics:
       base_ref: master
       path_alias: k8s.io/kubernetes
       workdir: true
+    - org: containerd
+      repo: containerd
+      base_ref: main
+      path_alias: github.com/containerd/containerd
     - org: kubernetes
       repo: test-infra
       base_ref: master

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -4112,7 +4112,6 @@ presubmits:
               requests:
                 cpu: 8
                 memory: 10Gi
-
     - name: pull-kubernetes-node-e2e-cri-proxy-serial
       cluster: k8s-infra-prow-build
       branches:
@@ -4135,6 +4134,15 @@ presubmits:
       path_alias: k8s.io/kubernetes
       extra_refs:
         - org: kubernetes
+          repo: kubernetes
+          base_ref: master
+          path_alias: k8s.io/kubernetes
+          workdir: true
+        - org: containerd
+          repo: containerd
+          base_ref: main
+          path_alias: github.com/containerd/containerd
+        - org: kubernetes
           repo: test-infra
           base_ref: master
           path_alias: k8s.io/test-infra
@@ -4148,7 +4156,7 @@ presubmits:
               - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
               - --deployment=node
               - --gcp-zone=us-central1-b
-              - '--node-test-args=--cri-proxy-enabled=true  --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
+              - '--node-test-args=--cri-proxy-enabled=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
               - --node-tests=true
               - --provider=gce
               # all criproxy tests are serial, but no need to specify it


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/33547 was merged for 2 days and 

```
/test pull-kubernetes-node-e2e-cri-proxy-serial
```
still not work

But https://testgrid.k8s.io/sig-node-presubmits#pr-node-kubelet-cri-proxy is already available.