### PR TITLE
etcd: run bbolt robustness tests in privileged mode

### DIFF
--- a/config/jobs/etcd/etcd-bbolt-periodics.yaml
+++ b/config/jobs/etcd/etcd-bbolt-periodics.yaml
@@ -31,5 +31,8 @@ periodics:
           limits:
             cpu: "4"
             memory: "8Gi"
+        # dmflakey needs privileged mode
+        securityContext:
+          privileged: true
     nodeSelector:
       kubernetes.io/arch: arm64

--- a/config/jobs/etcd/etcd-bbolt-presubmits.yaml
+++ b/config/jobs/etcd/etcd-bbolt-presubmits.yaml
@@ -142,5 +142,8 @@ presubmits:
               limits:
                 cpu: "4"
                 memory: "8Gi"
+            # dmflakey needs privileged mode
+            securityContext:
+              privileged: true
         nodeSelector:
           kubernetes.io/arch: arm64


### PR DESCRIPTION
bbolt's robustness tests use dmflakey, so we actually need to run in privileged mode.

/cc @jmhbnz 