### PR TITLE
etcd: always run fuzzing-v3rpc presubmit job

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -656,7 +656,7 @@ presubmits:
   - name: pull-etcd-fuzzing-v3rpc
     optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
-    always_run: false # remove once the job works
+    always_run: true
     branches:
       - main
     decorate: true


### PR DESCRIPTION
The job works as expected: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-fuzzing-v3rpc/1887584670061694976

I also intentionally triggered a failure to verify that it generates the expected artifacts: 
* https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-fuzzing-v3rpc/1887664356443820032
* https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/19357/pull-etcd-fuzzing-v3rpc/1887664356443820032/artifacts/

/cc @ahrtr 