### PR TITLE
splitfs-separate-disk-kubetest2: use empty skip-regex

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3817,6 +3817,7 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --parallelism=1
         - --focus-regex=KubeletSeparateDiskGC
+        - --skip-regex=""
         - '--test-args=--feature-gates="KubeletSeparateDiskGC=true" --service-feature-gates="KubeletSeparateDiskGC=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-splitfs.yaml
         resources:


### PR DESCRIPTION
Default value of the `--skip-regex` option is `\[Flaky\]|\[Slow\]|\[Serial\]` in `kubetest2`, which resulted in skipping 2 slow serial test cases from the test run. Using empty `skip-regex` should make amount of test cases the same as for `kubernetes_e2e.py splitfs-separate-disk` job.

Ref: https://github.com/kubernetes/test-infra/issues/32567

/sig node
/cc @elieser1101 @kannon92 @haircommander