### PR TITLE
Use uksouth for windows-unit-test job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/windows-unit.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-unit.yaml
@@ -30,8 +30,10 @@ periodics:
             cpu: 2
             memory: "5Gi"
         env:
+          - name: VM_LOCATION
+            value: uksouth
           - name: VM_SIZE
-            value: Standard_D8as_v4
+            value: Standard_D8as_v5
   annotations:
 #   testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-signal


### PR DESCRIPTION
8 core VM skus are in high demand in westus2 so run the windows unit tests in a different azure region

/assign @jsturtevant @BenTheElder 