### PR TITLE
openshift: hypershift: update for 4.19 and 4.18 OpenStack periodic jobs

### DIFF
--- a/config/testgrids/openshift/hypershift.yaml
+++ b/config/testgrids/openshift/hypershift.yaml
@@ -15,6 +15,14 @@ test_groups:
   name: 4.19-aks
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.19-periodics-e2e-azure-aks-ovn-conformance
   name: 4.19-aks-ovn-conformance
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.19-periodics-e2e-openstack-aws
+  name: 4.19-openstack-aws
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.19-periodics-e2e-openstack-aws-conformance
+  name: 4.19-openstack-aws-conformance
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.19-periodics-e2e-openstack-aws-csi-cinder
+  name: 4.19-openstack-aws-csi-cinder
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.19-periodics-e2e-openstack-aws-csi-manila
+  name: 4.19-openstack-aws-csi-manila
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.18-periodics-e2e-powervs
   name: 4.18-powervs
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.18-periodics-e2e-kubevirt-conformance
@@ -31,6 +39,14 @@ test_groups:
   name: 4.18-aks
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.18-periodics-e2e-azure-aks-ovn-conformance
   name: 4.18-aks-ovn-conformance
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.18-periodics-e2e-openstack-aws
+  name: 4.18-openstack-aws
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.18-periodics-e2e-openstack-aws-conformance
+  name: 4.18-openstack-aws-conformance
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.18-periodics-e2e-openstack-aws-csi-cinder
+  name: 4.18-openstack-aws-csi-cinder
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.18-periodics-e2e-openstack-aws-csi-manila
+  name: 4.18-openstack-aws-csi-manila
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.17-periodics-e2e-powervs
   name: 4.17-powervs
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.17-periodics-e2e-kubevirt-conformance
@@ -135,6 +151,30 @@ dashboards:
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: 4.19-aks-ovn-conformance
+  - name: 4.19-openstack-aws
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.19-openstack-aws
+  - name: 4.19-openstack-aws-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.19-openstack-aws-conformance
+  - name: 4.19-openstack-aws-csi-cinder
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.19-openstack-aws-csi-cinder
+  - name: 4.19-openstack-aws-csi-manila
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.19-openstack-aws-csi-manila
   - name: 4.18-powervs
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -183,6 +223,30 @@ dashboards:
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: 4.18-aks-ovn-conformance
+  - name: 4.18-openstack-aws
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.18-openstack-aws
+  - name: 4.18-openstack-aws-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.18-openstack-aws-conformance
+  - name: 4.18-openstack-aws-csi-cinder
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.18-openstack-aws-csi-cinder
+  - name: 4.18-openstack-aws-csi-manila
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.18-openstack-aws-csi-manila
   - name: 4.17-powervs
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>


### PR DESCRIPTION
These jobs were recently added and are there to stay for now. Let's add
them into testgrids.
