### PR TITLE
Setting back EventedPLEG=false for alpha-feature jobs

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -23,7 +23,7 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
@@ -250,7 +250,7 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
@@ -465,7 +465,7 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
@@ -681,7 +681,7 @@ periodics:
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -463,7 +463,7 @@ presubmits:
         args:
         - --ginkgo-parallel=1
         - --build=quick
-        - --env=KUBE_FEATURE_GATES=AllAlpha=true
+        - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
         - --env=KUBE_PROXY_DAEMONSET=true
         - --env=ENABLE_POD_PRIORITY=true
@@ -763,7 +763,7 @@ presubmits:
             - --check-leaked-resources
             - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
             - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
-            - --env=KUBE_FEATURE_GATES=AllAlpha=true
+            - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
             - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
             - --env=KUBE_PROXY_DAEMONSET=true
             - --env=ENABLE_POD_PRIORITY=true
@@ -893,7 +893,7 @@ periodics:
       - --check-leaked-resources
       - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
       - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -933,7 +933,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -65,6 +65,7 @@ jobs:
     interval: 1h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: alphafeatures-eventedpleg
 
   # stable1
   ci-kubernetes-e2e-gce-cos-k8sstable1-reboot:
@@ -95,6 +96,7 @@ jobs:
     interval: 2h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: alphafeatures-eventedpleg
 
   # stable2
   ci-kubernetes-e2e-gce-cos-k8sstable2-reboot:
@@ -124,6 +126,7 @@ jobs:
     interval: 6h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: alphafeatures-eventedpleg
 
   # stable3
   ci-kubernetes-e2e-gce-cos-k8sstable3-reboot:
@@ -153,6 +156,7 @@ jobs:
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
+    testSuite: alphafeatures-eventedpleg
 
   # stable4
   # ci-kubernetes-e2e-gce-cos-k8sstable4-ingress:
@@ -277,7 +281,6 @@ testSuites:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
     - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
-    - --env=ENABLE_AUTH_PROVIDER_GCP=true
     # Panic if anything mutates a shared informer cache
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/34105 started causing major Flakes in https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-alpha-features particularly with `[Feature:InPlacePodVerticalScaling]` tests.

Looking into Kublet log turned out that `EventedPLEG` is true. See [here](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gci-gce-alpha-features/1877700929533251584/artifacts/bootstrap-e2e-master/kubelet.log) and search for test `feature gates:`
Ref: https://kubernetes.slack.com/archives/CCK68P2Q2/p1736483874898029?thread_ts=1736391655.842469&cid=CCK68P2Q2

Related to https://github.com/kubernetes/kubernetes/issues/125624

Minor change removing `--env=ENABLE_AUTH_PROVIDER_GCP=true` from https://github.com/kubernetes/test-infra/blob/master/releng/test_config.yaml#L280 as default value is anyways true.