### PR TITLE
CI images are sig/testing

### DIFF
--- a/images/kubekins-e2e-v2/OWNERS
+++ b/images/kubekins-e2e-v2/OWNERS
@@ -17,7 +17,3 @@ approvers:
 emeritus_approvers:
 - amwat
 - spiffxp
-
-labels:
-- sig/release
-- area/release-eng

--- a/images/kubekins-e2e/OWNERS
+++ b/images/kubekins-e2e/OWNERS
@@ -18,7 +18,3 @@ emeritus_approvers:
 - amwat
 - spiffxp
 - MushuEE
-
-labels:
-- sig/release
-- area/release-eng


### PR DESCRIPTION
There's a lot of involvement across sigs, but these are and have always been SIG testing as part of the CI, as opposed to the release build images etc. These images are intended for use and _are_ used broadly across the project and are not limited to k/k, they're general CI base environments.
Noticed this while working on some cleanup

/assign @aojea