### PR TITLE
DRA: promote canary timeout handling to regular jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -19,7 +19,7 @@ presubmits:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
     decoration_config:
-      timeout: 25m # artificially low to test timeout handling, needs to be reverted
+      timeout: 90m
     path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -68,7 +68,7 @@ presubmits:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
     decoration_config:
-      timeout: 25m # artificially low to test timeout handling, needs to be reverted
+      timeout: 90m
     path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -121,7 +121,7 @@ presubmits:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
     decoration_config:
-      timeout: 25m # artificially low to test timeout handling, needs to be reverted
+      timeout: 90m
     path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
@@ -173,7 +173,7 @@ presubmits:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
     decoration_config:
-      timeout: 25m # artificially low to test timeout handling, needs to be reverted
+      timeout: 90m
     path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
@@ -225,7 +225,7 @@ presubmits:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
     decoration_config:
-      timeout: 25m # artificially low to test timeout handling, needs to be reverted
+      timeout: 90m
     path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -36,8 +36,13 @@ periodics:
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest .
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
           kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=2h30m hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky'
+          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky' &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -83,12 +88,17 @@ periodics:
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest .
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
           # Which DRA features exist can change over time.
           features=( $(grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/') )
           echo "Enabling DRA feature(s): ${features[*]}."
           # Those additional features are not in kind.yaml, but they can be added at the end.
           kind create cluster --retain --config <(cat test/e2e/dra/kind.yaml; for feature in ${features}; do echo "  ${feature}: true"; done) --image dra/node:latest
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=1h hack/ginkgo-e2e.sh -ginkgo.label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features}; do echo , ${feature}; done)} && !Flaky"
+          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features}; do echo , ${feature}; done)} && !Flaky" &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -36,8 +36,13 @@ presubmits:
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest .
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
           kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=2h30m hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky'
+          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky' &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -82,12 +87,17 @@ presubmits:
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest .
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
           # Which DRA features exist can change over time.
           features=( $(grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/') )
           echo "Enabling DRA feature(s): ${features[*]}."
           # Those additional features are not in kind.yaml, but they can be added at the end.
           kind create cluster --retain --config <(cat test/e2e/dra/kind.yaml; for feature in ${features}; do echo "  ${feature}: true"; done) --image dra/node:latest
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=1h hack/ginkgo-e2e.sh -ginkgo.label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features}; do echo , ${feature}; done)} && !Flaky && !Slow"
+          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features}; do echo , ${feature}; done)} && !Flaky && !Slow" &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -49,11 +49,7 @@
       {%- endif %}
     decorate: true
     decoration_config:
-    {%- if file == "canary" %}
-      timeout: 25m # artificially low to test timeout handling, needs to be reverted
-    {%- else %}
       timeout: {{timeout}}
-    {%- endif %}
     {%- if file == "ci" %}
     extra_refs:
     - org: kubernetes
@@ -108,7 +104,6 @@
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest .
           trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT
-{%- if file == "canary" %}
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
@@ -125,19 +120,6 @@
           {%- endif %}
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
-{%- else %}
-          {%- if all_features %}
-          # Which DRA features exist can change over time.
-          features=( $(grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/') )
-          echo "Enabling DRA feature(s): ${features[*]}."
-          # Those additional features are not in kind.yaml, but they can be added at the end.
-          kind create cluster --retain --config <(cat test/e2e/dra/kind.yaml; for feature in ${features}; do echo "  ${feature}: true"; done) --image dra/node:latest
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=1h hack/ginkgo-e2e.sh -ginkgo.label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features}; do echo , ${feature}; done)} && !Flaky {%- if file != "ci" %} && !Slow {%- endif %}"
-          {%- else %}
-          kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} GINKGO_TIMEOUT=2h30m hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky'
-          {%- endif %}
-{%- endif %}
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Forwarding SIGTERM to the ginkgo-e2e.sh script was indeed necessary to shut down Ginkgo in case of a job
timeout (https://github.com/kubernetes/kubernetes/pull/129545).

/assign @bart0sh 
/cc @elieser1101