### PR TITLE
CAPI: add KIND_BUILD_IMAGES variable where no version env vars are set

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
@@ -188,7 +188,6 @@ periodics:
     testgrid-tab-name: capi-e2e-mink8s-main
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
-
 - name: periodic-cluster-api-e2e-conformance-main
   cluster: eks-prow-build-cluster
   interval: 3h

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
@@ -110,6 +110,9 @@ periodics:
             value: "true"
           - name: GINKGO_SKIP
             value: "\\[Conformance\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -159,6 +162,9 @@ periodics:
         value: "true"
       - name: GINKGO_SKIP
         value: "\\[Conformance\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -214,6 +220,9 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[Conformance\\] \\[K8s-Install\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -260,6 +269,9 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION_LATEST_CI"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -176,6 +176,9 @@ presubmits:
           value: "true"
         - name: GINKGO_SKIP
           value: "\\[Conformance\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -224,6 +227,9 @@ presubmits:
         env:
           - name: GINKGO_FOCUS
             value: "\\[PR-Blocking\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -267,6 +273,9 @@ presubmits:
             value: "true"
           - name: GINKGO_SKIP
             value: "\\[Conformance\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -358,6 +367,9 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[Conformance\\] \\[K8s-Install\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -398,6 +410,9 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION_LATEST_CI"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -339,7 +339,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-main-1-32-1-33
-
   - name: pull-cluster-api-e2e-conformance-main
     cluster: eks-prow-build-cluster
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics.yaml
@@ -188,7 +188,6 @@ periodics:
     testgrid-tab-name: capi-e2e-mink8s-release-1-7
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
-
 - name: periodic-cluster-api-e2e-conformance-release-1-7
   cluster: eks-prow-build-cluster
   interval: 4h

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-periodics.yaml
@@ -110,6 +110,9 @@ periodics:
             value: "true"
           - name: GINKGO_SKIP
             value: "\\[Conformance\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -159,6 +162,9 @@ periodics:
         value: "true"
       - name: GINKGO_SKIP
         value: "\\[Conformance\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -214,6 +220,9 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[Conformance\\] \\[K8s-Install\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -260,6 +269,9 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION_LATEST_CI"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
@@ -176,6 +176,9 @@ presubmits:
           value: "true"
         - name: GINKGO_SKIP
           value: "\\[Conformance\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -224,6 +227,9 @@ presubmits:
         env:
           - name: GINKGO_FOCUS
             value: "\\[PR-Blocking\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -267,6 +273,9 @@ presubmits:
             value: "true"
           - name: GINKGO_SKIP
             value: "\\[Conformance\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -358,6 +367,9 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[Conformance\\] \\[K8s-Install\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -398,6 +410,9 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION_LATEST_CI"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-7-presubmits.yaml
@@ -339,7 +339,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.7
       testgrid-tab-name: capi-pr-e2e-release-1-7-1-29-1-30
-
   - name: pull-cluster-api-e2e-conformance-release-1-7
     cluster: eks-prow-build-cluster
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-8-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-8-periodics.yaml
@@ -188,7 +188,6 @@ periodics:
     testgrid-tab-name: capi-e2e-mink8s-release-1-8
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
-
 - name: periodic-cluster-api-e2e-conformance-release-1-8
   cluster: eks-prow-build-cluster
   interval: 4h

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-8-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-8-periodics.yaml
@@ -110,6 +110,9 @@ periodics:
             value: "true"
           - name: GINKGO_SKIP
             value: "\\[Conformance\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -159,6 +162,9 @@ periodics:
         value: "true"
       - name: GINKGO_SKIP
         value: "\\[Conformance\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -214,6 +220,9 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[Conformance\\] \\[K8s-Install\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -260,6 +269,9 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION_LATEST_CI"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-8-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-8-presubmits.yaml
@@ -339,7 +339,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.8
       testgrid-tab-name: capi-pr-e2e-release-1-8-1-30-1-31
-
   - name: pull-cluster-api-e2e-conformance-release-1-8
     cluster: eks-prow-build-cluster
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-8-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-8-presubmits.yaml
@@ -176,6 +176,9 @@ presubmits:
           value: "true"
         - name: GINKGO_SKIP
           value: "\\[Conformance\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -224,6 +227,9 @@ presubmits:
         env:
           - name: GINKGO_FOCUS
             value: "\\[PR-Blocking\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -267,6 +273,9 @@ presubmits:
             value: "true"
           - name: GINKGO_SKIP
             value: "\\[Conformance\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -358,6 +367,9 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[Conformance\\] \\[K8s-Install\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -398,6 +410,9 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION_LATEST_CI"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-9-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-9-periodics.yaml
@@ -188,7 +188,6 @@ periodics:
     testgrid-tab-name: capi-e2e-mink8s-release-1-9
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
-
 - name: periodic-cluster-api-e2e-conformance-release-1-9
   cluster: eks-prow-build-cluster
   interval: 4h

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-9-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-9-periodics.yaml
@@ -110,6 +110,9 @@ periodics:
             value: "true"
           - name: GINKGO_SKIP
             value: "\\[Conformance\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -159,6 +162,9 @@ periodics:
         value: "true"
       - name: GINKGO_SKIP
         value: "\\[Conformance\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -214,6 +220,9 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[Conformance\\] \\[K8s-Install\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -260,6 +269,9 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION_LATEST_CI"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-9-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-9-presubmits.yaml
@@ -176,6 +176,9 @@ presubmits:
           value: "true"
         - name: GINKGO_SKIP
           value: "\\[Conformance\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -224,6 +227,9 @@ presubmits:
         env:
           - name: GINKGO_FOCUS
             value: "\\[PR-Blocking\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -267,6 +273,9 @@ presubmits:
             value: "true"
           - name: GINKGO_SKIP
             value: "\\[Conformance\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -358,6 +367,9 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[Conformance\\] \\[K8s-Install\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -398,6 +410,9 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION_LATEST_CI"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-9-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-9-presubmits.yaml
@@ -339,7 +339,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-1.9
       testgrid-tab-name: capi-pr-e2e-release-1-9-1-31-1-32
-
   - name: pull-cluster-api-e2e-conformance-release-1-9
     cluster: eks-prow-build-cluster
     labels:

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
@@ -187,7 +187,6 @@ periodics:
     testgrid-tab-name: capi-e2e-mink8s-{{ ReplaceAll $.branch "." "-" }}
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
-{{ if eq $.branch "release-1.5" "release-1.6" | not }}
 - name: periodic-cluster-api-e2e-conformance-{{ ReplaceAll $.branch "." "-" }}
   cluster: eks-prow-build-cluster
   interval: {{ $.config.Interval }}
@@ -286,7 +285,6 @@ periodics:
     testgrid-tab-name: capi-e2e-conformance-ci-latest-{{ ReplaceAll $.branch "." "-" }}
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "4"
-{{ end -}}
 {{ if eq $.branch "main" }}
 - name: periodic-cluster-api-e2e-latestk8s-{{ ReplaceAll $.branch "." "-" }}
   cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
@@ -109,6 +109,9 @@ periodics:
             value: "true"
           - name: GINKGO_SKIP
             value: "\\[Conformance\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -158,6 +161,9 @@ periodics:
         value: "true"
       - name: GINKGO_SKIP
         value: "\\[Conformance\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
       # This value determines the minimum Kubernetes
       # supported version for Cluster API management cluster
       # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -213,6 +219,9 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[Conformance\\] \\[K8s-Install\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -259,6 +268,9 @@ periodics:
       env:
       - name: GINKGO_FOCUS
         value: "\\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+      # Ensure required kind images get built.
+      - name: KIND_BUILD_IMAGES
+        value: "KUBERNETES_VERSION_LATEST_CI"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
@@ -175,6 +175,9 @@ presubmits:
           value: "true"
         - name: GINKGO_SKIP
           value: "\\[Conformance\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # This value determines the minimum Kubernetes
         # supported version for Cluster API management cluster
         # and can be found by referring to [Supported Kubernetes Version](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions)
@@ -223,6 +226,9 @@ presubmits:
         env:
           - name: GINKGO_FOCUS
             value: "\\[PR-Blocking\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -309,6 +315,9 @@ presubmits:
             value: "true"
           - name: GINKGO_SKIP
             value: "\\[Conformance\\]"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -400,6 +409,9 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[Conformance\\] \\[K8s-Install\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -440,6 +452,9 @@ presubmits:
         env:
         - name: GINKGO_FOCUS
           value: "\\[Conformance\\] \\[K8s-Install-ci-latest\\]"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION_LATEST_CI"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
@@ -242,49 +242,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-blocking-{{ ReplaceAll $.branch "." "-" }}
-{{- if eq $.branch "release-1.5" }}
-  - name: pull-cluster-api-e2e-informing-{{ ReplaceAll $.branch "." "-" }}
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-    decorate: true
-    decoration_config:
-      timeout: 180m
-    optional: true
-    branches:
-      # The script this job runs is not in all branches.
-      - ^{{ $.branch }}$
-    path_alias: sigs.k8s.io/cluster-api
-    run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
-    spec:
-      containers:
-      - image: {{ $.config.TestImage }}
-        args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-        env:
-        - name: GINKGO_FOCUS
-          value: "\\[PR-Informing\\]"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 3000m
-            memory: 8Gi
-          limits:
-            cpu: 3000m
-            memory: 8Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
-      testgrid-tab-name: capi-pr-e2e-informing-{{ ReplaceAll $.branch "." "-" }}
-{{- end }}
   - name: pull-cluster-api-e2e-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     labels:
@@ -381,7 +338,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-{{ ReplaceAll $.branch "." "-" }}-{{ ReplaceAll (last $.config.Upgrades).From "." "-" }}-{{ ReplaceAll (last $.config.Upgrades).To "." "-" }}
-{{ if eq $.branch "release-1.5" "release-1.6" | not }}
   - name: pull-cluster-api-e2e-conformance-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster
     labels:
@@ -468,7 +424,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api{{ if eq $.branch "main" | not -}}{{ TrimPrefix $.branch "release" }}{{- end }}
       testgrid-tab-name: capi-pr-e2e-conformance-ci-latest-{{ ReplaceAll $.branch "." "-" }}
-{{ end -}}
 {{ if eq $.branch "main" }}
   - name: pull-cluster-api-e2e-latestk8s-{{ ReplaceAll $.branch "." "-" }}
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
More context at: https://github.com/kubernetes-sigs/cluster-api/pull/11784

Required to merge before CAPI PR.

Note: also some cleanup in the second commit.

Note2: I on purpose did not set the variable on jobs where we already set the relevant `KUBERNETES_` variables.