### PR TITLE
CAPO: Use separate presubmit jobs for release branches

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/README.md
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/README.md
@@ -1,0 +1,17 @@
+The presubmits for the main branch are defined in
+`cluster-api-provider-openstack-presubmits.yaml`.
+
+The presubmits for each release branch are defined in
+`cluster-api-provider-openstack-presubmits-<release branch>.yaml`
+
+When creating a new release branch, copy 
+`cluster-api-provider-openstack-presubmits.yaml` to a release version. For each
+job in the new release version you need to modify:
+* The branch name under `branches`
+* The variant of the kubekins-e2e image
+
+The main branch always uses the latest kubekins-e2e variant called
+`gcr.io/k8s-staging-test-infra/kubekins-e2e:v<build>-main`. Release jobs should
+be pinned to a specific variant. These are defined at
+https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e-v2/variants.yaml.
+Pick a variant with the `GO_VERSION` required by the new release branch.

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits-release-0.10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits-release-0.10.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-build
     cluster: eks-prow-build-cluster
     branches:
-    - ^main$
+    - ^release-0.10$
     always_run: true
     optional: false
     decorate: true
@@ -12,7 +12,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.30
         command:
         - "./scripts/ci-build.sh"
         # docker-in-docker needs privileged mode
@@ -31,14 +31,14 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-test
     cluster: eks-prow-build-cluster
     branches:
-    - ^main$
+    - ^release-0.10$
     always_run: true
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.30
         command:
         - "./scripts/ci-test.sh"
         resources:
@@ -54,7 +54,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-e2e-test
     cluster: k8s-infra-prow-build
     branches:
-    - ^main$
+    - ^release-0.10$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -72,7 +72,7 @@ presubmits:
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.30
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"
@@ -100,7 +100,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-conformance-test
     cluster: k8s-infra-prow-build
     branches:
-    - ^main$
+    - ^release-0.10$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -122,7 +122,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.30
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"
@@ -149,7 +149,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-e2e-full-test
     cluster: k8s-infra-prow-build
     branches:
-    - ^main$
+    - ^release-0.10$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -167,7 +167,7 @@ presubmits:
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.30
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits-release-0.11.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits-release-0.11.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-build
     cluster: eks-prow-build-cluster
     branches:
-    - ^main$
+    - ^release-0.11$
     always_run: true
     optional: false
     decorate: true
@@ -12,7 +12,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.31
         command:
         - "./scripts/ci-build.sh"
         # docker-in-docker needs privileged mode
@@ -31,14 +31,14 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-test
     cluster: eks-prow-build-cluster
     branches:
-    - ^main$
+    - ^release-0.11$
     always_run: true
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.31
         command:
         - "./scripts/ci-test.sh"
         resources:
@@ -54,7 +54,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-e2e-test
     cluster: k8s-infra-prow-build
     branches:
-    - ^main$
+    - ^release-0.11$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -72,7 +72,7 @@ presubmits:
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.31
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"
@@ -100,7 +100,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-conformance-test
     cluster: k8s-infra-prow-build
     branches:
-    - ^main$
+    - ^release-0.11$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -122,7 +122,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.31
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"
@@ -149,7 +149,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-e2e-full-test
     cluster: k8s-infra-prow-build
     branches:
-    - ^main$
+    - ^release-0.11$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -167,7 +167,7 @@ presubmits:
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.31
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits-release-0.9.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits-release-0.9.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-build
     cluster: eks-prow-build-cluster
     branches:
-    - ^main$
+    - ^release-0.9$
     always_run: true
     optional: false
     decorate: true
@@ -12,7 +12,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.28
         command:
         - "./scripts/ci-build.sh"
         # docker-in-docker needs privileged mode
@@ -31,14 +31,14 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-test
     cluster: eks-prow-build-cluster
     branches:
-    - ^main$
+    - ^release-0.9$
     always_run: true
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.28
         command:
         - "./scripts/ci-test.sh"
         resources:
@@ -54,7 +54,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-e2e-test
     cluster: k8s-infra-prow-build
     branches:
-    - ^main$
+    - ^release-0.9$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -72,7 +72,7 @@ presubmits:
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.28
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"
@@ -100,7 +100,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-conformance-test
     cluster: k8s-infra-prow-build
     branches:
-    - ^main$
+    - ^release-0.9$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -122,7 +122,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.28
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"
@@ -149,7 +149,7 @@ presubmits:
   - name: pull-cluster-api-provider-openstack-e2e-full-test
     cluster: k8s-infra-prow-build
     branches:
-    - ^main$
+    - ^release-0.9$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -167,7 +167,7 @@ presubmits:
       path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-main
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.28
         env:
         - name: "BOSKOS_HOST"
           value: "boskos.test-pods.svc.cluster.local"


### PR DESCRIPTION
This fixes an issue that the linter tests in release-0.10 don't pass when executed by go 1.23, and should prevent all similar issues in the future.