### PR TITLE
etcd: always run pull-etcd-release-tests

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -579,7 +579,7 @@ presubmits:
   - name: pull-etcd-release-tests
     optional: true # remove once the job is stable
     cluster: k8s-infra-prow-build
-    always_run: false # set it to true once the job works
+    always_run: true
     branches:
       - main
     decorate: true


### PR DESCRIPTION
After merging etcd-io/etcd#19305, this job is passing. Allow it to run for some time before removing the optional flag.

/cc @jmhbnz @ahrtr 