### PR TITLE
Add post-build job and configs for containerd 2.0

### DIFF
--- a/config/jobs/containerd/containerd/containerd-postsubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-postsubmit-jobs.yaml
@@ -94,6 +94,37 @@ postsubmits:
         testgrid-tab-name: post-containerd-build-1.7
         description: "builds release/1.7 branch of upstream containerd"
 
+    - name: post-containerd-build-2-0
+      labels:
+        preset-service-account: "true"
+      cluster: k8s-infra-prow-build
+      decorate: true
+      branches:
+        - release/2.0
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-master
+            command:
+              - runner.sh
+            args:
+              - test/build.sh
+            env:
+              - name: DEPLOY_DIR
+                value: release-2.0
+              - name: DEPLOY_BUCKET
+                value: k8s-staging-cri-tools
+            resources:
+              limits:
+                cpu: 4
+                memory: 6Gi
+              requests:
+                cpu: 4
+                memory: 6Gi
+      annotations:
+        testgrid-dashboards: sig-node-containerd,containerd-postsubmits
+        testgrid-tab-name: post-containerd-build-2.0
+        description: "builds release/2.0 branch of upstream containerd"
+
     - name: post-containerd-build-test-images
       labels:
         preset-service-account: "true"

--- a/jobs/e2e_node/containerd/containerd-release-2.0/env
+++ b/jobs/e2e_node/containerd/containerd-release-2.0/env
@@ -1,0 +1,9 @@
+CONTAINERD_TEST: 'true'
+CONTAINERD_LOG_LEVEL: 'debug'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools/containerd/release-2.0'
+CONTAINERD_PKG_PREFIX: 'containerd-cni'
+
+CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'
+CONTAINERD_EXTRA_RUNTIME_OPTIONS: |
+  BinaryName = "/home/containerd/usr/local/sbin/runc"
+CONTAINERD_SYSTEMD_CGROUP: 'true'

--- a/jobs/e2e_node/containerd/containerd-release-2.0/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-2.0/image-config.yaml
@@ -1,0 +1,9 @@
+images:
+  ubuntu:
+    image: ubuntu-gke-2204-1-24-v20220623
+    project: ubuntu-os-gke-cloud
+    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.0/env"
+  cos-stable:
+    image_family: cos-beta
+    project: cos-cloud
+    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.0/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
- Adding a new job `post-containerd-build-2-0` that generates tar.gz for contained 2.0 branch.
- Add `image-config.yaml` and `env` for new `k8s-staging-cri-tools/containerd/release-2.0` 