### PR TITLE
Migrate release-3.5 arm64 integration tests to prow

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -297,6 +297,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.5
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -359,6 +360,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.5
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -421,6 +423,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.5
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits


### PR DESCRIPTION
These jobs are currently the last use of old actuated arm64 runners in `etcd-io/etcd`.

cc @ivanvc 