### PR TITLE
fix release 0.6 integration test failure due to golang version

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-6.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-6.yaml
@@ -58,7 +58,7 @@ periodics:
     decorate: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         command:
         - make
         args:


### PR DESCRIPTION
Failure due to golang 1.22: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-jobset-test-integration-release-0-6/1860965676622024704

```
go: downloading github.com/pmezard/go-difflib v1.0.0
test -s /home/prow/go/src/sigs.k8s.io/jobset/bin/setup-envtest || GOBIN=/home/prow/go/src/sigs.k8s.io/jobset/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
go: downloading sigs.k8s.io/controller-runtime v0.19.2
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-202411202112[54](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-jobset-test-integration-release-0-6/1860965676622024704#1:build-log.txt%3A54)-b88f351e4ba2
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20241120211254-b88f351e4ba2 requires go >= 1.23.0 (running go 1.22.9; GOTOOLCHAIN=local)
make: *** [Makefile:249: /home/prow/go/src/sigs.k8s.io/jobset/bin/setup-envtest] Error 1
```


