### PR TITLE
Revert "skip cleaning up resources in ilb tests for debugging purposes"

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -872,8 +872,6 @@ presubmits:
           env:
             - name: GINKGO_FOCUS
               value: "\\[API-Server-ILB\\]"
-            - name: SKIP_CLEANUP
-              value: "true"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true


### PR DESCRIPTION
Reverts kubernetes/test-infra#33932

Explanation: We dont need this anymore to probe into the cluster.