### PR TITLE
cleanup krte/kubekins-e2e/kubekins-e2e-v2

### DIFF
--- a/config/jobs/kubernetes-sigs/prow/prow-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-periodics.yaml
@@ -12,7 +12,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-postsubmits.yaml
@@ -10,7 +10,7 @@ postsubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/prow/prow-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:
@@ -41,7 +41,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:
@@ -72,7 +72,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:
@@ -100,7 +100,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:
@@ -130,7 +130,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -12,7 +12,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -1,41 +1,5 @@
 presubmits:
   kubernetes/test-infra:
-  # pull-test-infra-bazel is deprecated, leave it here just in case. Will be
-  # completely removed once bazel footprint is removed from test-infra
-  - name: pull-test-infra-bazel
-    cluster: eks-prow-build-cluster
-    branches:
-    - master
-    always_run: false
-    optional: true
-    decorate: true
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20220314-46af1b01a6-test-infra
-        command:
-        - hack/bazel.sh
-        args:
-        - test
-        - --config=ci
-        - --nobuild_tests_only
-        - //...
-        env:
-        - name: BAZEL_FETCH_PLEASE
-          value: //...
-        resources:
-          requests:
-            cpu: "4"
-            memory: "8Gi"
-          limits:
-            cpu: "4"
-            memory: "8Gi"
-    annotations:
-      testgrid-dashboards: presubmits-test-infra
-      testgrid-tab-name: bazel
-
   - name: pull-test-infra-gubernator
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -111,7 +111,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:
@@ -144,7 +144,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:
@@ -175,7 +175,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:
@@ -206,7 +206,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:
@@ -236,7 +236,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-test-infra
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-master
         command:
         - runner.sh
         args:

--- a/images/kubekins-e2e-v2/OWNERS
+++ b/images/kubekins-e2e-v2/OWNERS
@@ -17,7 +17,3 @@ approvers:
 emeritus_approvers:
 - amwat
 - spiffxp
-
-labels:
-- sig/release
-- area/release-eng

--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -5,13 +5,6 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
-  test-infra:
-    CONFIG: test-infra
-    GO_VERSION: 1.21.12
-    K8S_RELEASE: stable
-    BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 3.1.0
-    KIND_VERSION: 0.17.0
   master:
     CONFIG: master
     GO_VERSION: 1.23.3

--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,11 +1,4 @@
 variants:
-  experimental:
-    CONFIG: experimental
-    GO_VERSION: 1.23.3
-    K8S_RELEASE: stable
-    BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0
-    KUBETEST2_VERSION: latest
   go-canary:
     CONFIG: go-canary
     GO_VERSION: 1.23.3

--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -48,9 +48,3 @@ variants:
     K8S_RELEASE: latest-1.29
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
-  '1.28':
-    CONFIG: '1.28'
-    GO_VERSION: 1.22.8
-    K8S_RELEASE: latest-1.28
-    BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0

--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -11,12 +11,6 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
-  main:
-    CONFIG: main
-    GO_VERSION: 1.23.3
-    K8S_RELEASE: stable
-    BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0
   '1.32':
     CONFIG: '1.32'
     GO_VERSION: 1.23.3

--- a/images/kubekins-e2e/OWNERS
+++ b/images/kubekins-e2e/OWNERS
@@ -18,7 +18,3 @@ emeritus_approvers:
 - amwat
 - spiffxp
 - MushuEE
-
-labels:
-- sig/release
-- area/release-eng


### PR DESCRIPTION
- Clarify sig/testing owns these images .... which has always been true, these are not used only to test k/k and they're the base CI environment, which is SIG Testing's charter
- drop multiple already unused variants
- make test-infra variant unused (we can just use -master at this point, test-infra can control the go version in-repo and should aim to keep up with k/k anyhow, and certainly isn't jumping ahead of k/k anymore)
- also drop test-infra variant after making it unused
- drop 1.28 which is out of support

/cc @aojea @liggitt 
/assign @aojea @liggitt 

TODO: revisit -go-canary variant.

Fixes https://github.com/kubernetes/test-infra/issues/33845 (and hopefully will help us get these jobs passingg agani)