### PR TITLE
pr-crio-cgrpv2-imagefsfs-e2e-kubetest2: decrease parallelism

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1335,7 +1335,7 @@ presubmits:
         - --
         - --repo-root=.
         - --gcp-zone=us-west1-b
-        - --parallelism=8
+        - --parallelism=2
         - --timeout=3h
         - --focus-regex=\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]


### PR DESCRIPTION
This PR is similar to https://github.com/kubernetes/test-infra/pull/33926, but for another job. [It helped a bit splitfs job](https://testgrid.k8s.io/sig-node-presubmits#pr-crio-cgrpv2-splitfs-e2e-kubetest2&width=90). Let's see if it helps imagefs.

Ref: https://github.com/kubernetes/test-infra/issues/32567 https://github.com/kubernetes/kubernetes/issues/127831

/sig node
/cc @elieser1101 @kannon92 @haircommander @dims