### PR TITLE
fix: Change KUBERNETES_VERSION to CI_VERSION in azure release-1.28 tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.28.yaml
@@ -68,7 +68,7 @@ presubmits:
         env:
         - name: TEST_CCM  # CAPZ config
           value: "true"
-        - name: KUBERNETES_VERSION  # CAPZ config
+        - name: CI_VERSION  # CAPZ config
           value: "v1.28.15"
         - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
@@ -136,7 +136,7 @@ presubmits:
           value: "true"
         - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
           value: "standard"
-        - name: KUBERNETES_VERSION  # CAPZ config
+        - name: CI_VERSION  # CAPZ config
           value: "v1.28.15"
         - name: GINKGO_ARGS  # cloud-provider-azure config
           value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
@@ -198,7 +198,7 @@ presubmits:
           value: "true"
         - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
           value: "standard"
-        - name: KUBERNETES_VERSION  # CAPZ config
+        - name: CI_VERSION  # CAPZ config
           value: "v1.28.15"
         - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
@@ -254,7 +254,7 @@ presubmits:
           value: "true"
         - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION  # CAPZ config
+        - name: CI_VERSION  # CAPZ config
           value: "v1.28.15"
         - name: CLUSTER_TEMPLATE  # CAPZ config
           value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-version.yaml
@@ -328,7 +328,7 @@ presubmits:
           value: "true"
         - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION  # CAPZ config
+        - name: CI_VERSION  # CAPZ config
           value: "v1.28.15"
         - name: CLUSTER_TEMPLATE  # CAPZ config
           value: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/cluster-api/linux-vmss-ci-no-win-oot-credential-provider.yaml
@@ -429,7 +429,7 @@ presubmits:
           value: "true"
         - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION  # CAPZ config
+        - name: CI_VERSION  # CAPZ config
           value: "v1.28.15"
         - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
           value: "Standard"
@@ -488,7 +488,7 @@ presubmits:
           value: "true"
         - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION  # CAPZ config
+        - name: CI_VERSION  # CAPZ config
           value: "v1.28.15"
         - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
           value: "Standard"
@@ -550,7 +550,7 @@ presubmits:
           value: "standard"
         - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION  # CAPZ config
+        - name: CI_VERSION  # CAPZ config
           value: "v1.28.15"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
@@ -610,7 +610,7 @@ presubmits:
           value: "standard"
         - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
-        - name: KUBERNETES_VERSION  # CAPZ config
+        - name: CI_VERSION  # CAPZ config
           value: "v1.28.15"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
@@ -672,7 +672,7 @@ periodics:
         value: "standard"
       - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
         value: "1"
-      - name: KUBERNETES_VERSION  # CAPZ config
+      - name: CI_VERSION  # CAPZ config
         value: "v1.28.15"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
@@ -733,7 +733,7 @@ periodics:
         value: "standard"
       - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
         value: "1"
-      - name: KUBERNETES_VERSION  # CAPZ config
+      - name: CI_VERSION  # CAPZ config
         value: "v1.28.15"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
@@ -794,7 +794,7 @@ periodics:
         value: "standard"
       - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
         value: "1"
-      - name: KUBERNETES_VERSION  # CAPZ config
+      - name: CI_VERSION  # CAPZ config
         value: "v1.28.15"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
@@ -855,7 +855,7 @@ periodics:
         value: "standard"
       - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
         value: "1"
-      - name: KUBERNETES_VERSION  # CAPZ config
+      - name: CI_VERSION  # CAPZ config
         value: "v1.28.15"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"


### PR DESCRIPTION
:%s/KUBERNETES_VERSION/CI_VERSION/g

/kind failing-test
/area provider/azure
/sig cloud-provider