### PR TITLE
etcd: use wrapper.sh for operator e2e command

### DIFF
--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20241230-3006692a6f-master
         command:
-        - runner.sh
+        - wrapper.sh
         args:
         - bash
         - -c


### PR DESCRIPTION
Sorry for the back and forth, but I'm still getting familiar with prow :sweat_smile: 

The krte image doesn't have a `runner.sh` script, but a `wrapper.sh`.

/cc @jmhbnz 