### PR TITLE
update the image for pull-jobset-verify-main

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -174,7 +174,7 @@ presubmits:
       description: "Run jobset verify checks"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image:  gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -174,7 +174,7 @@ presubmits:
       description: "Run jobset verify checks"
     spec:
       containers:
-      - image:  gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
         command:
         - runner.sh
         args:


### PR DESCRIPTION
update the image for pull jobset verify main to  gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master

previous pr were: https://github.com/kubernetes/test-infra/pull/33977


The owner of the Jobset are:

@ahg-g
@danielvegamyhre