### PR TITLE
enforce 1.32 code freeze

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -696,6 +696,32 @@ tide:
     - do-not-merge/work-in-progress
   - repos:
     - kubernetes/kubernetes
+    excludedBranches:
+      - master
+      - release-1.32
+    labels:
+      - lgtm
+      - approved
+      - "cncf-cla: yes"
+    missingLabels:
+      - do-not-merge
+      - do-not-merge/blocked-paths
+      - do-not-merge/cherry-pick-not-approved
+      - do-not-merge/contains-merge-commits
+      - do-not-merge/hold
+      - do-not-merge/invalid-commit-message
+      - do-not-merge/invalid-owners-file
+      - do-not-merge/needs-kind
+      - do-not-merge/needs-sig
+      - do-not-merge/release-note-label-needed
+      - do-not-merge/work-in-progress
+      - needs-rebase
+  - repos:
+      - kubernetes/kubernetes
+    milestone: v1.32
+    includedBranches:
+      - master
+      - release-1.32
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
The Kubernetes 1.32 Code Freeze is scheduled to start at **02:00 UTC Friday 8th November 2024 / 19:00 PDT Thursday 7th November 2024**

/hold

The hold should ONLY be cancelled by the Release Team Leads when the 1.32 Release Team is ready around the Code Freeze deadline.

/priority critical-urgent
/cc @kubernetes/release-team-leads 
/cc @kubernetes/release-engineering 