### PR TITLE
SIG Node: add bart0sh as approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -235,6 +235,7 @@ aliases:
     - SergeyKanzhelev
     - kannon92
   sig-node-test-approvers:
+    - bart0sh
     - Random-Liu
     - yujuhong
     - tallclair


### PR DESCRIPTION
We have a coverage gap for the European time zone, which makes it hard to get even small changes applied without waiting several days. Ed has been active as reviewer already and actively participates in the CI job maintenance.
