### PR TITLE
Disable kOps default StorageClass for `e2e-ci-kubernetes-e2e-cos-gce-serial-canary`

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -3036,7 +3036,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: ci-kubernetes-e2e-al2023-aws-disruptive-canary
 
-# {"cloud": "gce", "distro": "cos105", "extra_flags": "--image=cos-cloud/cos-105-17412-370-67 --node-volume-size=100 --gce-service-account=default", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+# {"cloud": "gce", "distro": "cos105", "extra_flags": "--set=cluster.spec.cloudConfig.manageStorageClasses=false --image=cos-cloud/cos-105-17412-370-67 --node-volume-size=100 --gce-service-account=default", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-ci-kubernetes-e2e-cos-gce-serial-canary
   cron: '31 4-23/6 * * *'
   labels:
@@ -3067,7 +3067,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--channel=alpha --networking=kubenet --image=cos-cloud/cos-105-17412-370-67 --node-volume-size=100 --gce-service-account=default" \
+          --create-args="--channel=alpha --networking=kubenet --set=cluster.spec.cloudConfig.manageStorageClasses=false --image=cos-cloud/cos-105-17412-370-67 --node-volume-size=100 --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \
@@ -3096,7 +3096,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: gce
     test.kops.k8s.io/distro: cos105
-    test.kops.k8s.io/extra_flags: --image=cos-cloud/cos-105-17412-370-67 --node-volume-size=100 --gce-service-account=default
+    test.kops.k8s.io/extra_flags: cluster.spec.cloudConfig.manageStorageClasses=false --image=cos-cloud/cos-105-17412-370-67 --node-volume-size=100 --gce-service-account=default
     test.kops.k8s.io/k8s_version: ci
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest


### PR DESCRIPTION
We tried adding additional validation to ensure that no default StorageClass is available before creating one for `should assign default StorageClass to PVCs retroactively` e2e test. However, it appears there is a reconciliation mechanism in place that continues to cause the test to fail:

```
{ failed [FAILED] Timed out after 120.000s.
failed to wait for PVC to have the storageclass test-default-sc
Value for field 'Spec.StorageClassName' failed to satisfy matcher.
Expected
    <*string | 0xc000fc8fe0>: balanced-csi
to equal
    <*string | 0xc0022fc1a0>: test-default-sc
In [It] at: k8s.io/kubernetes/test/e2e/storage/pvc_storageclass.go:91 @ 10/22/24 13:25:18.206

```

See this thread for important context: https://github.com/kubernetes/kubernetes/pull/127790#discussion_r1792081394 on why we are disabling the kOps managed default StorageClass for this job.


### Context

- We are striving to get https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/e2e-ci-kubernetes-e2e-cos-gce-serial-canary back reliably in the green.

- https://kops.sigs.k8s.io/cluster_spec/#managestorageclasses