### PR TITLE
etcd: re-enable release tests image testing

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -612,8 +612,7 @@ presubmits:
             # Add the origin remote as the remote is unnamed in the prow infra.
             git remote add origin https://github.com/etcd-io/etcd.git
             DRY_RUN=true ./scripts/release.sh --no-upload --no-docker-push --no-gh-release --in-place 3.6.99
-            # Skip testing images to narrow down failure
-            # VERSION=3.6.99 ./scripts/test_images.sh
+            VERSION=3.6.99 ./scripts/test_images.sh
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
Narrowed down the failure to testing the Docker images, the first part of the tests are green: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/19305/pull-etcd-release-tests/1884828688785084416.

Re-enabling the second part to continue working on this job.

/cc @jmhbnz 