### PR TITLE
Update of testgrid annotations by config-rotator

### DIFF
--- a/releng/config-rotator/main.go
+++ b/releng/config-rotator/main.go
@@ -119,6 +119,11 @@ func updateEverything(c *config.JobConfig, old, new string) {
 				}
 			}
 		}
+		for k, v := range p.Annotations {
+			if k == "testgrid-tab-name" || k == "testgrid-dashboards" {
+				p.Annotations[k] = updateString(v, old, new)
+			}
+		}
 		for j := range p.Tags {
 			p.Tags[j] = updateString(p.Tags[j], old, new)
 		}


### PR DESCRIPTION
This change is to make [config-rotator](https://github.com/kubernetes/test-infra/tree/master/releng/config-rotator) also update the version marker in test grid related annotations like `testgrid-tab-name` / `testgrid-dashboards`.

If Jobs at https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/generated/generated.yaml start using `config-forker`/`config-rotator`, it will be good if rotator takes care of replacing old version marker with new one while rotation.