### PR TITLE
feat: remove `needs-triage` label when any triage label is added

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -721,7 +721,7 @@ require_matching_label:
   repo: kubernetes
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -732,7 +732,7 @@ require_matching_label:
   org: kubernetes
   repo: website
   issues: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -743,7 +743,7 @@ require_matching_label:
   org: kubernetes
   repo: kubectl
   issues: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -755,7 +755,7 @@ require_matching_label:
   repo: cloud-provider-gcp
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -847,7 +847,7 @@ require_matching_label:
   repo: ingress-nginx
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -931,7 +931,7 @@ require_matching_label:
   repo: cluster-api
   issues: true
   prs: false
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -943,7 +943,7 @@ require_matching_label:
   repo: cluster-api-operator
   issues: true
   prs: false
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -955,7 +955,7 @@ require_matching_label:
   repo: cluster-api-provider-aws
   issues: true
   prs: false
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -984,7 +984,7 @@ require_matching_label:
   repo: cloud-provider-aws
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -996,7 +996,7 @@ require_matching_label:
   repo: custom-metrics-apiserver
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -1008,7 +1008,7 @@ require_matching_label:
   repo: instrumentation-addons
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -1020,7 +1020,7 @@ require_matching_label:
   repo: instrumentation-tools
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -1032,7 +1032,7 @@ require_matching_label:
   repo: klog
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -1044,7 +1044,7 @@ require_matching_label:
   repo: kube-state-metrics
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -1056,7 +1056,7 @@ require_matching_label:
   repo: metrics
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -1068,7 +1068,7 @@ require_matching_label:
   repo: gateway-api
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -1086,7 +1086,7 @@ require_matching_label:
   repo: metrics-server
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -1098,7 +1098,7 @@ require_matching_label:
   repo: prometheus-adapter
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -1110,7 +1110,7 @@ require_matching_label:
   repo: logtools
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 
@@ -1122,7 +1122,7 @@ require_matching_label:
   repo: usage-metrics-collector
   issues: true
   prs: true
-  regexp: ^triage/accepted$
+  regexp: ^triage/
   missing_comment: |
     This issue is currently awaiting triage.
 


### PR DESCRIPTION
This change will make prow remove the label `needs-triage` when any `triage/` label is added to an issue or PR. This is done via modifying the regex used to decide when to remove such label so that it accepts anything with the `triage/` prefix and not just `triage/accepted`

Fixes kubernetes-sigs/prow#344