### PR TITLE
etcd: use krte image for e2e operator tests

### DIFF
--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -41,7 +41,7 @@ presubmits:
       testgrid-tab-name: pull-etcd-operator-test-e2e
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20241230-3006692a6f-master
+      - image: gcr.io/k8s-staging-test-infra/krte:v20241230-3006692a6f-master
         command:
         - runner.sh
         args:


### PR DESCRIPTION
By looking at the error from the job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd-operator/39/pull-etcd-operator-test-e2e/1879367520129912832, and reading the description of https://github.com/kubernetes/test-infra/tree/master/images/krte, it seems that we need to use the krte image. It has a caveat that it's only tested for Kubernetes purposes, but it may be worth the trick. Adding all the tools to run Docker may be an overhead to maintain.

