### PR TITLE
image-builder: trigger non-optional GCP tests

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -130,12 +130,12 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
       testgrid-tab-name: pr-lint
-  - name: pull-image-builder-gcp-all
+  - name: pull-gcp-all
     cluster: k8s-infra-prow-build
     path_alias: sigs.k8s.io/image-builder
     always_run: false
-    optional: true
     decorate: true
+    run_if_changed: 'images/capi/(Makefile|ansible\.cfg)|images/capi/ansible/.*|images/capi/scripts/ci-gce\.sh|images/capi/packer/(config|goss|gce)/.*|images/capi/hack/ensure-(ansible|packer|jq|goss).*'
     decoration_config:
       timeout: 2h
     max_concurrency: 5
@@ -161,7 +161,7 @@ presubmits:
               cpu: 2000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-image-builder
-      testgrid-tab-name: pr-pull-image-builder-gcp-all
+      testgrid-tab-name: pr-pull-gcp-all
   - name: pull-goss-populate
     cluster: eks-prow-build-cluster
     path_alias: sigs.k8s.io/image-builder


### PR DESCRIPTION
Adds a trigger for image-builder's `pull-gcp-all` job (which also had its name shortened for consistency with the other image-builder jobs).

Refs kubernetes-sigs/image-builder#1605
Depends on kubernetes-sigs/image-builder#1600