### PR TITLE
Set data-items-dir to ARTIFACTS directly in scheduler_perf presubmit job

### DIFF
--- a/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
+++ b/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
@@ -80,7 +80,7 @@ presubmits:
         args:
         - /bin/sh
         - -c
-        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} make test-integration WHAT=./test/integration/scheduler_perf/... KUBE_TIMEOUT=--timeout=3h55m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1ns -bench=BenchmarkPerfScheduling -data-items-dir=${WORKSPACE}/artifacts" SHORT='--short=false' KUBE_PRUNE_JUNIT_TESTS=false
+        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} make test-integration WHAT=./test/integration/scheduler_perf/... KUBE_TIMEOUT=--timeout=3h55m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1ns -bench=BenchmarkPerfScheduling -data-items-dir=${ARTIFACTS}" SHORT='--short=false' KUBE_PRUNE_JUNIT_TESTS=false
         # We need to constraint compute resources so all the tests
         # finish approximately at the same time. More compute power
         # can increase scheduling throughput and make consequent results


### PR DESCRIPTION
pull-kubernetes-scheduler-perf presubmit jobs don't have a generated json result in their artifacts directory. Its location is determined by `-data-items-dir` flag that for periodic job is set directly to `ARTIFACTS` variable (via [jenkins/benchmark-dockerized.sh](https://github.com/kubernetes/kubernetes/blob/8770bd58d04555303a3a15b30c245a58723d0f4a/hack/jenkins/benchmark-dockerized.sh#L63) script in k/k). 