### PR TITLE
etcd: make bbolt robustness test optional

### DIFF
--- a/config/jobs/etcd/etcd-bbolt-periodics.yaml
+++ b/config/jobs/etcd/etcd-bbolt-periodics.yaml
@@ -1,7 +1,7 @@
 ---
 periodics:
 - name: ci-bbolt-robustness-main-arm64
-  cron: "25 9 * * *" # runs every day at 09:25 UTC
+  cron: "25 9 * * 0" # runs every Sunday at 09:25 UTC, change to daily once the job is stable
   cluster: k8s-infra-prow-build
   extra_refs:
     - org: etcd-io

--- a/config/jobs/etcd/etcd-bbolt-presubmits.yaml
+++ b/config/jobs/etcd/etcd-bbolt-presubmits.yaml
@@ -115,6 +115,7 @@ presubmits:
           kubernetes.io/arch: arm64
     - name: pull-bbolt-robustness-arm64
       cluster: k8s-infra-prow-build
+      optional: true # remove once the job is stable
       always_run: true
       branches:
         - main


### PR DESCRIPTION
While we figure out how to make bbolt's robustness test stable/work, set the presubmit as optional and the periodic with a weekly cadence.

/cc @jmhbnz 