### PR TITLE
Remove EventedPLEG=false and ENABLE_AUTH_PROVIDER_GCP=true from alpha-feature jobs

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -23,8 +23,7 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
-      - --env=ENABLE_AUTH_PROVIDER_GCP=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
@@ -251,8 +250,7 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
-      - --env=ENABLE_AUTH_PROVIDER_GCP=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -463,8 +463,7 @@ presubmits:
         args:
         - --ginkgo-parallel=1
         - --build=quick
-        # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
-        - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
+        - --env=KUBE_FEATURE_GATES=AllAlpha=true
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
         - --env=KUBE_PROXY_DAEMONSET=true
         - --env=ENABLE_POD_PRIORITY=true
@@ -764,7 +763,7 @@ presubmits:
             - --check-leaked-resources
             - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
             - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
-            - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
+            - --env=KUBE_FEATURE_GATES=AllAlpha=true
             - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
             - --env=KUBE_PROXY_DAEMONSET=true
             - --env=ENABLE_POD_PRIORITY=true
@@ -894,7 +893,7 @@ periodics:
       - --check-leaked-resources
       - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
       - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -934,7 +933,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -65,7 +65,6 @@ jobs:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: alphafeatures-eventedpleg
 
   # stable1
   ci-kubernetes-e2e-gce-cos-k8sstable1-reboot:
@@ -96,7 +95,6 @@ jobs:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
-    testSuite: alphafeatures-eventedpleg
 
   # stable2
   ci-kubernetes-e2e-gce-cos-k8sstable2-reboot:


### PR DESCRIPTION
Ref: https://kubernetes.slack.com/archives/CCK68P2Q2/p1736363315475859?thread_ts=1735906461.281649&cid=CCK68P2Q2
Removing `EventedPLEG=false` value while enabling alpha feature gates jobs.

Also removing `ENABLE_AUTH_PROVIDER_GCP=true` value from certain release branch jobs as the default value for this variable is anyways true. https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/config-default.sh#L567