### PR TITLE
descheduler: standarize all CI job timeouts

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -8,7 +8,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-verify-master
     decorate: true
     decoration_config:
-      timeout: 10m
+      timeout: 15m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.29.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.29.yaml
@@ -7,6 +7,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-verify-release-1.29
     decorate: true
+    decoration_config:
+      timeout: 15m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -32,6 +34,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-verify-build-release-1.29
     decorate: true
+    decoration_config:
+      timeout: 10m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -57,6 +61,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-unit-test-release-1.29
     decorate: true
+    decoration_config:
+      timeout: 10m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -84,7 +90,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-29-1.29
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 40m
     always_run: true
     labels:
       preset-dind-enabled: "true"
@@ -122,7 +128,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-29-1.28
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 40m
     always_run: true
     labels:
       preset-dind-enabled: "true"
@@ -160,7 +166,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-29-1.27
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 40m
     always_run: true
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.30.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.30.yaml
@@ -7,6 +7,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-verify-release-1.30
     decorate: true
+    decoration_config:
+      timeout: 15m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -32,6 +34,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-verify-build-release-1.30
     decorate: true
+    decoration_config:
+      timeout: 10m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -57,6 +61,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-unit-test-release-1.30
     decorate: true
+    decoration_config:
+      timeout: 10m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -84,7 +90,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-30-1.30
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 40m
     always_run: true
     labels:
       preset-dind-enabled: "true"
@@ -122,7 +128,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-30-1.29
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 40m
     always_run: true
     labels:
       preset-dind-enabled: "true"
@@ -160,7 +166,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-30-1.28
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 40m
     always_run: true
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.31.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.31.yaml
@@ -7,6 +7,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-verify-release-1.31
     decorate: true
+    decoration_config:
+      timeout: 15m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -32,6 +34,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-verify-build-release-1.31
     decorate: true
+    decoration_config:
+      timeout: 10m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -57,6 +61,8 @@ presubmits:
       testgrid-dashboards: sig-scheduling
       testgrid-tab-name: pull-descheduler-unit-test-release-1.31
     decorate: true
+    decoration_config:
+      timeout: 10m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
@@ -84,7 +90,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-31-1.31
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 40m
     always_run: true
     labels:
       preset-dind-enabled: "true"
@@ -122,7 +128,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-31-1.30
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 40m
     always_run: true
     labels:
       preset-dind-enabled: "true"
@@ -160,7 +166,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-31-1.29
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 40m
     always_run: true
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
* All e2e jobs now have a 40m timeout
* All unit test jobs now have a 10m timeout
* All build jobs how have a 10m timeout
* All verify jobs now have a 15m timeout (increased from 10m)