### PR TITLE
synchronized pull and ci arm64-e2e-containerd-ec2-canary job configs

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd-presubmit.yaml
@@ -103,6 +103,8 @@ presubmits:
       optional: true
       cluster: eks-prow-build-cluster
       decorate: true
+      decoration_config:
+        timeout: 240m
       extra_refs:
         - org: kubernetes
           repo: kubernetes
@@ -128,17 +130,17 @@ presubmits:
               - name: IMAGE_CONFIG_FILE
                 value: aws-instance-arm64.yaml
               - name: TEST_ARGS
-                value: '--kubelet-flags="--cgroup-driver=cgroupfs"'
+                value: '--kubelet-flags="--cgroup-driver=systemd"'
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
               limits:
-                cpu: 4
-                memory: 6Gi
+                cpu: 8
+                memory: 10Gi
               requests:
-                cpu: 4
-                memory: 6Gi
+                cpu: 8
+                memory: 10Gi
     - name: pull-kubernetes-node-e2e-containerd-serial-ec2-canary
       # duplicate job of in the k/k repo to test changes in provider-aws-test-infra repo
       annotations:


### PR DESCRIPTION
This PR is similar to https://github.com/kubernetes/test-infra/pull/33640
I hope it fixes [pull-kubernetes-node-arm64-e2e-containerd-ec2-canary](https://testgrid.k8s.io/sig-node-ec2#pull-kubernetes-node-arm64-e2e-containerd-ec2-canary&width=90) job.