### PR TITLE
gateway-api-inference-extension name update

### DIFF
--- a/config/jobs/image-pushing/k9s-staging-inference-extension.yaml
+++ b/config/jobs/image-pushing/k9s-staging-inference-extension.yaml
@@ -1,8 +1,8 @@
 # Source reference:
 # https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md
 postsubmits:
-  kubernetes-sigs/llm-instance-gateway:
-    - name: post-llm-i-gw-push-images
+  kubernetes-sigs/gateway-api-inference-extension:
+    - name: post-inference-extension-push-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-gateway-api, sig-k8s-infra-gcb

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -797,7 +797,7 @@ tide:
     kubernetes-sigs/kubespray: squash
     kubernetes-sigs/kueue: squash
     kubernetes-sigs/kui: rebase
-    kubernetes-sigs/llm-instance-gateway: squash
+    kubernetes-sigs/gateway-api-inference-extension: squash
     kubernetes-sigs/security-profiles-operator: rebase
     kubernetes-sigs/service-catalog: squash
     kubernetes-sigs/gateway-api: squash


### PR DESCRIPTION
updating existing test-infra to reflect name change of the now-called Inference-Extension