### PR TITLE
use SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE for cgroup v1 nodes

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupv1.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1.ign
@@ -4,7 +4,7 @@
   },
   "kernelArguments": {
     "shouldExist": [
-      "systemd.unified_cgroup_hierarchy=0"
+      "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1"
     ],
     "shouldNotExist": [
       "mitigations=auto,nosmt"

--- a/jobs/e2e_node/crio/crio_cgroupv1_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1_eventedpleg.ign
@@ -4,7 +4,7 @@
   },
   "kernelArguments": {
     "shouldExist": [
-      "systemd.unified_cgroup_hierarchy=0"
+      "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1"
     ],
     "shouldNotExist": [
       "mitigations=auto,nosmt"

--- a/jobs/e2e_node/crio/crio_cgroupv1_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1_hugepages.ign
@@ -4,7 +4,7 @@
   },
   "kernelArguments": {
     "shouldExist": [
-      "systemd.unified_cgroup_hierarchy=0"
+      "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1"
     ],
     "shouldNotExist": [
       "mitigations=auto,nosmt"

--- a/jobs/e2e_node/crio/templates/base/cgroupv1.yaml
+++ b/jobs/e2e_node/crio/templates/base/cgroupv1.yaml
@@ -1,4 +1,4 @@
 ---
 kernel_arguments:
   should_exist:
-    - systemd.unified_cgroup_hierarchy=0
+    - SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1.yaml
@@ -5,7 +5,7 @@ kernel_arguments:
   should_not_exist:
     - mitigations=auto,nosmt
   should_exist:
-    - systemd.unified_cgroup_hierarchy=0
+    - SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1
 storage:
   files:
     - path: /etc/zincati/config.d/90-disable-auto-updates.toml

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1_eventedpleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1_eventedpleg.yaml
@@ -5,7 +5,7 @@ kernel_arguments:
   should_not_exist:
     - mitigations=auto,nosmt
   should_exist:
-    - systemd.unified_cgroup_hierarchy=0
+    - SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1
 storage:
   files:
     - path: /etc/zincati/config.d/90-disable-auto-updates.toml

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1_hugepages.yaml
@@ -5,7 +5,7 @@ kernel_arguments:
   should_not_exist:
     - mitigations=auto,nosmt
   should_exist:
-    - systemd.unified_cgroup_hierarchy=0
+    - SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1
 storage:
   files:
     - path: /etc/zincati/config.d/90-disable-auto-updates.toml


### PR DESCRIPTION
In systemd 256, systemd has moved towards not booting on a cgroup v1 node. There is a special environment variable one can set in the kernel arguments to fall back to cgroup v1.

In upstream Kube, we have not dropped cgroup v1 so we must keep the CI running.

This started failing because fedora 41 uses systemd 256 and we are now using fedora coreos 41.