### PR TITLE
Increase prow tests timeout for cluster autoscaler tests.

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -237,7 +237,7 @@ periodics:
     preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
-    timeout: 350m
+    timeout: 450m
   spec:
     containers:
     - command:
@@ -260,7 +260,7 @@ periodics:
       - --provider=gce
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
-      - --timeout=300m
+      - --timeout=400m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
       resources:
         limits:
@@ -317,7 +317,7 @@ periodics:
     preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
-    timeout: 350m
+    timeout: 450m
   spec:
     containers:
     - command:
@@ -340,7 +340,7 @@ periodics:
       - --provider=gce
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
-      - --timeout=300m
+      - --timeout=400m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
       resources:
         limits:

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-dind-enabled: "true"
     decorate: true
     decoration_config:
-      timeout: 450m
+      timeout: 500m
     path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
@@ -44,7 +44,7 @@ presubmits:
         - --provider=gce
         - --runtime-config=scheduling.k8s.io/v1alpha1=true
         - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
-        - --timeout=400m
+        - --timeout=450m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
         securityContext:
           privileged: true


### PR DESCRIPTION
After changes in https://github.com/kubernetes/kubernetes/pull/125334 the tests take longer (which is expected as they rely on scaling up and down to set up the tests and this has default timeouts in the CA).