### PR TITLE
Update to latest containerd version - v2.0.0

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -266,7 +266,7 @@ presubmits:
           args:
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -345,7 +345,7 @@ presubmits:
           args:
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -531,7 +531,7 @@ presubmits:
           args:
             - --build=quick
             - --cluster=
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -771,7 +771,7 @@ presubmits:
           args:
             - --build=quick
             - --check-leaked-resources
-            - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v1.7.23
+            - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
             - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
             - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false
             - --env=KUBE_PROXY_DAEMONSET=true
@@ -852,7 +852,7 @@ periodics:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --check-leaked-resources
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0-rc.6
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -903,7 +903,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0-rc.6
+      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
       - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false
       - --env=KUBE_PROXY_DAEMONSET=true

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -37,7 +37,7 @@ presubmits:
         args:
         - --build=quick
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -166,7 +166,7 @@ presubmits:
         args:
         - --build=quick
         - --env=ALLOW_PRIVILEGED=true
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -300,7 +300,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.7.23
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0
       - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true


### PR DESCRIPTION
New version is out! - https://github.com/containerd/containerd/releases/tag/v2.0.0

Let's switch some of the CI jobs we have to point to that version.