### PR TITLE
etcd: always run coverage job

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -837,7 +837,7 @@ presubmits:
   - name: pull-etcd-coverage-report
     optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
-    always_run: false # set to true once the job works
+    always_run: true
     branches:
       - main
       - release-3.6


### PR DESCRIPTION
The job works: https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-coverage-report

We can safely enable it for all pull requests.

/cc @jmhbnz @ahrtr 