### PR TITLE
🌱  (Kubebuilder) Upgrade the latest k8s versions used to run the tests

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
-  - name: pull-kubebuilder-e2e-k8s-1-29-2
+  - name: pull-kubebuilder-e2e-k8s-1-30-8
     cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
@@ -41,7 +41,7 @@ presubmits:
             - ./test_e2e.sh
           env:
             - name: KIND_K8S_VERSION
-              value: "v1.29.2"
+              value: "v1.30.8"
           resources:
             limits:
               cpu: 4000m
@@ -53,11 +53,11 @@ presubmits:
             privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-29-2
+      testgrid-tab-name: kubebuilder-e2e-1-30-8
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-31-0
+  - name: pull-kubebuilder-e2e-k8s-1-31-4
     cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
@@ -74,7 +74,7 @@ presubmits:
             - ./test_e2e.sh
           env:
             - name: KIND_K8S_VERSION
-              value: "v1.31.0"
+              value: "v1.31.4"
           resources:
             limits:
               cpu: 4000m
@@ -86,11 +86,11 @@ presubmits:
             privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-31-0
+      testgrid-tab-name: kubebuilder-e2e-1-31-4
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-30-0
+  - name: pull-kubebuilder-e2e-k8s-1-32-0
     cluster: eks-prow-build-cluster
     decorate: true
     always_run: true
@@ -107,7 +107,7 @@ presubmits:
             - ./test_e2e.sh
           env:
             - name: KIND_K8S_VERSION
-              value: "v1.30.0"
+              value: "v1.32.0"
           resources:
             limits:
               cpu: 4000m
@@ -119,7 +119,7 @@ presubmits:
             privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-30-0
+      testgrid-tab-name: kubebuilder-e2e-1-32-0
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
- remove the oldest one (1.29) and add the latest 1.32 release
- also update 1.30 and 1.31 patch releases used