### PR TITLE
fix pull-kubernetes-e2e-kind-alpha-features

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -307,7 +307,7 @@ presubmits:
         env:
         # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
         - name: FEATURE_GATES
-          value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
+          value: '{"AllAlpha":true,"EventedPLEG":false}'
         - name: RUNTIME_CONFIG
           value: '{"api/alpha":"true", "api/ga":"true"}'
         - name: LABEL_FILTER


### PR DESCRIPTION
the job was also enabling feature gates that are beta but not the runtime beta options, hence feature gates in beta that depend on runtime beta options fail and the cluster is not able to run.

Fixes: https://github.com/kubernetes/kubernetes/issues/128227