### PR TITLE
autoscaling: add CA test for build tags

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -193,3 +193,32 @@ presubmits:
           requests:
             cpu: 2
             memory: 6Gi
+  - name: pull-kubernetes-e2e-autoscaling-ca-build
+    cluster: k8s-infra-prow-build
+    annotations:
+      testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+      testgrid-tab-name: cluster-autoscaler-build
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 120m
+    run_if_changed: '^cluster-autoscaler\/'
+    path_alias: k8s.io/autoscaler
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - make
+        - test-build-tags
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241014-ae08510d04-master
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi


### PR DESCRIPTION
Adds a new cluster-autoscaling presubmit to validate go build tags.

Won't work until https://github.com/kubernetes/autoscaler/pull/7391 is merged.