### PR TITLE
Replace walk with walkdir

### DIFF
--- a/config/tests/lint/config_lint_test.go
+++ b/config/tests/lint/config_lint_test.go
@@ -33,7 +33,10 @@ func Test_ForbidYmlExtension(t *testing.T) {
 	for _, path := range exemptPaths {
 		exempt[filepath.Join(configPath, path)] = true
 	}
-	err := filepath.Walk(configPath, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(configPath, func(path string, info os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		if _, ok := exempt[path]; ok {
 			return filepath.SkipDir
 		}

--- a/experiment/bumpmonitoring/main.go
+++ b/experiment/bumpmonitoring/main.go
@@ -147,7 +147,10 @@ func (c *client) findConfigToUpdate() error {
 		}
 
 		// No error is expected
-		filepath.Walk(fullPath, func(leafPath string, info os.FileInfo, err error) error {
+		filepath.WalkDir(fullPath, func(leafPath string, info os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
 			if !re.MatchString(leafPath) {
 				return nil
 			}

--- a/kubetest/dump_test.go
+++ b/kubetest/dump_test.go
@@ -268,7 +268,7 @@ func Test_logDumperNode_dump(t *testing.T) {
 	}
 
 	actual := []string{}
-	err = filepath.Walk(tmpdir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(tmpdir, func(path string, info os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/kubetest/e2e/runner.go
+++ b/kubetest/e2e/runner.go
@@ -223,7 +223,7 @@ func (t *GinkgoTester) findBinary(name string) (string, error) {
 	}
 
 	if bazelBinExists {
-		err := filepath.Walk(bazelBin, func(path string, info os.FileInfo, err error) error {
+		err := filepath.WalkDir(bazelBin, func(path string, info os.DirEntry, err error) error {
 			if err != nil {
 				return fmt.Errorf("error from walk: %w", err)
 			}


### PR DESCRIPTION
What would you like to be added:
filepath.WalkDir where its appropriate.

Why is this needed:
To reduce unnecessary stat call.
(filepath.WalkDir uses os.DirEntry, which is more lightweight and avoids redundant stat calls, making it faster and more efficient for traversing directories when full metadata is not needed.)

Fixes: #34250 