### PR TITLE
update ci-kubernetes-e2e-gce-scale-correctness  days_of_results to 60

### DIFF
--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -49,7 +49,7 @@ test_groups:
   short_text_metric: coverage
 - name: ci-kubernetes-e2e-gce-scale-correctness
   gcs_prefix: kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-correctness
-  days_of_results: 60
+  days_of_results: 30
   num_columns_recent: 3
 - name: ci-kubernetes-e2e-gce-scale-performance
   gcs_prefix: kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-performance


### PR DESCRIPTION
https://testgrid.k8s.io/sig-release-master-informing#gce-master-scale-correctness shows
- https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-correctness

> Internal Error: Refresh, and file an issue if problem persists. (Your table may be too big; consider lower `days_of_results` or `enable_test_methods = false`).

The current days_of_results is 60 days. It runs every 2 days.
- So it has 30 jobs.
- Each job has 1245/6621 Test

https://testgrid.k8s.io/presubmits-kubernetes-scalability#pull-kubernetes-e2e-gce-correctness is the presubmit CI for the same test cases. It is a long list.
I would suggest change the days_of_results to 30 or 40 to give a try.

@wendy-ha18 