### PR TITLE
temporarily disable verification of generated jobs

### DIFF
--- a/hack/make-rules/verify/all.sh
+++ b/hack/make-rules/verify/all.sh
@@ -92,7 +92,7 @@ if [[ "${VERIFY_GO_DEPS:-true}" == "true" ]]; then
   hack/make-rules/verify/go-deps.sh || { FAILED+=($name); echo "ERROR: $name failed"; }
   cd "${REPO_ROOT}"
 fi
-if [[ "${VERIFY_GENERATED_JOBS:-true}" == "true" ]]; then
+if [[ "${VERIFY_GENERATED_JOBS:-false}" == "true" ]]; then
   name="generated jobs"
   echo "verifying $name"
   hack/make-rules/verify/generated-jobs.sh || { FAILED+=($name); echo "ERROR: $name failed"; }


### PR DESCRIPTION
This is a quick fix to allow `k8s-infra-ci-robot` PRs passing `pull-test-infra-verify-lint` job.

/cc @pohly @dims