### PR TITLE
Pinning minio/minio container tag in starter-azure.yaml because minio gateway functionality was dropped in later releases

### DIFF
--- a/config/prow/cluster/starter/starter-azure.yaml
+++ b/config/prow/cluster/starter/starter-azure.yaml
@@ -1298,7 +1298,8 @@ spec:
     spec:
       containers:
       - name: minio
-        image: minio/minio:latest
+        # RELEASE.2022-04-29T01-27-09Z is the last minio release that contains gateway functionality
+        image: minio/minio:RELEASE.2022-04-29T01-27-09Z
         args:
         - gateway
         - azure


### PR DESCRIPTION
Related to https://github.com/kubernetes-sigs/prow/pull/341

MinIO gateway was deprecated and this PR pins the minio/minio container image to the LKG release in starter-azure.yaml