### PR TITLE
etcd: set release-tests presubmit as blocking

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -577,7 +577,6 @@ presubmits:
         kubernetes.io/arch: arm64
 
   - name: pull-etcd-release-tests
-    optional: true # remove once the job is stable
     cluster: k8s-infra-prow-build
     always_run: true
     branches:


### PR DESCRIPTION
The release tests have been stable for some days, as shown in:
* [testgrid](https://testgrid.k8s.io/sig-etcd-presubmits#pull-etcd-release-tests)
* [prow](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-contrib-mixin)

Therefore, it should be safe to mark them as blocking.