### PR TITLE
Use Go `slices` package instead of `k8s.io/utils/strings/slices`

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -29,6 +29,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -38,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/strings/slices"
 
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	cfg "sigs.k8s.io/prow/pkg/config"

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	k8s.io/client-go v0.25.9
 	k8s.io/code-generator v0.25.9
 	k8s.io/klog/v2 v2.90.1
-	k8s.io/utils v0.0.0-20230209194617-a36077c30491
+	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect
 	knative.dev/pkg v0.0.0-20230221145627-8efb3485adcf // indirect
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/controller-tools v0.9.2

--- a/hack/cluster-migration/main.go
+++ b/hack/cluster-migration/main.go
@@ -23,11 +23,11 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/utils/strings/slices"
 	cfg "sigs.k8s.io/prow/pkg/config"
 )
 


### PR DESCRIPTION
Use the functions provided by the Go standard library `slices` package since Go 1.21 instead of the deprecated functions in the `k8s.io/utils/strings/slices` package.