### PR TITLE
Autobump prow images

### DIFF
--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -22,6 +22,7 @@ extraFiles:
   - "config/jobs/kubernetes/kops/build_jobs.py"
   - "config/jobs/kubernetes-csi/gen-jobs.sh"
   - "config/jobs/README.md"
+  - "config/prow/config.yaml"
   - "releng/generate_tests.py"
   - "releng/test_config.yaml"
   - "images/kubekins-e2e/Dockerfile"
@@ -50,5 +51,10 @@ prefixes:
   - name: "k8s-staging-apisnoop-apisnoop"
     prefix: "gcr.io/k8s-staging-apisnoop/"
     repo: "https://github.com/kubernetes-sigs/apisnoop"
+    summarise: false
+    consistentImages: false
+  - name: "Prow images"
+    prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
+    repo: "https://github.com/kubernetes-sigs/prow"
     summarise: false
     consistentImages: false


### PR DESCRIPTION
Instruct the `generic-autobumper` to handle the Prow images in `config/prow/config.yaml`.
Most likely, what follows is the list of images that will periodically bumped:
```sh
$ grep -nF 'docker.pkg.dev' config/prow/config.yaml
19:        clonerefs: "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20240802-66b115076"
20:        initupload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240802-66b115076"
21:        entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240802-66b115076"
22:        sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240802-66b115076"

```