### PR TITLE
chore: Add needs-priority plugin for karpenter

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -866,6 +866,12 @@ require_matching_label:
     If Karpenter contributors determines this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
 
     The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+- missing_label: needs-priority
+  org: kubernetes-sigs
+  repo: karpenter
+  issues: true
+  prs: false
+  regexp: ^priority/
 - missing_label: needs-kind
   org: kubernetes
   repo: ingress-nginx


### PR DESCRIPTION
Add support for auto-adding `needs-priority` to new issues that are opened in `kubernetes-sigs/karpenter`