### PR TITLE
CAPV: bump versions for k8s v1.32 release

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-prowjob-gen.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-prowjob-gen.yaml
@@ -13,14 +13,14 @@ prow_ignored:
       # interval for coverage job
       interval: "24h"
       upgrades:
-      - from: "1.28"
-        to: "1.29"
       - from: "1.29"
         to: "1.30"
       - from: "1.30"
         to: "1.31"
       - from: "1.31"
         to: "1.32"
+      - from: "1.32"
+        to: "1.33"
     release-1.12:
       testImage: "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-1.30"
       upgrades:
@@ -72,4 +72,6 @@ prow_ignored:
     "1.31":
       k8sRelease: "stable-1.31"
     "1.32":
-      k8sRelease: "ci/latest-1.32"
+      k8sRelease: "stable-1.32"
+    "1.33":
+      k8sRelease: "ci/latest-1.33"


### PR DESCRIPTION
Due to GA release of v1.32

Does not change any upstream jobs but to keep it in sync for future.