### PR TITLE
Add more compute resources for scale test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -99,7 +99,7 @@ periodics:
       - name: CONTROL_PLANE_COUNT
         value: "3"
       - name: CONTROL_PLANE_SIZE
-        value: "c5.18xlarge"
+        value: "r6i.24xlarge"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-infra-kops-scale-tests"
       - name: PROMETHEUS_SCRAPE_KUBE_PROXY


### PR DESCRIPTION
Related to https://github.com/kubernetes/kubernetes/issues/129593#issuecomment-2603279255

>Next steps to understand
why etcd was not responding to health check probes within time from APIserver
why etcd transactions for lease renewals and patch node object etc API calls are taking O(seconds)
evaluate ^^^ if its due to high CPU/Mem/Network utilization or something else ?

To `quickly` validate/invalidate if there was an increase in resource consumption usage when etcd was bumped.
Bumping resources on the box where etcd is co-located.