### PR TITLE
mcs-api: update CI images to kubekins 1.32

### DIFF
--- a/config/jobs/kubernetes-sigs/mcs-api/mcs-api-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/mcs-api/mcs-api-presubmits-master.yaml
@@ -10,7 +10,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.31
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.32
         command:
         - make
         - controller
@@ -34,7 +34,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.31
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.32
         command:
         - make
         - verify
@@ -63,7 +63,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.31
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.32
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.31
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.32
         command:
           - runner.sh
         args:


### PR DESCRIPTION
Update kubekins image in mcs-api repo so that we can update to go 1.23 too.