### PR TITLE
use release-0.1 for kjob periodics

### DIFF
--- a/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
@@ -15,7 +15,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kjob
-        base_ref: release-0-1
+        base_ref: release-0.1
         path_alias: kubernetes-sigs/kjob
     decorate: true
     decoration_config:
@@ -55,7 +55,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kjob
-        base_ref: release-0-1
+        base_ref: release-0.1
         path_alias: kubernetes-sigs/kjob
     decorate: true
     decoration_config:
@@ -93,7 +93,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kjob
-        base_ref: release-0-1
+        base_ref: release-0.1
         path_alias: kubernetes-sigs/kjob
     decorate: true
     decoration_config:


### PR DESCRIPTION
kjob periodic tests are failing for release-0.1 due to a typo. 

https://testgrid.k8s.io/sig-apps#periodic-kjob-test-e2e-release-0-1