### PR TITLE
replace pull-crio-cgroupv2-splitfs-separate-disk with kubetest2 job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3729,57 +3729,6 @@ presubmits:
             value: "1"
   - name: pull-crio-cgroupv2-splitfs-separate-disk
     cluster: k8s-infra-prow-build
-    skip_branches:
-      - release-\d+\.\d+  # per-release image
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    optional: true
-    always_run: false
-    max_concurrency: 12
-    decorate: true
-    decoration_config:
-      timeout: 320m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        args:
-        - --deployment=node
-        - --env=KUBE_SSH_USER=core
-        - --gcp-zone=us-west1-b
-        - '--node-test-args=--feature-gates="KubeletSeparateDiskGC=true" --service-feature-gates="KubeletSeparateDiskGC=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-        - --node-tests=true
-        - --provider=gce
-        - --test_args=--nodes=1 --focus="KubeletSeparateDiskGC" --timeout=300m
-        - --timeout=300m
-        - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-splitfs.yaml
-        env:
-        - name: GOPATH
-          value: /go
-        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-          value: "1"
-        resources:
-          requests:
-            cpu: 4
-            memory: 6Gi
-          limits:
-            cpu: 4
-            memory: 6Gi
-    annotations:
-      testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgroupv2-splitfs-separate-disk
-  - name: pull-crio-cgroupv2-splitfs-separate-disk-kubetest2
-    cluster: k8s-infra-prow-build
-    # explicitly needs /test pull-crio-cgroupv2-splitfs-separate-disk-kubetest2 to run
     always_run: false
     optional: true
     max_concurrency: 12
@@ -3802,7 +3751,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgroupv2-splitfs-separate-disk-kubetest2
+      testgrid-tab-name: pr-crio-cgroupv2-splitfs-separate-disk
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241218-d4b51bc3e8-master


### PR DESCRIPTION
After https://github.com/kubernetes/test-infra/pull/34005 has been merged, testgrids look identical for these jobs, so it's safe to replace:
- https://testgrid.k8s.io/sig-node-cri-o#pr-crio-cgroupv2-splitfs-separate-disk
- https://testgrid.k8s.io/sig-node-cri-o#pr-crio-cgroupv2-splitfs-separate-disk-kubetest2

Ref: https://github.com/kubernetes/test-infra/issues/32567

/sig node
/cc @elieser1101 @kannon92 @haircommander