### PR TITLE
Enable reporting the outcome of in-place pod resize e2e presubmit job in GitHub

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -4095,7 +4095,7 @@ presubmits:
     optional: true
     always_run: false
     run_if_changed: 'test/e2e/node/pod_resize.go|pkg/kubelet/kubelet.go|pkg/kubelet/kubelet_pods.go|pkg/kubelet/kuberuntime/kuberuntime_manager.go'
-    skip_report: true
+    skip_report: false
     branches:
     # TODO(releng): Remove once repo default branch has been renamed
     - master


### PR DESCRIPTION
In-place pod resize test is run when certain kubelet files are changed but you have to go looking for it. This PR enables its visibility but does not require it (yet)