### PR TITLE
allow release managers + infra/release/testing leads to trigger image…

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -26,6 +26,16 @@ postsubmits:
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
       testgrid-num-failures-to-alert: '2'
   - name: post-k8sio-image-promo
+    rerun_auth_config:
+      github_team_slugs:
+      - org: kubernetes
+        slug: sig-k8s-infra-leads
+      - org: kubernetes
+        slug: sig-testing-leads
+      - org: kubernetes
+        slug: sig-release-leads
+      - org: kubernetes
+        slug: release-managers
     cluster: k8s-infra-prow-build-trusted
     decorate: true
     decoration_config:


### PR DESCRIPTION
… promo re-runs

we can reasonably trust these folks to not do this pointlessly (in no particular order)