### PR TITLE
use cdi for containerd 1.7

### DIFF
--- a/jobs/e2e_node/containerd/config-systemd.toml
+++ b/jobs/e2e_node/containerd/config-systemd.toml
@@ -21,6 +21,7 @@ oom_score = -999
 [plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = 262144
+  enable_cdi = true
 [plugins."io.containerd.grpc.v1.cri".cni]
   bin_dir = "/home/containerd/"
   conf_dir = "/etc/cni/net.d"


### PR DESCRIPTION
Fix: [It] [sig-node] Device Plugin [NodeFeature:DevicePlugin] [Serial] DevicePlugin [Serial] [Disruptive] can make a CDI device accessible in a container

Containerd 1.7 does not enable CDI by default. This config should enable it.

Note: I am not a containerd test-infra maintainer so I am sure I missed a few places.

@dims I need some help on aws settings. The ec2 jobs are failing for this reason but I could not find the aws config for containerd to enable CDI.