### PR TITLE
Disable periodic enhancements sync for v1.33 Enhancements Freeze

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -1,8 +1,8 @@
 periodics:
 - name: periodic-sync-enhancements-github-project-1-33
   # temporarily disable job by with an impossible cron date instead of deleting it
-  # cron: '0 0 31 2 *'
-  interval: 6h
+  cron: '0 0 31 2 *'
+  # interval: 6h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   annotations:


### PR DESCRIPTION
Disabling the periodic-sync-enhancements-github-project-1-33 job to stop syncing KEPs with `lead-opted-in` label to the enhancements tracking board post enhancements freeze. Opening this PR early so that we can merge it once Enhancements Freeze is enforced.

cc: @npolshakova @neoaggelos @katcosgrove @gracenng 



/hold
_(Okay to unhold after v1.33 Enhancements Freeze at [02:00 UTC Friday 14th February 2025 / 19:00 PDT Thursday 13th February 2025](https://everytimezone.com/s/db953795))_
