### PR TITLE
ipvs jobs

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -198,8 +198,9 @@ presubmits:
               value: "ipvs"
             - name: FOCUS
               value: \[sig-network\]|\[Conformance\]
+            # FIXME: AdmissionWebhooks flakes https://issues.k8s.io/128230
             - name: SKIP
-              value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|IPv6DualStack
+              value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|IPv6DualStack|AdmissionWebhook
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true
@@ -448,8 +449,9 @@ periodics:
         value: "true"
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
+      # FIXME: AdmissionWebhooks flakes https://issues.k8s.io/128230
       - name: SKIP
-        value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|IPv6DualStack
+        value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|IPv6DualStack|AdmissionWebhook
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -466,118 +468,7 @@ periodics:
     description: Runs network tests using KIND against latest kubernetes master with a kubernetes-in-docker cluster
     testgrid-alert-email: antonio.ojea.garcia@gmail.com, kubernetes-sig-network-test-failures@googlegroups.com
     testgrid-num-columns-recent: '3'
-# network test against kubernetes master branch with `kind` ipv6
-- interval: 24h
-  name: ci-kubernetes-kind-network-ipvs-ipv6
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  decorate: true
-  decoration_config:
-    timeout: 60m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20241021-d3a4913879-master
-      command:
-        - wrapper.sh
-        - bash
-        - -c
-        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
-      env:
-      # enable IPV6 in bootstrap image
-      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-        value: "true"
-      # tell kind CI script to use ipv6
-      - name: "IP_FAMILY"
-        value: "ipv6"
-      - name: KUBE_PROXY_MODE
-        value: "ipvs"
-      - name: "PARALLEL"
-        value: "true"
-      - name: FOCUS
-        value: \[sig-network\]|\[Conformance\]
-      - name: SKIP
-        value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv4|IPv6DualStack|Internet.connection
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        limits:
-          cpu: 4
-          memory: 9Gi
-        requests:
-          cpu: 4
-          memory: 9Gi
-  annotations:
-    testgrid-dashboards: sig-network-kind, sig-testing-kind
-    testgrid-tab-name: sig-network-kind, ipvs, IPv6, master
-    description: Runs network tests using KIND against latest kubernetes master with an IPv6 kubernetes-in-docker cluster
-    testgrid-alert-email: antonio.ojea.garcia@gmail.com, kubernetes-sig-network-test-failures@googlegroups.com
-    testgrid-num-columns-recent: '3'
 # network test against kubernetes master branch with `kind` dual stack
-- interval: 24h
-  name: ci-kubernetes-kind-network-ipvs-dual
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  decorate: true
-  decoration_config:
-    timeout: 60m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20241021-d3a4913879-master
-      command:
-        - wrapper.sh
-        - bash
-        - -c
-        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
-      env:
-      - name: BUILD_TYPE
-        value: docker
-      # enable IPV6 in bootstrap image
-      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-        value: "true"
-      # tell kind CI script to use ipv6
-      - name: "IP_FAMILY"
-        value: "dual"
-      - name: KUBE_PROXY_MODE
-        value: "ipvs"
-      - name: "PARALLEL"
-        value: "true"
-      - name: FOCUS
-        value: \[sig-network\]|\[Conformance\]
-      - name: SKIP
-        value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|Internet.connection
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        limits:
-          cpu: 4
-          memory: 9Gi
-        requests:
-          cpu: 4
-          memory: 9Gi
-  annotations:
-    testgrid-dashboards: sig-network-kind, sig-testing-kind
-    testgrid-tab-name: sig-network-kind, ipvs, dual, master
-    description: Runs network tests using KIND against latest kubernetes master with a DualStack kubernetes-in-docker cluster
-    testgrid-alert-email: antonio.ojea.garcia@gmail.com, kubernetes-sig-network-test-failures@googlegroups.com
-    testgrid-num-columns-recent: '3'
 - interval: 24h
   name: ci-kubernetes-kind-network-nftables
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
Reduce the number of jobs used for ipvs and leave the minimum necessary to understand the feature works, there is nobody paying attention or fixing the issues and this adds noise that can mask real issues.

For the jobs that still remain skip the flaky tests, that seems concentrated around the webhooks e2e feature, once somebody fix them they can be unskiped.

Ref https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20ipvs,%20master