### PR TITLE
Fix the dashboard from sig-scheduling to sig-apps for kjob

### DIFF
--- a/config/jobs/kubernetes-sigs/kjob/kjob-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-periodics-main.yaml
@@ -3,7 +3,7 @@ periodics:
     name: periodic-kjob-test-unit-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-kjob-test-unit-main
       testgrid-alert-email: kjob-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -43,7 +43,7 @@ periodics:
     name: periodic-kjob-test-integration-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-kjob-test-integration-main
       testgrid-alert-email: kjob-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -81,7 +81,7 @@ periodics:
     name: periodic-kjob-test-e2e-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-kjob-test-e2e-main
       testgrid-alert-email: kjob-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'

--- a/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-main.yaml
@@ -8,7 +8,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kjob
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-apps
         testgrid-tab-name: pull-kjob-verify-main
         description: "Run kjob verify checks"
       labels:
@@ -41,7 +41,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kjob
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-apps
         testgrid-tab-name: pull-kjob-test-unit-main
         description: "Run kjob unit tests"
       spec:
@@ -71,7 +71,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kjob
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-apps
         testgrid-tab-name: pull-kjob-test-integration-main
         description: "Run kjob test-integration"
       spec:
@@ -99,7 +99,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kjob
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-apps
         testgrid-tab-name: pull-kjob-test-e2e-main
         description: "Run kjob end to end tests"
       labels:


### PR DESCRIPTION
As kjob is under sig-apps: https://github.com/kubernetes/community/blob/master/sig-apps/README.md#kjob

Found in https://github.com/kubernetes/test-infra/pull/34098