### PR TITLE
add presubmit and periodic tests for 1.32

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -157,7 +157,7 @@ periodics:
         base_ref: main
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-e2e-main-1-32
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset end to end tests for Kubernetes 1.32"

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -148,3 +148,43 @@ periodics:
             requests:
               cpu: 3
               memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-main-1-32
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: main
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-jobset-test-e2e-main-1-32
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.32"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.32.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.23
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
@@ -188,3 +188,44 @@ periodics:
           requests:
             cpu: 3
             memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-release-0-7-1-32
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: release-7.1
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-7-1-32
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.32 on release 0.7"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+        env:
+        - name: E2E_KIND_VERSION
+          value: kindest/node:v1.32.0
+        - name: BUILDER_IMAGE
+          value: public.ecr.aws/docker/library/golang:1.23
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi
+

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
@@ -197,7 +197,7 @@ periodics:
         base_ref: release-7.1
         path_alias: sigs.k8s.io/jobset
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-apps
       testgrid-tab-name: periodic-jobset-test-e2e-release-0-7-1-32
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic jobset end to end tests for Kubernetes 1.32 on release 0.7"
@@ -228,4 +228,3 @@ periodics:
           requests:
             cpu: 3
             memory: 10Gi
-

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -161,6 +161,41 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-jobset-test-e2e-main-1-32
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: pull-jobset-test-e2e-main-1-32
+      description: "Run jobset end to end tests for Kubernetes 1.32"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241128-8df65c072f-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.32.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.23
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-jobset-verify-main
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
Adding e2e tests(Both presubmits and periodics) for jobset.

Fixes: [jobset//753](https://github.com/kubernetes-sigs/jobset/issues/753)
