### PR TITLE
disable branch protection for CVE feed branches

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -556,6 +556,9 @@ branch-protection:
               protect: true
             kubetest2-aks:
               protect: true
+        cve-feed-osv:
+          exclude:
+            - "^vulns-" # don't protect branches created by CVE feed github action
         descheduler:
           branches:
             gh-pages:


### PR DESCRIPTION
discussion in this thread: https://kubernetes.slack.com/archives/C1TU9EB9S/p1739549957011189

example failure: https://github.com/kubernetes-sigs/cve-feed-osv/actions/runs/13328738465/job/37227765220#step:6:16