### PR TITLE
Add presubmits and periodics for the KJob release-0.1

### DIFF
--- a/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
@@ -1,0 +1,124 @@
+periodics:
+  - interval: 12h
+    name: periodic-kjob-test-unit-release-0-1
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: periodic-kjob-test-unit-release-0-1
+      testgrid-alert-email: kjob-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kjob unit tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kjob
+        base_ref: release-0-1
+        path_alias: kubernetes-sigs/kjob
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.23
+          env:
+            - name: GO_TEST_FLAGS
+              value: "-race -count 3"
+            - name: GOMAXPROCS
+              value: "2"
+          command:
+            - make
+          args:
+            - test-unit
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+  - interval: 12h
+    name: periodic-kjob-test-integration-release-0-1
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: periodic-kjob-test-integration-release-0-1
+      testgrid-alert-email: kjob-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kjob test-integration"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kjob
+        base_ref: release-0-1
+        path_alias: kubernetes-sigs/kjob
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.23
+          command:
+            - make
+          args:
+            - test-integration
+          env:
+            - name: GOMAXPROCS
+              value: "2"
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+  - interval: 12h
+    name: periodic-kjob-test-e2e-release-0-1
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: periodic-kjob-test-e2e-release-0-1
+      testgrid-alert-email: kjob-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kjob end to end tests for Kubernetes 1.31"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kjob
+        base_ref: release-0-1
+        path_alias: kubernetes-sigs/kjob
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.31.2
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.23
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"

--- a/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-release-0.1.yaml
@@ -1,0 +1,130 @@
+presubmits:
+  kubernetes-sigs/kjob:
+    - name: pull-kjob-verify-release-0-1
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.1
+      skip_if_only_changed: "^docs/|^\\.github/|^(README|LICENSE|OWNERS)$"
+      decorate: true
+      path_alias: sigs.k8s.io/kjob
+      annotations:
+        testgrid-dashboards: sig-apps
+        testgrid-tab-name: pull-kjob-verify-release-0-1
+        description: "Run kjob verify checks"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
+            securityContext:
+              privileged: true
+            command:
+              - runner.sh
+            args:
+              - make
+              - verify
+            env:
+              - name: GOMAXPROCS
+                value: "2"
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "2"
+                memory: "4Gi"
+    - name: pull-kjob-test-unit-release-0-1
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.1
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$/"
+      decorate: true
+      path_alias: sigs.k8s.io/kjob
+      annotations:
+        testgrid-dashboards: sig-apps
+        testgrid-tab-name: pull-kjob-test-unit-release-0-1
+        description: "Run kjob unit tests"
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.23
+            env:
+              - name: GO_TEST_FLAGS
+                value: "-race -count 3"
+              - name: GOMAXPROCS
+                value: "2"
+            command:
+              - make
+            args:
+              - test-unit
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "2"
+                memory: "4Gi"
+    - name: pull-kjob-test-integration-release-0-1
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.1
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+      decorate: true
+      path_alias: sigs.k8s.io/kjob
+      annotations:
+        testgrid-dashboards: sig-apps
+        testgrid-tab-name: pull-kjob-test-integration-release-0-1
+        description: "Run kjob test-integration"
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.23
+            command:
+              - make
+            args:
+              - test-integration
+            env:
+              - name: GOMAXPROCS
+                value: "2"
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "2"
+                memory: "4Gi"
+    - name: pull-kjob-test-e2e-release-0-1
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.1
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+      decorate: true
+      path_alias: sigs.k8s.io/kjob
+      annotations:
+        testgrid-dashboards: sig-apps
+        testgrid-tab-name: pull-kjob-test-e2e-release-0-1
+        description: "Run kjob end to end tests"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
+            env:
+              - name: E2E_KIND_VERSION
+                value: kindest/node:v1.31.2
+              - name: BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang:1.23
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - test-e2e
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "2"
+                memory: "4Gi"


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/kjob/issues/29


Copied the main configs and replaced in order:
- `^main` -> `^release-0.1`
- `-main` -> `-release-0-1`
- `main` -> `release-0.1`