### PR TITLE
DRA: consolidate pre-submit jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3202,7 +3202,7 @@ presubmits:
     always_run: false
     # This covers most of the code related to dynamic resource allocation.
     # Periodic variant: ci-kind-dra
-    run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*.go
     # The tests might still be flaky or this job might get triggered accidentally for
     # an unrelated PR.
     optional: true
@@ -3259,7 +3259,7 @@ presubmits:
     always_run: false
     # This covers most of the code related to dynamic resource allocation.
     # Periodic variant: ci-kind-dra-all
-    run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*.go
     # The tests might still be flaky or this job might get triggered accidentally for
     # an unrelated PR.
     optional: true
@@ -4281,7 +4281,7 @@ presubmits:
     # Automatically testing with one container runtime in one configuration is sufficient to detect basic problems in kubelet early.
     # CRI-O was picked because it was solid for testing so far.
     # Periodic variant: ci-node-e2e-crio-cgrpv1-dra-features
-    run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
+    run_if_changed: (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resourceslice/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_).*\.(go|yaml)
     optional: true
     skip_report: false
     labels:
@@ -4332,7 +4332,7 @@ presubmits:
     # explicitly needs /test pull-kubernetes-node-e2e-crio-cgrpv1-dra-kubetest2 to run
     always_run: false
     # Don't run automatically while experimental!
-    # run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
+    # run_if_changed: (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resourceslice/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_).*\.(go|yaml)
     optional: true
     skip_report: false
     skip_branches:
@@ -4389,7 +4389,7 @@ presubmits:
     # Automatically testing with one container runtime in one configuration is sufficient to detect basic problems in kubelet early.
     # CRI-O was picked because it was solid for testing so far.
     # Periodic variant: ci-node-e2e-cgrpv2-crio-dra
-    # run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
+    # run_if_changed: (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resourceslice/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_).*\.(go|yaml)
     optional: true
     skip_report: false
     labels:
@@ -4440,7 +4440,7 @@ presubmits:
     # explicitly needs /test pull-kubernetes-node-e2e-crio-cgrpv2-dra-kubetest2 to run
     always_run: false
     # Don't run automatically while experimental!
-    # run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
+    # run_if_changed: (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resourceslice/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_).*\.(go|yaml)
     optional: true
     skip_report: false
     skip_branches:
@@ -4497,8 +4497,7 @@ presubmits:
     # Automatically testing with one container runtime in one configuration is sufficient to detect basic problems in kubelet early.
     # CRI-O was picked because it was solid for testing so far.
     # Periodic variant: ci-node-e2e-containerd-1-7-dra
-    # run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
-    optional: true
+    # run_if_changed: (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resourceslice/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/r    optional: true
     skip_report: false
     labels:
       preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3201,6 +3201,7 @@ presubmits:
     # Not relevant for most PRs.
     always_run: false
     # This covers most of the code related to dynamic resource allocation.
+    # Periodic variant: ci-kind-dra
     run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/
     # The tests might still be flaky or this job might get triggered accidentally for
     # an unrelated PR.
@@ -3257,6 +3258,7 @@ presubmits:
     # Not relevant for most PRs.
     always_run: false
     # This covers most of the code related to dynamic resource allocation.
+    # Periodic variant: ci-kind-dra-all
     run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/
     # The tests might still be flaky or this job might get triggered accidentally for
     # an unrelated PR.
@@ -4276,6 +4278,9 @@ presubmits:
     skip_branches:
     - release-\d+\.\d+  # per-release image
     always_run: false
+    # Automatically testing with one container runtime in one configuration is sufficient to detect basic problems in kubelet early.
+    # CRI-O was picked because it was solid for testing so far.
+    # Periodic variant: ci-node-e2e-crio-cgrpv1-dra-features
     run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
     optional: true
     skip_report: false
@@ -4381,7 +4386,10 @@ presubmits:
     skip_branches:
     - release-\d+\.\d+  # per-release image
     always_run: false
-    run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
+    # Automatically testing with one container runtime in one configuration is sufficient to detect basic problems in kubelet early.
+    # CRI-O was picked because it was solid for testing so far.
+    # Periodic variant: ci-node-e2e-cgrpv2-crio-dra
+    # run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
     optional: true
     skip_report: false
     labels:
@@ -4486,7 +4494,10 @@ presubmits:
     skip_branches:
     - release-\d+\.\d+  # per-release image
     always_run: false
-    run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
+    # Automatically testing with one container runtime in one configuration is sufficient to detect basic problems in kubelet early.
+    # CRI-O was picked because it was solid for testing so far.
+    # Periodic variant: ci-node-e2e-containerd-1-7-dra
+    # run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
     optional: true
     skip_report: false
     labels:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -4322,11 +4322,12 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
-  - name: pull-kubernetes-node-e2e-crio-cgrpv1-dra-kubetest2
+  - name: pull-kubernetes-node-e2e-crio-cgrpv1-dra-kubetest2 # experimental alternative to pull-kubernetes-node-e2e-crio-cgrpv1-dra
     cluster: k8s-infra-prow-build
     # explicitly needs /test pull-kubernetes-node-e2e-crio-cgrpv1-dra-kubetest2 to run
     always_run: false
-    run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
+    # Don't run automatically while experimental!
+    # run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
     optional: true
     skip_report: false
     skip_branches:
@@ -4426,11 +4427,12 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
-  - name: pull-kubernetes-node-e2e-crio-cgrpv2-dra-kubetest2
+  - name: pull-kubernetes-node-e2e-crio-cgrpv2-dra-kubetest2 # experimental alternative to pull-kubernetes-node-e2e-crio-cgrpv2-dra
     cluster: k8s-infra-prow-build
     # explicitly needs /test pull-kubernetes-node-e2e-crio-cgrpv2-dra-kubetest2 to run
     always_run: false
-    run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
+    # Don't run automatically while experimental!
+    # run_if_changed: /dra/|/dynamicresources/|/resourceclaim/|/resourceclass/|/podscheduling/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_test.go
     optional: true
     skip_report: false
     skip_branches:


### PR DESCRIPTION
This reduces the number of jobs which get triggered automatically to save costs and avoid noise in unrelated PRs. See https://github.com/kubernetes/community/pull/8196 for a suggested policy and rationale.
