### PR TITLE
Remove the periodic CA e2e tests that were for multiple migs.

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -309,50 +309,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
     testgrid-tab-name: gci-gce-autoscaling-hpa-cm
-- interval: 24h
-  name: ci-kubernetes-e2e-gci-gce-autoscaling-migs
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 450m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=ca
-      # Override GCE default for cluster size autoscaling purposes.
-      - --env=KUBE_ENABLE_CLUSTER_AUTOSCALER=true
-      - --env=MAX_INSTANCES_PER_MIG=2
-      - --env=KUBE_AUTOSCALER_MIN_NODES=1
-      - --env=KUBE_AUTOSCALER_MAX_NODES=6
-      - --env=KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
-      - --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,Priority
-      - --env=ENABLE_POD_PRIORITY=true
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-nodes=3
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --runtime-config=scheduling.k8s.io/v1alpha1=true
-      - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
-      - --timeout=400m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
-
-  annotations:
-    testgrid-dashboards: sig-autoscaling-cluster-autoscaler
-    testgrid-tab-name: gci-gce-autoscaling-migs
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
After removing the provider integration we do not have any more tests that differ between multiple and a single mig. The tests are run in another periodic.