### PR TITLE
remove pull-kubernetes-verify-lint

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -2059,31 +2059,6 @@ presubmits:
     branches:
     - release-1.29
     cluster: eks-prow-build-cluster
-    context: pull-kubernetes-verify-lint
-    decorate: true
-    name: pull-kubernetes-verify-lint
-    optional: true
-    path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-      - args:
-        - verify
-        - WHAT=golangci-lint golangci-lint-pr
-        command:
-        - make
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241126-5bbfc324b7-1.29
-        name: ""
-        resources:
-          limits:
-            cpu: "5"
-            memory: 12Gi
-          requests:
-            cpu: "5"
-            memory: 12Gi
-  - always_run: true
-    branches:
-    - release-1.29
-    cluster: eks-prow-build-cluster
     context: pull-kubernetes-linter-hints
     decorate: true
     name: pull-kubernetes-linter-hints

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -2169,30 +2169,6 @@ presubmits:
     branches:
     - release-1.30
     cluster: eks-prow-build-cluster
-    context: pull-kubernetes-verify-lint
-    decorate: true
-    name: pull-kubernetes-verify-lint
-    path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-      - args:
-        - verify
-        - WHAT=golangci-lint golangci-lint-pr
-        command:
-        - make
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241126-5bbfc324b7-1.30
-        name: ""
-        resources:
-          limits:
-            cpu: "5"
-            memory: 12Gi
-          requests:
-            cpu: "5"
-            memory: 12Gi
-  - always_run: true
-    branches:
-    - release-1.30
-    cluster: eks-prow-build-cluster
     context: pull-kubernetes-linter-hints
     decorate: true
     name: pull-kubernetes-linter-hints

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -2104,30 +2104,6 @@ presubmits:
     branches:
     - release-1.31
     cluster: eks-prow-build-cluster
-    context: pull-kubernetes-verify-lint
-    decorate: true
-    name: pull-kubernetes-verify-lint
-    path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-      - args:
-        - verify
-        - WHAT=golangci-lint golangci-lint-pr
-        command:
-        - make
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241126-5bbfc324b7-1.31
-        name: ""
-        resources:
-          limits:
-            cpu: "5"
-            memory: 12Gi
-          requests:
-            cpu: "5"
-            memory: 12Gi
-  - always_run: true
-    branches:
-    - release-1.31
-    cluster: eks-prow-build-cluster
     context: pull-kubernetes-linter-hints
     decorate: true
     name: pull-kubernetes-linter-hints

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -46,46 +46,6 @@ presubmits:
           requests:
             cpu: 7
             memory: 12Gi
-  - name: pull-kubernetes-verify-lint
-    cluster: eks-prow-build-cluster
-    decorate: true
-    # This job is running all required linter checks:
-    # - baseline for all code
-    # - stricter configuration for new or modified code in a pull request
-    #
-    # Both run in the same job to reuse the build and (to some extend)
-    # golangci-lint cache. Testing the baseline is necessary because,
-    # for example, a linter config change or tool update might cause
-    # failures in existing, unmodified code.
-    always_run: true
-    optional: false
-    skip_branches:
-    - release-\d+.\d+ # per-release job
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: sig-testing-misc
-      description: Runs golangci-lint with a stricter configuration for new code.
-      testgrid-alert-email: patrick.ohly@intel.com
-      testgrid-num-failures-to-alert: "15"
-    path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241126-5bbfc324b7-master
-        command:
-        - make
-        args:
-        - verify
-        - WHAT=golangci-lint golangci-lint-pr
-        resources:
-          # It peaks at around 7 cores of the EKS cluster. We can fit more jobs onto
-          # a node without much slowdown by requesting one third of a node
-          # (= 3 * 5 + 1 for kubelet).
-          limits:
-            cpu: 5
-            memory: 12Gi
-          requests:
-            cpu: 5
-            memory: 12Gi
   - name: pull-kubernetes-linter-hints
     cluster: eks-prow-build-cluster
     decorate: true

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -42,9 +42,6 @@ dashboards:
   - name: pull-kubernetes-verify
     test_group_name: pull-kubernetes-verify
     base_options: width=10
-  - name: pull-kubernetes-verify-lint
-    test_group_name: pull-kubernetes-verify-lint
-    base_options: width=10
   - name: pull-kubernetes-typecheck
     test_group_name: pull-kubernetes-typecheck
     base_options: width=10

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -40,5 +40,4 @@ jobs:
   - pull-kubernetes-unit
   - pull-kubernetes-unit-go-compatibility
   - pull-kubernetes-verify
-  - pull-kubernetes-verify-lint
 recursive_artifacts: false


### PR DESCRIPTION
The original intent behind this merge-blocking job was to enforce that certain linter issues get fixed in new or modified code for "intermediate severity" issues (not necessary to fix them in existing code, but should not occur in new code).

This approach had some drawbacks:
- It forced developers touching code which has such issues to address them, whether it makes sense in their PR or not.
- Reverting a PR which fixed such an issue as part of some other change failed in pull-kubernetes-verify-lint because the revert is treated like "updated code" and re-introduces the issue.
- It's not entirely clear which issues fall into this "intermediate severity".

Therefore the job gets removed. These issues still get reported as part of the optional pull-kubernetes-linter-hints job. Developers and reviewers are encouraged to pay attention to it and use their own judgement to decide whether something reported their needs to be addressed in a PR.

Kubernetes itself still has the hack/golangci-strict.yaml configuration. Once this PR is merged, that can and probably should be simplified.

/cc @bentheelder @liggitt  @aojea @dims

We previously agreed to remove the job in https://kubernetes.slack.com/archives/CN0K3TE2C/p1731087662490879?thread_ts=1731050233.713049&cid=CN0K3TE2C