### PR TITLE
Include sanity tests as part of unit test job

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -111,6 +111,9 @@ presubmits:
         args:
         - make
         - test
+        - "&"
+        - make
+        - sanity
         resources:
           requests:
             cpu: "2"


### PR DESCRIPTION
This Cr will make it so the csi sanity tests are run as part of our unit test CI job.

/hold 
until csi sanity CR is merged