### PR TITLE
Bump gcb-docker-gcloud to Go 1.23.1

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.22.9
+ARG GO_VERSION=1.23.4
 
 FROM multiarch/qemu-user-static:7.2.0-1 AS qemu-image
 

--- a/images/gcb-docker-gcloud/README.md
+++ b/images/gcb-docker-gcloud/README.md
@@ -6,7 +6,7 @@ combination of `docker`, `gcloud`, and `go` all in the same build step
 ## contents
 
 - base:
-  - golang:1.22.9-alpine
+  - golang:1.23.4-alpine
 - languages:
   - `go`
 - tools:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com