### PR TITLE
etcd: import bbolt arm64 robustness tests

### DIFF
--- a/config/jobs/etcd/etcd-bbolt-periodics.yaml
+++ b/config/jobs/etcd/etcd-bbolt-periodics.yaml
@@ -1,0 +1,35 @@
+---
+periodics:
+- name: ci-bbolt-robustness-main-arm64
+  cron: "25 9 * * *" # runs every day at 09:25 UTC
+  cluster: k8s-infra-prow-build
+  extra_refs:
+    - org: etcd-io
+      repo: bbolt
+      base_ref: main
+  decorate: true
+  decoration_config:
+    timeout: 210m
+  annotations:
+    testgrid-dashboards: sig-etcd-bbolt-periodics
+    testgrid-tab-name: ci-bbolt-robustness-main-arm64
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20241021-d3a4913879-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            apt-get -o APT::Update::Error-Mode=any update && apt-get --yes install dmsetup xfsprogs
+            ROBUSTNESS_TESTFLAGS="--count 100 --timeout 200m -failfast" make test-robustness
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
+    nodeSelector:
+      kubernetes.io/arch: arm64

--- a/config/jobs/etcd/etcd-bbolt-presubmits.yaml
+++ b/config/jobs/etcd/etcd-bbolt-presubmits.yaml
@@ -113,3 +113,34 @@ presubmits:
                 memory: "4Gi"
         nodeSelector:
           kubernetes.io/arch: arm64
+    - name: pull-bbolt-robustness-arm64
+      cluster: k8s-infra-prow-build
+      always_run: true
+      branches:
+        - main
+      decorate: true
+      decoration_config:
+        timeout: 40m
+      annotations:
+        testgrid-dashboards: sig-etcd-bbolt-presubmits
+        testgrid-tab-name: pull-bbolt-robustness-arm64
+      spec:
+        containers:
+          - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20241021-d3a4913879-master
+            command:
+              - runner.sh
+            args:
+              - bash
+              - -c
+              - |
+                apt-get -o APT::Update::Error-Mode=any update && apt-get --yes install dmsetup xfsprogs
+                ROBUSTNESS_TESTFLAGS="--count 10 --timeout 30m -failfast" make test-robustness
+            resources:
+              requests:
+                cpu: "4"
+                memory: "8Gi"
+              limits:
+                cpu: "4"
+                memory: "8Gi"
+        nodeSelector:
+          kubernetes.io/arch: arm64

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -11,6 +11,7 @@ dashboard_groups:
   - sig-etcd-website-presubmits
   - sig-etcd-raft-presubmits
   - sig-etcd-bbolt-presubmits
+  - sig-etcd-bbolt-periodics
 
 dashboards:
   - name: sig-etcd-amd64
@@ -102,3 +103,4 @@ dashboards:
   - name: sig-etcd-website-presubmits
   - name: sig-etcd-raft-presubmits
   - name: sig-etcd-bbolt-presubmits
+  - name: sig-etcd-bbolt-periodics


### PR DESCRIPTION
This pull request imports bbolt's robustness arm64 tests, presubmits, and periodic.

/cc @jmhbnz 