### PR TITLE
Increase timeout for post-kubetest2-push-binaries

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kubetest2.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kubetest2.yaml
@@ -7,6 +7,9 @@ postsubmits:
         testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com
         testgrid-num-columns-recent: '3'
       decorate: true
+      decoration_config:
+        timeout: 180m
+        grace_period: 10m
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
snippet from [log](https://storage.googleapis.com/kubernetes-ci-logs/logs/post-kubetest2-push-binaries/1853824976893775872/build-log.txt):
```
Your build timed out. Use the [--timeout=DURATION] flag to change the timeout threshold.
ERROR: (gcloud.builds.submit) build bfe2676c-5bb2-4587-a7a8-6cb2a4a4d059 completed with status "TIMEOUT"
```

/assign @upodroid @ameukam 