### PR TITLE
filter out swap tests on sig-node presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1804,7 +1804,7 @@ presubmits:
         - --provider=gce
         # *Manager jobs are skipped because they have corresponding test lanes with the right image
         # These jobs in serial get partially skipped and are long jobs.
-        - --test_args=--timeout=3h --nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]"
+        - --test_args=--timeout=3h --nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[NodeFeature:NodeSwap\]"
         - --timeout=3h
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-serial.yaml
         resources:
@@ -1857,7 +1857,7 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --parallelism=1
         - --focus-regex=\[Serial\]
-        - --skip-regex=\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]
+        - --skip-regex=\[Flaky\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[NodeFeature:NodeSwap\]
         - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-serial.yaml
         resources:


### PR DESCRIPTION
Swap tests shouldn't be run on cgroupv1 systems as they fail trying to access cgroupv1 sysfs entries, e.g.
```
[sig-node] Swap [LinuxOnly] [NodeFeature:NodeSwap] [Serial] [NodeConformance] with a critical pod - should avoid swap [sig-node, NodeFeature:NodeSwap, Serial, NodeConformance]
k8s.io/kubernetes/test/e2e_node/swap_test.go:88
  STEP: Creating a kubernetes client @ 10/10/24 15:15:11.265
  STEP: Building a namespace api object, basename swap-qos @ 10/10/24 15:15:11.265
  I1010 15:15:11.269193 3179 framework.go:275] Skipping waiting for service account
  STEP: figuring if NodeSwap feature gate is turned on @ 10/10/24 15:15:11.269
  STEP: Creating a critical pod @ 10/10/24 15:15:11.269
  STEP: running swap test pod @ 10/10/24 15:15:11.269
  STEP: expecting pod to not have swap access @ 10/10/24 15:15:13.281
  STEP: expecting no swap @ 10/10/24 15:15:13.281
  I1010 15:15:13.281835 3179 exec_util.go:59] ExecWithOptions {Command:[sh -c cat /sys/fs/cgroup/memory.swap.max] Namespace:swap-qos-2096 PodName:sleeping-test-pod-swap-tnm4d ContainerName:busybox-container Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
  I1010 15:15:13.281858 3179 exec_util.go:66] ExecWithOptions: Clientset creation
  I1010 15:15:13.281899 3179 exec_util.go:82] ExecWithOptions: execute(POST https://127.0.0.1:6443/api/v1/namespaces/swap-qos-2096/pods/sleeping-test-pod-swap-tnm4d/exec?command=sh&command=-c&command=cat+%2Fsys%2Ffs%2Fcgroup%2Fmemory.swap.max&container=busybox-container&stderr=true&stdout=true)
  I1010 15:15:13.334779 3179 exec_util.go:110] Exec stderr: "cat: can't open '/sys/fs/cgroup/memory.swap.max': No such file or directory"
  I1010 15:15:13.334868 3179 exec_util.go:111] Unexpected error: failed to execute command in pod sleeping-test-pod-swap-tnm4d, container busybox-container: command terminated with exit code 1: 
      <exec.CodeExitError>: 
      command terminated with exit code 1
      {
          Err: <*errors.errorString | 0xc000e55800>{
              s: "command terminated with exit code 1",
          },
          Code: 1,
      }
  [FAILED] in [It] - k8s.io/kubernetes/test/e2e/framework/pod/exec_util.go:111 @ 10/10/24 15:15:13.335
```