### PR TITLE
fix: resolve issue in e2e-compatibility-versions.sh where env var reference was incorrect

### DIFF
--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -298,7 +298,7 @@ main() {
   MINOR_VERSION=$(./hack/print-workspace-status.sh | awk '/STABLE_BUILD_MINOR_VERSION/ {split($2, minor, "+"); print minor[1]}')
   export CURRENT_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}"
   export N_MINUS_ONE_VERSION="${MAJOR_VERSION}.$((MINOR_VERSION - 1))"
-  export EMULATED_VERSION=$(N_MINUS_ONE_VERSION)
+  export EMULATED_VERSION="${N_MINUS_ONE_VERSION}"
 
   # export the KUBECONFIG to a unique path for testing
   KUBECONFIG="${HOME}/.kube/kind-test-config"


### PR DESCRIPTION
Fixes #34081 

Pasting issue text below for context:

Currently the nightly prow test associated with e2e-k8s-compatibility-versions.sh is failing :
https://testgrid.k8s.io/sig-testing-kind#compatibility-version-test

![image](https://github.com/user-attachments/assets/a0b228ca-b445-4b0a-bec0-70da619d4a15)

This is the associated error logs:
Looking at the error:
```
+ export PREV_RELEASE_BRANCH=release-
+ PREV_RELEASE_BRANCH=release-
+ git clone --filter=blob:none --single-branch --branch release- https://github.com/kubernetes/kubernetes.git release-
Cloning into 'release-'...
warning: Could not find remote branch release- to clone.
fatal: Remote branch release- not found in upstream origin
wrapper.sh] [TEST] Test Command exit code: 128
```

This is due to a variable-assignment issue due to an error/type in the script:
```
+ N_MINUS_ONE_VERSION=1.32
++ N_MINUS_ONE_VERSION
./../test-infra/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh: line 301: N_MINUS_ONE_VERSION: command not found
```

Currently the script has a type/issue:
Current script:
```
  export EMULATED_VERSION=$(N_MINUS_ONE_VERSION) # <--- ERROR, command not found
```
  should be:
```
  export EMULATED_VERSION="${N_MINUS_ONE_VERSION}"
```


**NOTE**
I manually verified this is working by running this script from a local kubernetes/kubernetes root directory (simulating what Prow would do)