### PR TITLE
etcd operator: set presubmit jobs as blocking

### DIFF
--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -2,7 +2,6 @@
 presubmits:
   etcd-io/etcd-operator:
   - name: pull-etcd-operator-test
-    optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
     always_run: true
     branches:
@@ -30,7 +29,6 @@ presubmits:
             cpu: "4"
             memory: "4Gi"
   - name: pull-etcd-operator-test-e2e
-    optional: true # remove once the job is stable
     cluster: k8s-infra-prow-build
     always_run: true
     branches:
@@ -65,7 +63,6 @@ presubmits:
             cpu: "4"
             memory: "4Gi"
   - name: pull-etcd-operator-lint
-    optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
     always_run: true
     branches:


### PR DESCRIPTION
With the jobs working successfully for the last few days and by having removed the GitHub workflows (https://github.com/etcd-io/etcd-operator/pull/58), mark the presubmit jobs as blocking.

Part of https://github.com/etcd-io/etcd-operator/issues/21