### PR TITLE
fix typo for release branches

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.8.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.8.yaml
@@ -269,7 +269,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0-8
+        base_ref: release-0.8
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.9.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.9.yaml
@@ -269,7 +269,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0-9
+        base_ref: release-0.9
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:


### PR DESCRIPTION
Typo for release-0-8 and release-0-9.

These were the only issues I saw in the test-grid.