### PR TITLE
add optional presubmit job to run apidiff on the client-go module

### DIFF
--- a/config/jobs/kubernetes/sig-testing/apidiff.yaml
+++ b/config/jobs/kubernetes/sig-testing/apidiff.yaml
@@ -56,5 +56,40 @@ presubmits:
             cpu: 2
             memory: 12Gi
 
+  - name: pull-kubernetes-apidiff-client-go
+    cluster: eks-prow-build-cluster
+    # A job which automatically runs for changes in client-go or the generated code
+    # to have visibility on the changes that will impact the external projects
+    # that are using the Kubernetes golang clients
+    run_if_changed: '(^staging\/src\/k8s.io\/client-go)|(^staging\/src\/k8s.io\/code-generator\/examples)'
+    optional: true
+    decorate: true
+    annotations:
+      # The apidiff.sh script uses the latest revision of apidiff.
+      # There is no guarantee that this will continue to work for
+      # older branches, so let's not even create per-release
+      # copies of this job.
+      fork-per-release: "false"
+      testgrid-dashboards: sig-testing-misc
+      testgrid-create-test-group: 'true'
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        args:
+        - /bin/sh
+        - -c
+        - "./hack/apidiff.sh ./staging/src/k8s.io/code-generator/examples ./staging/src/k8s.io/client-go"
+        resources:
+          # Memory limits are derived from pull-kubernetes-verify, with less CPUs.
+          limits:
+            cpu: 2
+            memory: 12Gi
+          requests:
+            cpu: 2
+            memory: 12Gi
+
 # A periodic job which shows API diffs for staging repos since the last release
 # might be useful. Not done yet.


### PR DESCRIPTION
Having an optional presubmit that gets executed automatically when a client-go file is modified, to run apidiff against the client-go module will be helpful for reviewers to understand the impact of the changes and, if necessary, evaluate if the breaking changes are necessary or can be done in a different way that does not break downstream clients (i.e. declare the old function deprecated and add a new one)

See gist with the differences between minors versions in client-go https://gist.github.com/aojea/696155fb3e2f8775574e6afddcb33cfc , it seems we were doing better overall, but being more consistent in this area will help to reduce the friction of the ecosystem that need to consume these APIS and clients, see https://github.com/kubernetes/kubernetes/issues/124380

Reference to slack discussion https://kubernetes.slack.com/archives/C0EG7JC6T/p1732746366129629

Example execution:
```
./hack/apidiff.sh -t 26c08dde527c0d4453e95f49e3c6ef7663042f7b -r 9d62330bfa31a4fce28093d052f65ff0e88ac3a0  ./staging/src/k8s.io/client-go
Checking 26c08dde527c0d4453e95f49e3c6ef7663042f7b (= v1.32.0-beta.0-516-g26c08dde527) for API changes since 9d62330bfa31a4fce28093d052f65ff0e88ac3a0 (= v1.33.0-alpha.0-3-g9d62330bfa3).
Installing apidiff into /tmp/tmp.yRagAHGNPP.
Preparing worktree (detached HEAD 26c08dde527)
Updating files: 100% (26242/26242), done.
HEAD is now at 26c08dde527 Wait for updated keys to be observed
Preparing worktree (detached HEAD 9d62330bfa3)
Updating files: 100% (26242/26242), done.
HEAD is now at 9d62330bfa3 Merge pull request #128286 from umagnus/fix_unmount_relative_path

## ./staging/src/k8s.io/client-go
no changes

Some notes about API differences:

Changes in internal packages are usually okay.
However, remember that custom schedulers
and scheduler plugins depend on pkg/scheduler/framework.

API changes in staging repos are more critical.
Try to avoid them as much as possible.
But sometimes changing an API is the lesser evil
and/or the impact on downstream consumers is low.
Use common sense and code searches.
````

