### PR TITLE
fix azure file test failure

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -230,9 +230,6 @@ presubmits:
               kubectl apply -f templates/addons/azurefile-role.yaml &&
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
-          env:
-            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
-              value: "kubernetes.io/azure-file" # In-tree Azure file storage class
           securityContext:
             privileged: true
           resources:
@@ -290,8 +287,6 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
-              value: "kubernetes.io/azure-file" # In-tree Azure file storage class
             - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
           securityContext:
@@ -351,8 +346,6 @@ presubmits:
               cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver && ./deploy/install-driver.sh master local,snapshot,enable-avset &&
               make e2e-test
           env:
-            - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
-              value: "kubernetes.io/azure-file" # In-tree Azure file storage class
             - name: WINDOWS # azuredisk-csi-driver config
               value: "true"
             - name: TEST_WINDOWS # CAPZ config


### PR DESCRIPTION
<details>

```
Events:
  Type     Reason       Age                  From               Message
  ----     ------       ----                 ----               -------
  Normal   Scheduled    6m19s                default-scheduler  Successfully assigned azurefile-734/azurefile-volume-tester-pfmbl to capz-07ehe5-md-0-h6b6h-mvs2z
  Warning  FailedMount  7s (x11 over 6m19s)  kubelet            MountVolume.SetUp failed for volume "pvc-a245efb6-836d-4d3d-976e-ff3d84457e8a" : kubernetes.io/csi: mounter.SetUpAt failed to get service accoount token attributes: failed to fetch token: serviceaccounts "default" is forbidden: audience "api://AzureADTokenExchange" not found in pod spec volume
```

</details>