### PR TITLE
replace pull-crio-cgroupv1-node-e2e-features with kubetest2 job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1724,58 +1724,7 @@ presubmits:
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2.yaml
   - name: pull-crio-cgroupv1-node-e2e-features
     cluster: k8s-infra-prow-build
-    always_run: false
-    optional: true
-    skip_branches:
-      - release-\d+\.\d+  # per-release image
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
-    decorate: true
-    decoration_config:
-      timeout: 440m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
-        command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-        args:
-        - --deployment=node
-        - --env=KUBE_SSH_USER=core
-        - --gcp-zone=us-west1-b
-        - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-        - --node-tests=true
-        - --provider=gce
-        - --test_args=--nodes=8 --focus="\[NodeFeature:.+\]|\[NodeFeature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-        - --timeout=180m
-        - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
-        env:
-        - name: GOPATH
-          value: /go
-        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-          value: "1"
-    annotations:
-      testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-node-crio-cgroupv1-node-e2e-features
-  - name: pull-crio-cgroupv1-node-e2e-features-kubetest2
-    cluster: k8s-infra-prow-build
-    # explicitly needs /test pull-crio-cgroupv1-node-e2e-features-kubetest2 to run
+    # explicitly needs /test pull-crio-cgroupv1-node-e2e-features to run
     always_run: false
     optional: true
     skip_branches:
@@ -1796,7 +1745,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-node-crio-cgroupv1-node-e2e-features-kubetest2
+      testgrid-tab-name: pr-node-crio-cgroupv1-node-e2e-features
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master


### PR DESCRIPTION
Promote the kubetest2 and remove the dependency on [kubernetes_e2e.py](https://github.com/kubernetes/test-infra/blob/master/scenarios/kubernetes_e2e.py) for the  `pull-crio-cgroupv1-node-e2e-features kubetest2` job

The job has consistently being working for the kubetest2 and the old version
- https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-crio-cgroupv1-node-e2e-features-kubetest2
- https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-crio-cgroupv1-node-e2e-features

/sig node
cc: @kannon92 @bart0sh 

ref:https://github.com/kubernetes/test-infra/issues/32567