### PR TITLE
don't run automatically jobs that are not supervised

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -169,7 +169,6 @@ presubmits:
     optional: true
     always_run: false
     skip_report: false
-    run_if_changed: '^(test/e2e/network/|pkg/apis/networking|pkg/proxy/ipvs/)'
     decorate: true
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -139,7 +139,6 @@ presubmits:
     - master
     - main
     always_run: false
-    run_if_changed: '^(test/e2e/network/|pkg/apis/networking|pkg/.*/ipvs/)'
     optional: true
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -58,7 +58,6 @@ presubmits:
     skip_report: false
     max_concurrency: 8
     optional: true
-    run_if_changed: '^test/'
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
These sig network jobs does not have owners, I was the only one watching them but I don't have time , so unless someone steps up and demonstrate is watching the jobs those will be limited to manual trigger and periodics