### PR TITLE
Fix kops cluster creation in registry-sandbox.k8s.io canary

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -106,7 +106,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --set=cluster.spec.cloudProvider.aws.nodeTerminationHandler.enabled=false --set=cluster.spec.cloudProvider.aws.ebsCSIDriver.enabled=false --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--channel=alpha --networking=kubenet --container-runtime=containerd --set=spec.assets.containerProxy=registry-sandbox.k8s.io --set=cluster.spec.cloudProvider.aws.nodeTerminationHandler.enabled=false --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kops/issues/16987


The ability to disable the AWS EBS CSI driver was removed in [kubernetes/kops@`47b1c37` (#15872)](https://github.com/kubernetes/kops/pull/15872/commits/47b1c370693179e4152521e498d5b8a4e21583ef)
