### PR TITLE
Remove the --cluster flag to gcp's e2e jobs

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -15,7 +15,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-eef92b583b
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -58,7 +57,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-1789b1211d
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -97,7 +95,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-6724261826
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -134,7 +131,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-0eda36b5c4
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -171,7 +167,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-34cf3ed1e3
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -210,7 +205,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-3ec9d97448
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -249,7 +243,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-86ab064463
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -292,7 +285,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-359c739436
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -325,7 +317,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-519f5e2df7
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -362,7 +353,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-c2db0160cf
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -399,7 +389,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-ef6e185752
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -438,7 +427,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-7d3ed76582
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -471,7 +459,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-a8a0b221b9
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -513,7 +500,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-5881f7ab7e
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -546,7 +532,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-df7ff40165
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -583,7 +568,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-c8c4b0ff1c
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -620,7 +604,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-9b5ed62f1f
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -659,7 +642,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-96f446fc82
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -692,7 +674,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-1d30227e33
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -734,7 +715,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-183d8deac8
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -767,7 +747,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-df914a9cd5
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -804,7 +783,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-4b7fa88c7e
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -841,7 +819,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-3154607d16
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b
@@ -880,7 +857,6 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=test-694be857a6
       - --check-leaked-resources
       - --provider=gce
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -44,7 +44,6 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
         - --build=quick
-        - --cluster=
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
@@ -98,7 +97,6 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
         - --build=quick
-        - --cluster=
         - --gcp-node-image=ubuntu
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
@@ -149,7 +147,6 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
         - --build=quick
-        - --cluster=
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
@@ -205,7 +202,6 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
         - --build=quick
-        - --cluster=
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
@@ -265,7 +261,6 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
           args:
             - --build=quick
-            - --cluster=
             - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
@@ -344,7 +339,6 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
           args:
             - --build=quick
-            - --cluster=
             - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
@@ -469,7 +463,6 @@ presubmits:
         args:
         - --ginkgo-parallel=1
         - --build=quick
-        - --cluster=
         # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
         - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
         - --env=KUBE_PROXY_DAEMONSET=true
@@ -530,7 +523,6 @@ presubmits:
             - /workspace/scenarios/kubernetes_e2e.py
           args:
             - --build=quick
-            - --cluster=
             - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.0.0
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.2.1
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
@@ -713,7 +705,6 @@ presubmits:
             - /workspace/scenarios/kubernetes_e2e.py
           args:
             - --build=quick
-            - --cluster=
             - --env=KUBE_FEATURE_GATES=DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true
             - --env=CLOUD_PROVIDER_FLAG=external
             - --env=ENABLE_AUTH_PROVIDER_GCP=true
@@ -1053,7 +1044,6 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --cluster=err-e2e
       - --extract=ci/fast/latest-fast
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b

--- a/releng/generate_tests.py
+++ b/releng/generate_tests.py
@@ -246,7 +246,7 @@ class E2ETest:
         self.env_filename = os.path.join(output_dir, '%s.env' % job_name)
         self.job_name = job_name
         self.job = job
-        self.common = config['common']
+        self.common = config.get('common')
         self.cloud_providers = config['cloudProviders']
         self.images = config['images']
         self.k8s_versions = config['k8sVersions']

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -202,10 +202,6 @@ jobs:
 
 # The following settings are used by cluster e2e tests.
 
-common:
-  args:
-  - --cluster=test-${job_name_hash}
-
 cloudProviders:
   gce:
     args:


### PR DESCRIPTION
The `--cluster` flag that passes name to CI k8s e2e jobs is not required as the prow jobs are on BOSKOS
Ref: https://github.com/kubernetes/test-infra/pull/33927#discussion_r1882481524

Most of the jobs that run against master branch for gcp are not passing this value in https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml. But a few have empty flag `--cluster=`

Removing the flag from https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/generated/generated.yaml and also from releng's config file [test_config.yaml](https://github.com/kubernetes/test-infra/blob/master/releng/test_config.yaml)

