### PR TITLE
parallel image pull for kubeadm init/join and kubelet

### DIFF
--- a/experiment/compatibility-versions/compatibility-versions-feature-gate-test.sh
+++ b/experiment/compatibility-versions/compatibility-versions-feature-gate-test.sh
@@ -178,6 +178,7 @@ ${scheduler_extra_args}
   ---
   kind: InitConfiguration
   nodeRegistration:
+    imagePullSerial: false
     kubeletExtraArgs:
 ${kubelet_extra_args}
   ---
@@ -185,6 +186,11 @@ ${kubelet_extra_args}
   nodeRegistration:
     kubeletExtraArgs:
 ${kubelet_extra_args}
+  ---
+  kind: KubeletConfiguration
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  serializeImagePulls: false
+  maxParallelImagePulls: 5
 EOF
 
   KIND_CREATE_ATTEMPTED=true

--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -193,6 +193,7 @@ ${scheduler_extra_args}
   ---
   kind: InitConfiguration
   nodeRegistration:
+    imagePullSerial: false
     kubeletExtraArgs:
 ${kubelet_extra_args}
   ---
@@ -200,6 +201,11 @@ ${kubelet_extra_args}
   nodeRegistration:
     kubeletExtraArgs:
 ${kubelet_extra_args}
+  ---
+  kind: KubeletConfiguration
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  serializeImagePulls: false
+  maxParallelImagePulls: 5
 EOF
   # NOTE: must match the number of workers above
   NUM_NODES=2

--- a/experiment/kind-detect-local-e2e.sh
+++ b/experiment/kind-detect-local-e2e.sh
@@ -174,6 +174,7 @@ ${scheduler_extra_args}
   ---
   kind: InitConfiguration
   nodeRegistration:
+    imagePullSerial: false
     kubeletExtraArgs:
 ${kubelet_extra_args}
   ---
@@ -186,6 +187,11 @@ ${kubelet_extra_args}
   detectLocalMode: ${KUBE_PROXY_DETECT_LOCAL_MODE:-ClusterCIDR}
   detectLocal:
     interfaceNamePrefix: veth # used only with detectLocalMode "InterfaceNamePrefix"
+  ---
+  kind: KubeletConfiguration
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  serializeImagePulls: false
+  maxParallelImagePulls: 5
 EOF
   # NOTE: must match the number of workers above
   NUM_NODES=2

--- a/experiment/kind-logs-e2e-k8s.sh
+++ b/experiment/kind-logs-e2e-k8s.sh
@@ -178,13 +178,21 @@ ${scheduler_extra_args}
   ---
   kind: InitConfiguration
   nodeRegistration:
+    imagePullSerial: false
     kubeletExtraArgs:
+      serializeImagePulls: false
+      maxParallelImagePulls: 5
 ${kubelet_extra_args}
   ---
   kind: JoinConfiguration
   nodeRegistration:
     kubeletExtraArgs:
 ${kubelet_extra_args}
+  ---
+  kind: KubeletConfiguration
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  serializeImagePulls: false
+  maxParallelImagePulls: 5
 EOF
   # NOTE: must match the number of workers above
   NUM_NODES=2

--- a/experiment/kind-multizone-e2e.sh
+++ b/experiment/kind-multizone-e2e.sh
@@ -101,7 +101,9 @@ create_cluster() {
       apiServer_extra_args="${apiServer_extra_args}
       \"logging-format\": \"${CLUSTER_LOG_FORMAT}\""
   fi
-  kubelet_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\""
+  kubelet_extra_args="      \"v\": \"${KIND_CLUSTER_LOG_LEVEL}\"
+      \""
+  "
   KUBELET_LOG_FORMAT=${KUBELET_LOG_FORMAT:-$CLUSTER_LOG_FORMAT}
   if [ -n "$KUBELET_LOG_FORMAT" ]; then
       check_structured_log_support "KUBECTL_LOG_FORMAT"
@@ -159,6 +161,11 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "topology.kubernetes.io/zone=zone-a"
+    ---
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    serializeImagePulls: false
+    maxParallelImagePulls: 5
 - role: worker
   kubeadmConfigPatches:
   - |
@@ -166,6 +173,11 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "topology.kubernetes.io/zone=zone-a"
+    ---
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    serializeImagePulls: false
+    maxParallelImagePulls: 5
 - role: worker
   kubeadmConfigPatches:
   - |
@@ -173,6 +185,11 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "topology.kubernetes.io/zone=zone-b"
+    ---
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    serializeImagePulls: false
+    maxParallelImagePulls: 5
 - role: worker
   kubeadmConfigPatches:
   - |
@@ -180,6 +197,11 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "topology.kubernetes.io/zone=zone-b"
+    ---
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    serializeImagePulls: false
+    maxParallelImagePulls: 5
 - role: worker
   kubeadmConfigPatches:
   - |
@@ -187,6 +209,11 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "topology.kubernetes.io/zone=zone-c"
+    ---
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    serializeImagePulls: false
+    maxParallelImagePulls: 5
 - role: worker
   kubeadmConfigPatches:
   - |
@@ -194,6 +221,11 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "topology.kubernetes.io/zone=zone-c"
+    ---
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    serializeImagePulls: false
+    maxParallelImagePulls: 5
 EOF
   # NOTE: must match the number of workers above
   NUM_NODES=6


### PR DESCRIPTION
xref https://github.com/kubernetes/enhancements/issues/3673 and https://github.com/kubernetes/kubernetes/pull/122616

Can we use serializeImagePulls: false and maxParallelImagePulls: 5 or 10 to accelerate current e2e?

