### PR TITLE
Update cluster api image building jobs to log to stdout

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -32,6 +32,9 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF
               - --with-git-dir
               - .
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
 
   kubernetes-sigs/cluster-api-provider-vsphere:
     - name: post-cluster-api-provider-vsphere-push-images
@@ -437,6 +440,8 @@ periodics:
         # way as it usually does.
             - name: PULL_BASE_REF
               value: main
+            - name: LOG_TO_STDOUT
+              value: "y"
     annotations:
     # this is the name of some testgrid dashboard to report to.
       testgrid-dashboards: sig-cluster-lifecycle-image-pushes, sig-k8s-infra-gcb


### PR DESCRIPTION
This PR updates the periodic and nightly CAPI image building jobs to enable Logging to STDOUT so that build results can be seen directly in the prow job log instead of having to check the build log artifact. 

This change was recommended by @BenTheElder in this Slack thread (https://kubernetes.slack.com/archives/C09QZ4DQB/p1738962318070059) as a general best practice. 

If this works well for the upstream project we could recommend the various providers who build images on Prow also make the change.