### PR TITLE
use normal scalability project instead of 5k node project for benchma…

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1058,7 +1058,7 @@ periodics:
       - --gcp-node-size=e2-standard-32
       - --gcp-node-image=gci
       - --gcp-nodes=1
-      - --gcp-project-type=scalability-scale-project
+      - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
       - --provider=gce
       - --metadata-sources=cl2-metadata.json


### PR DESCRIPTION
…rk-list job

the single 5k node project is highly contested, I think this job was intended to use a general scale project. see https://github.com/kubernetes/kubernetes/issues/130042