### PR TITLE
Make it possible to update AMIs separately from updating jobs

### DIFF
--- a/config/jobs/kubernetes/kops/Makefile
+++ b/config/jobs/kubernetes/kops/Makefile
@@ -13,5 +13,12 @@
 # limitations under the License.
 
 .PHONY: generate
-generate:
+generate: | invalidate-pins generate-jobs
+
+.PHONY: invalidate-pins
+invalidate-pins:
+	rm -f pinned.list
+
+.PHONY: generate-jobs
+generate-jobs:
 	PYTHONPATH=. python3 build_jobs.py

--- a/config/jobs/kubernetes/kops/pinned.list
+++ b/config/jobs/kubernetes/kops/pinned.list
@@ -1,0 +1,16 @@
+aws://images/137112412989/al2023-ami-2*-kernel-6.1-x86_64:x86_64=137112412989/al2023-ami-2023.6.20241121.0-kernel-6.1-x86_64
+aws://images/137112412989/amzn2-ami-kernel-5.10-hvm-*-x86_64-gp2:x86_64=137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20241113.1-x86_64-gp2
+aws://images/136693071363/debian-10-amd64-*:x86_64=136693071363/debian-10-amd64-20240703-1797
+aws://images/136693071363/debian-11-amd64-*:x86_64=136693071363/debian-11-amd64-20241111-1928
+aws://images/136693071363/debian-12-amd64-*:x86_64=136693071363/debian-12-amd64-20241125-1942
+aws://images/075585003325/Flatcar-beta-*-hvm:x86_64=075585003325/Flatcar-beta-4116.1.0-hvm
+aws://images/075585003325/Flatcar-beta-*-hvm:arm64=075585003325/Flatcar-beta-4116.1.0-arm64-hvm
+aws://images/309956199498/RHEL-8.*_HVM-*-x86_64-*:x86_64=309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3
+aws://images/309956199498/RHEL-9.*_HVM-*-x86_64-*:x86_64=309956199498/RHEL-9.4.0_HVM-20241114-x86_64-0-Hourly2-GP3
+aws://images/792107900819/Rocky-9-EC2-Base-9.*.x86_64:x86_64=792107900819/Rocky-9-EC2-Base-9.5-20241118.0.x86_64
+aws://images/099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*:x86_64=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20241112
+aws://images/099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-*:arm64=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20241112
+aws://images/099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*:x86_64=099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20241120
+aws://images/099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*:arm64=099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20241120
+aws://images/099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*:x86_64=099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20241109
+aws://images/099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*:arm64=099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20241109


### PR DESCRIPTION
This also avoids needing AWS credentials to update the jobs.

The default behaviour is unchanged, but the generate-jobs target
should not require AWS credentials.
