### PR TITLE
Add git-dir for ci-kubetest2-push-binaries

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kubetest2.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kubetest2.yaml
@@ -49,6 +49,7 @@ periodics:
             - --project=k8s-staging-kubetest2
             - --scratch-bucket=gs://k8s-staging-kubetest2-gcb
             - --env-passthrough=PULL_BASE_SHA
+            - --with-git-dir
             - --build-dir=.
             - hack/ci/push-binaries/
           env:


### PR DESCRIPTION
failure from [log](url):
```
+++ dirname hack/ci/push-binaries/push-binaries.sh
++ cd hack/ci/push-binaries/../../..
++ pwd -P
+ REPO_ROOT=/workspace
+ export REPO_ROOT
+ cd /workspace
+ '[' -n '' ']'
++ git rev-parse HEAD
+ COMMIT=
ERROR
```

Let's ensure git directory gets to cloud build as well.