### PR TITLE
Remove 1.29 from csi sidecar jobs and make all resizer jobs optional

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -2,103 +2,6 @@
 
 presubmits:
   kubernetes-csi/csi-driver-host-path:
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-29-on-kubernetes-1-29
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-29-on-kubernetes-1-29
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.29 on Kubernetes 1.29
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.29.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.29"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-29-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-29-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.29 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-csi-driver-host-path-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
@@ -199,7 +102,7 @@ presubmits:
   - name: pull-kubernetes-csi-csi-driver-host-path-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: []
@@ -293,58 +196,7 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-30-on-kubernetes-1-30
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.30 on Kubernetes 1.30
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "serial-alpha parallel-alpha"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-29-test-on-kubernetes-1-29
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
     always_run: true
     optional: true
@@ -357,8 +209,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-29-test-on-kubernetes-1-29
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.29-test on Kubernetes 1.29
+      testgrid-tab-name: 1-32-on-kubernetes-1-32
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.32 on Kubernetes 1.32
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -374,11 +226,11 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.29.0"
+          value: "1.32.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.29"
+          value: "1.32"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: "-test"
+          value: ""
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.15.0"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -395,7 +247,7 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-1-29-test-on-kubernetes-master
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-32-on-kubernetes-master
     # Explicitly needs to be started with /test.
     # This cannot be enabled by default because there's always the risk
     # that something changes in master which breaks the pre-merge check.
@@ -410,8 +262,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: 1-29-test-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.29-test on Kubernetes master
+      testgrid-tab-name: 1-32-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.32 on Kubernetes master
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -426,11 +278,62 @@ presubmits:
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.15.0"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: "-test"
+          value: ""
         - name: CSI_SNAPSHOTTER_VERSION
           value: "master"
         - name: CSI_PROW_TESTS
           value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: alpha-1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "serial-alpha parallel-alpha"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -635,9 +538,9 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-30-test-on-kubernetes-1-30
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-32-test-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -648,8 +551,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: alpha-1-30-test-on-kubernetes-1-30
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.30-test on Kubernetes 1.30
+      testgrid-tab-name: 1-32-test-on-kubernetes-1-32
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.32-test on Kubernetes 1.32
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -665,9 +568,106 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "1.32.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
+          value: "1.32"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: "-test"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-csi-driver-host-path-1-32-test-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: 1-32-test-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for non-alpha tests, using deployment 1.32-test on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: "-test"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-31-test-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-csi-driver-host-path
+      testgrid-tab-name: alpha-1-31-test-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for alpha tests, using deployment 1.31-test on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: "-test"
         - name: CSI_PROW_DRIVER_VERSION
@@ -723,198 +723,6 @@ presubmits:
             cpu: 4
 
 periodics:
-- interval: 6h
-  name: ci-kubernetes-csi-1-29-on-kubernetes-1-29
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.29-on-1.29
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29 on Kubernetes 1.29
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.29"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.29"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-29-on-kubernetes-1-30
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.29-on-1.30
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29 on Kubernetes 1.30
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.30"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.29"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-29-on-kubernetes-1-31
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.29-on-1.31
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29 on Kubernetes 1.31
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.31"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.29"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-29-on-kubernetes-master
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.29-on-master
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29 on Kubernetes master
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "latest"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "master"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.29"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
 - interval: 6h
   name: ci-kubernetes-csi-1-30-on-kubernetes-1-30
   cluster: k8s-infra-prow-build
@@ -991,6 +799,54 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.31"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.30"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: ""
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-1-30-on-kubernetes-1-32
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.30-on-1.32
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.30 on Kubernetes 1.32
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.32"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v6.1.0"
       - name: CSI_PROW_BUILD_JOB
@@ -1108,6 +964,54 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
+  name: ci-kubernetes-csi-1-31-on-kubernetes-1-32
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.31-on-1.32
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.31 on Kubernetes 1.32
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.32"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.31"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: ""
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
   name: ci-kubernetes-csi-1-31-on-kubernetes-master
   cluster: k8s-infra-prow-build
   decorate: true
@@ -1156,7 +1060,7 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-1-29-test-on-kubernetes-1-29
+  name: ci-kubernetes-csi-1-32-on-kubernetes-1-32
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
@@ -1169,9 +1073,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.29-test-on-1.29
+    testgrid-tab-name: 1.32-on-1.32
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29-test on Kubernetes 1.29
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.32 on Kubernetes 1.32
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1182,15 +1086,15 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.29"
+        value: "release-1.32"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v6.1.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.29"
+        value: "kubernetes-1.32"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
+        value: ""
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1204,7 +1108,7 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-1-29-test-on-kubernetes-1-30
+  name: ci-kubernetes-csi-1-32-on-kubernetes-master
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
@@ -1217,105 +1121,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.29-test-on-1.30
+    testgrid-tab-name: 1.32-on-master
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29-test on Kubernetes 1.30
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.30"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.29"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-29-test-on-kubernetes-1-31
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.29-test-on-1.31
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29-test on Kubernetes 1.31
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "release-1.31"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "v6.1.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.29"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
-  name: ci-kubernetes-csi-1-29-test-on-kubernetes-master
-  cluster: k8s-infra-prow-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: 1.29-test-on-master
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.29-test on Kubernetes master
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.32 on Kubernetes master
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1332,9 +1140,9 @@ periodics:
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       - name: CSI_PROW_DEPLOYMENT
-        value: "kubernetes-1.29"
+        value: "kubernetes-1.32"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
+        value: ""
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1423,6 +1231,54 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "release-1.31"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.30"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-1-30-test-on-kubernetes-1-32
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.30-test-on-1.32
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.30-test on Kubernetes 1.32
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.32"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "v6.1.0"
       - name: CSI_PROW_BUILD_JOB
@@ -1540,6 +1396,54 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
+  name: ci-kubernetes-csi-1-31-test-on-kubernetes-1-32
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.31-test-on-1.32
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.31-test on Kubernetes 1.32
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "release-1.32"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.31"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
   name: ci-kubernetes-csi-1-31-test-on-kubernetes-master
   cluster: k8s-infra-prow-build
   decorate: true
@@ -1588,8 +1492,8 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-canary-on-kubernetes-1-29
-  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-csi-1-32-test-on-kubernetes-1-32
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - org: kubernetes-csi
@@ -1601,9 +1505,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: canary-on-1.29
+    testgrid-tab-name: 1.32-test-on-1.32
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary on Kubernetes 1.29
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.32-test on Kubernetes 1.32
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -1614,21 +1518,63 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "1.29.0"
+        value: "release-1.32"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "v6.1.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
-      # Replace images....
-      - name: CSI_PROW_HOSTPATH_CANARY
-        value: "canary"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.32"
       - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: ""
+        value: "-test"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-1-32-test-on-kubernetes-master
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: 1.32-test-on-master
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment 1.32-test on Kubernetes master
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "latest"
       - name: CSI_SNAPSHOTTER_VERSION
         value: "master"
-      # ... but the RBAC rules only when testing on master.
-      # The other jobs test against the unmodified deployment for
-      # that Kubernetes version, i.e. with the original RBAC rules.
-      - name: UPDATE_RBAC_RULES
+      - name: CSI_PROW_BUILD_JOB
         value: "false"
+      - name: CSI_PROW_DEPLOYMENT
+        value: "kubernetes-1.32"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
       - name: CSI_PROW_TESTS
         value: "sanity serial parallel"
       # docker-in-docker needs privileged mode
@@ -1723,6 +1669,60 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "1.31.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      # Replace images....
+      - name: CSI_PROW_HOSTPATH_CANARY
+        value: "canary"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: ""
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "master"
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
+      - name: UPDATE_RBAC_RULES
+        value: "false"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-canary-on-kubernetes-1-32
+  cluster: eks-prow-build-cluster
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: canary-on-1.32
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary on Kubernetes 1.32
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "1.32.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       # Replace images....
@@ -1858,60 +1858,6 @@ periodics:
           memory: "9Gi"
           cpu: 4
 - interval: 6h
-  name: ci-kubernetes-csi-canary-test-on-kubernetes-1-29
-  cluster: eks-prow-build-cluster
-  decorate: true
-  extra_refs:
-  - org: kubernetes-csi
-    repo: csi-driver-host-path
-    base_ref: master
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  annotations:
-    testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: canary-test-on-1.29
-    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary-test on Kubernetes 1.29
-  spec:
-    containers:
-    # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-      command:
-      - runner.sh
-      args:
-      - ./.prow.sh
-      env:
-      - name: CSI_PROW_KUBERNETES_VERSION
-        value: "1.29.0"
-      - name: CSI_PROW_BUILD_JOB
-        value: "false"
-      # Replace images....
-      - name: CSI_PROW_HOSTPATH_CANARY
-        value: "canary"
-      - name: CSI_PROW_DEPLOYMENT_SUFFIX
-        value: "-test"
-      - name: CSI_SNAPSHOTTER_VERSION
-        value: "master"
-      # ... but the RBAC rules only when testing on master.
-      # The other jobs test against the unmodified deployment for
-      # that Kubernetes version, i.e. with the original RBAC rules.
-      - name: UPDATE_RBAC_RULES
-        value: "false"
-      - name: CSI_PROW_TESTS
-        value: "sanity serial parallel"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "9Gi"
-          cpu: 4
-        limits:
-          memory: "9Gi"
-          cpu: 4
-- interval: 6h
   name: ci-kubernetes-csi-canary-test-on-kubernetes-1-30
   cluster: eks-prow-build-cluster
   decorate: true
@@ -1993,6 +1939,60 @@ periodics:
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
         value: "1.31.0"
+      - name: CSI_PROW_BUILD_JOB
+        value: "false"
+      # Replace images....
+      - name: CSI_PROW_HOSTPATH_CANARY
+        value: "canary"
+      - name: CSI_PROW_DEPLOYMENT_SUFFIX
+        value: "-test"
+      - name: CSI_SNAPSHOTTER_VERSION
+        value: "master"
+      # ... but the RBAC rules only when testing on master.
+      # The other jobs test against the unmodified deployment for
+      # that Kubernetes version, i.e. with the original RBAC rules.
+      - name: UPDATE_RBAC_RULES
+        value: "false"
+      - name: CSI_PROW_TESTS
+        value: "sanity serial parallel"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "9Gi"
+          cpu: 4
+        limits:
+          memory: "9Gi"
+          cpu: 4
+- interval: 6h
+  name: ci-kubernetes-csi-canary-test-on-kubernetes-1-32
+  cluster: eks-prow-build-cluster
+  decorate: true
+  extra_refs:
+  - org: kubernetes-csi
+    repo: csi-driver-host-path
+    base_ref: master
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    testgrid-dashboards: sig-storage-csi-ci
+    testgrid-tab-name: canary-test-on-1.32
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+    description: periodic Kubernetes-CSI job for non-alpha tests, using deployment canary-test on Kubernetes 1.32
+  spec:
+    containers:
+    # We need this image because it has Docker in Docker and go.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+      command:
+      - runner.sh
+      args:
+      - ./.prow.sh
+      env:
+      - name: CSI_PROW_KUBERNETES_VERSION
+        value: "1.32.0"
       - name: CSI_PROW_BUILD_JOB
         value: "false"
       # Replace images....

--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -5,6 +5,7 @@ presubmits:
   - name: pull-kubernetes-csi-csi-driver-host-path-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have csi-driver-host-path removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -102,6 +103,7 @@ presubmits:
   - name: pull-kubernetes-csi-csi-driver-host-path-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have csi-driver-host-path removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -199,6 +201,7 @@ presubmits:
   - name: pull-kubernetes-csi-csi-driver-host-path-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have csi-driver-host-path removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -296,6 +299,7 @@ presubmits:
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: false
+    # TODO: pull_optional can have csi-driver-host-path removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -347,6 +351,7 @@ presubmits:
   - name: pull-kubernetes-csi-csi-driver-host-path-1-30-test-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have csi-driver-host-path removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -444,6 +449,7 @@ presubmits:
   - name: pull-kubernetes-csi-csi-driver-host-path-1-31-test-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have csi-driver-host-path removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -541,6 +547,7 @@ presubmits:
   - name: pull-kubernetes-csi-csi-driver-host-path-1-32-test-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have csi-driver-host-path removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -638,6 +645,7 @@ presubmits:
   - name: pull-kubernetes-csi-csi-driver-host-path-alpha-1-31-test-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: false
+    # TODO: pull_optional can have csi-driver-host-path removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -53,7 +53,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-csi-test
-      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-test, using deployment 1.30 on Kubernetes 1.30
+      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-test, using deployment 1.31 on Kubernetes 1.31
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -94,7 +94,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-external-provisioner
-      description: Kubernetes-CSI pull job in repo csi-release-tools for external-provisioner, using deployment 1.30 on Kubernetes 1.30
+      description: Kubernetes-CSI pull job in repo csi-release-tools for external-provisioner, using deployment 1.31 on Kubernetes 1.31
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -117,9 +117,9 @@ presubmits:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/external-provisioner
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "1.31.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
+          value: "1.31"
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.15.0"
         - name: CSI_PROW_TESTS
@@ -145,7 +145,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-external-snapshotter
-      description: Kubernetes-CSI pull job in repo csi-release-tools for external-snapshotter, using deployment 1.30 on Kubernetes 1.30
+      description: Kubernetes-CSI pull job in repo csi-release-tools for external-snapshotter, using deployment 1.31 on Kubernetes 1.31
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -168,9 +168,9 @@ presubmits:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "1.31.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
+          value: "1.31"
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.15.0"
         - name: CSI_PROW_TESTS
@@ -196,7 +196,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-release-tools-in-csi-driver-host-path
-      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-driver-host-path, using deployment 1.30 on Kubernetes 1.30
+      description: Kubernetes-CSI pull job in repo csi-release-tools for csi-driver-host-path, using deployment 1.31 on Kubernetes 1.31
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -219,9 +219,9 @@ presubmits:
         - name: PULL_TEST_REPO_DIR
           value: /home/prow/go/src/github.com/kubernetes-csi/csi-driver-host-path
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "1.31.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
+          value: "1.31"
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.15.0"
         - name: CSI_PROW_TESTS

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -2,103 +2,6 @@
 
 presubmits:
   kubernetes-csi/external-attacher:
-  - name: pull-kubernetes-csi-external-attacher-1-29-on-kubernetes-1-29
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-attacher
-      testgrid-tab-name: 1-29-on-kubernetes-1-29
-      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.29 on Kubernetes 1.29
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.29.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.29"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-attacher-1-29-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-attacher
-      testgrid-tab-name: 1-29-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.29 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-external-attacher-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
@@ -199,7 +102,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-attacher-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
@@ -293,9 +196,9 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-external-attacher-alpha-1-30-on-kubernetes-1-30
+  - name: pull-kubernetes-csi-external-attacher-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +209,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-attacher
-      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
-      description: Kubernetes-CSI pull job in repo external-attacher for alpha tests, using deployment 1.30 on Kubernetes 1.30
+      testgrid-tab-name: 1-32-on-kubernetes-1-32
+      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.32 on Kubernetes 1.32
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,9 +226,106 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "1.32.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
+          value: "1.32"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-attacher-1-32-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-attacher
+      testgrid-tab-name: 1-32-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-attacher for non-alpha tests, using deployment 1.32 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-attacher-alpha-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-attacher
+      testgrid-tab-name: alpha-1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo external-attacher for alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -5,6 +5,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-attacher-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-attacher removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -102,6 +103,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-attacher-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-attacher removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -199,6 +201,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-attacher-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-attacher removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -296,6 +299,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-attacher-alpha-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: false
+    # TODO: pull_optional can have external-attacher removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -5,6 +5,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-provisioner-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-provisioner removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -102,6 +103,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-provisioner-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-provisioner removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -199,6 +201,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-provisioner-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-provisioner removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -296,6 +299,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-provisioner-alpha-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: false
+    # TODO: pull_optional can have external-provisioner removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -2,103 +2,6 @@
 
 presubmits:
   kubernetes-csi/external-provisioner:
-  - name: pull-kubernetes-csi-external-provisioner-1-29-on-kubernetes-1-29
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: 1-29-on-kubernetes-1-29
-      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.29 on Kubernetes 1.29
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.29.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.29"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-provisioner-1-29-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: 1-29-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.29 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-external-provisioner-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
@@ -199,7 +102,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-provisioner-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
@@ -293,9 +196,9 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-external-provisioner-alpha-1-30-on-kubernetes-1-30
+  - name: pull-kubernetes-csi-external-provisioner-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +209,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
-      description: Kubernetes-CSI pull job in repo external-provisioner for alpha tests, using deployment 1.30 on Kubernetes 1.30
+      testgrid-tab-name: 1-32-on-kubernetes-1-32
+      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.32 on Kubernetes 1.32
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,9 +226,106 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "1.32.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
+          value: "1.32"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-provisioner-1-32-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-provisioner
+      testgrid-tab-name: 1-32-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-provisioner for non-alpha tests, using deployment 1.32 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-provisioner-alpha-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.2.0|release-0.3.0|release-0.4|release-1.0|v0.1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-provisioner
+      testgrid-tab-name: alpha-1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo external-provisioner for alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -5,7 +5,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-resizer-1-29-on-kubernetes-1-29
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: false
+    optional: true
     decorate: true
     skip_report: false
     skip_branches: []
@@ -102,7 +102,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-resizer-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: false
+    optional: true
     decorate: true
     skip_report: false
     skip_branches: []

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -2,103 +2,6 @@
 
 presubmits:
   kubernetes-csi/external-resizer:
-  - name: pull-kubernetes-csi-external-resizer-1-29-on-kubernetes-1-29
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: true
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-resizer
-      testgrid-tab-name: 1-29-on-kubernetes-1-29
-      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.29 on Kubernetes 1.29
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.29.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.29"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-resizer-1-29-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-resizer
-      testgrid-tab-name: 1-29-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.29 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-external-resizer-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
@@ -293,9 +196,9 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-external-resizer-alpha-1-30-on-kubernetes-1-30
+  - name: pull-kubernetes-csi-external-resizer-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +209,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-resizer
-      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
-      description: Kubernetes-CSI pull job in repo external-resizer for alpha tests, using deployment 1.30 on Kubernetes 1.30
+      testgrid-tab-name: 1-32-on-kubernetes-1-32
+      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.32 on Kubernetes 1.32
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,9 +226,106 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "1.32.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
+          value: "1.32"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-resizer-1-32-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-resizer
+      testgrid-tab-name: 1-32-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-resizer for non-alpha tests, using deployment 1.32 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-resizer-alpha-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-resizer
+      testgrid-tab-name: alpha-1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo external-resizer for alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -5,6 +5,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-resizer-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-resizer removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -102,6 +103,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-resizer-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-resizer removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -199,6 +201,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-resizer-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-resizer removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -296,6 +299,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-resizer-alpha-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: false
+    # TODO: pull_optional can have external-resizer removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-snapshot-metadata/external-snapshot-metadata-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshot-metadata/external-snapshot-metadata-config.yaml
@@ -2,103 +2,6 @@
 
 presubmits:
   kubernetes-csi/external-snapshot-metadata:
-  - name: pull-kubernetes-csi-external-snapshot-metadata-1-29-on-kubernetes-1-29
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: []
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-snapshot-metadata
-      testgrid-tab-name: 1-29-on-kubernetes-1-29
-      description: Kubernetes-CSI pull job in repo external-snapshot-metadata for non-alpha tests, using deployment 1.29 on Kubernetes 1.29
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.29.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.29"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-snapshot-metadata-1-29-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-snapshot-metadata
-      testgrid-tab-name: 1-29-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-snapshot-metadata for non-alpha tests, using deployment 1.29 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-external-snapshot-metadata-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
@@ -199,7 +102,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-snapshot-metadata-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: []
@@ -293,9 +196,9 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-external-snapshot-metadata-alpha-1-30-on-kubernetes-1-30
+  - name: pull-kubernetes-csi-external-snapshot-metadata-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +209,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-snapshot-metadata
-      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
-      description: Kubernetes-CSI pull job in repo external-snapshot-metadata for alpha tests, using deployment 1.30 on Kubernetes 1.30
+      testgrid-tab-name: 1-32-on-kubernetes-1-32
+      description: Kubernetes-CSI pull job in repo external-snapshot-metadata for non-alpha tests, using deployment 1.32 on Kubernetes 1.32
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,9 +226,106 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "1.32.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
+          value: "1.32"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-snapshot-metadata-1-32-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-snapshot-metadata
+      testgrid-tab-name: 1-32-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-snapshot-metadata for non-alpha tests, using deployment 1.32 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-snapshot-metadata-alpha-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-snapshot-metadata
+      testgrid-tab-name: alpha-1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo external-snapshot-metadata for alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/external-snapshot-metadata/external-snapshot-metadata-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshot-metadata/external-snapshot-metadata-config.yaml
@@ -5,6 +5,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-snapshot-metadata-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-snapshot-metadata removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -102,6 +103,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-snapshot-metadata-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-snapshot-metadata removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -199,6 +201,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-snapshot-metadata-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-snapshot-metadata removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -296,6 +299,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-snapshot-metadata-alpha-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: false
+    # TODO: pull_optional can have external-snapshot-metadata removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -2,103 +2,6 @@
 
 presubmits:
   kubernetes-csi/external-snapshotter:
-  - name: pull-kubernetes-csi-external-snapshotter-1-29-on-kubernetes-1-29
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-snapshotter
-      testgrid-tab-name: 1-29-on-kubernetes-1-29
-      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.29 on Kubernetes 1.29
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.29.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.29"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-external-snapshotter-1-29-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-external-snapshotter
-      testgrid-tab-name: 1-29-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.29 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-external-snapshotter-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
@@ -199,7 +102,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-snapshotter-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
@@ -293,9 +196,9 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-external-snapshotter-alpha-1-30-on-kubernetes-1-30
+  - name: pull-kubernetes-csi-external-snapshotter-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +209,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-snapshotter
-      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
-      description: Kubernetes-CSI pull job in repo external-snapshotter for alpha tests, using deployment 1.30 on Kubernetes 1.30
+      testgrid-tab-name: 1-32-on-kubernetes-1-32
+      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.32 on Kubernetes 1.32
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,9 +226,106 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "1.32.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
+          value: "1.32"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-snapshotter-1-32-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-snapshotter
+      testgrid-tab-name: 1-32-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-snapshotter for non-alpha tests, using deployment 1.32 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-snapshotter-alpha-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(k8s_1.12.0-beta.1|release-0.4|release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-snapshotter
+      testgrid-tab-name: alpha-1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo external-snapshotter for alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -5,6 +5,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-snapshotter-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-snapshotter removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -102,6 +103,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-snapshotter-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-snapshotter removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -199,6 +201,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-snapshotter-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have external-snapshotter removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -296,6 +299,7 @@ presubmits:
   - name: pull-kubernetes-csi-external-snapshotter-alpha-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: false
+    # TODO: pull_optional can have external-snapshotter removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -27,6 +27,7 @@ k8s_versions="
 1.29
 1.30
 1.31
+1.32
 "
 
 # All the deployment versions we're testing.
@@ -37,7 +38,7 @@ deployment_versions="
 "
 
 # The experimental version for which jobs are optional.
-experimental_k8s_version="1.31"
+experimental_k8s_version="1.32"
 
 # The latest stable Kubernetes version for testing alpha jobs
 latest_stable_k8s_version="1.30"
@@ -275,7 +276,11 @@ pull_optional() {
         # Make tests optional until everything is updated.
         echo "true"
     else
-        echo "false"
+	if [ "$repo" == "external-resizer" ] ; then
+	    echo "true"
+	else
+            echo "false"
+	fi
     fi
 }
 

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -369,7 +369,7 @@ EOF
   - name: $(job_name "pull" "$repo" "$tests" "$deployment$deployment_suffix" "$kubernetes")
     cluster: $(job_cluster "$repo")
     always_run: $(pull_alwaysrun "$tests")
-    optional: $(pull_optional "$tests" "$kubernetes" "$deployment_suffix")
+    optional: $(pull_optional "$tests" "$kubernetes" "$deployment_suffix" "$repo")
     decorate: true
     skip_report: false
     skip_branches: [$(skip_branches $repo)]
@@ -558,7 +558,7 @@ EOF
   - name: $(job_name "pull" "$repo" "$tests")
     cluster: $(job_cluster "$repo")
     always_run: true
-    optional: $(pull_optional "$tests")
+    optional: $(pull_optional "$tests" "$kubernetes" "$deployment_suffix" "$repo")
     decorate: true
     skip_report: false
     skip_branches: [$(skip_branches $repo)]

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -24,7 +24,6 @@ base="$(dirname $0)"
 # irrelevant because the prow.sh script will pick a suitable KinD
 # image or build from source.
 k8s_versions="
-1.29
 1.30
 1.31
 1.32
@@ -32,16 +31,16 @@ k8s_versions="
 
 # All the deployment versions we're testing.
 deployment_versions="
-1.29
 1.30
 1.31
+1.32
 "
 
 # The experimental version for which jobs are optional.
 experimental_k8s_version="1.32"
 
 # The latest stable Kubernetes version for testing alpha jobs
-latest_stable_k8s_version="1.30"
+latest_stable_k8s_version="1.31"
 
 # Tag of the hostpath driver we should use for sidecar pull jobs
 hostpath_driver_version="v1.15.0"
@@ -276,6 +275,7 @@ pull_optional() {
         # Make tests optional until everything is updated.
         echo "true"
     else
+	# remove this once https://github.com/kubernetes/kubernetes/pull/129234 merges
 	if [ "$repo" == "external-resizer" ] ; then
 	    echo "true"
 	else

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -374,6 +374,7 @@ EOF
   - name: $(job_name "pull" "$repo" "$tests" "$deployment$deployment_suffix" "$kubernetes")
     cluster: $(job_cluster "$repo")
     always_run: $(pull_alwaysrun "$tests")
+    # TODO: pull_optional can have $repo removed once special case for resizer is removed
     optional: $(pull_optional "$tests" "$kubernetes" "$deployment_suffix" "$repo")
     decorate: true
     skip_report: false
@@ -563,6 +564,7 @@ EOF
   - name: $(job_name "pull" "$repo" "$tests")
     cluster: $(job_cluster "$repo")
     always_run: true
+    # TODO: pull_optional can have $repo removed once special case for resizer is removed
     optional: $(pull_optional "$tests" "$kubernetes" "$deployment_suffix" "$repo")
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -2,103 +2,6 @@
 
 presubmits:
   kubernetes-csi/livenessprobe:
-  - name: pull-kubernetes-csi-livenessprobe-1-29-on-kubernetes-1-29
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-0.4|release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-livenessprobe
-      testgrid-tab-name: 1-29-on-kubernetes-1-29
-      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.29 on Kubernetes 1.29
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.29.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.29"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-livenessprobe-1-29-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-livenessprobe
-      testgrid-tab-name: 1-29-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.29 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-livenessprobe-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
@@ -199,7 +102,7 @@ presubmits:
   - name: pull-kubernetes-csi-livenessprobe-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-0.4|release-1.0)$"]
@@ -293,9 +196,9 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-livenessprobe-alpha-1-30-on-kubernetes-1-30
+  - name: pull-kubernetes-csi-livenessprobe-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +209,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-livenessprobe
-      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
-      description: Kubernetes-CSI pull job in repo livenessprobe for alpha tests, using deployment 1.30 on Kubernetes 1.30
+      testgrid-tab-name: 1-32-on-kubernetes-1-32
+      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.32 on Kubernetes 1.32
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,9 +226,106 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "1.32.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
+          value: "1.32"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-livenessprobe-1-32-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-livenessprobe
+      testgrid-tab-name: 1-32-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo livenessprobe for non-alpha tests, using deployment 1.32 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-livenessprobe-alpha-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-0.4|release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-livenessprobe
+      testgrid-tab-name: alpha-1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo livenessprobe for alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -5,6 +5,7 @@ presubmits:
   - name: pull-kubernetes-csi-livenessprobe-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have livenessprobe removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -102,6 +103,7 @@ presubmits:
   - name: pull-kubernetes-csi-livenessprobe-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have livenessprobe removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -199,6 +201,7 @@ presubmits:
   - name: pull-kubernetes-csi-livenessprobe-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have livenessprobe removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -296,6 +299,7 @@ presubmits:
   - name: pull-kubernetes-csi-livenessprobe-alpha-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: false
+    # TODO: pull_optional can have livenessprobe removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -5,6 +5,7 @@ presubmits:
   - name: pull-kubernetes-csi-node-driver-registrar-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have node-driver-registrar removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -102,6 +103,7 @@ presubmits:
   - name: pull-kubernetes-csi-node-driver-registrar-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have node-driver-registrar removed once special case for resizer is removed
     optional: false
     decorate: true
     skip_report: false
@@ -199,6 +201,7 @@ presubmits:
   - name: pull-kubernetes-csi-node-driver-registrar-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
     always_run: true
+    # TODO: pull_optional can have node-driver-registrar removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false
@@ -296,6 +299,7 @@ presubmits:
   - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: false
+    # TODO: pull_optional can have node-driver-registrar removed once special case for resizer is removed
     optional: true
     decorate: true
     skip_report: false

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -2,103 +2,6 @@
 
 presubmits:
   kubernetes-csi/node-driver-registrar:
-  - name: pull-kubernetes-csi-node-driver-registrar-1-29-on-kubernetes-1-29
-    cluster: eks-prow-build-cluster
-    always_run: true
-    optional: false
-    decorate: true
-    skip_report: false
-    skip_branches: ["^(release-1.0)$"]
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-node-driver-registrar
-      testgrid-tab-name: 1-29-on-kubernetes-1-29
-      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.29 on Kubernetes 1.29
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        # We pick some version for which there are pre-built images for kind.
-        # Update only when the newer version is known to not cause issues,
-        # otherwise presubmit jobs may start to fail for reasons that are
-        # unrelated to the PR. Testing against the latest Kubernetes is covered
-        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.29.0"
-        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.29"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v6.1.0"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
-  - name: pull-kubernetes-csi-node-driver-registrar-1-29-on-kubernetes-master
-    # Explicitly needs to be started with /test.
-    # This cannot be enabled by default because there's always the risk
-    # that something changes in master which breaks the pre-merge check.
-    cluster: eks-prow-build-cluster
-    always_run: false
-    optional: true
-    decorate: true
-    skip_report: false
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    annotations:
-      testgrid-dashboards: sig-storage-csi-node-driver-registrar
-      testgrid-tab-name: 1-29-on-kubernetes-master
-      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.29 on Kubernetes master
-    spec:
-      containers:
-      # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        args:
-        - ./.prow.sh
-        env:
-        - name: CSI_PROW_KUBERNETES_VERSION
-          value: "latest"
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.15.0"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "master"
-        - name: CSI_PROW_TESTS
-          value: "sanity serial parallel"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "9Gi"
-            cpu: 4
-          limits:
-            memory: "9Gi"
-            cpu: 4
   - name: pull-kubernetes-csi-node-driver-registrar-1-30-on-kubernetes-1-30
     cluster: eks-prow-build-cluster
     always_run: true
@@ -199,7 +102,7 @@ presubmits:
   - name: pull-kubernetes-csi-node-driver-registrar-1-31-on-kubernetes-1-31
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     skip_report: false
     skip_branches: ["^(release-1.0)$"]
@@ -293,9 +196,9 @@ presubmits:
           limits:
             memory: "9Gi"
             cpu: 4
-  - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-30-on-kubernetes-1-30
+  - name: pull-kubernetes-csi-node-driver-registrar-1-32-on-kubernetes-1-32
     cluster: eks-prow-build-cluster
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     skip_report: false
@@ -306,8 +209,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-node-driver-registrar
-      testgrid-tab-name: alpha-1-30-on-kubernetes-1-30
-      description: Kubernetes-CSI pull job in repo node-driver-registrar for alpha tests, using deployment 1.30 on Kubernetes 1.30
+      testgrid-tab-name: 1-32-on-kubernetes-1-32
+      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.32 on Kubernetes 1.32
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -323,9 +226,106 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "1.32.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
-          value: "1.30"
+          value: "1.32"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-node-driver-registrar-1-32-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-node-driver-registrar
+      testgrid-tab-name: 1-32-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo node-driver-registrar for non-alpha tests, using deployment 1.32 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.15.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-node-driver-registrar-alpha-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: ["^(release-1.0)$"]
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-node-driver-registrar
+      testgrid-tab-name: alpha-1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo node-driver-registrar for alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
           value: ""
         - name: CSI_PROW_DRIVER_VERSION


### PR DESCRIPTION
This PR removes 1.29 from CSI sidecar jobs and makes 1.32 experimental.

It also makes all resizer jobs optional, so as we can merge - https://github.com/kubernetes-csi/external-resizer/pull/456

Once https://github.com/kubernetes/kubernetes/pull/129234 merges, the 1.32 jobs for resizer should start passing and then we can make those required.

