### PR TITLE
update descheduler-presubmits-master to allocate more resources

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -23,11 +23,11 @@ presubmits:
         - verify
         resources:
           limits:
-            cpu: 6
-            memory: 4Gi
+            cpu: 8
+            memory: 8Gi
           requests:
-            cpu: 6
-            memory: 4Gi
+            cpu: 8
+            memory: 8Gi
   - name: pull-descheduler-verify-build-master
     cluster: eks-prow-build-cluster
     annotations:


### PR DESCRIPTION
We're exhausting resources and pipelines are never finishing

https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?var-org=kubernetes-sigs&var-repo=descheduler&var-job=pull-descheduler-verify-master&orgId=1&from=1734041463549&to=1734045104101

![Screenshot 2024-12-13 at 10 09 40 AM](https://github.com/user-attachments/assets/e6068e19-1352-45da-aea3-38a6f94a3678)
