### PR TITLE
pull-kubernetes-scheduler-perf: fix and enhance JUnit upload

### DIFF
--- a/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
+++ b/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
@@ -80,7 +80,7 @@ presubmits:
         args:
         - /bin/sh
         - -c
-        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} ARTIFACTS=${WORKSPACE}/artifacts make test-integration WHAT=./test/integration/scheduler_perf/... KUBE_TIMEOUT=--timeout=3h55m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1ns -bench=BenchmarkPerfScheduling -data-items-dir=${WORKSPACE}/artifacts" SHORT='--short=false'
+        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} make test-integration WHAT=./test/integration/scheduler_perf/... KUBE_TIMEOUT=--timeout=3h55m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1ns -bench=BenchmarkPerfScheduling -data-items-dir=${WORKSPACE}/artifacts" SHORT='--short=false' KUBE_PRUNE_JUNIT_TESTS=false
         # We need to constraint compute resources so all the tests
         # finish approximately at the same time. More compute power
         # can increase scheduling throughput and make consequent results


### PR DESCRIPTION
The manual ARTIFACTS was wrong. It gets set to something else in the final pod YAML, so we must not override it.

With KUBE_PRUNE_JUNIT_TESTS=false (from
https://github.com/kubernetes/kubernetes/pull/128834) we will get more detailed reporting.