### PR TITLE
Use URL-escaped filter in scale-correctness job.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -18,7 +18,8 @@ periodics:
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com, release-team@kubernetes.io
     testgrid-dashboards: sig-release-master-informing, sig-scalability-gce, google-gce
     testgrid-tab-name: gce-master-scale-correctness
-    testgrid-base-options: 'exclude-filter-by-regex=^(kubetest\.Test|ci-kubernetes-e2e-gce-scale-correctness\.Overall)$'
+    # exclude-filter-by-regex=^(kubetest\.Test|ci-kubernetes-e2e-gce-scale-correctness\.Overall)$
+    testgrid-base-options: 'exclude-filter-by-regex=%5E(kubetest%5C.Test%7Cci-kubernetes-e2e-gce-scale-correctness%5C.Overall)%24'
     description: "Uses kubetest to run correctness tests against a 5000-node cluster created with cluster/kube-up.sh"
   spec:
     volumes:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/test-infra/issues/33679

Follow-up to https://github.com/kubernetes/test-infra/pull/33683

ETA: Got this by entering `^(kubetest\.Test|ci-kubernetes-e2e-gce-scale-correctness\.Overall)$` on "Options" > "Exclude Filter by RegEx" on the UI (for example https://testgrid.k8s.io/sig-testing-misc#branchprotector&exclude-filter-by-regex=%5E(kubetest%5C.Test%7Cci-kubernetes-e2e-gce-scale-correctness%5C.Overall)%24; didn't do it on the tab in question since I'm having some trouble loading it)

I did say I think the `.` character was causing the issues, but I wonder if it's instead the `\.` combination, since the `.` in this URL seem to work fine.