### PR TITLE
Update sig-storage image pushing for new cosi monorepo

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-storage.sh
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.sh
@@ -37,13 +37,13 @@ readonly REPOS=(
     kubernetes-sigs/sig-storage-local-static-provisioner
     kubernetes-sigs/nfs-ganesha-server-and-external-provisioner
     kubernetes-sigs/nfs-subdir-external-provisioner
-    kubernetes-sigs/container-object-storage-interface-controller
-    kubernetes-sigs/container-object-storage-interface-provisioner-sidecar
+    kubernetes-sigs/container-object-storage-interface
 )
 
 # Repos using "main" branch instead of "master" as default
 readonly REPOS_MAIN_BRANCH=(
     kubernetes-csi/external-snapshot-metadata
+    kubernetes-sigs/container-object-storage-interface
 )
 
 # Repos which should eventually enable cloud image builds but currently

--- a/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
@@ -721,8 +721,8 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
-  kubernetes-sigs/container-object-storage-interface-controller:
-    - name: post-container-object-storage-interface-controller-push-images
+  kubernetes-sigs/container-object-storage-interface:
+    - name: post-container-object-storage-interface-push-images
       rerun_auth_config:
         github_team_slugs:
           - org: kubernetes
@@ -740,47 +740,7 @@ postsubmits:
         grace_period: 15m
       branches:
         # For publishing canary images.
-        - ^master$
-        - ^release-
-        # For publishing tagged images. Those will only get built once, i.e.
-        # existing images are not getting overwritten. A new tag must be set to
-        # trigger another image build. Images are only built for tags that follow
-        # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
-        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/image-builder:v20241015-ff9ecc4d73
-            command:
-              - /run.sh
-            args:
-              # this is the project GCB will run in, which is the same as the GCR
-              # images are pushed to.
-              - --project=k8s-staging-sig-storage
-              # This is the same as above, but with -gcb appended.
-              - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
-              - --env-passthrough=PULL_BASE_REF
-              - .
-  kubernetes-sigs/container-object-storage-interface-provisioner-sidecar:
-    - name: post-container-object-storage-interface-provisioner-sidecar-push-images
-      rerun_auth_config:
-        github_team_slugs:
-          - org: kubernetes
-            slug: release-managers
-          - org: kubernetes
-            slug: test-infra-admins
-          - org: kubernetes
-            slug: sig-storage-image-build-admins
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: sig-storage-image-build, sig-k8s-infra-gcb
-      decorate: true
-      decoration_config:
-        timeout: 240m
-        grace_period: 15m
-      branches:
-        # For publishing canary images.
-        - ^master$
+        - ^main$
         - ^release-
         # For publishing tagged images. Those will only get built once, i.e.
         # existing images are not getting overwritten. A new tag must be set to
@@ -1410,7 +1370,7 @@ periodics:
             - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
             - --env-passthrough=PULL_BASE_REF
             - .
-  - name: canary-container-object-storage-interface-controller-push-images
+  - name: canary-container-object-storage-interface-push-images
     cluster: k8s-infra-prow-build-trusted
     annotations:
       testgrid-dashboards: sig-storage-image-build, sig-k8s-infra-gcb
@@ -1420,8 +1380,8 @@ periodics:
       # This also becomes the current directory for run.sh and thus
       # the cloud image build.
       - org: kubernetes-sigs
-        repo: container-object-storage-interface-controller
-        base_ref: master
+        repo: container-object-storage-interface
+        base_ref: main
     spec:
       serviceAccountName: gcb-builder
       containers:
@@ -1432,38 +1392,7 @@ periodics:
             # We need to emulate a pull job for the cloud build to work the same
             # way as it usually does.
             - name: PULL_BASE_REF
-              value: master
-          args:
-            # this is the project GCB will run in, which is the same as the GCR
-            # images are pushed to.
-            - --project=k8s-staging-sig-storage
-            # This is the same as above, but with -gcb appended.
-            - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
-            - --env-passthrough=PULL_BASE_REF
-            - .
-  - name: canary-container-object-storage-interface-provisioner-sidecar-push-images
-    cluster: k8s-infra-prow-build-trusted
-    annotations:
-      testgrid-dashboards: sig-storage-image-build, sig-k8s-infra-gcb
-    decorate: true
-    interval: 168h # one week
-    extra_refs:
-      # This also becomes the current directory for run.sh and thus
-      # the cloud image build.
-      - org: kubernetes-sigs
-        repo: container-object-storage-interface-provisioner-sidecar
-        base_ref: master
-    spec:
-      serviceAccountName: gcb-builder
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/image-builder:v20241015-ff9ecc4d73
-          command:
-            - /run.sh
-          env:
-            # We need to emulate a pull job for the cloud build to work the same
-            # way as it usually does.
-            - name: PULL_BASE_REF
-              value: master
+              value: main
           args:
             # this is the project GCB will run in, which is the same as the GCR
             # images are pushed to.


### PR DESCRIPTION
Update the sig-storage script that manages image pushing and canary building to reflect the latest COSI monorepo. Run the script to update the Prow configs.