### PR TITLE
Fix url for kind installation during etcd operator e2e tests

### DIFF
--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
         - bash
         - -c
         - |
-          curl -sSL https://kind.sigs.k8s.io/dl/latest/kind-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind create cluster
           make test-e2e
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
Addresses failure seen here: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd-operator/39/pull-etcd-operator-test-e2e/1879347715347845120

cc @ivanvc, @ahrtr 