### PR TITLE
DRA: increase timeout in test jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-manual-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-manual-canary.yaml
@@ -15,7 +15,7 @@ presubmits:
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind, using a 15min timeout
     decorate: true
     decoration_config:
-      timeout: 15m # artificially low to test timeout handling
+      timeout: 25m # artificially low to test timeout handling
     path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -58,7 +58,7 @@ presubmits:
       description: Runs E2E node tests for Dynamic Resource Allocation beta features with CRI-O using cgroup v1, using a 15 min timeout
     decorate: true
     decoration_config:
-      timeout: 15m # artificially low to test timeout handling
+      timeout: 25m # artificially low to test timeout handling
     path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes


### PR DESCRIPTION
15min was not enough to build Kubernetes and bringing up the Kind cluster. I swear it was when I looked earlier... <shrug>

/assign @dims 