### PR TITLE
Run all workloads in pull-kubernetes-scheduler-perf presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
+++ b/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
@@ -80,7 +80,7 @@ presubmits:
         args:
         - /bin/sh
         - -c
-        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} make test-integration WHAT=./test/integration/scheduler_perf KUBE_TIMEOUT=--timeout=2h10m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1ns -bench=BenchmarkPerfScheduling"
+        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} make test-integration WHAT=./test/integration/scheduler_perf KUBE_TIMEOUT=--timeout=2h10m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1ns -bench=BenchmarkPerfScheduling" SHORT='--short=false'
         # We need to constraint compute resources so all the tests
         # finish approximately at the same time. More compute power
         # can increase scheduling throughput and make consequent results


### PR DESCRIPTION
By default, `make test-integration` runs with short flag set to true, what limits number of workloads tested in scheduler_perf presubmit job. Periodic job has the short flag set to false ([ref](https://github.com/kubernetes/test-infra/blob/29c89ad9290dbb5e7b26d08a492706a4de8a4fa7/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml#L760-L763)).