### PR TITLE
add kueue-viz-image-build to image build presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -307,6 +307,7 @@ presubmits:
         - make
         - image-local-build
         - importer-image
+        - kueue-viz-image-build
         env:
         - name: GOMAXPROCS
           value: "2"


### PR DESCRIPTION
Enable presubmit runs of https://github.com/kubernetes-sigs/kueue/pull/3849/files

I want to make sure that dependabot/code changes do not break the build of the containers.