### PR TITLE
DRA: reduce memory requests, use tmp for etcd

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -45,6 +45,13 @@ periodics:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # Inject ClusterConfiguration which causes etcd to use /tmp
+          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+          if ! echo "$kind_yaml" | grep -q '^kubeadmConfigPatches:'; then
+              # Add kubeadmConfigPatches list before node list, there is none at the moment.
+              kind_yaml=$(echo "$kind_yaml" | sed -e '/nodes:/ i\kubeadmConfigPatches:')
+          fi
+          kind_yaml=$(echo "$kind_yaml" | sed -e '/^kubeadmConfigPatches:/ a\- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd')
           # Additional features are not in kind.yaml, but they can be added at the end.
           kind create cluster --retain --config <(echo "${kind_yaml}"; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
           atexit () {
@@ -61,10 +68,10 @@ periodics:
         resources:
           limits:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
 
   - name: ci-kind-dra-all
     cluster: eks-prow-build-cluster
@@ -111,6 +118,13 @@ periodics:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # Inject ClusterConfiguration which causes etcd to use /tmp
+          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+          if ! echo "$kind_yaml" | grep -q '^kubeadmConfigPatches:'; then
+              # Add kubeadmConfigPatches list before node list, there is none at the moment.
+              kind_yaml=$(echo "$kind_yaml" | sed -e '/nodes:/ i\kubeadmConfigPatches:')
+          fi
+          kind_yaml=$(echo "$kind_yaml" | sed -e '/^kubeadmConfigPatches:/ a\- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd')
           # Additional features are not in kind.yaml, but they can be added at the end.
           kind create cluster --retain --config <(echo "${kind_yaml}"; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
           atexit () {
@@ -127,10 +141,10 @@ periodics:
         resources:
           limits:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
 
   - name: ci-node-e2e-crio-cgrpv1-dra
     cluster: k8s-infra-prow-build
@@ -184,10 +198,10 @@ periodics:
         resources:
           limits:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
 
   - name: ci-node-e2e-crio-cgrpv2-dra
     cluster: k8s-infra-prow-build
@@ -241,10 +255,10 @@ periodics:
         resources:
           limits:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
 
   - name: ci-node-e2e-containerd-1-7-dra
     cluster: k8s-infra-prow-build
@@ -291,7 +305,7 @@ periodics:
         resources:
           limits:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -46,6 +46,13 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # Inject ClusterConfiguration which causes etcd to use /tmp
+          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+          if ! echo "$kind_yaml" | grep -q '^kubeadmConfigPatches:'; then
+              # Add kubeadmConfigPatches list before node list, there is none at the moment.
+              kind_yaml=$(echo "$kind_yaml" | sed -e '/nodes:/ i\kubeadmConfigPatches:')
+          fi
+          kind_yaml=$(echo "$kind_yaml" | sed -e '/^kubeadmConfigPatches:/ a\- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd')
           # Additional features are not in kind.yaml, but they can be added at the end.
           kind create cluster --retain --config <(echo "${kind_yaml}"; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
           atexit () {
@@ -62,10 +69,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
 
   - name: pull-kubernetes-kind-dra-all
     cluster: eks-prow-build-cluster
@@ -112,6 +119,13 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # Inject ClusterConfiguration which causes etcd to use /tmp
+          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+          if ! echo "$kind_yaml" | grep -q '^kubeadmConfigPatches:'; then
+              # Add kubeadmConfigPatches list before node list, there is none at the moment.
+              kind_yaml=$(echo "$kind_yaml" | sed -e '/nodes:/ i\kubeadmConfigPatches:')
+          fi
+          kind_yaml=$(echo "$kind_yaml" | sed -e '/^kubeadmConfigPatches:/ a\- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd')
           # Additional features are not in kind.yaml, but they can be added at the end.
           kind create cluster --retain --config <(echo "${kind_yaml}"; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
           atexit () {
@@ -128,10 +142,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
 
   - name: pull-kubernetes-node-e2e-crio-cgrpv1-dra
     cluster: k8s-infra-prow-build
@@ -186,10 +200,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
 
   - name: pull-kubernetes-node-e2e-crio-cgrpv2-dra
     cluster: k8s-infra-prow-build
@@ -243,10 +257,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
 
   - name: pull-kubernetes-node-e2e-containerd-1-7-dra
     cluster: k8s-infra-prow-build
@@ -293,7 +307,7 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 9Gi
+            memory: 6Gi

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -140,7 +140,6 @@
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
-          {%- if file == "canary" %}
           # Inject ClusterConfiguration which causes etcd to use /tmp
           # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
           if ! echo "$kind_yaml" | grep -q '^kubeadmConfigPatches:'; then
@@ -148,7 +147,6 @@
               kind_yaml=$(echo "$kind_yaml" | sed -e '/nodes:/ i\kubeadmConfigPatches:')
           fi
           kind_yaml=$(echo "$kind_yaml" | sed -e '/^kubeadmConfigPatches:/ a\- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd')
-          {%- endif %}
           # Additional features are not in kind.yaml, but they can be added at the end.
           kind create cluster --retain --config <(echo "${kind_yaml}"; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
           atexit () {
@@ -164,19 +162,10 @@
           privileged: true
         {%- endif %}
         resources:
-          {%- if file == "canary" %}
           limits:
             cpu: 2
             memory: 6Gi
           requests:
             cpu: 2
             memory: 6Gi
-          {%- else %}
-          limits:
-            cpu: 2
-            memory: 9Gi
-          requests:
-            cpu: 2
-            memory: 9Gi
-          {%- endif %}
 


### PR DESCRIPTION
This was tested successfully in a canary job first, see those commits for details.

https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/129976/pull-kubernetes-kind-dra-all-canary/1891482849857507328/build-log.txt

/assign @bart0sh 