### PR TITLE
fake pull-kubernetes-verify-lint

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -2055,6 +2055,28 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
+  - always_run: false
+    branches:
+    - release-1.29
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-verify-lint
+    decorate: true
+    name: pull-kubernetes-verify-lint
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - "true"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241126-5bbfc324b7-1.29
+        name: ""
+        resources:
+          limits:
+            cpu: 0.1
+            memory: 10Mi
+          requests:
+            cpu: 0.1
+            memory: 10Mi
   - always_run: true
     branches:
     - release-1.29

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -2165,6 +2165,28 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
+  - always_run: false
+    branches:
+    - release-1.30
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-verify-lint
+    decorate: true
+    name: pull-kubernetes-verify-lint
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - "true"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241126-5bbfc324b7-1.30
+        name: ""
+        resources:
+          limits:
+            cpu: 0.1
+            memory: 10Mi
+          requests:
+            cpu: 0.1
+            memory: 10Mi
   - always_run: true
     branches:
     - release-1.30

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -2100,6 +2100,28 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
+  - always_run: false
+    branches:
+    - release-1.31
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-verify-lint
+    decorate: true
+    name: pull-kubernetes-verify-lint
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - "true"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241126-5bbfc324b7-1.31
+        name: ""
+        resources:
+          limits:
+            cpu: 0.1
+            memory: 10Mi
+          requests:
+            cpu: 0.1
+            memory: 10Mi
   - always_run: true
     branches:
     - release-1.31

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -46,6 +46,35 @@ presubmits:
           requests:
             cpu: 7
             memory: 12Gi
+  - name: pull-kubernetes-verify-lint
+    cluster: eks-prow-build-cluster
+    decorate: true
+    always_run: false
+    optional: true
+    skip_branches:
+    - release-\d+.\d+ # per-release job
+    annotations:
+      fork-per-release: "false"
+      testgrid-dashboards: sig-testing-misc
+      description: Runs golangci-lint with a stricter configuration for new code.
+      testgrid-alert-email: patrick.ohly@intel.com
+      testgrid-num-failures-to-alert: "15"
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241126-5bbfc324b7-master
+        command:
+        # This job is transitional: it's provided for PRs where the previous, real
+        # pull-kubernetes-verify-lint was run while it still existed and where the
+        # PR now is blocked by not having a successful test run.
+        - "true"
+        resources:
+          limits:
+            cpu: 0.1
+            memory: 10Mi
+          requests:
+            cpu: 0.1
+            memory: 10Mi
   - name: pull-kubernetes-linter-hints
     cluster: eks-prow-build-cluster
     decorate: true


### PR DESCRIPTION
Removing the required pull-kubernetes-verify-lint caused a problem for pending PRs: tide is now "Waiting for status to be reported", but no such status is going to appear because the job is gone. This blocks merging those PRs.

Authors would have to close the PR and create a new one. Closing and reopening is not enough. Both is confusing. A simpler solution is to have a job with the same name which doesn't do anything and thus can be run to provide the expected status.