### PR TITLE
images/ - remove _OLD_BAZEL_VERSION

### DIFF
--- a/images/krte/cloudbuild.yaml
+++ b/images/krte/cloudbuild.yaml
@@ -6,9 +6,6 @@ steps:
     - --tag=gcr.io/$PROJECT_ID/krte:$_GIT_TAG-$_CONFIG
     - --build-arg=GO_VERSION=$_GO_VERSION
     - --build-arg=K8S_RELEASE=$_K8S_RELEASE
-    - --build-arg=BAZEL_VERSION_ARG=$_BAZEL_VERSION
-    - --build-arg=OLD_BAZEL_VERSION=$_OLD_BAZEL_VERSION
-    - --build-arg=CFSSL_VERSION=$_CFSSL_VERSION
     - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/krte:$_GIT_TAG-$_CONFIG
     - .
     dir: images/krte

--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -4,34 +4,28 @@ variants:
     GO_VERSION: 1.23.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0
   master:
     CONFIG: master
     GO_VERSION: 1.23.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0
   '1.32':
     CONFIG: '1.32'
     GO_VERSION: 1.23.3
     K8S_RELEASE: latest-1.32
     BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0
   '1.31':
     CONFIG: '1.31'
     GO_VERSION: 1.22.8
     K8S_RELEASE: latest-1.31
     BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0
   '1.30':
     CONFIG: '1.30'
     GO_VERSION: 1.22.8
     K8S_RELEASE: latest-1.30
     BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0
   '1.29':
     CONFIG: '1.29'
     GO_VERSION: 1.22.8
     K8S_RELEASE: latest-1.29
     BAZEL_VERSION: 3.4.1
-    OLD_BAZEL_VERSION: 2.2.0

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -81,10 +81,6 @@ ENV BAZEL_VERSION=${BAZEL_VERSION_ARG}
 COPY images/kubekins-e2e/install-bazel.sh /
 RUN bash /install-bazel.sh
 
-ARG OLD_BAZEL_VERSION
-COPY --from=old \
-    /usr/local/lib/bazel/bin/bazel-real /usr/local/lib/bazel/bin/bazel-${OLD_BAZEL_VERSION}
-
 # install kind if a version is provided
 ARG KIND_VERSION
 RUN if [ -n "${KIND_VERSION}" ]; then \

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -22,7 +22,6 @@ steps:
     - --build-arg=GO_VERSION=$_GO_VERSION
     - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG
     - --build-arg=K8S_RELEASE=$_K8S_RELEASE
-    - --build-arg=OLD_BAZEL_VERSION=$_OLD_BAZEL_VERSION
     - --build-arg=KIND_VERSION=$_KIND_VERSION
     - --build-arg=KUBETEST2_VERSION=$_KUBETEST2_VERSION
     - --build-arg=YQ_VERSION=$_YQ_VERSION


### PR DESCRIPTION
TODO: drop bazel entirely. Need to audit any remaining users first. But there's no reason we need to keep shipping two versions including one extremely old fallback version.

This commit will help test the image push queuing. (https://github.com/kubernetes/test-infra/pull/33854)