### PR TITLE
Revert "pr-crio-cgrpv2-splitfs-e2e-kubetest2: decrease parallelism"

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1596,7 +1596,7 @@ presubmits:
         - --
         - --repo-root=.
         - --gcp-zone=us-west1-b
-        - --parallelism=2
+        - --parallelism=8
         - --focus-regex=\[NodeConformance\]|\[NodeFeature:.+\]|\[NodeFeature\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
         - --timeout=3h


### PR DESCRIPTION
This reverts commit 7eb2bfe7fd5c1547721d6301999a20aa0a780a30.

https://github.com/kubernetes/test-infra/pull/33975 seems to fix the issue, reverting https://github.com/kubernetes/test-infra/pull/33926 to make the job running faster

Ref: https://github.com/kubernetes/test-infra/issues/32567 https://github.com/kubernetes/kubernetes/issues/127831

/sig node
/cc @elieser1101 @kannon92 @haircommander