### PR TITLE
Update OWNERS for sig-security test config

### DIFF
--- a/config/jobs/kubernetes/sig-security/OWNERS
+++ b/config/jobs/kubernetes/sig-security/OWNERS
@@ -1,9 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-# This is the owner of the security related code.  The test data itself is owned by sig-security.
 reviewers:
-  - tallclair
+  - sig-security-leads
 approvers:
-  - tallclair
+  - sig-security-leads
 labels:
   - sig/security

--- a/config/testgrids/kubernetes/sig-security/OWNERS
+++ b/config/testgrids/kubernetes/sig-security/OWNERS
@@ -1,9 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-# This is the owner of the security related code.  The test data itself is owned by sig-security.
 reviewers:
-  - tallclair
+  - sig-security-leads
 approvers:
-  - tallclair
+  - sig-security-leads
 labels:
   - sig/security


### PR DESCRIPTION
SIG Security Tooling is moving an low-privileged job out of the trusted cluster ( see https://github.com/kubernetes/test-infra/pull/33817 )

To prepare for that, modernize the OWNERS files so we can maintain our low-privileged tests independently.