### PR TITLE
cosi-driver-sample: added sample driver to image-pushing

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-storage.sh
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.sh
@@ -38,6 +38,7 @@ readonly REPOS=(
     kubernetes-sigs/nfs-ganesha-server-and-external-provisioner
     kubernetes-sigs/nfs-subdir-external-provisioner
     kubernetes-sigs/container-object-storage-interface
+    kubernetes-sigs/cosi-driver-sample
 )
 
 # Repos using "main" branch instead of "master" as default

--- a/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
@@ -761,6 +761,46 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+  kubernetes-sigs/cosi-driver-sample:
+    - name: post-cosi-driver-sample-push-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+          - org: kubernetes
+            slug: sig-storage-image-build-admins
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-storage-image-build, sig-k8s-infra-gcb
+      decorate: true
+      decoration_config:
+        timeout: 240m
+        grace_period: 15m
+      branches:
+        # For publishing canary images.
+        - ^master$
+        - ^release-
+        # For publishing tagged images. Those will only get built once, i.e.
+        # existing images are not getting overwritten. A new tag must be set to
+        # trigger another image build. Images are only built for tags that follow
+        # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20241224-fe22c549c1
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-sig-storage
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .
   kubernetes-csi/csi-proxy:
     - name: post-csi-proxy-push-images
       rerun_auth_config:
@@ -1393,6 +1433,37 @@ periodics:
             # way as it usually does.
             - name: PULL_BASE_REF
               value: main
+          args:
+            # this is the project GCB will run in, which is the same as the GCR
+            # images are pushed to.
+            - --project=k8s-staging-sig-storage
+            # This is the same as above, but with -gcb appended.
+            - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
+            - --env-passthrough=PULL_BASE_REF
+            - .
+  - name: canary-cosi-driver-sample-push-images
+    cluster: k8s-infra-prow-build-trusted
+    annotations:
+      testgrid-dashboards: sig-storage-image-build, sig-k8s-infra-gcb
+    decorate: true
+    interval: 168h # one week
+    extra_refs:
+      # This also becomes the current directory for run.sh and thus
+      # the cloud image build.
+      - org: kubernetes-sigs
+        repo: cosi-driver-sample
+        base_ref: master
+    spec:
+      serviceAccountName: gcb-builder
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/image-builder:v20241224-fe22c549c1
+          command:
+            - /run.sh
+          env:
+            # We need to emulate a pull job for the cloud build to work the same
+            # way as it usually does.
+            - name: PULL_BASE_REF
+              value: master
           args:
             # this is the project GCB will run in, which is the same as the GCR
             # images are pushed to.


### PR DESCRIPTION
COSI Sample Driver was never built/released through the cloudbuild. Adding it to configs, so it can be built/pushed.