### PR TITLE
Revert "Changed base option to exclude Overall row from ci-kubernetes-e2e-gce-scale-correctness test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -18,7 +18,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com, release-team@kubernetes.io
     testgrid-dashboards: sig-release-master-informing, sig-scalability-gce, google-gce
     testgrid-tab-name: gce-master-scale-correctness
-    testgrid-base-options: 'exclude-filter-by-regex=^(kubetest\.Test|ci-kubernetes-e2e-gce-scale-correctness\.Overall)$'
+    testgrid-base-options: 'exclude-filter-by-regex=^kubetest.Test$'
     description: "Uses kubetest to run correctness tests against a 5000-node cluster created with cluster/kube-up.sh"
   spec:
     volumes:


### PR DESCRIPTION
Following up from:
https://github.com/kubernetes/test-infra/issues/33679#issuecomment-2423317393

Let's try remove `exclude-filter-by-regex` from the base options to see if that helps.

This reverts commit d7a51c7787a8067dc994ddbbbd36276e3d4f5875.