### PR TITLE
etcd: import release tests presubmit job

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -575,3 +575,49 @@ presubmits:
             privileged: true
       nodeSelector:
         kubernetes.io/arch: arm64
+
+  - name: pull-etcd-release-tests
+    optional: true # remove once the job is stable
+    cluster: k8s-infra-prow-build
+    always_run: true
+    branches:
+      - main
+    decorate: true
+    decoration_config:
+      timeout: 60m
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-release-tests
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20241230-3006692a6f-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            git config --global user.email "prow@etcd.io"
+            git config --global user.name "Prow"
+            gpg --batch --gen-key <<EOF
+            %no-protection
+            Key-Type: 1
+            Key-Length: 2048
+            Subkey-Type: 1
+            Subkey-Length: 2048
+            Name-Real: Prow
+            Name-Email: prow@etcd.io
+            Expire-Date: 0
+            EOF
+            DRY_RUN=true ./scripts/release.sh --no-upload --no-docker-push --no-gh-release --in-place 3.6.99
+            VERSION=3.6.99 ./scripts/test_images.sh
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true


### PR DESCRIPTION
Name the job "pull-etcd-release-tests" to emphasize that it runs tests from the release scripts and does not do automated releases.

Part of #32754.

/cc @jmhbnz 