### PR TITLE
fix: update owners to sync with the k/k ones

### DIFF
--- a/config/jobs/kubernetes/sig-scheduling/OWNERS
+++ b/config/jobs/kubernetes/sig-scheduling/OWNERS
@@ -1,18 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+    - ahg-g
     - alculquicondor
-    - Huang-Wei
     - AxeZhan
     - damemi
     - denkensk
+    - Huang-Wei
+    - kerthcet
     - macsko
     - sanposhiho
-    - kerthcet
 approvers:
+    - ahg-g
     - alculquicondor
     - Huang-Wei
-    - ahg-g
     - kerthcet
     - sanposhiho
 labels:

--- a/config/jobs/kubernetes/sig-scheduling/OWNERS
+++ b/config/jobs/kubernetes/sig-scheduling/OWNERS
@@ -1,12 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- ahg-g
-- alculquicondor
-- Huang-Wei
+    - alculquicondor
+    - Huang-Wei
+    - AxeZhan
+    - damemi
+    - denkensk
+    - macsko
+    - sanposhiho
+    - kerthcet
 approvers:
-- ahg-g
-- alculquicondor
-- Huang-Wei
+    - alculquicondor
+    - Huang-Wei
+    - ahg-g
+    - kerthcet
+    - sanposhiho
 labels:
 - sig/scheduling


### PR DESCRIPTION
config/jobs/kubernetes/sig-scheduling/OWNERS isn't updated for a while.
This PR syncs it with -
https://github.com/kubernetes/kubernetes/blob/master/OWNERS_ALIASES#L156-L174

One difference, in k/k, we don't have some approvers in reviewers intentionally to reduce the burden, but this PR keeps them as well. We can do the same as k/k if anyone wants.