### PR TITLE
Whoops! fix image in ci-containerd-arm64-build-2-0

### DIFF
--- a/config/jobs/containerd/containerd/containerd-periodic-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-periodic-jobs.yaml
@@ -149,7 +149,7 @@ periodics:
       base_ref: release/2.0
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20241021-d3a4913879-master
         command:
           - runner.sh
         args:


### PR DESCRIPTION
got the image wrong in https://github.com/kubernetes/test-infra/pull/33771/files#diff-669927a638396eb51d888d0752bf589ea0ee622ac29fab684feda313eb88edd7R152