### PR TITLE
cosi: update presubmit tests for latest targets

### DIFF
--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface.yaml
@@ -1,10 +1,13 @@
 presubmits:
   kubernetes-sigs/container-object-storage-interface:
+
   - name: pull-container-object-storage-interface-build
     cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
     path_alias: sigs.k8s.io/container-object-storage-interface
+    labels:
+      preset-dind-enabled: "true" # build uses docker, requires DinD
     annotations:
       testgrid-dashboards: sig-storage-container-object-storage-interface
       testgrid-tab-name: build
@@ -16,6 +19,7 @@ presubmits:
         - runner.sh
         args:
         - make
+        - build
         resources:
           limits:
             cpu: 2
@@ -23,6 +27,9 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
 
   - name: pull-container-object-storage-interface-unit
     cluster: eks-prow-build-cluster
@@ -48,3 +55,81 @@ presubmits:
           requests:
             cpu: 2
             memory: 4Gi
+
+  - name: pull-container-object-storage-interface-lint
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/container-object-storage-interface
+    annotations:
+      testgrid-dashboards: sig-storage-container-object-storage-interface
+      testgrid-tab-name: lint
+      description: Linters in container-object-storage-interface repo.
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250121-4aed057712-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - lint
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
+
+  - name: pull-container-object-storage-interface-check-generated-files
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/container-object-storage-interface
+    annotations:
+      testgrid-dashboards: sig-storage-container-object-storage-interface
+      testgrid-tab-name: check-generated-files
+      description: Check generated files in container-object-storage-interface repo.
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250121-4aed057712-master
+        command:
+        - runner.sh
+        args:
+        - ./hack/prow-check-generate.sh
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
+
+  - name: pull-container-object-storage-interface-e2e
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/container-object-storage-interface
+    labels:
+      preset-dind-enabled: "true" # e2e uses docker and kind, requires DinD
+    annotations:
+      testgrid-dashboards: sig-storage-container-object-storage-interface
+      testgrid-tab-name: e2e
+      description: E2e tests in container-object-storage-interface repo.
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250121-4aed057712-master
+        command:
+        - runner.sh
+        args:
+        - ./hack/prow-e2e.sh
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true


### PR DESCRIPTION
Update COSI's presubmit (on pull-request) prow jobs to reflect the latest make targets and test scripts in the repo.

Jobs are now:
- Check builds via `make build`
- Unit tests via `make test` (hasn't changed)
- Run all linters via `make lint`
- Check generated files via bash script
- Run e2e tests via bash script