### PR TITLE
etcd: add contrib-mixin presubmit job

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -623,3 +623,33 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
+
+  - name: pull-etcd-contrib-mixin
+    optional: true # remove once the job is stable
+    cluster: eks-prow-build-cluster
+    always_run: false # set to true once the job works
+    branches:
+      - main
+    decorate: true
+    decoration_config:
+      timeout: 60m
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-contrib-mixin
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20241230-3006692a6f-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            make -C contrib/mixin tools test
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"


### PR DESCRIPTION
Import contrib-mixin tests. Set optional to true and always run to false (to avoid annoyances [and broken CI runs in PRs] while ensuring the job works).

Part of #32754.

/cc @ahrtr @jmhbnz 