### PR TITLE
Re-enable gcp provider prow jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -724,6 +724,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
 
   - name: release-secrets-store-csi-driver-e2e-gcp
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       timeout: 25m
@@ -900,6 +901,7 @@ postsubmits:
       - aramase
       - ritazh
   - name: secrets-store-csi-driver-e2e-gcp-postsubmit
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
       timeout: 25m

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -684,8 +684,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 25m
-    always_run: false
-    optional: true
+    always_run: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - ^main$
@@ -722,6 +721,52 @@ presubmits:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-gcp
       description: "Run e2e test with gcp provider for Secrets Store CSI driver."
+      testgrid-num-columns-recent: '30'
+
+  - name: release-secrets-store-csi-driver-e2e-gcp
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: false
+    run_if_changed: "^charts/.*"
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - ^main$
+    - ^release-*
+    labels:
+      preset-service-account: "true"
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
+        env:
+        - name: "BOSKOS_HOST"
+          value: "boskos.test-pods.svc.cluster.local"
+        - name: RELEASE
+          value: "true"
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - >-
+            ./test/scripts/run-e2e-gcp.sh
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "6Gi"
+          limits:
+            cpu: "4"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-release-signal
+      testgrid-tab-name: release-secrets-store-csi-driver-e2e-gcp
+      description: "Run e2e test with gcp provider for Secrets Store CSI driver release."
       testgrid-num-columns-recent: '30'
 
 postsubmits:
@@ -849,6 +894,51 @@ postsubmits:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
       testgrid-tab-name: secrets-store-csi-driver-e2e-aws-postsubmit
       description: "Run e2e test with aws provider for Secrets Store CSI driver postsubmit"
+      testgrid-num-columns-recent: '30'
+    rerun_auth_config:
+      github_users:
+      - aramase
+      - ritazh
+  - name: secrets-store-csi-driver-e2e-gcp-postsubmit
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: true
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - ^main$
+    labels:
+      preset-service-account: "true"
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
+        env:
+        - name: "BOSKOS_HOST"
+          value: "boskos.test-pods.svc.cluster.local"
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - >-
+            ./test/scripts/run-e2e-gcp.sh
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "6Gi"
+          limits:
+            cpu: "4"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-postsubmit
+      testgrid-tab-name: secrets-store-csi-driver-e2e-gcp-postsubmit
+      description: "Run e2e test with gcp provider for Secrets Store CSI driver postsubmit"
       testgrid-num-columns-recent: '30'
     rerun_auth_config:
       github_users:


### PR DESCRIPTION
These jobs were removed when infra was migrated to community.

Now we got the required resources from community, hence re-enabling the jobs.