### PR TITLE
Add Red Hat Test Platform members as reviewers to tools they heavily use

### DIFF
--- a/boskos/OWNERS
+++ b/boskos/OWNERS
@@ -7,6 +7,9 @@ approvers:
 reviewers:
 - alvaroaleman
 - ixdy
+- smg247
+- danilo-gemoli
+- droslean
 
 labels:
 - area/boskos

--- a/label_sync/OWNERS
+++ b/label_sync/OWNERS
@@ -8,6 +8,9 @@ filters:
     reviewers:
       - sig-contributor-experience-technical-leads
       - cblecker
+      - smg247
+      - danilo-gemoli
+      - droslean
     emeritus_approvers:
       - fejta
       - spiffxp

--- a/robots/OWNERS
+++ b/robots/OWNERS
@@ -3,6 +3,9 @@
 reviewers:
 - cjwagner
 - stevekuznetsov
+- smg247
+- danilo-gemoli
+- droslean
 approvers:
 - cjwagner
 - stevekuznetsov


### PR DESCRIPTION
As discussed in [this thread](https://kubernetes.slack.com/archives/C09QZ4DQB/p1734531295307049), some senior Red Hat Test Platform members would like to be added as reviewers to the tools that we use heavily. The intent here is contribute more to this tooling and eventually gain approval rights.

/cc @danilo-gemoli @droslean @stevekuznetsov @BenTheElder