### PR TITLE
kubeadm: move release-informing jobs to blocking

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -9,7 +9,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-master-informing
+    testgrid-dashboards: sig-release-master-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-upgrade-1-31-latest
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster, upgrade it and run kubeadm-e2e and the conformance suite"
@@ -53,7 +53,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-1.31-informing
+    testgrid-dashboards: sig-release-1.31-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-upgrade-1-30-1-31
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster, upgrade it and run kubeadm-e2e and the conformance suite"
@@ -97,7 +97,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-1.30-informing
+    testgrid-dashboards: sig-release-1.30-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-upgrade-1-29-1-30
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster, upgrade it and run kubeadm-e2e and the conformance suite"
@@ -141,7 +141,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-1.29-informing
+    testgrid-dashboards: sig-release-1.29-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-upgrade-1-28-1-29
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster, upgrade it and run kubeadm-e2e and the conformance suite"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -9,7 +9,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-master-informing
+    testgrid-dashboards: sig-release-master-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-latest-on-1-31
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with version skew and run kubeadm-e2e and the conformance suite"
@@ -53,7 +53,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-1.31-informing
+    testgrid-dashboards: sig-release-1.31-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-1-31-on-1-30
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with version skew and run kubeadm-e2e and the conformance suite"
@@ -97,7 +97,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-1.30-informing
+    testgrid-dashboards: sig-release-1.30-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-1-30-on-1-29
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with version skew and run kubeadm-e2e and the conformance suite"
@@ -141,7 +141,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-1.29-informing
+    testgrid-dashboards: sig-release-1.29-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-1-29-on-1-28
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster with version skew and run kubeadm-e2e and the conformance suite"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -9,7 +9,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-master-informing
+    testgrid-dashboards: sig-release-master-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-latest
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and run kubeadm-e2e and the conformance suite"
@@ -53,7 +53,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-1.31-informing
+    testgrid-dashboards: sig-release-1.31-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-1-31
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and run kubeadm-e2e and the conformance suite"
@@ -97,7 +97,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-1.30-informing
+    testgrid-dashboards: sig-release-1.30-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-1-30
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and run kubeadm-e2e and the conformance suite"
@@ -141,7 +141,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-1.29-informing
+    testgrid-dashboards: sig-release-1.29-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-1-29
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and run kubeadm-e2e and the conformance suite"
@@ -185,7 +185,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-release-1.28-informing
+    testgrid-dashboards: sig-release-1.28-blocking, sig-cluster-lifecycle-kubeadm
     testgrid-tab-name: kubeadm-kinder-1-28
     testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder); Uses kubeadm/kinder to create a cluster and run kubeadm-e2e and the conformance suite"

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -591,7 +591,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce, sig-network-gce
     testgrid-tab-name: gci-gce-ingress
-    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io
     description: Uses kubetest to run e2e tests (+Feature:Ingress|NEG) against a cluster created with cluster/kube-up.sh
     testgrid-alert-stale-results-hours: '24'
 - interval: 6h

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -539,20 +539,28 @@ func TestReleaseBlockingJobsMustHaveTestgridDescriptions(t *testing.T) {
 			if dashboardtab.Description == "" {
 				t.Errorf("%v: - Must have a description", intro)
 			}
+
 			// TODO(spiffxp): enforce for informing as well
 			if suffix == "informing" {
-				if !strings.HasPrefix(dashboardtab.Description, "OWNER: ") {
-					t.Logf("NOTICE: %v: - Must have a description that starts with OWNER: ", intro)
-				}
-				if dashboardtab.AlertOptions == nil {
-					t.Logf("NOTICE: %v: - Must have alert_options (ensure informing dashboard is listed first in testgrid-dashboards)", intro)
-				} else if dashboardtab.AlertOptions.AlertMailToAddresses == "" {
-					t.Logf("NOTICE: %v: - Must have alert_options.alert_mail_to_addresses", intro)
-				}
+				// if !strings.HasPrefix(dashboardtab.Description, "OWNER: ") {
+				// 	t.Logf("NOTICE: %v: - Must have a description that starts with OWNER: ", intro)
+				// }
+				// if dashboardtab.AlertOptions == nil {
+				// 	t.Logf("NOTICE: %v: - Must have alert_options (ensure informing dashboard is listed first in testgrid-dashboards)", intro)
+				// } else if dashboardtab.AlertOptions.AlertMailToAddresses == "" {
+				// 	t.Logf("NOTICE: %v: - Must have alert_options.alert_mail_to_addresses", intro)
+				// }
 			} else {
+				// if dashboardtab.AlertOptions != nil {
+				// 	t.Log("------", dashboardtab.Name, dashboardtab.AlertOptions.AlertMailToAddresses)
+				// }
+				if dashboardtab.Name == "gci-gce-ingress" {
+					t.Log("------------------------------", dashboardtab.AlertOptions.AlertMailToAddresses)
+				}
 				if dashboardtab.AlertOptions == nil {
 					t.Errorf("%v: - Must have alert_options (ensure blocking dashboard is listed first in testgrid-dashboards)", intro)
 				} else if dashboardtab.AlertOptions.AlertMailToAddresses == "" {
+
 					t.Errorf("%v: - Must have alert_options.alert_mail_to_addresses", intro)
 				}
 			}


### PR DESCRIPTION
The jobs have been in release-informing and mostly green, well maintained for multiple releases.

https://groups.google.com/g/kubernetes-sig-testing/c/XP1SzED2x2k/m/mEmxGPyTBAAJ?pli=1

/sig cluster-lifecycle testing release

