### PR TITLE
Remove --extract-ci-bucket=k8s-release-dev value from jobs as it is anyways default value

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -21,7 +21,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.32
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -65,7 +64,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.32
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -105,7 +103,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.32
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
@@ -143,7 +140,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.32
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -181,7 +177,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.32
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=660m
       - --ginkgo-parallel=1
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\] --minStartupPods=8
@@ -221,7 +216,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.32
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -261,7 +255,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.31
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -305,7 +298,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.31
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -339,7 +331,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.31
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
@@ -377,7 +368,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.31
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -415,7 +405,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.31
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=660m
       - --ginkgo-parallel=1
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\] --minStartupPods=8
@@ -455,7 +444,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.31
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -489,7 +477,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.30
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -532,7 +519,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.30
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -566,7 +552,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.30
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
@@ -604,7 +589,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.30
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -642,7 +626,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.30
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -682,7 +665,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.30
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -716,7 +698,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.29
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -759,7 +740,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.29
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -793,7 +773,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.29
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
@@ -831,7 +810,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.29
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -869,7 +847,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.29
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -909,7 +886,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.29
-      - --extract-ci-bucket=k8s-release-dev
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -207,7 +207,6 @@ periodics:
       - --check-version-skew=false
       - --extract=ci/k8s-stable1
       - --extract=ci/latest
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=25

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -21,7 +21,6 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -812,7 +812,6 @@ periodics:
       args:
       - --check-leaked-resources
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
@@ -862,7 +861,6 @@ periodics:
           - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
           - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
           - --extract=ci/fast/latest-fast
-          - --extract-ci-bucket=k8s-release-dev
           - --gcp-master-image=ubuntu
           - --gcp-node-image=ubuntu
           - --gcp-nodes=4
@@ -908,7 +906,6 @@ periodics:
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
@@ -948,7 +945,6 @@ periodics:
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -1059,7 +1055,6 @@ periodics:
       - --check-leaked-resources
       - --cluster=err-e2e
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -43,7 +43,6 @@ periodics:
       args:
       - --check-leaked-resources
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       # Note: The GCE Node image used may have a dependency on the nvidia-driver-installer image defined in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/testing-manifests/scheduling/nvidia-driver-installer.yaml
       # If updating the image defined here, the cos-gpu-installer image may need to updated to support the corresponding COS image.
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -621,7 +621,6 @@ periodics:
       - --env=GCE_ALPHA_FEATURES=NetworkEndpointGroup
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -660,7 +659,6 @@ periodics:
       - --env=GCE_ALPHA_FEATURES=NetworkEndpointGroup
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -15,7 +15,6 @@ periodics:
     containers:
     - args:
       - --extract=ci/latest-1.29
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -56,7 +55,6 @@ periodics:
     - args:
       - --check-leaked-resources
       - --extract=ci/latest-1.29
-      - --extract-ci-bucket=k8s-release-dev
       - --env=KUBE_NODE_OS_DISTRIBUTION=gci
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
       - --env=KUBE_GCE_NODE_PROJECT=cos-cloud
@@ -287,7 +285,6 @@ periodics:
       - --env=APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0 --profiling --contention-profiling
       - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
       - --extract=ci/latest-1.29
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -15,7 +15,6 @@ periodics:
     containers:
     - args:
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -97,7 +96,6 @@ periodics:
     - args:
       - --check-leaked-resources
       - --extract=ci/latest-1.30
-      - --extract-ci-bucket=k8s-release-dev
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
       - --gcp-node-image=gci
       - --gcp-nodes=1
@@ -327,7 +325,6 @@ periodics:
       - --env=APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0 --profiling --contention-profiling
       - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
       - --extract=ci/latest-1.30
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -15,7 +15,6 @@ periodics:
     containers:
     - args:
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -97,7 +96,6 @@ periodics:
     - args:
       - --check-leaked-resources
       - --extract=ci/latest-1.31
-      - --extract-ci-bucket=k8s-release-dev
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
       - --gcp-node-image=gci
       - --gcp-nodes=1
@@ -322,7 +320,6 @@ periodics:
       - --env=APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0 --profiling --contention-profiling
       - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
       - --extract=ci/latest-1.31
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -15,7 +15,6 @@ periodics:
     containers:
     - args:
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -97,7 +96,6 @@ periodics:
     - args:
       - --check-leaked-resources
       - --extract=ci/latest-1.32
-      - --extract-ci-bucket=k8s-release-dev
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
       - --gcp-node-image=gci
       - --gcp-nodes=2
@@ -322,7 +320,6 @@ periodics:
       - --env=APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0 --profiling --contention-profiling
       - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
       - --extract=ci/latest-1.32
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -182,7 +182,6 @@ periodics:
       - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
       - --env=KUBE_PROXY_MODE=nftables
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -553,7 +553,6 @@ presubmits:
         # memory usage regression.
         - --env=KUBE_DNS_MEMORY_LIMIT=300Mi
         - --extract=ci/fast/latest-fast
-        - --extract-ci-bucket=k8s-release-dev
         - --gcp-nodes=5000
         - --gcp-project-type=scalability-scale-project
         - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -45,7 +45,6 @@ periodics:
       - --env=CONCURRENT_SERVICE_SYNCS=20 # support 20 LoadBalancer Services in parallel to deal with existing CI load #122286
       - --env=HEAPSTER_MACHINE_TYPE=e2-standard-32
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --env=KUBE_CONTROLLER_MANAGER_TEST_ARGS=--endpointslice-updates-batch-period=500ms --endpoint-updates-batch-period=500ms
       # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
       - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --contention-profiling --kube-api-qps=100 --kube-api-burst=100
@@ -128,7 +127,6 @@ periodics:
       # memory usage regression.
       - --env=KUBE_DNS_MEMORY_LIMIT=300Mi
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-nodes=5000
       - --gcp-project-type=scalability-scale-project
       - --gcp-zone=us-east1-b
@@ -226,7 +224,6 @@ periodics:
       - --env=APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0 --profiling --contention-profiling
       - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -311,7 +311,6 @@ periodics:
       - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
       - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
       - --extract=ci/fast/latest-fast
-      - --extract-ci-bucket=k8s-release-dev
       - --gcp-master-image=ubuntu
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -246,29 +246,24 @@ k8sVersions:
   dev:
     args:
     - --extract=ci/latest
-    - --extract-ci-bucket=k8s-release-dev
     version: master
   # TODO(1.31): Comment this out when moving 1.31 to stable1.
   # TODO(1.32): Uncomment this when adding jobs for release-1.32 branch.
   beta:
     args:
     - --extract=ci/latest-1.32
-    - --extract-ci-bucket=k8s-release-dev
     version: '1.32'
   stable1:
     args:
     - --extract=ci/latest-1.31
-    - --extract-ci-bucket=k8s-release-dev
     version: '1.31'
   stable2:
     args:
     - --extract=ci/latest-1.30
-    - --extract-ci-bucket=k8s-release-dev
     version: '1.30'
   stable3:
     args:
     - --extract=ci/latest-1.29
-    - --extract-ci-bucket=k8s-release-dev
     version: '1.29'
   stable4:
 


### PR DESCRIPTION
The default value of ci bucket in kubetest is `k8s-release-dev`, hence passing the same value from jobs isn't required.

https://github.com/kubernetes/test-infra/pull/22840/commits/5ff9997571a1d52210650810aa00d03f5a73aa93 has made default value of `extract-ci-bucket` to `k8s-release-dev`