### PR TITLE
Use a COS version with nftable support

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -238,6 +238,7 @@ presubmits:
         - --build=quick
         - --env=ALLOW_PRIVILEGED=true
         - --env=KUBE_PROXY_MODE=nftables
+        - --env=KUBE_GCE_NODE_IMAGE=cos-113-18244-236-88
         - --gcp-nodes=4
         - --gcp-zone=us-west1-b
         - --provider=gce
@@ -788,48 +789,49 @@ periodics:
   annotations:
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-stale-results-hours: '24'
-# skip until COS support all the necessary kernel modules
-#- interval: 6h
-#  name: ci-kubernetes-e2e-gci-gce-nftables
-#  cluster: k8s-infra-prow-build
-#  labels:
-#    preset-service-account: "true"
-#    preset-k8s-ssh: "true"
-#  decorate: true
-#  decoration_config:
-#    timeout: 170m
-#  spec:
-#    containers:
-#    - command:
-#      - runner.sh
-#      - /workspace/scenarios/kubernetes_e2e.py
-#     args:
-#      - --check-leaked-resources
-#      - --env=KUBE_PROXY_MODE=nftables
-#      - --extract=ci/latest
-#      - --gcp-master-image=gci
-#      - --gcp-node-image=gci
-#      - --gcp-zone=us-west1-b
-#      - --ginkgo-parallel=30
-#      - --provider=gce
-#      # skip ESIPP should work from pods #97081
-#      - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\]|ESIPP|LoadBalancers --minStartupPods=8
-#      - --timeout=150m
-#      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
-#      resources:
-#        limits:
-#          cpu: 2
-#          memory: "6Gi"
-#        requests:
-#          cpu: 2
-#          memory: "6Gi"
-#  annotations:
-#    testgrid-dashboards: sig-network-gce
-#    testgrid-tab-name: periodic-network-nftables, google-gce
-#    testgrid-num-failures-to-alert: '6'
-#    testgrid-alert-stale-results-hours: '24'
-#    testgrid-alert-email: antonio.ojea.garcia@gmail.com, danwinship@redhat.com
-#    description: Uses kubetest to run e2e Conformance, SIG-Network tests against a cluster using nftables created with cluster/kube-up.sh
+
+- interval: 6h
+  name: ci-kubernetes-e2e-gci-gce-nftables
+  cluster: k8s-infra-prow-build
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 170m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --check-leaked-resources
+      - --env=KUBE_PROXY_MODE=nftables
+      - --env=KUBE_GCE_NODE_IMAGE=cos-113-18244-236-88
+      - --extract=ci/latest
+      - --gcp-master-image=gci
+      - --gcp-node-image=gci
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --provider=gce
+      # skip ESIPP should work from pods #97081
+      - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\]|ESIPP|LoadBalancers --minStartupPods=8
+      - --timeout=150m
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
+      resources:
+        limits:
+          cpu: 2
+          memory: "6Gi"
+        requests:
+          cpu: 2
+          memory: "6Gi"
+  annotations:
+    testgrid-dashboards: sig-network-gce
+    testgrid-tab-name: periodic-network-nftables, google-gce
+    testgrid-num-failures-to-alert: '6'
+    testgrid-alert-stale-results-hours: '24'
+    testgrid-alert-email: antonio.ojea.garcia@gmail.com, danwinship@redhat.com
+    description: Uses kubetest to run e2e Conformance, SIG-Network tests against a cluster using nftables created with cluster/kube-up.sh
 
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-kube-dns


### PR DESCRIPTION
COS-113 added support for nftables so we can use it to test the new proxy and network policies implimentation.