### PR TITLE
sig-k8s-infra: bump go version for peribolos jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
@@ -21,7 +21,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.23
         command:
         - ./admin/update.sh
         args:
@@ -61,7 +61,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: public.ecr.aws/docker/library/golang:1.22
+    - image: public.ecr.aws/docker/library/golang:1.23
       command:
       - ./admin/update.sh
       args:


### PR DESCRIPTION
Bump golang version to get job back on its feet: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-org-peribolos/1871603959144124416