### PR TITLE
Enable cherrypicker, needs-rebase for bbolt and raft

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1989,3 +1989,21 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  etcd-io/bbolt:
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request
+  - name: needs-rebase
+    events:
+      - issue_comment
+      - pull_request
+  etcd-io/raft:
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request
+  - name: needs-rebase
+    events:
+      - issue_comment
+      - pull_request


### PR DESCRIPTION
This commit enables `cherrypicker` and `needs-rebase` plugin on etcd.io/bbolt, etcd.io/raft.

 Ref: https://github.com/etcd-io/bbolt/pull/904#issuecomment-2650044580