### PR TITLE
pr-crio-cgrpv2-splitfs-e2e-kubetest2: decrease parallelism

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1647,7 +1647,7 @@ presubmits:
         - --
         - --repo-root=.
         - --gcp-zone=us-west1-b
-        - --parallelism=8
+        - --parallelism=2
         - --focus-regex=\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
         - --timeout=3h


### PR DESCRIPTION
This is a test PR to see if decreasing test load would fix the job. The idea is to see if the error "sh: error while loading shared libraries: /lib/libc.so.6: cannot apply additional memory protection after relocation: Permission denied" is caused by the higher load created by kubetest2. See more details about failure [here](https://github.com/kubernetes/test-infra/issues/32567#issuecomment-2535326045).

I'm not sure it helps, but it's harmless as the job is failing anyway.

Ref: #32567 https://github.com/kubernetes/kubernetes/issues/127831 

/sig node
/cc @elieser1101 @kannon92 @haircommander @dims