### PR TITLE
download the go tool that is needed to build release-sdk

### DIFF
--- a/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
@@ -15,6 +15,9 @@ presubmits:
         - run
         - mage.go
         - Test
+        env:
+        - name: GOTOOLCHAIN
+          value: auto
         resources:
           limits:
             cpu: 4
@@ -45,6 +48,9 @@ presubmits:
         - run
         - mage.go
         - IntegrationTest
+        env:
+        - name: GOTOOLCHAIN
+          value: auto
         # docker-in-docker needs privileged mode
         resources:
           limits:
@@ -75,6 +81,9 @@ presubmits:
         - run
         - mage.go
         - Verify
+        env:
+        - name: GOTOOLCHAIN
+          value: auto
         resources:
           limits:
             cpu: 4


### PR DESCRIPTION
xref: https://github.com/kubernetes-sigs/release-sdk/pull/420


this will download the required go tool to be able to satify the requirement and build/test the project, and we dont need to bump the minimum go version in the go.mod when is not required

/assign @saschagrunert @puerco 