### PR TITLE
stopgap: allow branch protector to run for longer

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-branchprotector.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-branchprotector.yaml
@@ -6,7 +6,9 @@ periodics:
     app: branchprotector
   decorate: true
   decoration_config:
-    timeout: 5h
+    # TODO: this is WAY too long, the latency on applying rules needs to be much lower.
+    # ... but failing on timeout isn't better when we already know it takes too long.
+    timeout: 12h
   extra_refs:
   - org: kubernetes
     repo: test-infra


### PR DESCRIPTION
ref: https://github.com/kubernetes/test-infra/issues/33900

not a real fix, but maybe we can get the rules sync.

TODO: can we afford to raise the rate limit? (we did before by >3x, not sure how much spare capacity we have)

cc @kubernetes/owners @kubernetes/sig-testing-leads