### PR TITLE
chore: disable MultiCIDRServiceAllocator in compat version e2e test as it has known issue with --emulation-version

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -42,7 +42,7 @@ periodics:
       - name: PARALLEL
         value: "true"
       - name: FEATURE_GATES
-        value: '{"AllBeta":true}'
+        value: '{"AllBeta":true, "MultiCIDRServiceAllocator":false}'
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       # we need privileged mode in order to do docker in docker
@@ -100,7 +100,7 @@ periodics:
       - name: PARALLEL
         value: "true"
       - name: FEATURE_GATES
-        value: '{"AllBeta":true}'
+        value: '{"AllBeta":true, "MultiCIDRServiceAllocator":false}'
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
Recently the Emulation Version E2E tests started to fail for n-1 and n-2:

https://testgrid.k8s.io/sig-testing-kind#compatibility-version-test-n-minus-1
https://testgrid.k8s.io/sig-testing-kind#compatibility-version-test-n-minus-2

```
✗ Starting control-plane 🕹️
ERROR: failed to create cluster: failed to init node with kubeadm: command "docker exec --privileged kind-control-plane kubeadm init --config=/kind/kubeadm.conf --skip-token-print --v=6" failed with error: exit status 1
```

This is related to an issue with the recently graduated feature gate `MultiCIDRServiceAllocator` and the `--emulation-version` feature:

PR promoting MultiCIDRServiceAllocator (merged recently): https://github.com/kubernetes/kubernetes/pull/128971

This feature must be disabled for beta when using `--emulation-version` until we fix https://github.com/kubernetes/kubernetes/issues/127791


This KEP explains the issue and outlines a solution:
https://github.com/kubernetes/enhancements/pull/5038