### PR TITLE
SIG Instrumentation: fix JSON logging periodic

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
@@ -52,7 +52,7 @@ periodics:
       - name: GINKGO_TOLERATE_FLAKES
         value: "n"
       - name: LABEL_FILTER
-      - value: >-
+        value: >-
           (Conformance || Feature: containsAny DynamicResourceAllocation) &&
           Feature: isSubsetOf DynamicResourceAllocation && !Slow && !Disruptive && !Flaky
       - name: PARALLEL

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -159,7 +159,6 @@ periodics:
       - name: GINKGO_TOLERATE_FLAKES
         value: "n"
       - name: LABEL_FILTER
-      - name: ""
         value: '(Conformance || Feature: containsAny DynamicResourceAllocation) && Feature: isSubsetOf DynamicResourceAllocation && !Slow && !Disruptive && !Flaky'
       - name: PARALLEL
         value: "true"


### PR DESCRIPTION
I broke it in 632bccc1ce7a7e668b62ef78110ad667eacd4c78 when adding a stray - in front of the env variable value.