### PR TITLE
Add e2e tests for 1.32 for lws

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -146,6 +146,37 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-lws-test-e2e-main-1-32
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/lws
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: pull-lws-test-e2e-main-1-32
+      description: "Run lws end to end tests for Kubernetes 1.32"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.32.0
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-lws-verify-main
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
**Description**: Add e2e tests for 1.32 lws in kubernetes/test-infra

**Fixes**: [lws/327](https://github.com/kubernetes-sigs/lws/issues/327)