### PR TITLE
block PRs to cri-api repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -340,6 +340,11 @@ blockades:
   blockregexps:
   - ^k8s.gcr.io/
   explanation: "k8s.gcr.io Image registry is frozen from April 2023. Please update the manifests in registry.k8s.io folder instead"
+- repos:
+  - kubernetes/cri-api
+  blockregexps:
+  - .*
+  explanation: "We do not accept changes directly against this repository. Please see `CONTRIBUTING.md` for information on where and how to contribute instead."
 
 blunderbuss:
   max_request_count: 2


### PR DESCRIPTION
/sig node
/cc @samuelkarp @BenTheElder 

the precedence is above for client-go.