### PR TITLE
Allow milestones in kubernetes/autoscaler

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -590,6 +590,9 @@ repo_milestone:
   kubernetes-sigs/node-feature-discovery:
     maintainers_team: node-feature-discovery-maintainers
     maintainers_friendly_name: Node Feature Discovery Maintainers
+  kubernetes/autoscaler:
+    maintainers_team: sig-autoscaling-milestone-maintainers
+    maintainers_friendly_name: Autoscaler milestone maintainers
   kubernetes/community:
     maintainers_team: community-milestone-maintainers
     maintainers_friendly_name: Community Milestone Maintainers
@@ -1197,6 +1200,10 @@ plugins:
     - welcome
     - wip
     - yuks
+
+  kubernetes/autoscaler:
+    plugins:
+    - milestone
 
   kubernetes/cloud-provider-aws:
     plugins:


### PR DESCRIPTION
Allow sig-autoscaling-milestone-maintainers to manage milestones in kubernetes/autoscaler

Depends on https://github.com/kubernetes/org/pull/5328

cc'ing @gjtempleton, who is the chair of sig-autoscaling

Note: I'm unsure if this is the correct process, please point me in the right direction if it is not