### PR TITLE
set reasonable timeout for pull-kubernetes-e2e-ec2 (1h)

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -19,7 +19,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
-      timeout: 4h
+      timeout: 1h
     extra_refs:
       - org: kubernetes-sigs
         repo: provider-aws-test-infra


### PR DESCRIPTION
these are normally completing in ~30m, I've seen a 4h timeout that is clearly a bugged run, no point in hanging for 4h on a PR

Is there work on making this release informing? I don't want to keep jobs around longterm that aren't reporting or blocking but are running on every PR .. I don't see a direct equivalent in master-informing yet. 

/cc @dims 

(also: what are we doing to get cloud e2e down to 30m? are we running bigger clusters or something?)