### PR TITLE
etcd: update contrib mixin, fuzzing, and grpcproxy presubmit jobs

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -709,7 +709,7 @@ presubmits:
   - name: pull-etcd-grpcproxy-integration-amd64
     optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
-    always_run: false # set to true once the job works
+    always_run: true
     branches:
       - main
       - release-3.6
@@ -740,7 +740,7 @@ presubmits:
   - name: pull-etcd-grpcproxy-e2e-amd64
     optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
-    always_run: false # set to true once the job works
+    always_run: true
     branches:
       - main
       - release-3.6
@@ -771,7 +771,7 @@ presubmits:
   - name: pull-etcd-grpcproxy-integration-arm64
     optional: true # remove once the job is stable
     cluster: k8s-infra-prow-build
-    always_run: false # set to true once the job works
+    always_run: true
     branches:
       - main
       - release-3.6
@@ -804,7 +804,7 @@ presubmits:
   - name: pull-etcd-grpcproxy-e2e-arm64
     optional: true # remove once the job is stable
     cluster: k8s-infra-prow-build
-    always_run: false # set to true once the job works
+    always_run: true
     branches:
       - main
       - release-3.6

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -642,7 +642,6 @@ presubmits:
           privileged: true
 
   - name: pull-etcd-contrib-mixin
-    optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
     always_run: true
     branches:
@@ -673,7 +672,6 @@ presubmits:
             memory: "4Gi"
 
   - name: pull-etcd-fuzzing-v3rpc
-    optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
     always_run: true
     branches:


### PR DESCRIPTION
This pull request sets the following two jobs as blocking:
* The `contrib-mixin` job has been running stable: https://testgrid.k8s.io/sig-etcd-presubmits#pull-etcd-contrib-mixin / https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-contrib-mixin?buildId=
* The `fuzzing-v3rpc` job is also stable: https://testgrid.k8s.io/sig-etcd-presubmits#pull-etcd-fuzzing-v3rpc / https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-fuzzing-v3rpc

Sets `always_run` to test for the grpcproxy jobs, as they worked:
* https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-grpcproxy-integration-amd64
* https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-grpcproxy-integration-arm64
* https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-grpcproxy-e2e-amd64
* https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-grpcproxy-e2e-arm64