### PR TITLE
chore: Revert the deletion of cloud provider azure 1.28 presubmit test

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
@@ -1,0 +1,875 @@
+---
+presubmits:
+  kubernetes-sigs/cloud-provider-azure:
+  - name: pull-cloud-provider-azure-check-1-28
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-check
+        resources:
+          limits:
+            memory: "9Gi"
+            cpu: "2"
+          requests:
+            memory: "9Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-check-1-28
+      description: "Run lint check tests for cloud-provider-azure release-1.28."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-28
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-capz-1-28
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^.pipelines/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.17
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-capz-1-28
+      description: "Runs Azure specific tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-capz-1-28 runs kubernetes conformance tests.
+  - name: pull-cloud-provider-azure-e2e-capz-1-28
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.17
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: release-1.28
+      path_alias: k8s.io/kubernetes
+      workdir: false
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-e2e-capz
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: GINKGO_ARGS  # cloud-provider-azure config
+          value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: GINKGO_PARALLEL_NODES  # cloud-provider-azure config
+          value: "30"
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-capz-1-28
+      description: "Runs Kubernetes conformance tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-ccm-1-28
+  - name: pull-cloud-provider-azure-e2e-ccm-capz-1-28
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.17
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-capz-1-28
+      description: "Runs Azure specific tests with cloud-provider-azure release-1.28 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: "30"
+    # pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-28 runs Azure specific e2e tests with cloud controller manager v1.28 and IP-based load balancer backend pools.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-28
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.17
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: ENABLE_MULTI_SLB  # cloud-provider-azure config
+          value: "false"
+        - name: PUT_VMSS_VM_BATCH_SIZE  # cloud-provider-azure config
+          value: "0"
+        - name: LB_BACKEND_POOL_CONFIG_TYPE  # cloud-provider-azure config
+          value: "nodeIP"
+        - name: CUSTOM_CLOUD_PROVIDER_CONFIG  # CAPZ config
+          value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-default.json"
+        - name: CCM_E2E_ARGS  # cloud-provider-azure config
+          value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
+        - name: LABEL_FILTER  # cloud-provider-azure config
+          value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config
+          value: "false"
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz-1-28
+      description: "Runs Azure specific e2e tests with cloud controller manager v1.28 and IP-based load balancer backend pools."
+      testgrid-num-columns-recent: '30'
+    # pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-28 runs Azure specific e2e tests with cloud controller manager v1.28 and multiple standard load balancers.
+  - name: pull-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-28
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.17
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CUSTOM_CLOUD_PROVIDER_CONFIG  # CAPZ config
+          value: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cloud-config-vmss-multi-slb.json"
+        - name: CCM_E2E_ARGS  # cloud-provider-azure config
+          value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
+        - name: LABEL_FILTER  # cloud-provider-azure config
+          value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config
+          value: "false"
+        - name: TEST_MULTI_SLB
+          value: "true"
+        - name: WINDOWS_WORKER_MACHINE_COUNT
+          value: "2"
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-vmss-multi-slb-capz-1-28
+      description: "Runs Azure specific e2e tests with cloud controller manager v1.28 and multiple standard load balancers."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-unit-1-28
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|^site/|^tests/e2e/|^\\.github/|^.pipelines/|\\.(md|adoc)$|^(README|LICENSE)$"
+    decorate: true
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-service-account: "true"
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-unit
+        resources:
+          limits:
+            memory: "9Gi"
+            cpu: "2"
+          requests:
+            memory: "9Gi"
+            cpu: "2"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-unit-1-28
+      description: "Run unit tests for cloud-provider-azure release-1.28."
+      testgrid-num-columns-recent: "30"
+  - name: pull-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-28
+    cluster: eks-prow-build-cluster
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.17
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-vmss-capz-1-28-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on IPv6 vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-28
+    cluster: eks-prow-build-cluster
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.17
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        args:
+        - ./scripts/ci-entrypoint.sh
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "Standard"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-vmss-capz-1-28-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on DualStack vmss, using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-ipv6-capz-1-28
+    cluster: eks-prow-build-cluster
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.17
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e &&
+          popd
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.17/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-ipv6-capz-1-28-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure IPv6 (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+  - name: pull-cloud-provider-azure-e2e-ccm-dualstack-capz-1-28
+    cluster: eks-prow-build-cluster
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+    - release-1.28
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.17
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+        - bash
+        - -c
+        - >-
+          pushd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e &&
+          popd
+        securityContext:
+          privileged: true
+        env:
+        - name: TEST_CCM  # CAPZ config
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+          value: "1"
+        - name: KUBERNETES_VERSION  # CAPZ config
+          value: "latest-1.28"
+        - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+          value: "capz"
+        - name: CLUSTER_TEMPLATE  # CAPZ config
+          value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.17/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm-dualstack-capz-1-28-presubmit
+      description: "Runs Azure specific tests with cloud-provider-azure DualStack (https://github.com/kubernetes-sigs/cloud-provider-azure) using cluster-api-provider-azure."
+      testgrid-num-columns-recent: '30'
+periodics:
+- cron: '0 22 * * *'  # Run at 22:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-capz-1-28
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.17
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.28
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.28"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.17/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+    testgrid-tab-name: cloud-provider-azure-master-ipv6-capz-1-28
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in an IPv6 single stack cluster."
+- cron: '0 22 * * *'  # Run at 22:00 UTC everyday
+  name: cloud-provider-azure-master-ipv6-vmss-capz-1-28
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.17
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.28
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.28"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-ipv6-mp.yaml
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+    testgrid-tab-name: cloud-provider-azure-master-ipv6-vmss-capz-1-28
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in an IPv6 single stack cluster with vmss."
+- cron: '0 22 * * *'  # Run at 22:00 UTC everyday
+  name: cloud-provider-azure-master-dualstack-capz-1-28
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.17
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.28
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.28"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/release-1.17/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+    testgrid-tab-name: cloud-provider-azure-master-dualstack-capz-1-28
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in a dualstack cluster."
+- cron: '0 22 * * *'  # Run at 22:00 UTC everyday
+  name: cloud-provider-azure-master-dualstack-vmss-capz-1-28
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.17
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: release-1.28
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest-1.28"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/cluster-template-prow-dual-stack-mp.yaml
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure-1-28
+    testgrid-tab-name: cloud-provider-azure-master-dualstack-vmss-capz-1-28
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using a stable capz release in a dualstack cluster with vmss."

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
@@ -5,6 +5,7 @@ dashboard_groups:
       - provider-azure-azurefile-csi-driver
       - provider-azure-blobfuse-csi-driver
       - provider-azure-cloud-provider-azure
+      - provider-azure-cloud-provider-azure-1-28
       - provider-azure-cloud-provider-azure-1-29
       - provider-azure-cloud-provider-azure-1-30
       - provider-azure-cloud-provider-azure-1-31
@@ -15,6 +16,7 @@ dashboards:
   - name: provider-azure-azurefile-csi-driver
   - name: provider-azure-blobfuse-csi-driver
   - name: provider-azure-cloud-provider-azure
+  - name: provider-azure-cloud-provider-azure-1-28
   - name: provider-azure-cloud-provider-azure-1-29
   - name: provider-azure-cloud-provider-azure-1-30
   - name: provider-azure-cloud-provider-azure-1-31


### PR DESCRIPTION
chore: Revert the deletion of cloud provider azure 1.28 presubmit test

/sig cloud-provider
/area provider/azure
/kind cleanup