### PR TITLE
provider-aws: fix image tag in presubmits

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
@@ -79,7 +79,7 @@ presubmits:
               BUILD_IMAGE=ko.local:${VERSION}
               REGION=${REGION:-"us-east-1"}
 
-              make switch-to-latest-k8s ko-build-local
+              make switch-to-latest-k8s ko-build-local VERSION=${VERSION}
 
               AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
               IMAGE_NAME=${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/provider-aws/cloud-controller-manager
@@ -162,7 +162,7 @@ presubmits:
               BUILD_IMAGE=ko.local:${VERSION}
               REGION=${REGION:-"us-east-1"}
 
-              make switch-to-latest-k8s ko-build-local
+              make switch-to-latest-k8s ko-build-local VERSION=${VERSION}
 
               AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
               IMAGE_NAME=${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/provider-aws/cloud-controller-manager


### PR DESCRIPTION
The `switch-to-latest-k8s` target may make our checkout `dirty`. The `ko-build-local` target may then decide the `VERSION` (within the `Makefile`) needs a `-dirty` suffix, which causes a mismatch with the `VERSION` in the scripting (because the variable is not exported or passed on the `make` cmdline). I chose the latter to make it more obvious in the future that this is load-bearing.