### PR TITLE
Switch to newest versions of Containerd and Runc for master CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -266,8 +266,8 @@ presubmits:
           args:
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.20
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.13
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
             - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -345,8 +345,8 @@ presubmits:
           args:
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.20
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.13
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
             - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -531,8 +531,8 @@ presubmits:
           args:
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.20
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.13
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
             - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -771,8 +771,8 @@ presubmits:
           args:
             - --build=quick
             - --check-leaked-resources
-            - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v1.7.20
-            - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.1.13
+            - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v1.7.23
+            - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
             - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false
             - --env=KUBE_PROXY_DAEMONSET=true
             - --env=ENABLE_POD_PRIORITY=true
@@ -852,8 +852,8 @@ periodics:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --check-leaked-resources
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0-rc.5
-          - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.13
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0-rc.6
+          - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
           - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -903,8 +903,8 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0-rc.5
-      - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.1.13
+      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0-rc.6
+      - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -37,8 +37,8 @@ presubmits:
         args:
         - --build=quick
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.20
-        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.13
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
         - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
@@ -166,8 +166,8 @@ presubmits:
         args:
         - --build=quick
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.20
-        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.13
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
         - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -300,8 +300,8 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.20
-      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.1.13
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
       - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu


### PR DESCRIPTION
Switch to v1.7.23 and v2.0.0-rc.6 of containerd instead of what we have now. Also switch to v1.2.1 of runc.

xref: https://github.com/containerd/containerd/pull/10877
xref: https://github.com/kubernetes/kubernetes/pull/128276
