### PR TITLE
DRA: prepare for beta and new alpha features

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2728,14 +2728,14 @@ presubmits:
   # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha, soon beta)
   # on a kind cluster with containerd updated to a version with CDI support.
   #
-  # Compared to pull-kubernetes-dra, this one also adds all DRA-related alpha features.
-  - name: pull-kubernetes-kind-dra-alpha
+  # Compared to pull-kubernetes-dra, this one enables all DRA-related features.
+  - name: pull-kubernetes-kind-dra-all
     cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+\.\d+  # per-release image
     annotations:
       testgrid-dashboards: sig-node-presubmits
-      testgrid-tab-name: pr-kind-dra-alpha
+      testgrid-tab-name: pr-kind-dra-all
     decorate: true
     path_alias: k8s.io/kubernetes
     # Not relevant for most PRs.
@@ -2759,13 +2759,18 @@ presubmits:
         args:
         - /bin/bash
         - -xc
-        - >
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
-          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
-          kind build node-image --image=dra/node:latest . &&
-          trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT &&
-          kind create cluster --retain --config <(cat test/e2e/dra/kind.yaml; echo "  DRAAdminAccess: true") --image dra/node:latest &&
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=1h hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf {DynamicResourceAllocation, DRAAdminAccess} && !Flaky && !Slow'
+        - |
+          set -ex
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          kind build node-image --image=dra/node:latest .
+          trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT
+          # Which DRA features exist depends on the PR that is being tested.
+          features=( $(grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/') )
+          echo "Enabling DRA feature(s): ${features[*]}."
+          # Those additional features are not in kind.yaml, but they can be added at the end.
+          kind create cluster --retain --config <(cat test/e2e/dra/kind.yaml; for feature in ${features}; do echo "  ${feature}: true"; done) --image dra/node:latest
+          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=1h hack/ginkgo-e2e.sh -ginkgo.label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf {DynamicResourceAllocation$(for feature in ${features}; do echo , ${feature}; done)} && !Flaky && !Slow"
 
         # docker-in-docker needs privileged mode
         securityContext:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2671,7 +2671,7 @@ presubmits:
             cpu: 4
             memory: 6Gi
 
-  # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha)
+  # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha, soon beta)
   # on a kind cluster with containerd updated to a version with CDI support.
   - name: pull-kubernetes-kind-dra
     cluster: k8s-infra-prow-build
@@ -2725,16 +2725,17 @@ presubmits:
             memory: "9000Mi"
             cpu: 2000m
 
-  # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha)
-  # on a kind cluster with containerd updated to a version with CDI support. It also enables and tests the
-  # DRAControlPlaneController feature.
-  - name: pull-kubernetes-kind-classic-dra
+  # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha, soon beta)
+  # on a kind cluster with containerd updated to a version with CDI support.
+  #
+  # Compared to pull-kubernetes-dra, this one also adds all DRA-related alpha features.
+  - name: pull-kubernetes-kind-dra-alpha
     cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+\.\d+  # per-release image
     annotations:
       testgrid-dashboards: sig-node-presubmits
-      testgrid-tab-name: pr-kind-classic-dra
+      testgrid-tab-name: pr-kind-dra-alpha
     decorate: true
     path_alias: k8s.io/kubernetes
     # Not relevant for most PRs.
@@ -2756,15 +2757,15 @@ presubmits:
         command:
         - runner.sh
         args:
-        - /bin/sh
+        - /bin/bash
         - -xc
         - >
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
           kind build node-image --image=dra/node:latest . &&
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT &&
-          kind create cluster --retain --config test/e2e/dra/kind-classic-dra.yaml --image dra/node:latest &&
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=1h hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf {DynamicResourceAllocation, DRAControlPlaneController} && !Flaky && !Slow'
+          kind create cluster --retain --config <(cat test/e2e/dra/kind.yaml; echo "  DRAAdminAccess: true") --image dra/node:latest &&
+          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=1h hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf {DynamicResourceAllocation, DRAAdminAccess} && !Flaky && !Slow'
 
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
pull-kubernetes-kind-dra remains as-is and will be used to test the core functionality (soon beta).

pull-kubernetes-kind-dra-all replaces pr-kind-classic-dra (to be removed soon) and enables additional alpha features. DRAAdminAccess is about to be added, others will follow.

/cc @klueska @johnbelamaric 
