### PR TITLE
[1.29] sig-release: change go version for go-compat jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -1758,7 +1758,7 @@ presubmits:
         - runner.sh
         env:
         - name: GO_VERSION
-          value: 1.21.4
+          value: 1.22.10
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.29
         name: ""
         resources:
@@ -1935,7 +1935,7 @@ presubmits:
         - test
         env:
         - name: GO_VERSION
-          value: 1.21.4
+          value: 1.22.10
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.29
         name: ""
         resources:


### PR DESCRIPTION
Changing the go version of the compatibility job to be 1.22.9 which is the go version of the latest K8s 1.29 patch release

Needed for bumping K8s release-1.29 to go1.23
See https://github.com/kubernetes/kubernetes/pull/126713#issuecomment-2568467612 

/assign @liggitt @dims 
/hold 
for discussion if needed 