### PR TITLE
Revert "pr-crio-cgrpv2-imagefs-e2e-kubetest2: use n1-standard-4 mac…

### DIFF
--- a/jobs/e2e_node/crio/latest/image-config-cgroupv2-imagefs.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgroupv2-imagefs.yaml
@@ -2,5 +2,5 @@ images:
   fedora:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
-    machine: n1-standard-4
+    machine: n1-standard-2
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupv2_imagefs.ign"


### PR DESCRIPTION
This reverts https://github.com/kubernetes/test-infra/pull/33944 as it didn't help to fix the "sh: error while loading shared libraries: /lib/libc.so.6: cannot apply additional memory protection after relocation: Permission denied" error.

/sig node
/cc @elieser1101 @kannon92 @haircommander