### PR TITLE
fix warnings

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION
+ARG GO_VERSION=1.22.9
 
-FROM multiarch/qemu-user-static:7.2.0-1 as qemu-image
+FROM multiarch/qemu-user-static:7.2.0-1 AS qemu-image
 
 # Includes bash, docker, and gcloud
 FROM golang:${GO_VERSION}-alpine

--- a/images/gcb-docker-gcloud/cloudbuild.yaml
+++ b/images/gcb-docker-gcloud/cloudbuild.yaml
@@ -4,7 +4,6 @@ steps:
       - build
       - --tag=gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG
       - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG
-      - --build-arg=GO_VERSION=$_GO_VERSION
       - .
     dir: images/gcb-docker-gcloud/
   - name: gcr.io/cloud-builders/docker
@@ -14,7 +13,6 @@ steps:
     - gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest
 substitutions:
   _GIT_TAG: '12345'
-  _GO_VERSION: 1.22.9
 images:
   - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest'


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/test-infra/issues/33921

This PR is created just to rebuild this image to install the latest version `google-cloud-sdk`, so to trigger the build - fixing the first warning.

```
 2 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 17)
 - InvalidDefaultArgInFrom: Default value for ARG golang:${GO_VERSION}-alpine results in empty or invalid base image name (line 20)
```