### PR TITLE
drop classic dra from periodics

### DIFF
--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -47,54 +47,6 @@ periodics:
             cpu: 2
             memory: 9Gi
 
-  # This job runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha)
-  # on a kind cluster with containerd updated to a version with CDI support.
-  # It also enables and tests the DRAControlPlaneController feature.
-  - name: ci-kind-classic-dra
-    cluster: eks-prow-build-cluster
-    interval: 6h
-    annotations:
-      testgrid-dashboards: sig-node-dynamic-resource-allocation
-      testgrid-tab-name: ci-kind-classic-dra
-      testgrid-alert-email: patrick.ohly@intel.com
-    decorate: true
-    decoration_config:
-      timeout: 3h
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241017-ea6eab1555-master
-        command:
-        - runner.sh
-        args:
-        - /bin/sh
-        - -xc
-        - >
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
-          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
-          kind build node-image --image=dra/node:latest . &&
-          trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT &&
-          kind create cluster --retain --config test/e2e/dra/kind-classic-dra.yaml --image dra/node:latest &&
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=2h30m hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf {DynamicResourceAllocation, DRAControlPlaneController} && !Flaky'
-
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 2
-            memory: 9Gi
-          requests:
-            cpu: 2
-            memory: 9Gi
 
   # This job runs e2e_node.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha)
   - name: ci-node-e2e-cgrpv1-crio-dra


### PR DESCRIPTION
Classic DRA was removed.

We should drop this periodic as it is failing because we removed the kind config to enable classic DRA.

https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-kind-classic-dra

@pohly I did a quick glance and I only saw this job that still was testing classic DRA. Let me know if I missed any.