### PR TITLE
Sync CAPZ approvers with Azure provider project

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -4,12 +4,12 @@ approvers:
 - jackfrancis
 - Jont828
 - mboersma
+- nawazkh
 - nojnhuh
 - willie-yao
 reviewers:
 - jsturtevant
 - marosset
-- nawazkh
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

Specifically, moves @nawazkh to approvers.

/cc @jackfrancis @Jont828 @nojnhuh @willie-yao