### PR TITLE
etcd e2e jobs: set 60m timeout

### DIFF
--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -180,6 +180,8 @@ postsubmits:
     - main
     - release-3.6
     decorate: true
+    decoration_config:
+      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: post-etcd-e2e-amd64
@@ -209,6 +211,8 @@ postsubmits:
     - main
     - release-3.6
     decorate: true
+    decoration_config:
+      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: post-etcd-e2e-arm64
@@ -239,6 +243,8 @@ postsubmits:
     - main
     - release-3.6
     decorate: true
+    decoration_config:
+      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: post-etcd-e2e-386

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -188,6 +188,8 @@ presubmits:
     - main
     - release-3.6
     decorate: true
+    decoration_config:
+      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: pull-etcd-e2e-amd64
@@ -218,6 +220,8 @@ presubmits:
     - main
     - release-3.6
     decorate: true
+    decoration_config:
+      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: pull-etcd-e2e-386
@@ -247,6 +251,8 @@ presubmits:
     - main
     - release-3.6
     decorate: true
+    decoration_config:
+      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: pull-etcd-e2e-arm64


### PR DESCRIPTION
Periodic jobs had the 60 minute timeout, but the pre and postsubmits didn't.

/cc @ahrtr 