### PR TITLE
Kettle subscribes to gs://kubernetes-ci-logs changes.

### DIFF
--- a/kettle/deployment.yaml
+++ b/kettle/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: DEPLOYMENT
           value: prod
         - name: SUBSCRIPTION_PATH
-          value: kubernetes-jenkins/gcs-changes/kettle-filtered
+          value: kubernetes-public/kubernetes-ci-logs-updates/k8s-infra-kettle
         resources:
           requests:
             memory: 4Gi


### PR DESCRIPTION
Switch kettle from the old PubSub subscription on kubernetes-jenkins to one on kubernetes-ci-logs.

Ref: https://github.com/kubernetes/test-infra/issues/33381

(I believe no jobs care about this file, so this is just for consistency. The only auto-deploy job I found for Kettle is on the file in k8s.io: https://github.com/kubernetes/test-infra/blob/cd57fdbec5cdc52c6a9235d3c2d7db85fd5e8b53/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps.yaml#L128)