### PR TITLE
[sig-windows] Add presets to create Windows VMs in GCE

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
@@ -23,3 +23,28 @@ presets:
   env:
   - name: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION
     value: https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list
+- labels:
+    preset-common-gce-windows: "true"
+  env:
+  - name: KUBE_GCE_ENABLE_IP_ALIASES
+    value: "true"
+  - name: KUBERNETES_NODE_PLATFORM
+    value: "windows"
+  - name: KUBELET_TEST_ARGS
+    value: "--feature-gates=KubeletPodResources=false"
+  - name: USE_TEST_INFRA_LOG_DUMPING
+    value: "true"
+- labels:
+    preset-e2e-gce-windows: "true"
+  env:
+  - name: NUM_WINDOWS_NODES
+    value: "3"
+  - name: NUM_NODES
+    value: "2"
+- labels:
+    preset-e2e-gce-windows-containerd: "true"
+  env:
+  - name: PREPULL_TIMEOUT
+    value: "30m"
+  - name: WINDOWS_ENABLE_DSR
+    value: "true"


### PR DESCRIPTION
Add SIG Windows presets to create Windows VMs on GCE. 

These presets were removed in https://github.com/kubernetes/test-infra/pull/34103, some projects like https://github.com/kubernetes-csi/csi-proxy rely on kube-up.sh in k/k to create Windows GCE VMs in the presubmit jobs so adding them back will unblock their presubmits.

https://github.com/kubernetes/test-infra/blob/efe4a96f3fa969515b137433e0ee085f89cabcbf/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-manual-config.yaml#L12-L13

The removed CI jobs aren't added back, only the presets. Maintenance of the scripts to have CI for Windows VMs in GCE is still a topic for discussion in SIG Node for the GKE Node team.

I also restored OWNERS to the way it was before.

Ref https://github.com/kubernetes/kubernetes/issues/130203, https://github.com/kubernetes-csi/csi-proxy/pull/369

/sig window
/sig test
/cc @jsturtevant @marosset @AnishShah @yujuhong @wangzhen127 