### PR TITLE
Enable cgo for raft arm64 presubmit

### DIFF
--- a/config/jobs/etcd/etcd-raft-presubmits.yaml
+++ b/config/jobs/etcd/etcd-raft-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
               - bash
               - -c
               - |
-                GOARCH=arm64 PASSES='unit' RACE='true' CPU='4' ./scripts/test.sh -p=2
+                CGO_ENABLED=1 GOARCH=arm64 PASSES='unit' RACE='true' CPU='4' ./scripts/test.sh -p=2
             resources:
               requests:
                 cpu: "4"


### PR DESCRIPTION
First test of the new presubmit failed https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_raft/229/pull-raft-test-arm64/1849179126896791552

Failure was ` go: -race requires cgo `.

Added `CGO_ENABLED=1` to resolve.