### PR TITLE
Add new sig-etcd job for raft arm64 presubmits

### DIFF
--- a/config/jobs/etcd/etcd-raft-presubmits.yaml
+++ b/config/jobs/etcd/etcd-raft-presubmits.yaml
@@ -1,0 +1,29 @@
+---
+presubmits:
+  etcd-io/raft:
+    - name: pull-raft-test-arm64
+      cluster: k8s-infra-prow-build
+      always_run: true
+      branches:
+        - main
+      decorate: true
+      annotations:
+        testgrid-dashboards: sig-etcd-raft-presubmits
+        testgrid-tab-name: pull-raft-test-arm64
+      spec:
+        containers:
+          - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20241021-d3a4913879-master
+            command:
+              - runner.sh
+            args:
+              - bash
+              - -c
+              - |
+                GOARCH=arm64 PASSES='unit' RACE='true' CPU='4' ./scripts/test.sh -p=2
+            resources:
+              requests:
+                cpu: "4"
+                memory: "4Gi"
+              limits:
+                cpu: "4"
+                memory: "4Gi"

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -9,6 +9,7 @@ dashboard_groups:
   - sig-etcd-robustness
   - sig-etcd-etcd-manager
   - sig-etcd-website-presubmits
+  - sig-etcd-raft-presubmits
 
 dashboards:
   - name: sig-etcd-amd64
@@ -98,3 +99,4 @@ dashboards:
           value: v3.4
   - name: sig-etcd-etcd-manager
   - name: sig-etcd-website-presubmits
+  - name: sig-etcd-raft-presubmits


### PR DESCRIPTION
`etcd-io/raft` currently has a GitHub actions presubmit to run tests against `arm64` using actuated.dev arm64 runners https://github.com/etcd-io/raft/blob/main/.github/workflows/test_arm64.yaml

Funding for these runners is no longer available beyond the end of this month so we need to migrate the job to prow as the job will stop working.

The same applies to arm64 actuated jobs in `etcd-io/bbolt`. I will raise separate pull request(s) for those.

cc @ahrtr, @ivanvc 
