### PR TITLE
DRA: promote beta CI jobs to release informing

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -10,7 +10,7 @@ periodics:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     annotations:
-      testgrid-dashboards: sig-node-dynamic-resource-allocation
+      testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-master-informing
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -117,7 +117,7 @@ periodics:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     annotations:
-      testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o
+      testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o, sig-release-master-informing
       description: Runs E2E node tests for Dynamic Resource Allocation beta features with CRI-O using cgroup v1
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -170,7 +170,7 @@ periodics:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     annotations:
-      testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o
+      testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o, sig-release-master-informing
       description: Runs E2E node tests for Dynamic Resource Allocation beta features with CRI-O using cgroup v2
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -223,7 +223,7 @@ periodics:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     annotations:
-      testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-containerd
+      testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-containerd, sig-release-master-informing
       description: Runs E2E node tests for Dynamic Resource Allocation beta features with containerd
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -15,6 +15,9 @@
 {%- set testgrid_dashboards = testgrid_dashboards + ", sig-node-containerd" %}
 {%- set runtime = "containerd" %}
 {%- endif %}
+{%- if file == "ci" and not all_features %}
+{%- set testgrid_dashboards = testgrid_dashboards + ", sig-release-master-informing" %}
+{%- endif %}
   - name: {{job_name}}
     cluster: {{cluster}}
     {%- if file == "ci" %}
@@ -71,7 +74,7 @@
     {%- endif %}
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250121-4aed057712-master
         command:
         - runner.sh
         {%- if job_type == "node" %}


### PR DESCRIPTION
The intent was first announced in December in
https://groups.google.com/a/kubernetes.io/g/dev/c/76qs9sPiD-o/m/6MnoHeEaAQAJ, with one agreement and no objections. From that email:

After the promotion of the core Dynamic Resource Allocation (KEP 4381 = DRA with structured parameters) to beta in 1.32, I'd like to suggest that we promote the corresponding periodic CI jobs (ci-kind-dra, ci-node-*-dra) to "release informing".

These jobs are already closely monitored by the DRA developers (including alerting), but it would be good to increase visibility and get the release team officially involved.

The ci-kind-dra job covers E2E testing. It has to be a separate job because the cluster setup must enable DRA. The ci-node-*-dra jobs cover E2E node testing for key runtimes (containerd, CRI-O with cgroup v1 and v2). They have been stable leading up to the 1.32 release and we fully intend to keep it that way.

Links:
- process: https://github.com/kubernetes/sig-release/blob/master/release-blocking-jobs.md#promoting-or-demoting-jobs
- dashboard: https://testgrid.k8s.io/sig-node-dynamic-resource-allocation
- triage:
- https://storage.googleapis.com/k8s-triage/index.html?job=ci-kind-dra
- https://storage.googleapis.com/k8s-triage/index.html?job=ci-node-e2e-cgroupv1-crio-dra
- https://storage.googleapis.com/k8s-triage/index.html?job=ci-node-e2e-cgroupv2-crio-dra
- https://storage.googleapis.com/k8s-triage/index.html?job=ci-node-e2e-containerd-1-7-dra

cc @cpanato 