### PR TITLE
testgrid: bump presubmit image

### DIFF
--- a/config/jobs/kubernetes-sigs/testgrid/testgrid-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/testgrid/testgrid-presubmits.yaml
@@ -1,30 +1,30 @@
 presubmits:
   kubernetes-sigs/testgrid:
-  - name: test-testgrid-npm
-    cluster: eks-prow-build-cluster
-    decorate: true
-    always_run: true
-    spec:
-      containers:
-      # See https://playwright.dev/docs/ci
-      - image: mcr.microsoft.com/playwright:v1.46.0-noble
-        command:
-        - bash
-        args:
-        - -c
-        - |
-          cd web
-          npm install -g pnpm
-          pnpm install
-          pnpm build
-          pnpm test
-        resources:
-          requests:
-            cpu: 2
-            memory: 2Gi
-          limits:
-            cpu: 2
-            memory: 2Gi
-    annotations:
-      description: Unit tests for the new TestGrid UI.
-      testgrid-dashboards: sig-testing-testgrid
+    - name: test-testgrid-npm
+      cluster: eks-prow-build-cluster
+      decorate: true
+      always_run: true
+      spec:
+        containers:
+          # See https://playwright.dev/docs/ci
+          - image: mcr.microsoft.com/playwright:v1.49.1-noble
+            command:
+              - bash
+            args:
+              - -c
+              - |
+                cd web
+                npm install -g pnpm
+                pnpm install
+                pnpm build
+                pnpm test
+            resources:
+              requests:
+                cpu: 2
+                memory: 2Gi
+              limits:
+                cpu: 2
+                memory: 2Gi
+      annotations:
+        description: Unit tests for the new TestGrid UI.
+        testgrid-dashboards: sig-testing-testgrid


### PR DESCRIPTION
Bump image used for Typescript tests.
Failures are seen in https://github.com/kubernetes-sigs/testgrid/pull/29.

```
  ❌ browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1148/chrome-linux/headless_shell
╔══════════════════════════════════════════════════════════════════════╗
║ Looks like Playwright Test or Playwright was just updated to 1.49.1. ║
║ Please update docker image as well.                                  ║
║ -  current: mcr.microsoft.com/playwright:v1.46.0-jammy               ║
║ - required: mcr.microsoft.com/playwright:v1.49.1-jammy               ║
║                                                                      ║
║ <3 Playwright Team                                                   ║ 
```