### PR TITLE
Update descheduler e2e tests to use 6 CPUs

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -116,10 +116,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 4
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 4
+            cpu: 6
             memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-31
     cluster: eks-prow-build-cluster
@@ -154,10 +154,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 4
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 4
+            cpu: 6
             memory: 4Gi
   - name: pull-descheduler-test-e2e-k8s-master-1-30
     cluster: eks-prow-build-cluster
@@ -192,8 +192,8 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 4
+            cpu: 6
             memory: 4Gi
           requests:
-            cpu: 4
+            cpu: 6
             memory: 4Gi


### PR DESCRIPTION
All of the e2e CI jobs for the release branches of the descheduler project are using 6 CPUs. Therefore the master branch e2e CI jobs should also use 6 CPUs for consistancy.