### PR TITLE
Add ENABLE_CACHE_MUTATION_DETECTOR=true for gcp gci e2e default and alpha test suites

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -508,6 +508,7 @@ periodics:
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       env:
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
       resources: *id001
@@ -723,6 +724,7 @@ periodics:
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       env:
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
       resources: *id001

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -465,6 +465,7 @@ presubmits:
         - --build=quick
         # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
         - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
+        - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
         - --env=KUBE_PROXY_DAEMONSET=true
         - --env=ENABLE_POD_PRIORITY=true
         - --env=ENABLE_APISERVER_TRACING=true
@@ -764,6 +765,7 @@ presubmits:
             - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
             - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
             - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
+            - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
             - --env=KUBE_PROXY_DAEMONSET=true
             - --env=ENABLE_POD_PRIORITY=true
             - --gcp-node-image=gci
@@ -893,6 +895,7 @@ periodics:
       - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
       - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/fast/latest-fast
@@ -932,6 +935,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/fast/latest-fast

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -46,8 +46,6 @@ jobs:
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sbeta-default:
-    args:
-    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
@@ -79,8 +77,6 @@ jobs:
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
   ci-kubernetes-e2e-gce-cos-k8sstable1-default:
-    args:
-    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
@@ -324,6 +320,7 @@ testSuites:
     - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
       --minStartupPods=8
     - --ginkgo-parallel=30
+    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     cluster: k8s-infra-prow-build
     resources:
       requests:


### PR DESCRIPTION
Making the `ENABLE_CACHE_MUTATION_DETECTOR=true` for all the marker jobs of default test suite in https://github.com/kubernetes/test-infra/blob/master/releng/test_config.yaml.

Also enabling this env for alpha feature jobs for master branch in https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml

This is being done to make master branch jobs and release branch jobs have the same set of parameters.