### PR TITLE
Also install pnpm globally in test.

### DIFF
--- a/config/jobs/kubernetes-sigs/testgrid/testgrid-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/testgrid/testgrid-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
         - bash
         args:
         - -c
-        - cd web && npm install && pnpm run build && pnpm test
+        - cd web && npm install && npm install -g pnpm && pnpm run build && pnpm test
         resources:
           requests:
             cpu: 2


### PR DESCRIPTION
re: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_testgrid/17/test-testgrid-npm/1861554431389077504

(Agree we should add pnpm as a dependency, but `npm install pnpm` is insufficient since we need to run pnpm. Instead using `npm install -g pnpm` to install it globally; more in https://nodejs.org/en/blog/npm/npm-1-0-global-vs-local-installation/#which-to-choose).