### PR TITLE
Add timeout for node-arm64-ubuntu-serial-gce job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -301,6 +301,7 @@ presubmits:
           - --skip-regex=\[Flaky\]|\[Slow\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[NodeFeature:NodeSwap\]
           - '--test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/image-config-serial.yaml
+          - --timeout=180m
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
The job [fails with timeout](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/120459/pull-kubernetes-node-arm64-ubuntu-serial-gce/1848052706497794048/build-log.txt) in 30m after the start. 30m looks like a default kubetest2 timeout.

Here is a quote from the job build log with highlighted timeout-related pieces:

W1020 17:42:53.348475   10169 remote.go:158] **ginkgo flags are missing explicit --timeout** (ginkgo defaults to 60 minutes)
I1020 17:42:53.348508   10169 remote.go:165] **updated ginkgo flags:** -timeout=24h -focus="\[Serial\]"  -skip="\[Flaky\]|\[Slow\]|\[Benchmark\]|\[NodeSpecialFeature:.+\]|\[NodeSpecialFeature\]|\[NodeAlphaFeature:.+\]|\[NodeAlphaFeature\]|\[NodeFeature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[NodeFeature:NodeSwap\]"  --no-color -v **--timeout=30m**

Specifying the timeout explicitly should help the job to run longer and, hopefully, to succeed or at least to fail for another reason.

Ref: kubernetes/kubernetes/issues/127831