### PR TITLE
LWS: update go version to 1.23

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -41,7 +41,7 @@ presubmits:
       description: "Run lws integration tests"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         command:
         - make
         args:
@@ -190,7 +190,7 @@ presubmits:
       description: "Run lws verify checks"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         command:
         - make
         args:


### PR DESCRIPTION
Update to fix https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_lws/229/pull-lws-test-integration-main/1845971337814740992 failing tests

/assign @liurupeng 

