### PR TITLE
Add package.json and package-lock.json to trigger condition

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-docs.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-docs.yaml
@@ -7,7 +7,7 @@ postsubmits:
         testgrid-tab-name: post-website-push-image-k8s-website-hugo
       decorate: true
       run_if_changed: >-
-        ^(Dockerfile|Makefile|netlify\.toml|\.dockerignore|cloudbuild\.yaml)$
+        ^(Dockerfile|Makefile|netlify\.toml|\.dockerignore|cloudbuild\.yaml|package\.json|package-lock\.json)$
       branches:
         - ^main$
       spec:


### PR DESCRIPTION
After the docs moved to using Docsy as an npm module, it became necessary that containers be created when the package.json and the associated lockfile gets changed. See https://github.com/kubernetes/website/pull/48812