### PR TITLE
Fix pull-kubernetes-e2e-gce-storage-disruptive

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -205,7 +205,6 @@ presubmits:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
         - --build=quick
-        - --extract=local
         - --gcp-master-image=gci
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/31981 migrated sig-storage gce config jobs to the community cluster. It dropped the `--stage=` flag but forgot to drop the `--extract=local` flag. This PR removes the `--extract=local` flag. I learned it from https://github.com/kubernetes/test-infra/pull/33276 and https://github.com/kubernetes/test-infra/pull/33258#discussion_r1707811788

This PR want to fix this issue:

```
2025/01/17 08:43:35 process.go:155: Step 'make -C /home/prow/go/src/k8s.io/kubernetes quick-release' finished in 16m1.133187637s
2025/01/17 08:43:35 util.go:263: Flushing memory.
2025/01/17 08:43:40 process.go:96: Saved XML output to /logs/artifacts/junit_runner.xml.
2025/01/17 08:43:40 process.go:153: Running: bash -c . hack/lib/version.sh && KUBE_ROOT=. kube::version::get_version_vars && echo "${KUBE_GIT_VERSION-}"
2025/01/17 08:43:42 process.go:155: Step 'bash -c . hack/lib/version.sh && KUBE_ROOT=. kube::version::get_version_vars && echo "${KUBE_GIT_VERSION-}"' finished in 1.681961649s
2025/01/17 08:43:42 main.go:326: Something went wrong: failed to acquire k8s binaries: open /home/prow/go/src/k8s.io/kubernetes/_output/gcs-stage: no such file or directory
Traceback (most recent call last):
  File "/workspace/scenarios/kubernetes_e2e.py", line 391, in <module>
    main(parse_args())
  File "/workspace/scenarios/kubernetes_e2e.py", line 307, in main
    mode.start(runner_args)
  File "/workspace/scenarios/kubernetes_e2e.py", line 136, in start
    check_env(env, self.command, *args)
  File "/workspace/scenarios/kubernetes_e2e.py", line 57, in check_env
    subprocess.check_call(cmd, env=env)
  File "/usr/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '('kubetest', '--dump=/logs/artifacts', '--gcp-service-account=/etc/service-account/service-account.json', '--build=quick', '--up', '--down', '--test', '--provider=gce', '--cluster=bootstrap-e2e', '--gcp-network=bootstrap-e2e', '--extract=local', '--gcp-master-image=gci', '--gcp-node-image=gci', '--gcp-zone=us-west1-b', '--test_args=--ginkgo.focus=\\[sig-storage\\].*\\[Disruptive\\] --ginkgo.skip=\\[Driver:.gcepd\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8', '--timeout=240m')' returned non-zero exit status 1.
+ EXIT_VALUE=1
```

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129680/pull-kubernetes-e2e-gce-storage-disruptive/1880169827780268032

Related-to https://github.com/kubernetes/kubernetes/pull/129680