### PR TITLE
set ci-k8sio-file-promo-mirrors to 3h

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -135,6 +135,8 @@ periodics:
   max_concurrency: 1
   name: ci-k8sio-file-promo-mirrors
   decorate: true
+  decoration_config:
+    timeout: 3h
   extra_refs:
   - org: kubernetes
     repo: k8s.io


### PR DESCRIPTION
xref https://github.com/kubernetes/k8s.io/issues/7391

https://testgrid.k8s.io/sig-release-releng-blocking#ci-k8sio-file-promo-mirrors


> {"component":"entrypoint","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:169","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 2h0m0s timeout","severity":"error","time":"2024-10-10T04:35:35Z"}


