### PR TITLE
test: update e2e compatibility test to have a n minus param and update to have n-1 and n-2 prow periodic tests

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -1,11 +1,11 @@
 periodics:
 - interval: 6h
   cluster: k8s-infra-prow-build
-  name: ci-kubernetes-e2e-kind-compatibility-versions
+  name: ci-kubernetes-e2e-kind-compatibility-versions-n-minus-1
   annotations:
     testgrid-dashboards: sig-testing-kind
-    testgrid-tab-name: compatibility-version-test
-    description: Uses kubetest & kind to run e2e tests from older (n-1..3) kubernetes releases against a latest kubernetes master components w/ --emulated-version=<n-1..3> set.
+    testgrid-tab-name: compatibility-version-test-n-minus-1
+    description: Uses kind to run e2e tests from the n-1 kubernetes release against a latest kubernetes master components w/ --emulated-version=n-1 set.
     # TODO(aaron-prindle) route the alert email to a rotation vs individual email
     testgrid-alert-email: aprindle@google.com
     testgrid-num-columns-recent: '6'
@@ -35,6 +35,66 @@ periodics:
       - -c
       - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && ./../test-infra/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
       env:
+      - name: VERSION_DELTA
+        value: "1"
+      - name: SKIP
+        value: Alpha|Disruptive|Slow|Flaky|IPv6|LoadBalancer|PodSecurityPolicy|nfs
+      - name: PARALLEL
+        value: "true"
+      - name: FEATURE_GATES
+        value: '{"AllBeta":true}'
+      - name: RUNTIME_CONFIG
+        value: '{"api/beta":"true", "api/ga":"true"}'
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7
+- interval: 6h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-e2e-kind-compatibility-versions-n-minus-2
+  annotations:
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: compatibility-version-test-n-minus-2
+    description: Uses kind to run e2e tests from the n-2 kubernetes release against a latest kubernetes master components w/ --emulated-version=n-2 set.
+    # TODO(aaron-prindle) route the alert email to a rotation vs individual email
+    testgrid-alert-email: aprindle@google.com
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20241230-3006692a6f-master
+      imagePullPolicy: Always  # pull latest image for canary testing
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && ./../test-infra/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+      env:
+      - name: VERSION_DELTA
+        value: "2"
       - name: SKIP
         value: Alpha|Disruptive|Slow|Flaky|IPv6|LoadBalancer|PodSecurityPolicy|nfs
       - name: PARALLEL

--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -296,9 +296,10 @@ main() {
   # Get current and n-1 version numbers
   MAJOR_VERSION=$(./hack/print-workspace-status.sh | awk '/STABLE_BUILD_MAJOR_VERSION/ {print $2}')
   MINOR_VERSION=$(./hack/print-workspace-status.sh | awk '/STABLE_BUILD_MINOR_VERSION/ {split($2, minor, "+"); print minor[1]}')
+  export VERSION_DELTA=${VERSION_DELTA:-1}
   export CURRENT_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}"
-  export N_MINUS_ONE_VERSION="${MAJOR_VERSION}.$((MINOR_VERSION - 1))"
-  export EMULATED_VERSION="${N_MINUS_ONE_VERSION}"
+  export PREV_VERSION="${MAJOR_VERSION}.$((MINOR_VERSION - VERSION_DELTA))"
+  export EMULATED_VERSION="${PREV_VERSION}"
 
   # export the KUBECONFIG to a unique path for testing
   KUBECONFIG="${HOME}/.kube/kind-test-config"


### PR DESCRIPTION
This PR modifies the previous periodic Prow test for compatibility versions that only ran for n-1:
ci-kubernetes-e2e-kind-compatibility-versions

to now have two period prow tests that run for n-1 and n-2:

ci-kubernetes-e2e-kind-compatibility-versions-n-minus-1
ci-kubernetes-e2e-kind-compatibility-versions-n-minus-2