### PR TITLE
pr-crio-cgrpv2-imagefsfs-e2e-kubetest2: use n1-standard-4 machine

### DIFF
--- a/jobs/e2e_node/crio/latest/image-config-cgroupv2-imagefs.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgroupv2-imagefs.yaml
@@ -2,5 +2,5 @@ images:
   fedora:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
-    machine: n1-standard-2
+    machine: n1-standard-4
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupv2_imagefs.ign"


### PR DESCRIPTION
Decreasing parallelism for this job in the https://github.com/kubernetes/test-infra/pull/33929 helped, but not fully fixed the issue. It also increased job run time significantly. Let's try to use bigger instance. 

Note: this is a test PR, it doesn't guarantee the expected effect as I can't reproduce the issue in my setup. 

Ref: #https://github.com/kubernetes/test-infra/issues/32567#issuecomment-2535326045 https://github.com/kubernetes/kubernetes/issues/127831

/sig node
/cc @elieser1101 @kannon92 @haircommander