### PR TITLE
sig-scalability: keep more detailed JUnit for scheduler_perf job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -761,6 +761,10 @@ periodics:
       # We have to explicitly disable --short flag because the script enables by default.
       - name: SHORT
         value: --short=false
+      # Capture success/failure and duration for each individual test case instead
+      # of reducing everything at the package level.
+      - name: KUBE_PRUNE_JUNIT_TESTS
+        value: "false"
       # We need to constraint compute resources so all the tests
       # finish approximately at the same time. More compute power
       # can increase scheduling throughput and make consequent results


### PR DESCRIPTION
Instead of combining all tests under their package, each test is listed separately. This makes it more visible how long each test runs.

This mirrors the corresponding change made earlier in https://github.com/kubernetes/test-infra/pull/33809

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/directory/pull-kubernetes-scheduler-perf/1858554004104024064 is an example of a job with the details. Older runs of that job did not have any JUnit results.
