### PR TITLE
etcd: fix pull-etcd-release-tests GPG singing key 

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -583,6 +583,8 @@ presubmits:
     branches:
       - main
     decorate: true
+    labels:
+      preset-dind-enabled: "true"
     decoration_config:
       timeout: 60m
     annotations:
@@ -597,8 +599,6 @@ presubmits:
           - bash
           - -c
           - |
-            git config --global user.email "prow@etcd.io"
-            git config --global user.name "Prow"
             gpg --batch --gen-key <<EOF
             %no-protection
             Key-Type: 1
@@ -606,7 +606,7 @@ presubmits:
             Subkey-Type: 1
             Subkey-Length: 2048
             Name-Real: Prow
-            Name-Email: prow@etcd.io
+            Name-Email: ci-robot@k8s.io
             Expire-Date: 0
             EOF
             DRY_RUN=true ./scripts/release.sh --no-upload --no-docker-push --no-gh-release --in-place 3.6.99

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -579,7 +579,7 @@ presubmits:
   - name: pull-etcd-release-tests
     optional: true # remove once the job is stable
     cluster: k8s-infra-prow-build
-    always_run: true
+    always_run: false # set it to true once the job works
     branches:
       - main
     decorate: true


### PR DESCRIPTION
This pull request does the following:

1. Sets the new job `always_run` to `false` so that while fine-tuning the job and getting it green, it doesn't flood current pull requests.
2. The current job fails with [Failed to load gpg key. Is gpg set up correctly for etcd releases?](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-release-tests/1884644494763102208#1:build-log.txt%3A663-668). Update the configuration to use the correct k8s bot email address.

/cc @jmhbnz @ahrtr 