### PR TITLE
Clean up most references to kubernetes-jenkins.

### DIFF
--- a/config/jobs/README.md
+++ b/config/jobs/README.md
@@ -78,7 +78,7 @@ A presubmit job named "pull-community-verify" that will run against all PRs to
 kubernetes/community's master branch. It will run `make verify` in a checkout
 of kubernetes/community at the PR's HEAD. It will report back to the PR via a
 status context named `pull-kubernetes-community`. Its logs and results are going
-to end up in GCS under `kubernetes-jenkins/pr-logs/pull/community`. Historical
+to end up in GCS under `kubernetes-ci-logs/pr-logs/pull/community`. Historical
 results will display in testgrid on the `sig-contribex-community` dashboard
 under the `pull-verify` tab
 
@@ -110,7 +110,7 @@ branch. It will run `./scripts/ci-aws-cred-test.sh` in a checkout of the repo
 located at `sigs.k8s.io/cluster-api-provider-aws`. The presets it's using will
 ensure it has aws credentials and aws ssh keys in well known locations. Its
 logs and results are going to end up in GCS under 
-`kubernetes-jenkins/logs/periodic-cluster-api-provider-aws-test-creds`.
+`kubernetes-ci-logs/logs/periodic-cluster-api-provider-aws-test-creds`.
 Historical results will display in testgrid on the `sig-cluster-lifecycle-cluster-api-provider-aws`
 dashboard under the `test-creds` tab
 

--- a/images/builder/README.md
+++ b/images/builder/README.md
@@ -53,16 +53,16 @@ go run ./images/builder [options] path/to/build-directory/
 ### A note about logging in Prow
 
 Prow job logs can be viewed at a URI constructed as follows:
-`https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/<job-name>/<job-number>` e.g.,
-https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-prototype-build/1187171788975509509
+`https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/<job-name>/<job-number>` e.g.,
+https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-prototype-build/1187171788975509509
 
 When `--log-dir` is specified (which is the default case when running in Prow),
 the GCB build logs will be written to a set of log files, based on the variant(s).
 
 For example:
-- No variant --> `build.log` (https://storage.googleapis.com/kubernetes-jenkins/logs/post-release-push-image-k8s-cloud-builder/1186437931728900096/artifacts/build.log)
-- Variant: `build-ci` --> `build-ci.log` (https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-prototype-build/1187156434249322500/artifacts/build-ci.log)
+- No variant --> `build.log` (https://storage.googleapis.com/kubernetes-ci-logs/logs/post-release-push-image-k8s-cloud-builder/1186437931728900096/artifacts/build.log)
+- Variant: `build-ci` --> `build-ci.log` (https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-prototype-build/1187156434249322500/artifacts/build-ci.log)
 
 For single-variant jobs where the preference is to log directly to stdout (so
-that the log is instead visible in `https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/<job-name>/<job-number>`),
+that the log is instead visible in `https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/<job-name>/<job-number>`),
 `LOG_TO_STDOUT="y"` can be specified.

--- a/kettle/OVERVIEW.md
+++ b/kettle/OVERVIEW.md
@@ -40,7 +40,7 @@ This stage gets run for each [BigQuery] table that Kettle is tasked with uploadi
 This step uploads all of the `tar.gz` data to BQ while conforming to the [Schema], this schema must match the defined fields within [BigQuery] (see README for details on adding fields).
 
 # Stream Results
-After all historical data has been uploaded, Kettle enters a Streaming phase. It subscribes to pub-sub results from `kubernetes-jenkins/gcs-changes/kettle` (or the specified GCS subscription path) and listens for events (Jobs completing). When a job triggers an event, it:
+After all historical data has been uploaded, Kettle enters a Streaming phase. It subscribes to pub-sub results from `kubernetes-public/kubernetes-ci-logs-updates/k8s-infra-kettle` (or the specified GCS subscription path) and listens for events (Jobs completing). When a job triggers an event, it:
 - will collect data for this job
 - insert it in the database
 - create a BQ client

--- a/kettle/deployment-staging.yaml
+++ b/kettle/deployment-staging.yaml
@@ -31,7 +31,7 @@ spec:
         - name: DEPLOYMENT
           value: staging
         - name: SUBSCRIPTION_PATH
-          value: kubernetes-jenkins/gcs-changes/kettle-staging
+          value: kubernetes-public/kubernetes-ci-logs-updates/k8s-infra-kettle-staging
         volumeMounts:
         - name: data
           mountPath: /data

--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -235,7 +235,7 @@ def load_sub(poll):
 
     Args:
         poll: Follow GCS changes from project/topic/subscription
-              Ex: kubernetes-jenkins/gcs-changes/kettle
+              Ex: kubernetes-public/kubernetes-ci-logs-updates/k8s-infra-kettle
 
     Return:
         Subscribed client

--- a/robots/commenter/main_test.go
+++ b/robots/commenter/main_test.go
@@ -64,7 +64,7 @@ func TestParseHTMLURL(t *testing.T) {
 		},
 		{
 			name: "weird issue",
-			url:  "https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce/11947/",
+			url:  "https://gubernator.k8s.io/build/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gci-gce/11947/",
 			fail: true,
 		},
 	}

--- a/testgrid/config.md
+++ b/testgrid/config.md
@@ -132,7 +132,7 @@ Ex:
 ```yaml
 test_groups:
 - name: {test_group_name}
-  gcs_prefix: kubernetes-jenkins/logs/{test_group_name}
+  gcs_prefix: kubernetes-ci-logs/logs/{test_group_name}
 ```
 
 See the `TestGroup` message in [`config.proto`] for additional fields to
@@ -198,7 +198,7 @@ Specify `days_of_results` in a test group to increase or decrease the number of 
 ```yaml
 test_groups:
 - name: kubernetes-build
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build
+  gcs_prefix: kubernetes-ci-logs/logs/ci-kubernetes-build
   days_of_results: 7
 ```
 
@@ -273,7 +273,7 @@ for your test group. Example:
 test_groups:
 - name: ci-kubernetes-e2e-gce-ubuntudev-k8sdev-default
   gcs_prefix:
-  kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-default
+  kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-default
   column_header:
   - configuration_value: Commit
   - configuration_value: my_custom_key
@@ -305,7 +305,7 @@ runs).
 # haven't run in the last day.
 test_groups:
 - name: ci-kubernetes-e2e-gce
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce
+  gcs_prefix: kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce
   alert_stale_results_hours: 24
   num_failures_to_alert: 3
 
@@ -338,7 +338,7 @@ If you run multiple versions of a test against different parameters, show which 
 ```yaml
 # Show a test case as "{test_case_name} [{Context}]"
 - name: ci-kubernetes-node-kubelet-benchmark
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-benchmark
+  gcs_prefix: kubernetes-ci-logs/logs/ci-kubernetes-node-kubelet-benchmark
   test_name_config:
     name_elements:
     - target_config: Tests name
@@ -392,7 +392,7 @@ or
 ```yaml
 test_groups:  # Attach to a specific test_group
 - name: kubernetes-build
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build
+  gcs_prefix: kubernetes-ci-logs/logs/ci-kubernetes-build
   notifications:
   - summary: Hello world (first notification)
   - summary: Tests are failing to start (second notification).
@@ -407,7 +407,7 @@ TestGrid uses this to calculate things like 'is this test stale?' (and hides the
 ```yaml
 test_groups:
 - name: kubernetes-build
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build
+  gcs_prefix: kubernetes-ci-logs/logs/ci-kubernetes-build
   num_columns_recent: 3
 ```
 
@@ -432,7 +432,7 @@ be shown if we have data for them. If you want to have these not show up, add:
 ```yaml
 test_groups:
 - name: kubernetes-build
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build
+  gcs_prefix: kubernetes-ci-logs/logs/ci-kubernetes-build
   ignore_pending: true
 ```
 
@@ -443,7 +443,7 @@ Specify `short_text_metric` to display a custom numeric metric in the TestGrid c
 ```yaml
 test_groups:
 - name: ci-kubernetes-coverage-conformance
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-coverage-conformance
+  gcs_prefix: kubernetes-ci-logs/logs/ci-kubernetes-coverage-conformance
   short_text_metric: coverage
 ```
 

--- a/testgrid/conformance/design.md
+++ b/testgrid/conformance/design.md
@@ -39,17 +39,17 @@ For each scenario the command line will look something like the following.
 
 - Forwarding to testgrid from e2e.log and junit.xml already obtained by the user (EG dumped from the cluster or downloaded manually from Scanner, etc...):
 
-`conformance2testgrid --bucket=gs://kubernetes-jenkins/logs/foo-job-name --junit=/path/to/junit_01.xml --log=/path/to/e2e.log`
+`conformance2testgrid --bucket=gs://kubernetes-ci-logs/logs/foo-job-name --junit=/path/to/junit_01.xml --log=/path/to/e2e.log`
 
 - Forwarding to testgrid from a running cluster that has just run the tests (assumes kubectl in path and KUBECONFIG pointed at the cluster):
 
-`conformance2testgrid --bucket=gs://kubernetes-jenkins/logs/foo-job-name --dump-from-cluster`
+`conformance2testgrid --bucket=gs://kubernetes-ci-logs/logs/foo-job-name --dump-from-cluster`
 
 - Forwarding to testgrid from Heptio Scanner results (automatically downloaded by the tool):
 
-`conformance2testgrid --bucket=gs://kubernetes-jenkins/logs/foo-job-name --scanner-url=https://scanner.heptio.com/3f15e956994d70722e8e306b7bd4d13d/diagnostics/`
+`conformance2testgrid --bucket=gs://kubernetes-ci-logs/logs/foo-job-name --scanner-url=https://scanner.heptio.com/3f15e956994d70722e8e306b7bd4d13d/diagnostics/`
 
-`conformance2testgrid --bucket=gs://kubernetes-jenkins/logs/foo-job-name --scanner-uuid=3f15e956994d70722e8e306b7bd4d13d`
+`conformance2testgrid --bucket=gs://kubernetes-ci-logs/logs/foo-job-name --scanner-uuid=3f15e956994d70722e8e306b7bd4d13d`
 
 _Note: Scanner integration was dropped in the final design in order to focus on Continuous Integration results, however the tool can still be used to upload scanner results once they've been downloaded._
 

--- a/triage/script_test.js
+++ b/triage/script_test.js
@@ -33,14 +33,14 @@ describe('spyglassURLForBuild', () => {
     }
     builds = {
       jobPaths: {
-        'pr:pull-kubernetes-verify': 'gs://kubernetes-jenkins/pr-logs/pull/122078/pull-kubernetes-verify',
-        'pr:cloud-provider-gcp-e2e-full': 'gs://kubernetes-jenkins/pr-logs/pull/cloud-provider-gcp/636/cloud-provider-gcp-e2e-full',
-        'pr:pull-cluster-api-provider-azure-e2e': 'gs://kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/4302/pull-cluster-api-provider-azure-e2e',
+        'pr:pull-kubernetes-verify': 'gs://kubernetes-ci-logs/pr-logs/pull/122078/pull-kubernetes-verify',
+        'pr:cloud-provider-gcp-e2e-full': 'gs://kubernetes-ci-logs/pr-logs/pull/cloud-provider-gcp/636/cloud-provider-gcp-e2e-full',
+        'pr:pull-cluster-api-provider-azure-e2e': 'gs://kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/4302/pull-cluster-api-provider-azure-e2e',
       }
     };
-    expect('handles k/k jobs', 'https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/122272/pull-kubernetes-verify/1734547176656211968', {job: 'pr:pull-kubernetes-verify', number: '1734547176656211968', pr: '122272'});
-    expect('handles non-k/k jobs in the kubernetes org', 'https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/cloud-provider-gcp/638/cloud-provider-gcp-e2e-full/1734630461432401920', {job: 'pr:cloud-provider-gcp-e2e-full', number: '1734630461432401920', pr: '638'});
-    expect('handles non-kubernetes org jobs', 'https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/4345/pull-cluster-api-provider-azure-e2e/1734613965410930688', {job: 'pr:pull-cluster-api-provider-azure-e2e', number: '1734613965410930688', pr: '4345'});
+    expect('handles k/k jobs', 'https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/122272/pull-kubernetes-verify/1734547176656211968', {job: 'pr:pull-kubernetes-verify', number: '1734547176656211968', pr: '122272'});
+    expect('handles non-k/k jobs in the kubernetes org', 'https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/cloud-provider-gcp/638/cloud-provider-gcp-e2e-full/1734630461432401920', {job: 'pr:cloud-provider-gcp-e2e-full', number: '1734630461432401920', pr: '638'});
+    expect('handles non-kubernetes org jobs', 'https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/4345/pull-cluster-api-provider-azure-e2e/1734613965410930688', {job: 'pr:pull-cluster-api-provider-azure-e2e', number: '1734613965410930688', pr: '4345'});
 })
 
 describe('Clusters', () => {


### PR DESCRIPTION
There are a few references remaining in test-infra after this, but I believe they mostly fall under defunct tooling (Gubernator, experiment/ml, scenarios/kubernetes_e2e?), are referencing actual links to builds that are not necessarily in kubernetes-ci-logs, or are still needed for compatibility (for a while).

Ref: https://github.com/kubernetes/test-infra/issues/33381