### PR TITLE
update: pull-kubernetes-e2e-gci-gce-ingress run regex

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -10,7 +10,7 @@ presubmits:
     - master
     - main
     always_run: false
-    run_if_changed: '^(test/e2e/network/|pkg/apis/networking)'
+    run_if_changed: '^(test/e2e/network/|pkg/apis/networking|pkg/proxy)'
     optional: true
     decorate: true
     decoration_config:


### PR DESCRIPTION
This adds `pkg/proxy` path to the trigger path for `pull-kubernetes-e2e-gci-gce-ingress`