### PR TITLE
CAPZ: Trigger api version upgrade scope changes

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -567,7 +567,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
     decorate: true
-    run_if_changed: '^test\/e2e\/(config\/azure-dev\.yaml)|(data\/shared\/v1beta1_provider\/metadata\.yaml)$'
+    run_if_changed: '^(test\/e2e\/(config\/azure-dev\.yaml|data\/shared\/v1beta1_provider\/metadata\.yaml)|azure\/scope\/.*)$'
     optional: false
     always_run: false
     branches:


### PR DESCRIPTION
This PR will enable `pull-cluster-api-provider-azure-apiversion-upgrade` test job to run on changes in `azure/scope/.*` 
Part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5311. Originated from https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5311#issuecomment-2515683417