### PR TITLE
experiment: limit concurrency of test-infra image push postsubmits

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -16,6 +16,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -40,6 +42,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -64,6 +68,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -112,6 +118,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -136,6 +144,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -160,6 +170,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -184,6 +196,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -211,6 +225,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -239,6 +255,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -249,7 +267,6 @@ postsubmits:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra
           - images/kubekins-e2e-v2/
-
     - name: post-test-infra-push-alpine
       cluster: k8s-infra-prow-build-trusted
       run_if_changed: '^images/alpine/'
@@ -260,6 +277,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -280,6 +299,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -300,6 +321,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -323,6 +346,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -355,6 +380,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -379,6 +406,8 @@ postsubmits:
       branches:
       - ^master$
       max_concurrency: 1
+      # avoid overloading GCB logs quota for the shared staging project
+      job_queue_name: "test-infra-staging-image-push"
       spec:
         serviceAccountName: gcb-builder
         containers:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -7,7 +7,10 @@ plank:
   pod_pending_timeout: 15m
   pod_unscheduled_timeout: 5m
   job_queue_capacities:
+    # limits concurrency for image promoter jobs
     'k8sio-image-promo': 1
+    # limits concurrency for k8s-test-infra-staging project
+    'test-infra-staging-image-push': 1
   default_decoration_config_entries:
   - config:
       timeout: 2h


### PR DESCRIPTION
this should prevent exceeding quota to fetch GCB results so the jobs succeed. we might be able to increase quota instead, but this is readily available by PR and we shouldn't need to run many concurrently anyhow. the jobs can queue instead.

follow-up to https://github.com/kubernetes/test-infra/issues/33845 and the issues with 1.32 go image updates