### PR TITLE
Remove 'kind create cluster' command in etcd-operator workflow

### DIFF
--- a/config/jobs/etcd/etcd-operator-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-postsubmits.yaml
@@ -47,8 +47,8 @@ postsubmits:
         - bash
         - -c
         - |
+          # We can't remove the line below for now, because the e2e test needs the kind binary present
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
-          kind create cluster
           make test-e2e
         # docker-in-docker needs privileged mode
         securityContext:

--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -49,8 +49,8 @@ presubmits:
         - bash
         - -c
         - |
+          # We can't remove the line below for now, because the e2e test needs the kind binary present
           curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
-          kind create cluster
           make test-e2e
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
The etcd-operator's e2e test will automatically create kind cluster, so no need to create it anymore in the workflow scripts.

But we still need to download the kind binary for now. We will remove it once we manage all tools using tool/mod.

See also https://github.com/etcd-io/etcd-operator/issues/19#issuecomment-2658761043

cc @ivanvc @abdurrehman107 @ArkaSaha30

/wg etcd-operator

cc @jmhbnz @hakman