### PR TITLE
Add prow job config for autoscaler repo

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
+++ b/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
@@ -1,0 +1,23 @@
+postsubmits:
+  kubernetes/autoscaler:
+    - name: post-autoscaler-push-addon-resizer-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-autoscaling-addon-resizer, sig-k8s-infra-gcb
+      decorate: true
+      branches:
+        - ^addon-resizer-release-1.8$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20241015-ff9ecc4d73
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-autoscaling
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-autoscaling-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - addon-resizer

--- a/config/testgrids/kubernetes/sig-autoscaling/config.yaml
+++ b/config/testgrids/kubernetes/sig-autoscaling/config.yaml
@@ -1,13 +1,15 @@
 dashboard_groups:
-- name: sig-autoscaling
-  dashboard_names:
-    - sig-autoscaling-cluster-autoscaler
-    - sig-autoscaling-hpa
-    - sig-autoscaling-vpa
-    - sig-autoscaling-karpenter
+  - name: sig-autoscaling
+    dashboard_names:
+      - sig-autoscaling-cluster-autoscaler
+      - sig-autoscaling-hpa
+      - sig-autoscaling-vpa
+      - sig-autoscaling-karpenter
+      - sig-autoscaling-addon-resizer
 
 dashboards:
-- name: sig-autoscaling-cluster-autoscaler
-- name: sig-autoscaling-hpa
-- name: sig-autoscaling-vpa
-- name: sig-autoscaling-karpenter
+  - name: sig-autoscaling-cluster-autoscaler
+  - name: sig-autoscaling-hpa
+  - name: sig-autoscaling-vpa
+  - name: sig-autoscaling-karpenter
+  - name: sig-autoscaling-addon-resizer


### PR DESCRIPTION
I am onboarding the various projects within https://github.com/kubernetes/autoscaler to the automatic image pushing process as described in https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md.

I am starting with the `addon-resizer` sub-project which has a relatively straight-forward build process to get myself familiar, then I'll onboard the rest.

Ref: https://github.com/kubernetes/autoscaler/issues/7615