### PR TITLE
Bump timeout for post-release-push-image-go-runner

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
@@ -70,6 +70,9 @@ postsubmits:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
+      decoration_config:
+        timeout: 240m
+        grace_period: 10m
       run_if_changed: '^images\/build\/go-runner\/'
       branches:
         - ^main$


### PR DESCRIPTION
log snippet from [log](https://storage.googleapis.com/kubernetes-ci-logs/logs/post-release-push-image-go-runner/1854806249011417088/build-log.txt)

```
{"component":"entrypoint","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:169","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 2h0m0s timeout","severity":"error","time":"2024-11-08T10:40:51Z"}
{"component":"entrypoint","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:267","func":"sigs.k8s.io/prow/pkg/entrypoint.gracefullyTerminate","level":"error","msg":"Process did not exit before 15m0s grace period","severity":"error","time":"2024-11-08T10:55:51Z"}
```