### PR TITLE
CAPZ: Lower VM sizes for 100 node load test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -411,13 +411,13 @@ periodics:
       - name: AZURE_LOCATION
         value: "northeurope"
       - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
-        value: "Standard_D8s_v3"
+        value: "Standard_D4s_v3"
       - name: CONTROL_PLANE_MACHINE_TYPE
-        value: "Standard_D8s_v3"
+        value: "Standard_D4s_v3"
       - name: AZURE_NODE_MACHINE_TYPE
-        value: "Standard_D8s_v3"
+        value: "Standard_D2s_v3"
       - name: NODE_MACHINE_TYPE
-        value: "Standard_D8s_v3"
+        value: "Standard_D2s_v3"
       - name: TEST_WINDOWS
         value: "false"
       - name: "CONTROL_PLANE_MACHINE_COUNT"


### PR DESCRIPTION
Based on findings from metrics, we can optimize the 100-node load test with smaller vm sizes for the control plane and worker nodes.

Control Plane: Standard_D8s_v3 -> Standard_D4s_v3
Workers: Standard_D8s_v3 -> Standard_D2s_v3