### PR TITLE
Bump Go version for cli-utils build

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^release-.*$
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         command:
         - make
         args:


### PR DESCRIPTION
This is to match Kubernetes 1.32 so that we can use libraries from that version in cli-utils.