### PR TITLE
set hypothetical env to control hack/tools go toolchain version versu…

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.29.yaml
@@ -1759,6 +1759,8 @@ presubmits:
         env:
         - name: GO_VERSION
           value: 1.21.4
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.29
         name: ""
         resources:
@@ -1936,6 +1938,8 @@ presubmits:
         env:
         - name: GO_VERSION
           value: 1.21.4
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.29
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -1867,6 +1867,8 @@ presubmits:
         env:
         - name: GO_VERSION
           value: 1.22.1
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.30
         name: ""
         resources:
@@ -2044,6 +2046,8 @@ presubmits:
         env:
         - name: GO_VERSION
           value: 1.22.1
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.30
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -1802,6 +1802,8 @@ presubmits:
         env:
         - name: GO_VERSION
           value: 1.22.5
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.31
         name: ""
         resources:
@@ -1979,6 +1981,8 @@ presubmits:
         env:
         - name: GO_VERSION
           value: 1.22.5
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.31
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -1909,6 +1909,8 @@ presubmits:
         env:
         - name: GO_VERSION
           value: 1.23.3
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.32
         name: ""
         resources:
@@ -2086,6 +2088,8 @@ presubmits:
         env:
         - name: GO_VERSION
           value: 1.23.3
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-1.32
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -61,6 +61,8 @@ presubmits:
         env:
         - name: GO_VERSION
           value: ""
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
         args:
         - ./hack/jenkins/test-dockerized.sh
         # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -66,6 +66,8 @@ presubmits:
           env:
           - name: GO_VERSION
             value: ""
+          - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+            value: auto
           # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:


### PR DESCRIPTION
…s the packages under test

this will allow us to update tools (like gotestsum) to use a required new go version while continuing to force GO_VERSION to some lower value for the rest of the repo

/hold
/assign @liggitt 
/cc @MadhavJivrajani 

~~TODO: not sure if we should set an empty value in master.~~
TODO: we should consider using GOTOOLCHAIN instead of GO_VERSION, I think longterm we want to reduce the complexity/api-surface we have here versus the standard env now that it exists.