### PR TITLE
chore: add network benchmark tool test script and documentation

### DIFF
--- a/experiment/network-benchmark-test/readme.md
+++ b/experiment/network-benchmark-test/readme.md
@@ -1,0 +1,15 @@
+# Test for Network Benchmark Tool
+
+[This script](./test.sh) verifies the network benchmarks in the [kubernetes/perf-tests](https://github.com/kubernetes/perf-tests) package. It clones the specified fork and branch, runs network benchmark tests against a provided image, and cleans up after execution.
+
+## Usage
+
+Set environment variables as needed:
+• FORK_TO_TEST (default: kubernetes/perf-tests)
+• BRANCH_TO_TEST (default: master)
+• IMAGE_TO_TEST (default: ghcr.io/ritwikranjan/nptest:latest)
+• KUBECONFIG (default: ~/.kube/config)
+
+```shell
+bash test.sh
+```

--- a/experiment/network-benchmark-test/test.sh
+++ b/experiment/network-benchmark-test/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+FORK_TO_TEST="${FORK_TO_TEST:-kubernetes/perf-tests}"
+BRANCH_TO_TEST="${BRANCH_TO_TEST:-master}"
+IMAGE_TO_TEST="${IMAGE_TO_TEST:-ghcr.io/ritwikranjan/nptest:latest}"
+
+KUBECONFIG=${KUBECONFIG:-~/.kube/config}
+
+echo "Forking the repository..."
+git clone "https://github.com/$FORK_TO_TEST.git"
+cd $(basename $FORK_TO_TEST)
+git checkout "$BRANCH_TO_TEST"
+
+echo "Navigating to network/benchmarks/netperf directory..."
+cd network/benchmarks/netperf
+echo "Running netperf test..."
+go run launch.go -image=$IMAGE_TO_TEST -kubeConfig=$KUBECONFIG -testFrom=0 -testTo=1 -json
+
+echo "Cleaning up..."
+cd ../../../..
+rm -rf $(basename $FORK_TO_TEST)
+echo "Script execution completed."

--- a/experiment/network-benchmark-test/test.sh
+++ b/experiment/network-benchmark-test/test.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FORK_TO_TEST="${FORK_TO_TEST:-kubernetes/perf-tests}"
 BRANCH_TO_TEST="${BRANCH_TO_TEST:-master}"
 IMAGE_TO_TEST="${IMAGE_TO_TEST:-ghcr.io/ritwikranjan/nptest:latest}"


### PR DESCRIPTION
## Summary

This pull request introduces a new network benchmark testing tool for Kubernetes performance tests. It includes a script and accompanying documentation to help users run and manage network benchmark tests.

### Documentation and Usage Instructions:

* [`experiment/network-benchmark-test/readme.md`](diffhunk://#diff-95cc29e6acef8318220b08d47b7107eabf08bb2b3eab9915fbea8de13ef9109dR1-R15): Added a README file that provides an overview of the network benchmark tool, including usage instructions and environment variable configurations.

### Script for Running Network Benchmarks:

* [`experiment/network-benchmark-test/test.sh`](diffhunk://#diff-3eff348b3f5508be9296ab6d0ce0d3d1c952479d0fc5b1dff5d520cbaa6bbf9aR1-R22): Added a shell script that automates the process of cloning the specified fork and branch, running network benchmark tests with a provided image, and cleaning up after execution.

## Related Items
- This PR tests the PR kubernetes/perf-tests#2969 whis is associated with issue kubernetes/perf-tests#2876