### PR TITLE
Set artifacts and data-items-dir in pull-kubernetes-scheduler-perf

### DIFF
--- a/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
+++ b/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
@@ -80,7 +80,7 @@ presubmits:
         args:
         - /bin/sh
         - -c
-        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} make test-integration WHAT=./test/integration/scheduler_perf/... KUBE_TIMEOUT=--timeout=3h55m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1ns -bench=BenchmarkPerfScheduling" SHORT='--short=false'
+        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} ARTIFACTS=${WORKSPACE}/artifacts make test-integration WHAT=./test/integration/scheduler_perf/... KUBE_TIMEOUT=--timeout=3h55m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1ns -bench=BenchmarkPerfScheduling -data-items-dir=${WORKSPACE}/artifacts" SHORT='--short=false'
         # We need to constraint compute resources so all the tests
         # finish approximately at the same time. More compute power
         # can increase scheduling throughput and make consequent results


### PR DESCRIPTION
We want to access benchmark results while running `pull-kubernetes-scheduler-perf`. Right now, they are not stored anywhere in job artifacts. Setting `ARTIFACTS` variable as well as `-data-items-dir` should fix this. 