### PR TITLE
remove GINKGO_TOLERATE_FLAKES from master branch jobs 

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -1348,8 +1348,6 @@ periodics:
         value: "capz"
       - name: GINKGO_PARALLEL_NODES  # cloud-provider-azure config
         value: "3"
-      - name: GINKGO_TOLERATE_FLAKES  # cloud-provider-azure config
-        value: "y"
       resources:
         limits:
           cpu: 4
@@ -1627,8 +1625,6 @@ periodics:
         value: "capz"
       - name: GINKGO_PARALLEL_NODES  # cloud-provider-azure config
         value: "1"
-      - name: GINKGO_TOLERATE_FLAKES  # cloud-provider-azure config
-        value: "y"
       resources:
         limits:
           cpu: 4

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -57,9 +57,6 @@ periodics:
         - -c
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
-      # don't retry conformance tests
-      - name: GINKGO_TOLERATE_FLAKES
-        value: "n"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -107,9 +104,6 @@ periodics:
       # tell kind CI script to use ipv6
       - name: "IP_FAMILY"
         value: "ipv6"
-      # don't retry conformance tests
-      - name: GINKGO_TOLERATE_FLAKES
-        value: "n"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -148,9 +142,6 @@ periodics:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
         value: "true"
-      # don't retry conformance tests
-      - name: GINKGO_TOLERATE_FLAKES
-        value: "n"
       command:
         - wrapper.sh
         - bash
@@ -199,9 +190,6 @@ periodics:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
         value: "true"
-      # don't retry conformance tests
-      - name: GINKGO_TOLERATE_FLAKES
-        value: "n"
       command:
         - wrapper.sh
         - bash

--- a/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
@@ -29,9 +29,6 @@ periodics:
             && curl -sO https://raw.githubusercontent.com/ii/kind/ci-audit-logging/hack/ci/e2e-k8s.sh
             && bash e2e-k8s.sh
       env:
-      # don't retry conformance tests
-      - name: GINKGO_TOLERATE_FLAKES
-        value: "n"
       - name: BUILD_TYPE
         value: docker
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-kind-periodics.yaml
@@ -44,9 +44,6 @@ periodics:
       - name: KIND_CLUSTER_LOG_LEVEL
         # Default is 4, but we want to exercise more log calls and get more output.
         value: "6"
-      # don't retry conformance tests
-      - name: GINKGO_TOLERATE_FLAKES
-        value: "n"
       - name: LABEL_FILTER
         value: 'Conformance && !Slow && !Disruptive && !Flaky'
       - name: PARALLEL

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
@@ -33,7 +33,6 @@ presubmits:
           curl -sSL https://github.com/kubernetes/test-infra/raw/master/experiment/kind-logs-e2e-k8s.sh >$(which e2e-k8s.sh) &&
           chmod u+x $(which e2e-k8s.sh) &&
           e2e-k8s.sh
-
         env:
         # Options from https://github.com/kubernetes-sigs/kind/blob/d1eecc46e30cac9d35cd32dc52677ef75ec22e18/hack/ci/e2e-k8s.sh#L79-L83
         - name: CLUSTER_LOG_FORMAT
@@ -43,9 +42,6 @@ presubmits:
           value: "6"
         - name: FEATURE_GATES
           value: '{"ContextualLogging":true}'
-        # don't retry conformance tests
-        - name: GINKGO_TOLERATE_FLAKES
-          value: "n"
         - name: FOCUS
           value: \[Conformance\]|\[Driver:.csi-hostpath\]
         # TODO(bentheelder): reduce the skip list further
@@ -111,9 +107,6 @@ presubmits:
           value: "6"
         - name: FEATURE_GATES
           value: '{"ContextualLogging":true}'
-        # don't retry conformance tests
-        - name: GINKGO_TOLERATE_FLAKES
-          value: "n"
         - name: FOCUS
           value: \[Conformance\]|\[Driver:.csi-hostpath\]
         # TODO(bentheelder): reduce the skip list further

--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -493,9 +493,6 @@ periodics:
         - -c
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
-      # don't retry network tests
-      - name: GINKGO_TOLERATE_FLAKES
-        value: "n"
       - name: KUBE_PROXY_MODE
         value: "nftables"
       - name: "PARALLEL"


### PR DESCRIPTION
… following https://github.com/kubernetes/kubernetes/pull/128887

NOTE: I did not touch release-branched jobs, there aren't many hits and they're all set to "n" anyhow (they are `ci-kubernetes-kind-e2e-json-logging-1-*`)