### PR TITLE
🌱 Kubebuilder: Remove k8s 1.32 since it is blocking PRs and is not working yet

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -90,36 +90,3 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-32-0
-    cluster: eks-prow-build-cluster
-    decorate: true
-    always_run: true
-    optional: false
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-      - ^master$
-      - ^feature/plugins-.+$
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
-          command:
-            - runner.sh
-            - ./test_e2e.sh
-          env:
-            - name: KIND_K8S_VERSION
-              value: "v1.32.0"
-          resources:
-            limits:
-              cpu: 4000m
-              memory: 8Gi
-            requests:
-              cpu: 4000m
-              memory: 8Gi
-          securityContext:
-            privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-32-0
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"


### PR DESCRIPTION
It has been failing with:

```
Docker in Docker enabled, initializing...
================================================================================
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.all.forwarding = 1
Starting Docker: docker.
Waiting for docker to be ready, sleeping for 1 seconds.
================================================================================
Done setting up docker in docker.
+ WRAPPED_COMMAND_PID=234
+ wait 234
+ ./test_e2e.sh
+ EXIT_VALUE=1
+ set +o xtrace
Cleaning up after docker in docker.
================================================================================
Waiting 30 seconds for pods stopped with terminationGracePeriod:30
Cleaning up after docker
Waiting for docker to stop for 30 seconds
Stopping Docker: dockerProgram process in pidfile '/var/run/docker-ssd.pid', 1 process(es), refused to die.
================================================================================
Done cleaning up after docker in docker.
```

We will try to add the new release in the future, but for now, it seems not to be working yet and is disturbing our process.