### PR TITLE
etcd: add origin remote to release tests presubmit

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -609,8 +609,11 @@ presubmits:
             Name-Email: ci-robot@k8s.io
             Expire-Date: 0
             EOF
+            # Add the origin remote as the remote is unnamed in the prow infra.
+            git remote add origin https://github.com/etcd-io/etcd.git
             DRY_RUN=true ./scripts/release.sh --no-upload --no-docker-push --no-gh-release --in-place 3.6.99
-            VERSION=3.6.99 ./scripts/test_images.sh
+            # Skip testing images to narrow down failure
+            # VERSION=3.6.99 ./scripts/test_images.sh
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
I've been working on this job from the pull request: https://github.com/etcd-io/etcd/pull/19305. It is failing, but I don't see an apparent error. 

* Commenting the image verification in the meantime.
* And address the issue of not having an origin remote.

/cc @jmhbnz 