### PR TITLE
etcd: fix operator presubmit test job

### DIFF
--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -17,8 +17,11 @@ presubmits:
         command:
         - runner.sh
         args:
-        - go mod tidy
-        - make test
+        - bash
+        - -c
+        - |
+          go mod tidy
+          make test
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
Fixes the new etcd-operator presubmit test job.

Part of https://github.com/etcd-io/etcd-operator/issues/21.

/cc @jmhbnz