### PR TITLE
etcd: import operator test presubmit job

### DIFF
--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -1,0 +1,28 @@
+---
+presubmits:
+  etcd-io/etcd-operator:
+  - name: pull-etcd-operator-test
+    optional: true # remove once the job is stable
+    cluster: eks-prow-build-cluster
+    always_run: true
+    branches:
+    - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-operator-presubmits
+      testgrid-tab-name: pull-etcd-operator-test
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20241230-3006692a6f-master
+        command:
+        - runner.sh
+        args:
+        - go mod tidy
+        - make test
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -12,6 +12,7 @@ dashboard_groups:
   - sig-etcd-raft-presubmits
   - sig-etcd-bbolt-presubmits
   - sig-etcd-bbolt-periodics
+  - sig-etcd-operator-presubmits
 
 dashboards:
   - name: sig-etcd-amd64
@@ -104,3 +105,4 @@ dashboards:
   - name: sig-etcd-raft-presubmits
   - name: sig-etcd-bbolt-presubmits
   - name: sig-etcd-bbolt-periodics
+  - name: sig-etcd-operator-presubmits


### PR DESCRIPTION
Imports the test workflow as a prow job, which is marked as optional while we fine tune it.

Part of etcd-io/etcd-operator#21.

/cc @jmhbnz 