### PR TITLE
Reduce number of runs in periodic to avoid timeout

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -508,7 +508,7 @@ presubmits:
               make install-lazyfs
               set -euo pipefail
               go clean -testcache
-              GO_TEST_FLAGS="-v --count 12 --timeout '30m' --run TestRobustness"
+              GO_TEST_FLAGS="-v --count 10 --timeout '30m' --run TestRobustness"
               make gofail-enable
               make build
               make gofail-disable


### PR DESCRIPTION
cc @ahrtr 

Presubmits started timing out with addition of new regression scenario https://testgrid.k8s.io/sig-etcd-robustness#pull-etcd-robustness-amd64