### PR TITLE
etcd: always run pull-etcd-contrib-mixin job

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -627,7 +627,7 @@ presubmits:
   - name: pull-etcd-contrib-mixin
     optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
-    always_run: false # set to true once the job works
+    always_run: true
     branches:
       - main
     decorate: true


### PR DESCRIPTION
The job works as expected: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/19322/pull-etcd-contrib-mixin/1886894617278812160

Set `always_run` to `true`.