### PR TITLE
etcd operator: increase lint job memory

### DIFF
--- a/config/jobs/etcd/etcd-operator-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-postsubmits.yaml
@@ -21,7 +21,7 @@ postsubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "4Gi"
+            memory: "6Gi"
           limits:
             cpu: "4"
-            memory: "4Gi"
+            memory: "6Gi"

--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -86,7 +86,7 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "4Gi"
+            memory: "6Gi"
           limits:
             cpu: "4"
-            memory: "4Gi"
+            memory: "6Gi"


### PR DESCRIPTION
Increase the memory based on Grafana stats (https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?var-org=etcd-io&var-repo=etcd-operator&var-job=post-etcd-operator-lint&orgId=1&refresh=30s&var-build=All) and job failures (i.e., https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd-operator/56/pull-etcd-operator-lint/1883927055427440640).

/cc @jmhbnz @ahrtr 