### PR TITLE
JSON logging: disable additional features like DRA

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
@@ -44,17 +44,11 @@ periodics:
       - name: KIND_CLUSTER_LOG_LEVEL
         # Default is 4, but we want to exercise more log calls and get more output.
         value: "6"
-      - name: FEATURE_GATES
-        value: '{"DynamicResourceAllocation":true,"ContextualLogging":true}'
-      - name: RUNTIME_CONFIG
-        value: '{"api/alpha":"true", "api/beta":"true"}'
       # don't retry conformance tests
       - name: GINKGO_TOLERATE_FLAKES
         value: "n"
       - name: LABEL_FILTER
-        value: >-
-          (Conformance || Feature: containsAny DynamicResourceAllocation) &&
-          Feature: isSubsetOf DynamicResourceAllocation && !Slow && !Disruptive && !Flaky
+        value: 'Conformance && !Slow && !Disruptive && !Flaky'
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -152,14 +152,10 @@ periodics:
         value: json
       - name: KIND_CLUSTER_LOG_LEVEL
         value: "6"
-      - name: FEATURE_GATES
-        value: '{"DynamicResourceAllocation":true,"ContextualLogging":true}'
-      - name: RUNTIME_CONFIG
-        value: '{"api/alpha":"true", "api/beta":"true"}'
       - name: GINKGO_TOLERATE_FLAKES
         value: "n"
       - name: LABEL_FILTER
-        value: '(Conformance || Feature: containsAny DynamicResourceAllocation) && Feature: isSubsetOf DynamicResourceAllocation && !Slow && !Disruptive && !Flaky'
+        value: 'Conformance && !Slow && !Disruptive && !Flaky'
       - name: PARALLEL
         value: "true"
       image: gcr.io/k8s-staging-test-infra/krte:v20241021-d3a4913879-1.31


### PR DESCRIPTION
The original intent was to test more than just the core functionality with JSON logging. But keeping those additional features working adds complexity that shouldn't be needed for this job, so all non-standard API groups, feature gates and DRA get removed.

Fixes: https://github.com/kubernetes/kubernetes/issues/128520

/assign @dims 
