### PR TITLE
periodic jobs for jobset should be under sig-apps not sig-scheduling

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -8,7 +8,7 @@ periodics:
         base_ref: main
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-unit-main
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset unit tests"
@@ -46,7 +46,7 @@ periodics:
         base_ref: main
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-integration-main
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset integration tests"
@@ -77,7 +77,7 @@ periodics:
         base_ref: main
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-e2e-main-1-29
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset end to end tests for Kubernetes 1.29"
@@ -117,7 +117,7 @@ periodics:
         base_ref: main
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-e2e-main-1-30
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset end to end tests for Kubernetes 1.30"

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-6.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-6.yaml
@@ -10,7 +10,7 @@ periodics:
         base_ref: release-6.0
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-unit-release-0-6
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset unit tests"
@@ -48,7 +48,7 @@ periodics:
         base_ref: release-6.0
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-integration-release-0-6
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset integration tests for release 0.6"
@@ -79,7 +79,7 @@ periodics:
         base_ref: release-6.0
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-e2e-release-0-6-1-29
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset end to end tests for Kubernetes 1.29 with release 0.6"

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
@@ -8,7 +8,7 @@ periodics:
         base_ref: release-7.1
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-unit-release-0-7
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset unit tests on release 0.7"
@@ -46,7 +46,7 @@ periodics:
         base_ref: release-7.1
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-integration-release-0-7
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset integration tests on release 0.7"
@@ -77,7 +77,7 @@ periodics:
         base_ref: release-7.1
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-e2e-release-0-7-1-29
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset end to end tests for Kubernetes 1.29 on release 0.7"
@@ -117,7 +117,7 @@ periodics:
         base_ref: release-7.1
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-e2e-release-0-7-1-30
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset end to end tests for Kubernetes 1.30 on release 0.7"
@@ -157,7 +157,7 @@ periodics:
         base_ref: release-7.1
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-e2e-release-0-7-1-31
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset end to end tests for Kubernetes 1.31 on release 0.7"


### PR DESCRIPTION
The presubmits are in the sig-apps dashboard while the periodics are in the sig-scheduling dashboard.