### PR TITLE
CAPI: ensure KUBERNETES_VERSION_LATEST_CI gets built

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
@@ -321,6 +321,9 @@ periodics:
             value: "true"
           - name: GINKGO_LABEL_FILTER
             value: "!Conformance"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION_LATEST_CI"
           - name: KUBERNETES_VERSION_MANAGEMENT
             value: ci/latest-1.33
           - name: KUBERNETES_VERSION

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
@@ -345,6 +345,9 @@ periodics:
           - name: GINKGO_LABEL_FILTER
             value: "!Conformance"
 {{- end }}
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION_LATEST_CI"
           - name: KUBERNETES_VERSION_MANAGEMENT
             value: {{ index (index $.versions ((last $.config.Upgrades).To)) "k8sRelease" }}
           - name: KUBERNETES_VERSION


### PR DESCRIPTION
This should fix:

https://github.com/kubernetes-sigs/cluster-api/issues/11855