### PR TITLE
rename tab name from ci-kind-classic-dra to ci-kind-dra-all

### DIFF
--- a/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
+++ b/config/jobs/kubernetes/sig-node/dynamic-resource-allocation.yaml
@@ -56,7 +56,7 @@ periodics:
     interval: 6h
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation
-      testgrid-tab-name: ci-kind-classic-dra
+      testgrid-tab-name: ci-kind-dra-all
       testgrid-alert-email: patrick.ohly@intel.com
     decorate: true
     decoration_config:


### PR DESCRIPTION
cc @pohly 

Nit.

I see that in test-grid it still shows up as ci-kind-classic-dra which I think has no meaning now.

https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-kind-classic-dra