### PR TITLE
use release-7.0 for jobset release branch for release-0.7

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
@@ -5,7 +5,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: jobset
-        base_ref: release-0.7
+        base_ref: release-7.0
         path_alias: sigs.k8s.io/jobset
     annotations:
       testgrid-dashboards: sig-scheduling
@@ -43,7 +43,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: jobset
-        base_ref: release-0.7
+        base_ref: release-7.0
         path_alias: sigs.k8s.io/jobset
     annotations:
       testgrid-dashboards: sig-scheduling
@@ -74,7 +74,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: jobset
-        base_ref: release-0.7
+        base_ref: release-7.0
         path_alias: sigs.k8s.io/jobset
     annotations:
       testgrid-dashboards: sig-scheduling
@@ -114,11 +114,11 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: jobset
-        base_ref: release-0.7
+        base_ref: release-7.0
         path_alias: sigs.k8s.io/jobset
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-jobset-test-e2e-release-0-5-1-29
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-7-1-29
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset end to end tests for Kubernetes 1.29 on release 0.7"
       testgrid-num-columns-recent: '30'


### PR DESCRIPTION
There were some failures with jobset release 0.7 jobs. 

- https://testgrid.k8s.io/sig-scheduling#periodic-jobset-test-unit-release-0-7
- https://testgrid.k8s.io/sig-scheduling#periodic-jobset-test-e2e-release-0-5-1-29
- https://testgrid.k8s.io/sig-scheduling#periodic-jobset-test-e2e-release-0-7-1-28

Looking at these, these are all related to the branch name for jobset release 0.7 is release-7.0 rather than release-0.7. This PR should get the periodics running for real now.

/cc @ahg-g @danielvegamyhre 