### PR TITLE
Rename kueue e2e ci jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -242,7 +242,7 @@ presubmits:
             limits:
               cpu: "7"
               memory: "10Gi"
-  - name: pull-kueue-test-multikueue-e2e-main
+  - name: pull-kueue-test-e2e-multikueue-main
     cluster: eks-prow-build-cluster
     branches:
       - ^main
@@ -251,7 +251,7 @@ presubmits:
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-multikueue-e2e-main
+      testgrid-tab-name: pull-kueue-test-e2e-multikueue-main
       description: "Run multikueue end to end tests"
     labels:
       preset-dind-enabled: "true"
@@ -280,7 +280,7 @@ presubmits:
             limits:
               cpu: "10"
               memory: "10Gi"
-  - name: pull-kueue-test-tas-e2e-main
+  - name: pull-kueue-test-e2e-tas-main
     cluster: eks-prow-build-cluster
     branches:
       - ^main
@@ -289,7 +289,7 @@ presubmits:
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-tas-e2e-main
+      testgrid-tab-name: pull-kueue-test-e2e-tas-main
       description: "Run tas end to end tests"
     labels:
       preset-dind-enabled: "true"
@@ -318,7 +318,7 @@ presubmits:
             limits:
               cpu: "7"
               memory: "10Gi"
-  - name: pull-kueue-test-customconfigs-e2e-main
+  - name: pull-kueue-test-e2e-customconfigs-main
     cluster: eks-prow-build-cluster
     branches:
       - ^main
@@ -327,7 +327,7 @@ presubmits:
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-customconfigs-e2e-main
+      testgrid-tab-name: pull-kueue-test-e2e-customconfigs-main
       description: "Run customconfigs end to end tests"
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
@@ -174,7 +174,7 @@ presubmits:
             limits:
               cpu: "7"
               memory: "10Gi"
-  - name: pull-kueue-test-multikueue-e2e-release-0-10
+  - name: pull-kueue-test-e2e-multikueue-release-0-10
     cluster: eks-prow-build-cluster
     branches:
       - ^release-0.10
@@ -183,7 +183,7 @@ presubmits:
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-multikueue-e2e-release-0-10
+      testgrid-tab-name: pull-kueue-test-e2e-multikueue-release-0-10
       description: "Run multikueue end to end tests"
     labels:
       preset-dind-enabled: "true"
@@ -212,7 +212,7 @@ presubmits:
             limits:
               cpu: "10"
               memory: "10Gi"
-  - name: pull-kueue-test-tas-e2e-release-0-10
+  - name: pull-kueue-test-e2e-tas-release-0-10
     cluster: eks-prow-build-cluster
     branches:
       - ^release-0.10
@@ -221,7 +221,7 @@ presubmits:
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-tas-e2e-release-0-10
+      testgrid-tab-name: pull-kueue-test-e2e-tas-release-0-10
       description: "Run tas end to end tests"
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-9.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-9.yaml
@@ -174,7 +174,7 @@ presubmits:
             limits:
               cpu: "7"
               memory: "10Gi"
-  - name: pull-kueue-test-multikueue-e2e-release-0-9
+  - name: pull-kueue-test-e2e-multikueue-release-0-9
     cluster: eks-prow-build-cluster
     branches:
       - ^release-0.9
@@ -183,7 +183,7 @@ presubmits:
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-multikueue-e2e-release-0-9
+      testgrid-tab-name: pull-kueue-test-e2e-multikueue-release-0-9
       description: "Run multikueue end to end tests"
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
This PR  renames the e2e CI Jobs so that they all start with `pull-kueue-test-e2e`, making them nicely group together. 

This is a follow-up from https://github.com/kubernetes/test-infra/pull/34311