### PR TITLE
enable prow cherry picker on sig-storage COSI repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1827,6 +1827,12 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/container-object-storage-interface:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   kubernetes-sigs/controller-tools:
   - name: cherrypicker
     events:


### PR DESCRIPTION
Enable the prow cherry picker plugin on the sig-storage Container Object Storage Interface (COSI) repo.
https://github.com/kubernetes-sigs/container-object-storage-interface