### PR TITLE
Kueue: upgrade Go version to 1.23

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -13,7 +13,7 @@ presubmits:
       description: "Run kueue unit tests"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         env:
         - name: GO_TEST_FLAGS
           value: "-race -count 3"
@@ -43,7 +43,7 @@ presubmits:
       description: "Run kueue test-integration"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         command:
         - make
         args:
@@ -80,7 +80,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.28.9
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.22
+              value: public.ecr.aws/docker/library/golang:1.23
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -118,7 +118,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.29.4
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.22
+              value: public.ecr.aws/docker/library/golang:1.23
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -156,7 +156,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.22
+              value: public.ecr.aws/docker/library/golang:1.23
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -194,7 +194,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.22
+              value: public.ecr.aws/docker/library/golang:1.23
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -232,7 +232,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.22
+              value: public.ecr.aws/docker/library/golang:1.23
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -311,7 +311,7 @@ presubmits:
         - name: GOMAXPROCS
           value: "2"
         - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.22
+          value: public.ecr.aws/docker/library/golang:1.23
         resources:
           requests:
             cpu: "2"
@@ -332,7 +332,7 @@ presubmits:
       description: "Run kueue test-scheduling-perf"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking.yaml
@@ -22,7 +22,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.22
+        - image: public.ecr.aws/docker/library/golang:1.23
           env:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
@@ -62,7 +62,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.22
+        - image: public.ecr.aws/docker/library/golang:1.23
           command:
             - make
           args:
@@ -100,7 +100,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.22
+        - image: public.ecr.aws/docker/library/golang:1.23
           command:
             - make
           args:
@@ -143,7 +143,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.28.9
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.22
+              value: public.ecr.aws/docker/library/golang:1.23
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -189,7 +189,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.29.4
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.22
+              value: public.ecr.aws/docker/library/golang:1.23
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -235,7 +235,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.22
+              value: public.ecr.aws/docker/library/golang:1.23
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -281,7 +281,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.22
+              value: public.ecr.aws/docker/library/golang:1.23
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -327,7 +327,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.22
+              value: public.ecr.aws/docker/library/golang:1.23
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh


### PR DESCRIPTION
Preparation for https://github.com/kubernetes-sigs/kueue/pull/3225

/assign @mimowo 

The kubekins image has already been contained the Go 1.23 https://github.com/kubernetes/test-infra/blob/a55732ef576402302ad06e134dad450154e1cd1f/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml#L78

```shell
docker run -it --entrypoint bash gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241011-e8871c079d-master
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
root@166f8d6dad96:/workspace# go version
go version go1.23.0 linux/amd6
```