### PR TITLE
Add missing arm64 nodeselector for new raft presubmit

### DIFF
--- a/config/jobs/etcd/etcd-raft-presubmits.yaml
+++ b/config/jobs/etcd/etcd-raft-presubmits.yaml
@@ -27,3 +27,5 @@ presubmits:
               limits:
                 cpu: "4"
                 memory: "4Gi"
+        nodeSelector:
+          kubernetes.io/arch: arm64


### PR DESCRIPTION
Missed this when initially creating the job and is causing job failures: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_raft/229/pull-raft-test-arm64/1849230236902756352

cc @ivanvc 