### PR TITLE
[releng] 1.32: Update kubekins-e2e variants.yaml with 1.32 config

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -31,6 +31,12 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
+  '1.32':
+    CONFIG: '1.32'
+    GO_VERSION: 1.23.2
+    K8S_RELEASE: latest-1.32
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   '1.31':
     CONFIG: '1.31'
     GO_VERSION: 1.22.8

--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,14 +1,14 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.23.2
+    GO_VERSION: 1.23.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
     KUBETEST2_VERSION: latest
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.23.2
+    GO_VERSION: 1.23.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
@@ -21,19 +21,19 @@ variants:
     KIND_VERSION: 0.17.0
   master:
     CONFIG: master
-    GO_VERSION: 1.23.2
+    GO_VERSION: 1.23.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   main:
     CONFIG: main
-    GO_VERSION: 1.23.2
+    GO_VERSION: 1.23.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.32':
     CONFIG: '1.32'
-    GO_VERSION: 1.23.2
+    GO_VERSION: 1.23.3
     K8S_RELEASE: latest-1.32
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0


### PR DESCRIPTION
Update kubekins-e2e variant with 1.32 config.

/sig release
/area release-eng

cc @kubernetes/release-engineering @mickeyboxell 