### PR TITLE
Use the new AR registries for archeo, octodns and porche

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
@@ -19,8 +19,8 @@ postsubmits:
           args:
           # this is the project GCB will run in, which is the same as the GCR
           # images are pushed to.
-          - --project=k8s-staging-infra-tools
-          - --scratch-bucket=gs://k8s-staging-infra-tools-gcb
+          - --project=k8s-staging-images
+          - --scratch-bucket=gs://k8s-staging-images-gcb
           - .
           env:
           - name: LOG_TO_STDOUT
@@ -42,8 +42,8 @@ postsubmits:
           args:
           # this is the project GCB will run in, which is the same as the GCR
           # images are pushed to.
-          - --project=k8s-staging-infra-tools
-          - --scratch-bucket=gs://k8s-staging-infra-tools-gcb
+          - --project=k8s-staging-images
+          - --scratch-bucket=gs://k8s-staging-images-gcb
           - --with-git-dir
           - .
   kubernetes/k8s.io:
@@ -75,8 +75,8 @@ postsubmits:
           args:
           # this is the project GCB will run in, which is the same as the GCR
           # images are pushed to.
-          - --project=k8s-staging-infra-tools
-          - --scratch-bucket=gs://k8s-staging-infra-tools-gcb
+          - --project=k8s-staging-images
+          - --scratch-bucket=gs://k8s-staging-images-gcb
           - .
           env:
           - name: LOG_TO_STDOUT
@@ -99,8 +99,8 @@ postsubmits:
           args:
             # this is the project GCB will run in, which is the same as the GCR
             # images are pushed to.
-            - --project=k8s-staging-infra-tools
-            - --scratch-bucket=gs://k8s-staging-infra-tools-gcb
+            - --project=k8s-staging-images
+            - --scratch-bucket=gs://k8s-staging-images-gcb
             - --env-passthrough=PULL_BASE_REF
             - dns/octodns-docker
   - name: post-k8sio-push-image-k8s-infra


### PR DESCRIPTION
Part of https://github.com/kubernetes/k8s.io/issues/3961

I scoped the change to archeo, octodns as they are the images we publish on registry.k8s.io. I also updated the porche job as it hasn't been built for a very long time and I see exactly 1 image in the registry and its a PoC project.

https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-infra-tools/images.yaml

/hold

