### PR TITLE
add mising timeouts for imagefs and splitfs jobs on kubetest2 migration

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1336,6 +1336,7 @@ presubmits:
         - --repo-root=.
         - --gcp-zone=us-west1-b
         - --parallelism=8
+        - --timeout=3h
         - --focus-regex=\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
         - '--test-args=--ginkgo.timeout=3h --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
@@ -1649,6 +1650,7 @@ presubmits:
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
+        - --timeout=3h
         - '--test-args=--ginkgo.timeout=3h --service-feature-gates="KubeletSeparateDiskGC=true" --feature-gates="KubeletSeparateDiskGC=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-splitfs.yaml
         resources:


### PR DESCRIPTION
Still missing the timeout needed in node-e2e

```
I1123 11:15:28.590442   10178 ssh.go:146] Running the command ssh, with args: [-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o LogLevel=ERROR -i /root/.ssh/google_compute_engine core@34.168.14.229 -- sudo /bin/bash -c 'cd /tmp/node-e2e-20241123T111515 && set -o pipefail; timeout -k 30s 0.000000s ./ginkgo -timeout=24h -nodes=8  -focus="\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]"  -skip="\[Flaky\]|\[Slow\]|\[Serial\]"  --no-color -v --timeout=30m ./e2e_node.test -- --system-spec-name= --system-spec-file= --extra-envs= --runtime-config= --v 4 --node-name=n1-standard-2-fedora-coreos-41-20241027-3-0-gcp-x86-64-1037a7f5 --report-dir=/tmp/node-e2e-20241123T111515/results --report-prefix=fedora --image-description="fedora-coreos-41-20241027-3-0-gcp-x86-64" --kubelet-flags="--cluster-domain=cluster.local" --dns-domain="cluster.local" --prepull-images=false  --container-runtime-endpoint=unix:///run/containerd/containerd.sock --ginkgo.timeout=3h --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}" 2>&1 | tee -i /tmp/node-e2e-20241123T111515/results/n1-standard-2-fedora-coreos-41-20241027-3-0-gcp-x86-64-1037a7f5-ginkgo.log']
```
in particular this bit show it does not have the timeout set
```
... timeout -k 30s 0.000000s ./ginkgo ...
```
traking it here https://github.com/kubernetes/kubernetes/pull/128092

failing jobs
```
pull-kubernetes-node-crio-cgrpv2-imagefs-e2e-kubetest2
pull-kubernetes-node-crio-cgrpv2-splitfs-e2e-kubetest2
```
part of https://github.com/kubernetes/test-infra/issues/32567