### PR TITLE
DRA: replace classic DRA periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -1,5 +1,5 @@
 periodics:
-  # This job runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha)
+  # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha, soon beta)
   # on a kind cluster with containerd updated to a version with CDI support.
   - name: ci-kind-dra
     cluster: eks-prow-build-cluster
@@ -47,10 +47,11 @@ periodics:
             cpu: 2
             memory: 9Gi
 
-  # This job runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha)
+  # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha, soon beta)
   # on a kind cluster with containerd updated to a version with CDI support.
-  # It also enables and tests the DRAControlPlaneController feature.
-  - name: ci-kind-classic-dra
+  #
+  # Compared to ci-kind-dra, this one enables all DRA-related features.
+  - name: ci-kind-dra-all
     cluster: eks-prow-build-cluster
     interval: 6h
     annotations:
@@ -75,15 +76,20 @@ periodics:
         command:
         - runner.sh
         args:
-        - /bin/sh
+        - /bin/bash
         - -xc
-        - >
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test" &&
-          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind &&
-          kind build node-image --image=dra/node:latest . &&
-          trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT &&
-          kind create cluster --retain --config test/e2e/dra/kind-classic-dra.yaml --image dra/node:latest &&
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=2h30m hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf {DynamicResourceAllocation, DRAControlPlaneController} && !Flaky'
+        - |
+          set -ex
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          kind build node-image --image=dra/node:latest .
+          trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT
+          # Which DRA features exist can change over time.
+          features=( $(grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/') )
+          echo "Enabling DRA feature(s): ${features[*]}."
+          # Those additional features are not in kind.yaml, but they can be added at the end.
+          kind create cluster --retain --config <(cat test/e2e/dra/kind.yaml; for feature in ${features}; do echo "  ${feature}: true"; done) --image dra/node:latest
+          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=1h hack/ginkgo-e2e.sh -ginkgo.label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf {DynamicResourceAllocation$(for feature in ${features}; do echo , ${feature}; done)} && !Flaky && !Slow"
 
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
This copies what was done earlier for pull-kubernetes-kind-dra-all. It is necessary now because the removal of classic DRA was merged into Kubernetes master.

/assign @kannon92 