### PR TITLE
Modify gcp-gce e2e-gci default periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -803,7 +803,7 @@ periodics:
     preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
-    timeout: 70m
+    timeout: 140m
   spec:
     containers:
     - command:
@@ -813,14 +813,13 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/fast/latest-fast
       - --extract-ci-bucket=k8s-release-dev
-      - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=50m
+      - --timeout=120m
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
       resources:
         limits:


### PR DESCRIPTION
Changing [ci-kubernetes-e2e-gci-gce](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml#L799) master job to match with release branch job at [ci-kubernetes-e2e-gce-cos-k8sbeta-default](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/generated/generated.yaml#L55)
Ref: https://kubernetes.slack.com/archives/C2C40FMNF/p1734529922763579?thread_ts=1734528191.048989&cid=C2C40FMNF

- The job name is being changed from `ci-kubernetes-e2e-gci-gce` to `ci-kubernetes-e2e-gce-cos-master-default` so as to make this use `config-forker` in future as per the plan [here](https://github.com/kubernetes/test-infra/issues/32340#issuecomment-2263252791) 

- Addition of `--env=ENABLE_CACHE_MUTATION_DETECTOR=true` helps catch the scenario where anything mutates a shared informer cache as per @dims comment [here](https://github.com/kubernetes/test-infra/issues/32340#issuecomment-2260548829)

- Removing the args `--gcp-node-image=gci` and `--gcp-nodes=4` in master branch job will probably cut down the run to single node cluster. Looks like single node would be enough as release branch jobs are not having these args [here](https://github.com/kubernetes/test-infra/blob/master/releng/test_config.yaml#L243) and are running fine.

- The timeout value of job and the timeout arg passed to test run are increased as per https://github.com/kubernetes/test-infra/blob/master/releng/test_config.yaml#L332 and https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/generated/generated.yaml#L294