### PR TITLE
Make new aws vpc + 24.04 presubmit optional

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -2066,7 +2066,7 @@ def generate_presubmits_e2e():
             ],
             networking='amazonvpc',
             tab_name='e2e-aws-amazonvpc-u2404',
-            always_run=True,
+            optional=True,
         ),
         presubmit_test(
             cloud='gce',

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -282,8 +282,8 @@ presubmits:
     cluster: k8s-infra-kops-prow-build
     branches:
     - master
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     skip_report: false
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
The new job is expected to fail so we need to make it optional

/cc @hakman