### PR TITLE
add cdi to more containerd configs

### DIFF
--- a/jobs/e2e_node/containerd/config-v2.toml
+++ b/jobs/e2e_node/containerd/config-v2.toml
@@ -17,6 +17,7 @@ oom_score = -999
 [plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = 262144
+  enable_cdi = true
 [plugins."io.containerd.grpc.v1.cri".cni]
   bin_dir = "/home/containerd/"
   conf_dir = "/etc/cni/net.d"

--- a/jobs/e2e_node/containerd/config.toml
+++ b/jobs/e2e_node/containerd/config.toml
@@ -17,6 +17,7 @@ oom_score = -999
 [plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = 262144
+  enable_cdi = true
 [plugins."io.containerd.grpc.v1.cri".cni]
   bin_dir = "/home/containerd/"
   conf_dir = "/etc/cni/net.d"


### PR DESCRIPTION
CDI is GA in kube so we should enable it on containerd also.