### PR TITLE
etcd: add 1 cpu unit test bbolt presubmit

### DIFF
--- a/config/jobs/etcd/etcd-bbolt-presubmits.yaml
+++ b/config/jobs/etcd/etcd-bbolt-presubmits.yaml
@@ -1,0 +1,31 @@
+---
+presubmits:
+  etcd-io/bbolt:
+    - name: pull-bbolt-test-1-cpu-arm64
+      cluster: k8s-infra-prow-build
+      always_run: true
+      branches:
+        - main
+      decorate: true
+      annotations:
+        testgrid-dashboards: sig-etcd-bbolt-presubmits
+        testgrid-tab-name: pull-bbolt-test-1-cpu-arm64
+      spec:
+        containers:
+          - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20241021-d3a4913879-master
+            command:
+              - runner.sh
+            args:
+              - bash
+              - -c
+              - |
+                CPU=1 make test
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "2"
+                memory: "4Gi"
+        nodeSelector:
+          kubernetes.io/arch: arm64

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -10,6 +10,7 @@ dashboard_groups:
   - sig-etcd-etcd-manager
   - sig-etcd-website-presubmits
   - sig-etcd-raft-presubmits
+  - sig-etcd-bbolt-presubmits
 
 dashboards:
   - name: sig-etcd-amd64
@@ -100,3 +101,4 @@ dashboards:
   - name: sig-etcd-etcd-manager
   - name: sig-etcd-website-presubmits
   - name: sig-etcd-raft-presubmits
+  - name: sig-etcd-bbolt-presubmits


### PR DESCRIPTION
While we sort out the race issue, I'm adding bbolt's unit tests for a single CPU. I want a green build before migrating 2 CPUs, 4 CPUs, and 4 CPUs with race.

/cc @jmhbnz 