### PR TITLE
DRA: experiment with not using checked-out code

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -30,15 +30,34 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
-          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
-          kind build node-image --image=dra/node:latest .
-          trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT
+          # This turns the canary pull job into a test for a ci job because it ignores the checked out source code!
+          cd /tmp # Remove me, just for testing with blank slate.
+          set -o pipefail
+          # Report what was tested and the outcome when the script terminates.
+          atexit () {
+              if [ "$?" -gt 0 ]; then
+                  echo "{\"timestamp\":$(date +%s),\"passed\":false,\"metadata\":{\"revision\":\"$revision\"},\"result\":\"FAILURE\"}"
+              else
+                  echo "{\"timestamp\":$(date +%s),\"passed\":true,\"metadata\":{\"revision\":\"$revision\"},\"result\":\"SUCCESS\"}"
+              fi | tee "${ARTIFACTS}/finished.json"
+              kind export logs "${ARTIFACTS}/kind"
+              kind delete cluster
+          }
+          trap atexit EXIT
+          revision=$(curl --fail --silent -L https://dl.k8s.io/ci/latest.txt)
+          # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
+          hash=${revision/*+/}
+          kind_yaml=$(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
+          features=( )
+          # The latest kind is assumed to work also for older release branches, should this job get forked.
+          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          kind build node-image --image=dra/node:latest "https://dl.k8s.io/ci/$revision/kubernetes-server-linux-amd64.tar.gz"
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
-          kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky' &
+          # Additional features are not in kind.yaml, but they can be added at the end.
+          kind create cluster --retain --config <(echo "${kind_yaml}"; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
+          KUBECONFIG=${HOME}/.kube/config kubernetes/test/bin/ginkgo run --nodes=8 --output-dir="${ARTIFACTS}" --silence-skips --force-newlines --no-color --label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features[@]}; do echo , ${feature}; done)} && !Flaky && !Slow" kubernetes/test/bin/e2e.test -- -provider=local -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode
@@ -79,19 +98,37 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
-          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
-          kind build node-image --image=dra/node:latest .
-          trap 'kind export logs "${ARTIFACTS}/kind"; kind delete cluster' EXIT
+          # This turns the canary pull job into a test for a ci job because it ignores the checked out source code!
+          cd /tmp # Remove me, just for testing with blank slate.
+          set -o pipefail
+          # Report what was tested and the outcome when the script terminates.
+          atexit () {
+              if [ "$?" -gt 0 ]; then
+                  echo "{\"timestamp\":$(date +%s),\"passed\":false,\"metadata\":{\"revision\":\"$revision\"},\"result\":\"FAILURE\"}"
+              else
+                  echo "{\"timestamp\":$(date +%s),\"passed\":true,\"metadata\":{\"revision\":\"$revision\"},\"result\":\"SUCCESS\"}"
+              fi | tee "${ARTIFACTS}/finished.json"
+              kind export logs "${ARTIFACTS}/kind"
+              kind delete cluster
+          }
+          trap atexit EXIT
+          revision=$(curl --fail --silent -L https://dl.k8s.io/ci/latest.txt)
+          # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
+          hash=${revision/*+/}
+          kind_yaml=$(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
+          # Which DRA features exist can change over time.
+          features=( $( curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/pkg/features/kube_features.go" | grep '"DRA' | sed 's/.*"\(.*\)"/\1/' ) )
+          : "Enabling DRA feature(s): ${features[*]}."
+          curl --fail --silent --show-error --location "https://dl.k8s.io/ci/$revision/kubernetes-test-linux-amd64.tar.gz" | tar ztvf -
+          # The latest kind is assumed to work also for older release branches, should this job get forked.
+          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          kind build node-image --image=dra/node:latest "https://dl.k8s.io/ci/$revision/kubernetes-server-linux-amd64.tar.gz"
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
-          # Which DRA features exist can change over time.
-          features=( $(grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/') )
-          echo "Enabling DRA feature(s): ${features[*]}."
-          # Those additional features are not in kind.yaml, but they can be added at the end.
-          kind create cluster --retain --config <(cat test/e2e/dra/kind.yaml; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
-          KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features[@]}; do echo , ${feature}; done)} && !Flaky && !Slow" &
+          # Additional features are not in kind.yaml, but they can be added at the end.
+          kind create cluster --retain --config <(echo "${kind_yaml}"; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
+          KUBECONFIG=${HOME}/.kube/config kubernetes/test/bin/ginkgo run --nodes=8 --output-dir="${ARTIFACTS}" --silence-skips --force-newlines --no-color --label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features[@]}; do echo , ${feature}; done)} && !Flaky && !Slow" kubernetes/test/bin/e2e.test -- -provider=local -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -128,6 +128,43 @@
         - /bin/bash
         - -xce
         - |
+          {%- if file == "canary" %}
+          # This turns the canary pull job into a test for a ci job because it ignores the checked out source code!
+          cd /tmp # Remove me, just for testing with blank slate.
+          set -o pipefail
+          # Report what was tested and the outcome when the script terminates.
+          atexit () {
+              if [ "$?" -gt 0 ]; then
+                  echo "{\"timestamp\":$(date +%s),\"passed\":false,\"metadata\":{\"revision\":\"$revision\"},\"result\":\"FAILURE\"}"
+              else
+                  echo "{\"timestamp\":$(date +%s),\"passed\":true,\"metadata\":{\"revision\":\"$revision\"},\"result\":\"SUCCESS\"}"
+              fi | tee "${ARTIFACTS}/finished.json"
+              kind export logs "${ARTIFACTS}/kind"
+              kind delete cluster
+          }
+          trap atexit EXIT
+          revision=$(curl --fail --silent -L https://dl.k8s.io/ci/latest.txt)
+          # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
+          hash=${revision/*+/}
+          kind_yaml=$(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
+          {%- if all_features %}
+          # Which DRA features exist can change over time.
+          features=( $( curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/pkg/features/kube_features.go" | grep '"DRA' | sed 's/.*"\(.*\)"/\1/' ) )
+          : "Enabling DRA feature(s): ${features[*]}."
+          curl --fail --silent --show-error --location "https://dl.k8s.io/ci/$revision/kubernetes-test-linux-amd64.tar.gz" | tar ztvf -
+          {%- else %}
+          features=( )
+          {%- endif %}
+          # The latest kind is assumed to work also for older release branches, should this job get forked.
+          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          kind build node-image --image=dra/node:latest "https://dl.k8s.io/ci/$revision/kubernetes-server-linux-amd64.tar.gz"
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # Additional features are not in kind.yaml, but they can be added at the end.
+          kind create cluster --retain --config <(echo "${kind_yaml}"; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
+          KUBECONFIG=${HOME}/.kube/config kubernetes/test/bin/ginkgo run --nodes=8 --output-dir="${ARTIFACTS}" --silence-skips --force-newlines --no-color --label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features[@]}; do echo , ${feature}; done)} && !Flaky {%- if file != "ci" %} && !Slow {%- endif %}" kubernetes/test/bin/e2e.test -- -provider=local -report-complete-ginkgo -report-complete-junit &
+          {%- else %}
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest .
@@ -145,6 +182,7 @@
           {%- else %}
           kind create cluster --retain --config test/e2e/dra/kind.yaml --image dra/node:latest
           KUBERNETES_PROVIDER=local KUBECONFIG=${HOME}/.kube/config GINKGO_PARALLEL_NODES=8 E2E_REPORT_DIR=${ARTIFACTS} hack/ginkgo-e2e.sh -ginkgo.label-filter='Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky' &
+          {%- endif %}
           {%- endif %}
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"


### PR DESCRIPTION
This is an attempt to solve https://github.com/kubernetes/test-infra/issues/33980, running CI jobs without building Kubernetes from source.

The real change will have to be made only for the CI jobs, not canary pull jobs.
