### PR TITLE
fix: make compatibility versions test use dynamic n-1 branch for test (from hardcoded release-1.31)

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -35,8 +35,6 @@ periodics:
       - -c
       - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && ./../test-infra/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
       env:
-      - name: EMULATED_VERSION
-        value: "1.31"  # TODO(aaron-prindle) FIXME - hardcoded for now
       - name: SKIP
         value: Alpha|Disruptive|Slow|Flaky|IPv6|LoadBalancer|PodSecurityPolicy|nfs
       - name: PARALLEL


### PR DESCRIPTION
Fixes #33573 

This PR modifies `experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh` to fetch the latest release-X.Y branch from https://github.com/kubernetes/kubernetes.git and use that as the n-1 version for compatibility versions testing.  This way this test is dynamic and updates the n-1 version as new releases are made - updating automatically over time vs the current hardcoded `release-1.31` value currently present in the test.  