### PR TITLE
Consolidating gcp-zone of ci-kubernetes-e2e-gci-gce-slow with other jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -1139,7 +1139,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-zone=europe-west1-c
+      - --gcp-zone=us-west1-b
       - --ginkgo-parallel=25
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --minStartupPods=8


### PR DESCRIPTION
The gcp-zone for job [ci-kubernetes-e2e-gci-gce-slow](https://github.com/Rajalakshmi-Girish/test-infra-1/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml#L1142)  `europe-west1-c` is different from all other jobs in https://github.com/Rajalakshmi-Girish/test-infra-1/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml

Hence consolidating to `us-west1-b` like other jobs
Slack Ref: https://kubernetes.slack.com/archives/C718BPBQ8/p1734987151285019?thread_ts=1734984163.932169&cid=C718BPBQ8

Also, the counter part jobs on release branches are already running at `us-west1-b` https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/generated/generated.yaml#L221

Sample job that ran on release branch 1.32 -  https://prow.k8s.io/prowjob?prowjob=f32ac228-aa26-4e3f-b79c-eaa441e62fec