### PR TITLE
Allow Cluster API maintainers to rerun cluster-api post-submit jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -2,6 +2,10 @@ postsubmits:
   # this is the github repo we'll build from; this block needs to be repeated for each repo.
   kubernetes-sigs/cluster-api:
     - name: post-cluster-api-push-images
+      rerun_auth_config:
+        github_team_slugs:
+        - org: kubernetes-sigs
+          slug: cluster-api-maintainers
       cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
@@ -402,6 +406,10 @@ postsubmits:
 
 periodics:
   - name: cluster-api-push-images-nightly
+    rerun_auth_config:
+      github_team_slugs:
+      - org: kubernetes-sigs
+        slug: cluster-api-maintainers
     cluster: k8s-infra-prow-build-trusted
     decorate: true
     cron: '0 8 * * *' # everyday at 0:00 PT (8:00 UTC)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com