### PR TITLE
Use specific branches for resizer tests

### DIFF
--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -33,7 +33,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.30.0"
+          value: "release-1.30"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.30"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
@@ -131,7 +131,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.31.0"
+          value: "release-1.31"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.31"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
@@ -229,7 +229,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.32.0"
+          value: "release-1.32"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.32"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
@@ -327,7 +327,7 @@ presubmits:
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.31.0"
+          value: "release-1.31"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.31"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -289,6 +289,9 @@ kubernetes_branch_name() {
     local kubernetes="$1"
     local repo="$2"
     if [ "$repo" == "external-resizer" ]; then
+	# Since kubernetes tag from which e2e defaults to v1.xx.0 tags, we need to pull
+	# latest branch to get fixes we need for external-resizer. We will remove this workaround
+	# once we upgrade all sidecars to use a newer TAG.
 	echo "\"release-${kubernetes}\""
     else
 	echo "\"${kubernetes}.0\""

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -264,6 +264,7 @@ pull_optional() {
     local tests="$1"
     local kubernetes="$2"
     local deployment_suffix="$3"
+    local repo="$4"
 
     # https://github.com/kubernetes-csi/csi-driver-host-path/pull/282 has not been merged yet,
     # therefore pull jobs which depend on the new deployment flavors have to be optional.
@@ -281,6 +282,16 @@ pull_optional() {
 	else
             echo "false"
 	fi
+    fi
+}
+
+kubernetes_branch_name() {
+    local kubernetes="$1"
+    local repo="$2"
+    if [ "$repo" == "external-resizer" ]; then
+	echo "\"release-${kubernetes}\""
+    else
+	echo "\"${kubernetes}.0\""
     fi
 }
 
@@ -399,7 +410,7 @@ EOF
         # unrelated to the PR. Testing against the latest Kubernetes is covered
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "$kubernetes.0"
+          value: $(kubernetes_branch_name "$kubernetes" "$repo")
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "$deployment"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX


### PR DESCRIPTION
Traditionally we were building e2e only from `v1.xx.0` release of Kubernetes. This has a downside that, if a test is fixed in newer tag then we are never using them. 

This PR fixes this just for external-resizer.
