### PR TITLE
Fix branch-protection-periodic: add allow_job_disabled_policies

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -205,6 +205,7 @@ slack_reporter_configs:
 
 branch-protection:
   allow_disabled_policies: true
+  allow_disabled_job_policies: true
   orgs:
     kubernetes:
       protect: true


### PR DESCRIPTION
Trying to fix https://github.com/kubernetes/test-infra/issues/33900#issuecomment-2588110123 this time.

The current configuration requires the entire `kubernetes-sigs` to be branch-protected, but as it can be seen from [here](https://github.com/kubernetes/test-infra/blob/d0f396a5f4442f4a3c8b7e4ebb20151bfa5d42b4/config/prow/config.yaml#L206-L644), there is at least one repository that opts out of that.

As an example:
```yaml
branch-protection:
  orgs:
    kubernetes-sigs:
      protect: true
      repos:
        external-dns:
          branches:
            gh-pages:
              protect: false
```

Adding `allow_disabled_job_policies: true` should solve the problem, hopefully.

Relevant code [here](https://github.com/kubernetes-sigs/prow/blob/db89760fea406dd2813e331c3d52b53b5bcbd140/pkg/config/branch_protection.go#L469-L481).