### PR TITLE
reduce the period of time to run the kind alpha and beta features jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -475,7 +475,7 @@ presubmits:
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
 periodics:
-- interval: 24h
+- interval: 4h
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-e2e-kind-alpha-features
   annotations:
@@ -527,7 +527,7 @@ periodics:
           memory: 9Gi
           cpu: 7
 
-- interval: 24h
+- interval: 4h
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-e2e-kind-beta-features
   annotations:
@@ -579,7 +579,7 @@ periodics:
           memory: 9Gi
           cpu: 7
 
-- interval: 24h
+- interval: 4h
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-e2e-kind-alpha-beta-features
   annotations:


### PR DESCRIPTION
current time is not enough to get signal https://testgrid.k8s.io/sig-testing-kind#kind-master-alpha and these are likely the most stable and reliable jobs (and cheapest)