### PR TITLE
update slack-infra jobs to use go1.23

### DIFF
--- a/config/jobs/kubernetes-sigs/slack-infra/slack-infra-config.yaml
+++ b/config/jobs/kubernetes-sigs/slack-infra/slack-infra-config.yaml
@@ -7,7 +7,8 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.11.5
+        - image: public.ecr.aws/docker/library/golang:1.23
+          imagePullPolicy: Always
           command:
             - "./hack/verify-all.sh"
           resources:
@@ -24,7 +25,8 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.11.5
+        - image: public.ecr.aws/docker/library/golang:1.23
+          imagePullPolicy: Always
           command:
             - "./hack/verify-build.sh"
           resources:
@@ -41,7 +43,8 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.11.5
+        - image: public.ecr.aws/docker/library/golang:1.23
+          imagePullPolicy: Always
           command:
             - "go"
           args:


### PR DESCRIPTION
need for https://github.com/kubernetes-sigs/slack-infra/pull/68


also the current image does not exist anymore


/assign @jeefy @Katharine @nikhita 