### PR TITLE
Increase resources for Kueue test-integration

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -55,11 +55,11 @@ presubmits:
           value: "false"
         resources:
           requests:
-            cpu: "6"
-            memory: "9Gi"
+            cpu: "7"
+            memory: "10Gi"
           limits:
-            cpu: "6"
-            memory: "9Gi"
+            cpu: "7"
+            memory: "10Gi"
   - name: pull-kueue-test-e2e-main-1-29
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -50,7 +50,7 @@ presubmits:
         - test-integration
         env:
         - name: GOMAXPROCS
-          value: "6"
+          value: "7"
         - name: INTEGRATION_RUN_ALL
           value: "false"
         resources:


### PR DESCRIPTION
Relates to Kueue [#3986](https://github.com/kubernetes-sigs/kueue/pull/3986)

Adding more CRDs to the tests cause them to fail with timeout