### PR TITLE
chore: bump golang to 1.23 for build image

### DIFF
--- a/images/builder/cloudbuild.yaml
+++ b/images/builder/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
     dir: images/builder
 substitutions:
   _GIT_TAG: '12345'
-  _GO_VERSION: '1.22'
+  _GO_VERSION: '1.23'
 images:
   - 'gcr.io/$PROJECT_ID/image-builder:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/image-builder:latest'


### PR DESCRIPTION
Update golang to 1.23 to support new features like godebug directives for components like [cloud-provider-azure](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/go.mod#L5) and as a follow-up to https://github.com/kubernetes/test-infra/pull/32647

cc @dims 