### PR TITLE
CAPO: Conformance test without CI artifacts

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -75,12 +75,9 @@ periodics:
       env:
       - name: "BOSKOS_HOST"
         value: "boskos.test-pods.svc.cluster.local"
-      - name: E2E_ARGS
-        value: "-kubetest.use-ci-artifacts"
       command:
       - "runner.sh"
       - "./scripts/ci-conformance.sh"
-      - "--use-ci-artifacts"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true


### PR DESCRIPTION
The conformance suite has been using the latest unreleased version of kubernetes. However, this is quite unstable and has not been working now for a few weeks. Since we don't run any other tests against the same kubernetes version, I suggest we switch the conformance suite to use the same kubernetes version that we use elsewhere.