### PR TITLE
etcd: run pre and postsubmits on new release branches

### DIFF
--- a/config/jobs/etcd/etcd-bbolt-presubmits.yaml
+++ b/config/jobs/etcd/etcd-bbolt-presubmits.yaml
@@ -6,6 +6,7 @@ presubmits:
       always_run: true
       branches:
         - main
+        - release-1.4
       decorate: true
       annotations:
         testgrid-dashboards: sig-etcd-bbolt-presubmits
@@ -34,6 +35,7 @@ presubmits:
       always_run: true
       branches:
         - main
+        - release-1.4
       decorate: true
       annotations:
         testgrid-dashboards: sig-etcd-bbolt-presubmits
@@ -62,6 +64,7 @@ presubmits:
       always_run: true
       branches:
         - main
+        - release-1.4
       decorate: true
       annotations:
         testgrid-dashboards: sig-etcd-bbolt-presubmits
@@ -90,6 +93,7 @@ presubmits:
       always_run: false
       branches:
         - main
+        - release-1.4
       decorate: true
       annotations:
         testgrid-dashboards: sig-etcd-bbolt-presubmits
@@ -119,6 +123,7 @@ presubmits:
       always_run: false
       branches:
         - main
+        - release-1.4
       decorate: true
       decoration_config:
         timeout: 40m

--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -5,6 +5,7 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-postsubmits
@@ -28,6 +29,7 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-postsubmits
@@ -63,6 +65,7 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-postsubmits
@@ -89,6 +92,7 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -116,6 +120,7 @@ postsubmits:
     cluster: k8s-infra-prow-build
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -145,6 +150,7 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -172,6 +178,7 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -200,6 +207,7 @@ postsubmits:
     cluster: k8s-infra-prow-build
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -229,6 +237,7 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -256,6 +265,7 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -285,6 +295,7 @@ postsubmits:
     cluster: k8s-infra-prow-build
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -6,6 +6,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -31,6 +32,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -59,6 +61,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -89,6 +92,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -117,6 +121,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -153,6 +158,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -180,6 +186,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -209,6 +216,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -237,6 +245,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -267,6 +276,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -298,6 +308,7 @@ presubmits:
     branches:
     - main
     - release-3.5
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -330,6 +341,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -361,6 +373,7 @@ presubmits:
     branches:
     - main
     - release-3.5
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -393,6 +406,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -424,6 +438,7 @@ presubmits:
     branches:
     - main
     - release-3.5
+    - release-3.6
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -487,6 +502,7 @@ presubmits:
     always_run: true
     branches:
       - main
+      - release-3.6
     decorate: true
     decoration_config:
       timeout: 60m
@@ -533,6 +549,7 @@ presubmits:
     always_run: true
     branches:
       - main
+      - release-3.6
     decorate: true
     decoration_config:
       timeout: 60m
@@ -581,6 +598,7 @@ presubmits:
     always_run: true
     branches:
       - main
+      - release-3.6
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -629,6 +647,7 @@ presubmits:
     always_run: true
     branches:
       - main
+      - release-3.6
     decorate: true
     decoration_config:
       timeout: 60m
@@ -659,6 +678,7 @@ presubmits:
     always_run: false # remove once the job works
     branches:
       - main
+      - release-3.6
     decorate: true
     decoration_config:
       timeout: 60m

--- a/config/jobs/etcd/etcd-raft-presubmits.yaml
+++ b/config/jobs/etcd/etcd-raft-presubmits.yaml
@@ -6,6 +6,7 @@ presubmits:
       always_run: true
       branches:
         - main
+        - release-3.6
       decorate: true
       annotations:
         testgrid-dashboards: sig-etcd-raft-presubmits


### PR DESCRIPTION
Run pre and postsubmit jobs on new release branches:

* etcd: `release-3.6`
* raft: `release-3.6`
* bbolt: `release-1.4`

Do we also want to run all our periodic jobs against these branches?

/cc @ahrtr 