### PR TITLE
Move aws scale prebumits to previous prow

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1679,6 +1679,7 @@ def generate_presubmits_scale():
         presubmit_test(
             name='presubmit-kops-aws-scale-amazonvpc-using-cl2',
             scenario='scalability',
+            build_cluster='eks-prow-build-cluster',
             # only helps with setting the right anotation test.kops.k8s.io/networking
             networking='amazonvpc',
             always_run=False,

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -72,7 +72,7 @@ presubmits:
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
   - name: presubmit-kops-aws-scale-amazonvpc-using-cl2
-    cluster: k8s-infra-kops-prow-build
+    cluster: eks-prow-build-cluster
     branches:
     - master
     always_run: false


### PR DESCRIPTION
Fix - https://github.com/kubernetes/test-infra/issues/34201 

Basically a revert of prow build cluster for aws scale job introduced in this [PR](33820)