### PR TITLE
Skipping dump node info when SKIP_DUMP_NODE_INFO=true.

### DIFF
--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -926,11 +926,11 @@ function main() {
 
   dump_logs
   
-  if [[ "${DUMP_ONLY_MASTER_LOGS:-}" == "true" ]]; then
-    echo 'Skipping dumping of more node info'
-    return
+  if [[ "${SKIP_DUMP_NODE_INFO:-}" == "true" ]]; then
+    echo 'Skipping dumping of node info'
+  else
+    dump_node_info
   fi
-  dump_node_info
 
   if [[ "${DUMP_TO_GCS_ONLY:-}" == "true" ]] && [[ -n "${gcs_artifacts_dir}" ]]; then
     if [[ "$(ls -A ${report_dir})" ]]; then

--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -928,9 +928,9 @@ function main() {
   
   if [[ "${SKIP_DUMP_NODE_INFO:-}" == "true" ]]; then
     echo 'Skipping dumping of node info'
-  else
-    dump_node_info
+    return
   fi
+  dump_node_info
 
   if [[ "${DUMP_TO_GCS_ONLY:-}" == "true" ]] && [[ -n "${gcs_artifacts_dir}" ]]; then
     if [[ "$(ls -A ${report_dir})" ]]; then

--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -825,6 +825,11 @@ function dump_nodes_with_logexporter() {
 # Writes node information that's available through the gcloud and kubectl API
 # surfaces to a nodes/ subdirectory of $report_dir.
 function dump_node_info() {
+  if [[ "${SKIP_DUMP_NODE_INFO:-}" == "true" ]]; then
+    echo 'Skipping dumping of node info'
+    return
+  fi
+
   nodes_dir="${report_dir}/nodes"
   mkdir -p "${nodes_dir}"
 
@@ -925,11 +930,6 @@ function main() {
   fi
 
   dump_logs
-  
-  if [[ "${SKIP_DUMP_NODE_INFO:-}" == "true" ]]; then
-    echo 'Skipping dumping of node info'
-    return
-  fi
   dump_node_info
 
   if [[ "${DUMP_TO_GCS_ONLY:-}" == "true" ]] && [[ -n "${gcs_artifacts_dir}" ]]; then

--- a/logexporter/cluster/log-dump.sh
+++ b/logexporter/cluster/log-dump.sh
@@ -925,6 +925,11 @@ function main() {
   fi
 
   dump_logs
+  
+  if [[ "${DUMP_ONLY_MASTER_LOGS:-}" == "true" ]]; then
+    echo 'Skipping dumping of more node info'
+    return
+  fi
   dump_node_info
 
   if [[ "${DUMP_TO_GCS_ONLY:-}" == "true" ]] && [[ -n "${gcs_artifacts_dir}" ]]; then


### PR DESCRIPTION
To stop dumping on extra node info when DUMP_ONLY_MASTER_LOGS is set true, which would usually set for Autopilot and would avoid permission issues to the nodes when calling `kubectl get --raw "/api/v1/nodes/${node_name}/proxy/metrics" > "${nodes_dir}/${node_name}/kubelet_metrics.txt"`
