### PR TITLE
skip benchmark for arm64 al2023 serial aws jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -621,7 +621,7 @@ periodics:
             - name: FOCUS
               value: \[Serial\]
             - name: SKIP
-              value: \[Flaky\]|\[NodeFeature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+              value: \[Flaky\]|\[Benchmark\]|\[NodeFeature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
             - name: BUILD_EKS_AMI
               value: "true"
             - name: BUILD_EKS_AMI_OS


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/129342

All other serial jobs in this file filter out benchmark. This one seems to not have that. This is causing the test to run longer and hit a timeout.