### PR TITLE
etcd: mark etcd arm integration presubmits as blocking

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -293,7 +293,6 @@ presubmits:
             memory: "3Gi"
 
   - name: pull-etcd-integration-1-cpu-arm64
-    optional: true # remove when stable
     cluster: k8s-infra-prow-build
     always_run: true
     branches:
@@ -356,7 +355,6 @@ presubmits:
             memory: "3Gi"
 
   - name: pull-etcd-integration-2-cpu-arm64
-    optional: true # remove when stable
     cluster: k8s-infra-prow-build
     always_run: true
     branches:
@@ -419,7 +417,6 @@ presubmits:
             memory: "3Gi"
 
   - name: pull-etcd-integration-4-cpu-arm64
-    optional: true # remove when stable
     cluster: k8s-infra-prow-build
     always_run: true
     branches:


### PR DESCRIPTION
The integration ARM jobs have been relatively stable over the past two weeks:

* [1 CPU](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-etcd-integration-1-cpu-arm64)
* [2 CPUs](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-etcd-integration-2-cpu-arm64)
* [4 CPUs](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-etcd-integration-4-cpu-arm64)

Therefore, it would be a good time to mark them as blocking and remove the GitHub workflow from the repository (as these are the last remaining ARM jobs we have).

Part to #32754 / kubernetes/k8s.io#6102