### PR TITLE
remove 1.28 from jobset

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -69,46 +69,6 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-e2e-main-1-28
-    cluster: eks-prow-build-cluster
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: jobset
-        base_ref: main
-        path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-jobset-test-e2e-main-1-28
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset end to end tests for Kubernetes 1.28"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.28.9
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.23
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - test-e2e-kind
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 3
-            memory: 10Gi
-          requests:
-            cpu: 3
-            memory: 10Gi
-  - interval: 12h
     name: periodic-jobset-test-e2e-main-1-29
     cluster: eks-prow-build-cluster
     extra_refs:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-6.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-6.yaml
@@ -71,46 +71,6 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-e2e-release-0-6-1-28
-    cluster: eks-prow-build-cluster
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: jobset
-        base_ref: release-6.0
-        path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-jobset-test-e2e-release-0-6-1-28
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset end to end tests for Kubernetes 1.28 for release 0.6"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.28.9
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.22
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - test-e2e-kind
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 3
-            memory: 10Gi
-          requests:
-            cpu: 3
-            memory: 10Gi
-  - interval: 12h
     name: periodic-jobset-test-e2e-release-0-6-1-29
     cluster: eks-prow-build-cluster
     extra_refs:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
@@ -69,46 +69,6 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-e2e-release-0-7-1-28
-    cluster: eks-prow-build-cluster
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: jobset
-        base_ref: release-7.1
-        path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-jobset-test-e2e-release-0-7-1-28
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset end to end tests for Kubernetes 1.28 on release 0.7"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.28.9
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.23
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - test-e2e-kind
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 3
-            memory: 10Gi
-          requests:
-            cpu: 3
-            memory: 10Gi
-  - interval: 12h
     name: periodic-jobset-test-e2e-release-0-7-1-29
     cluster: eks-prow-build-cluster
     extra_refs:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -55,41 +55,6 @@ presubmits:
           requests:
             cpu: 3
             memory: 10Gi
-  - name: pull-jobset-test-e2e-main-1-28
-    cluster: eks-prow-build-cluster
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: pull-jobset-test-e2e-main-1-28
-      description: "Run jobset end to end tests for Kubernetes 1.28"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.28.9
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.23
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - test-e2e-kind
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 3
-            memory: 10Gi
-          requests:
-            cpu: 3
-            memory: 10Gi
   - name: pull-jobset-test-e2e-main-1-29
     cluster: eks-prow-build-cluster
     always_run: true


### PR DESCRIPTION
1.28 is out of support so we should not test it in jobset CI.