### PR TITLE
skip NodeSwap pull-kubernetes-node-arm64-ubuntu-serial-gce

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -296,7 +296,7 @@ presubmits:
           - --focus-regex=\[Serial\]
           - --use-dockerized-build=true
           - --target-build-arch=linux/arm64
-          - --skip-regex=\[Flaky\]|\[Slow\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:DynamicResourceAllocation\]
+          - --skip-regex=\[Flaky\]|\[Slow\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[NodeFeature:NodeSwap\]
           - '--test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/image-config-serial.yaml
         securityContext:


### PR DESCRIPTION
https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-kubernetes-node-arm64-ubuntu-serial-gce
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/120459/pull-kubernetes-node-arm64-ubuntu-serial-gce/1845664240568897536
```
E2eNode Suite: [It] [sig-node] Swap [LinuxOnly] [NodeFeature:NodeSwap] [Serial] [Serial] with swap stress LimitedSwap should be able to use more than the node memory capacity

- Reason: skipped - swap is not provisioned on the node
```
We can skip those Swap e2e  here as the swap is not enabled on the node.

- The failure of the CI is not swap related but kubelet restart and not available.

