### PR TITLE
Run ginkgo -v in SELinux pull request job

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -266,7 +266,7 @@ presubmits:
                 --create-args "--image='rhel-cloud/rhel-9-v20240815' --channel=alpha --networking=cilium --set=cluster.spec.containerd.selinuxEnabled=true --set=cluster.spec.kubeControllerManager.controllers='*' --set=cluster.spec.kubeControllerManager.controllers=selinux-warning-controller --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
                 --test=kops \
                 -- \
-                --ginkgo-args="--debug" \
+                --ginkgo-args="--debug -v" \
                 --test-args="--master-os-distro=custom --node-os-distro=custom" \
                 --timeout=120m \
                 --focus-regex="\[Feature:SELinux\]" \


### PR DESCRIPTION
Explicitly log output of successful tests when running SELinux `pull-` job. It allow users that don't have a machine with SELinux enabled to see how their changes affect the tests, even when the tests succeed.

The CI job runs only ~40 test, so the output is not that large.

Sample of output with the current setting (without `-v`): https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129888/pull-kubernetes-e2e-gce-storage-selinux/1884615766880292864
You can see it succeeded, but there are no logs from the tests.