### PR TITLE
test: move compat versions feature gate tests to kubekins image for jq and yq deps

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -144,7 +144,7 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20241230-3006692a6f-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250205-f1f3519e6b-master
       imagePullPolicy: Always  # pull latest image for canary testing
       command:
       - wrapper.sh


### PR DESCRIPTION
Fixes issue with current `compatibility-versions-feature-gate-test` where `yq` and `jq` deps the test depends are are not installed in the original container image.  Moves the test to use `kubekins-e2e` which has these tools:

https://testgrid.k8s.io/sig-testing-kind#compatibility-versions-feature-gate-test

```
Validating features for 1.32...
/home/prow/go/src/k8s.io/kubernetes/../test-infra/experiment/compatibility-versions/validate-compatibility-versions-feature-gates.sh: line 69: yq: command not found
/home/prow/go/src/k8s.io/kubernetes/../test-infra/experiment/compatibility-versions/validate-compatibility-versions-feature-gates.sh: line 69: jq: command not found
```

/sig api-machinery
/assign @BenTheElder 