### PR TITLE
verify: restore running of golangci-lint

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -2147,8 +2147,6 @@ presubmits:
           value: "y"
         - name: EXCLUDE_GODEP
           value: "y"
-        - name: EXCLUDE_GOLANGCI_LINT
-          value: "y"
         - name: KUBE_VERIFY_GIT_BRANCH
           value: release-1.30
         - name: REPO_DIR

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -2082,8 +2082,6 @@ presubmits:
           value: "y"
         - name: EXCLUDE_GODEP
           value: "y"
-        - name: EXCLUDE_GOLANGCI_LINT
-          value: "y"
         - name: KUBE_VERIFY_GIT_BRANCH
           value: release-1.31
         - name: REPO_DIR

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -2189,8 +2189,6 @@ presubmits:
           value: "y"
         - name: EXCLUDE_GODEP
           value: "y"
-        - name: EXCLUDE_GOLANGCI_LINT
-          value: "y"
         - name: KUBE_VERIFY_GIT_BRANCH
           value: release-1.32
         - name: REPO_DIR

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -28,8 +28,6 @@ presubmits:
           value: "y"
         - name: EXCLUDE_GODEP
           value: "y"
-        - name: EXCLUDE_GOLANGCI_LINT
-          value: "y"
         - name: KUBE_VERIFY_GIT_BRANCH
           value: master
         - name: REPO_DIR


### PR DESCRIPTION
When making pull-kubernetes-verify-lint mandatory in ea1d0271f8f5cf32f5f3923336ad094992438a06, running golangci-lint got disabled in pull-kubernetes-verify because of the redundancy.

But later pull-kubernetes-verify-lint was removed in 741e08c46cee6bebef846f2d7b659aa82768250f, without re-enabling it in pull-kubernetes-verify.

ci-kubernetes-verify-master still caught regressions, but clearly we want this again in the presumit.

Discovered when merging https://github.com/kubernetes/kubernetes/pull/129517 broke ci-kubernetes-verify-master.

/assign @pacoxu 