### PR TITLE
added docker-in-docker into the image

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -176,9 +176,13 @@ presubmits:
       containers:
       - image: public.ecr.aws/docker/library/golang:1.23
         command:
-        - make
+        - runner.sh
         args:
+        - make
         - verify
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
         resources:
           limits:
             cpu: 3


### PR DESCRIPTION
I'm planning to enable docker-in-docker for `pull-jobset-verify-main`. 

I followed the steps in the comments here https://github.com/kubernetes/test-infra/pull/33955#issuecomment-2546149997

I'm not sure if I have everything correct as I'm not very sure what might be the docker-in-docker preset. 

This is for generating python sdk using a container engine, related pr is here https://github.com/kubernetes-sigs/jobset/pull/681


The owner of the Jobset are:

@ahg-g
@danielvegamyhre