### PR TITLE
CAPO: Adjust periodic intervals

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.10.yaml
@@ -8,7 +8,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
-  interval: 12h
+  interval: 48h
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-openstack
@@ -44,7 +44,7 @@ periodics:
     testgrid-tab-name: periodic-e2e-test-release-0.10
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-openstack-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-    testgrid-alert-stale-results-hours: "48"
+    testgrid-alert-stale-results-hours: "72"
   reporter_config:
     slack:
       channel: "cluster-api-openstack"
@@ -62,7 +62,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
-  interval: 12h
+  interval: 48h
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-openstack
@@ -104,7 +104,7 @@ periodics:
     testgrid-tab-name: periodic-e2e-full-test-release-0.10
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-openstack-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-    testgrid-alert-stale-results-hours: "48"
+    testgrid-alert-stale-results-hours: "72"
   reporter_config:
     slack:
       channel: "cluster-api-openstack"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.11.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.11.yaml
@@ -8,7 +8,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
-  interval: 12h
+  interval: 48h
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-openstack
@@ -44,7 +44,7 @@ periodics:
     testgrid-tab-name: periodic-e2e-test-release-0.11
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-openstack-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-    testgrid-alert-stale-results-hours: "48"
+    testgrid-alert-stale-results-hours: "72"
   reporter_config:
     slack:
       channel: "cluster-api-openstack"
@@ -62,7 +62,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
-  interval: 12h
+  interval: 48h
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-openstack
@@ -104,7 +104,7 @@ periodics:
     testgrid-tab-name: periodic-e2e-full-test-release-0.11
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-openstack-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-    testgrid-alert-stale-results-hours: "48"
+    testgrid-alert-stale-results-hours: "72"
   reporter_config:
     slack:
       channel: "cluster-api-openstack"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.9.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.9.yaml
@@ -8,7 +8,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
-  interval: 12h
+  interval: 48h
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-openstack
@@ -44,7 +44,7 @@ periodics:
     testgrid-tab-name: periodic-e2e-test-release-0.9
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-openstack-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-    testgrid-alert-stale-results-hours: "48"
+    testgrid-alert-stale-results-hours: "72"
   reporter_config:
     slack:
       channel: "cluster-api-openstack"
@@ -62,7 +62,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
-  interval: 12h
+  interval: 48h
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-openstack
@@ -104,7 +104,7 @@ periodics:
     testgrid-tab-name: periodic-e2e-full-test-release-0.9
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-openstack-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-    testgrid-alert-stale-results-hours: "48"
+    testgrid-alert-stale-results-hours: "72"
   reporter_config:
     slack:
       channel: "cluster-api-openstack"


### PR DESCRIPTION
I didn't pay attention when I copied the main periodic jobs, so the release branch periodic jobs got unnecessarily short intervals.