### PR TITLE
Increase mem/cpu limits for scale test pod

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -166,11 +166,11 @@ presubmits:
           value: "true"
         resources:
           requests:
-            cpu: "6"
-            memory: "16Gi"
+            cpu: "10"
+            memory: "48Gi"
           limits:
-            cpu: "6"
-            memory: "16Gi"
+            cpu: "10"
+            memory: "48Gi"
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2204


### PR DESCRIPTION
To rule out OOM issues - https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/17224/presubmit-kops-aws-scale-amazonvpc-using-cl2/1882485366724759552 

```
Job execution failed: Pod got deleted unexpectedly
```

Matching same cpu/mem limits as Periodic pod.