### PR TITLE
Updating Windows unit tests job to run on an 8 core machine

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/windows-unit.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-unit.yaml
@@ -29,6 +29,9 @@ periodics:
           limits:
             cpu: 2
             memory: "5Gi"
+        env:
+          - name: VM_SIZE
+            value: Standard_D8as_v4
   annotations:
 #   testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-signal


### PR DESCRIPTION
/assign @BenTheElder @jsturtevant 

testing to see how much time this can save in the Windows Unit test job.
I'll follow up with changes to the actual script (which lives in k-sigs/windows-testing) to run unit tests on different packages in parallel