### PR TITLE
Upgrade ANP test to use golang 1.22.7

### DIFF
--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits-master.yaml
@@ -11,7 +11,7 @@ presubmits:
     path_alias: sigs.k8s.io/apiserver-network-proxy
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22.5
+      - image: public.ecr.aws/docker/library/golang:1.22.7
         command:
         - make
         args:


### PR DESCRIPTION
Dependency update requires newer version of golang.