### PR TITLE
DRA: fork periodics for release-1.32

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -84,7 +84,6 @@ periodics:
       testgrid-dashboards: sig-node-dynamic-resource-allocation
       description: Runs E2E tests for Dynamic Resource Allocation alpha and beta features against a Kubernetes master cluster created with sigs.k8s.io/kind
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
-      fork-per-release: "true"
     decorate: true
     decoration_config:
       timeout: 90m

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -15,6 +15,7 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -29,15 +30,15 @@ periodics:
         - |
           set -o pipefail
           # A CI job uses pre-built release artifacts and pulls necessary source files from GitHub.
-          revision=$(curl --fail --silent --show-error --location https://dl.k8s.io/ci/fast/latest-fast.txt)
+          revision=$(curl --fail --silent --show-error --location ${CI_URL}/${LATEST_TXT})
           # Report what was tested.
           echo "{\"revision\":\"$revision\"}" >"${ARTIFACTS}/metadata.json"
           # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
           hash=${revision/*+/}
           kind_yaml=$(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
-          kind_node_source="https://dl.k8s.io/ci/fast/$revision/kubernetes-server-linux-amd64.tar.gz"
+          kind_node_source="${CI_URL}/$revision/kubernetes-server-linux-amd64.tar.gz"
           features=( )
-          curl --fail --silent --show-error --location "https://dl.k8s.io/ci/fast/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
+          curl --fail --silent --show-error --location "${CI_URL}/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
           ginkgo=kubernetes/test/bin/ginkgo
           e2e_test=kubernetes/test/bin/e2e.test
           # The latest kind is assumed to work also for older release branches, should this job get forked.
@@ -63,6 +64,11 @@ periodics:
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features[@]}; do echo , ${feature}; done)} && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
+        env:
+        - name: LATEST_TXT
+          value: latest-fast.txt
+        - name: CI_URL
+          value: https://dl.k8s.io/ci/fast
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -99,17 +105,17 @@ periodics:
         - |
           set -o pipefail
           # A CI job uses pre-built release artifacts and pulls necessary source files from GitHub.
-          revision=$(curl --fail --silent --show-error --location https://dl.k8s.io/ci/fast/latest-fast.txt)
+          revision=$(curl --fail --silent --show-error --location ${CI_URL}/${LATEST_TXT})
           # Report what was tested.
           echo "{\"revision\":\"$revision\"}" >"${ARTIFACTS}/metadata.json"
           # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
           hash=${revision/*+/}
           kind_yaml=$(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
-          kind_node_source="https://dl.k8s.io/ci/fast/$revision/kubernetes-server-linux-amd64.tar.gz"
+          kind_node_source="${CI_URL}/$revision/kubernetes-server-linux-amd64.tar.gz"
           # Which DRA features exist can change over time.
           features=( $( curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/pkg/features/kube_features.go" | grep '"DRA'  | sed 's/.*"\(.*\)"/\1/' ) )
           : "Enabling DRA feature(s): ${features[*]}."
-          curl --fail --silent --show-error --location "https://dl.k8s.io/ci/fast/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
+          curl --fail --silent --show-error --location "${CI_URL}/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
           ginkgo=kubernetes/test/bin/ginkgo
           e2e_test=kubernetes/test/bin/e2e.test
           # The latest kind is assumed to work also for older release branches, should this job get forked.
@@ -135,6 +141,11 @@ periodics:
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features[@]}; do echo , ${feature}; done)} && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
+        env:
+        - name: LATEST_TXT
+          value: latest-fast.txt
+        - name: CI_URL
+          value: https://dl.k8s.io/ci/fast
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -158,6 +169,7 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -216,6 +228,7 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -274,6 +287,7 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
     decorate: true
     decoration_config:
       timeout: 90m

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -14,6 +14,7 @@ periodics:
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
+      fork-per-release-periodic-interval: 24h
     decorate: true
     decoration_config:
       timeout: 90m
@@ -156,6 +157,7 @@ periodics:
       description: Runs E2E node tests for Dynamic Resource Allocation beta features with CRI-O using cgroup v1
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
+      fork-per-release-periodic-interval: 24h
     decorate: true
     decoration_config:
       timeout: 90m
@@ -213,6 +215,7 @@ periodics:
       description: Runs E2E node tests for Dynamic Resource Allocation beta features with CRI-O using cgroup v2
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
+      fork-per-release-periodic-interval: 24h
     decorate: true
     decoration_config:
       timeout: 90m
@@ -270,6 +273,7 @@ periodics:
       description: Runs E2E node tests for Dynamic Resource Allocation beta features with containerd
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
+      fork-per-release-periodic-interval: 24h
     decorate: true
     decoration_config:
       timeout: 90m

--- a/config/jobs/kubernetes/sig-node/dra.generate.conf
+++ b/config/jobs/kubernetes/sig-node/dra.generate.conf
@@ -10,7 +10,6 @@ files = canary:pull-kubernetes-{section}-canary,presubmit:pull-kubernetes-{secti
 # attempt to run node jobs on eks-prow-build-cluster fails
 # with "boskos failed to acquire project: resources not found" error
 cluster = k8s-infra-prow-build
-interval = 6h
 testgrid_dashboards = sig-node-dynamic-resource-allocation
 testgrid_alert_email = eduard.bartosh@intel.com, patrick.ohly@intel.com
 # Overall job timeout.

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -21,7 +21,7 @@
   - name: {{job_name}}
     cluster: {{cluster}}
     {%- if file == "ci" %}
-    interval: {{interval}}
+    interval: 6h
     {%- else %}
     skip_branches:
     - release-\d+\.\d+  # per-release image
@@ -49,6 +49,9 @@
       testgrid-alert-email: {{testgrid_alert_email}}
       {%- if file != "canary" and ( not all_features or file == "presubmit" ) %}
       fork-per-release: "true"
+      {%- if file == "ci" %}
+      fork-per-release-periodic-interval: 24h
+      {%- endif %}
       {%- endif %}
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -51,6 +51,7 @@
       fork-per-release: "true"
       {%- if file == "ci" %}
       fork-per-release-periodic-interval: 24h
+      fork-per-release-replacements: latest-fast.txt -> latest-{% raw %}{{.Version}}{% endraw %}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
       {%- endif %}
       {%- endif %}
     decorate: true
@@ -109,13 +110,13 @@
           set -o pipefail
           {%- if file == "ci" %}
           # A CI job uses pre-built release artifacts and pulls necessary source files from GitHub.
-          revision=$(curl --fail --silent --show-error --location https://dl.k8s.io/ci/fast/latest-fast.txt)
+          revision=$(curl --fail --silent --show-error --location ${CI_URL}/${LATEST_TXT})
           # Report what was tested.
           echo "{\"revision\":\"$revision\"}" >"${ARTIFACTS}/metadata.json"
           # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
           hash=${revision/*+/}
           kind_yaml=$(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
-          kind_node_source="https://dl.k8s.io/ci/fast/$revision/kubernetes-server-linux-amd64.tar.gz"
+          kind_node_source="${CI_URL}/$revision/kubernetes-server-linux-amd64.tar.gz"
           {%- else %}
           # A presubmit job uses the checked out and merged source code.
           kind_yaml=$(cat test/e2e/dra/kind.yaml)
@@ -129,7 +130,7 @@
           features=( )
           {%- endif %}
           {%- if file == "ci" %}
-          curl --fail --silent --show-error --location "https://dl.k8s.io/ci/fast/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
+          curl --fail --silent --show-error --location "${CI_URL}/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
           ginkgo=kubernetes/test/bin/ginkgo
           e2e_test=kubernetes/test/bin/e2e.test
           {%- else %}
@@ -160,6 +161,13 @@
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features[@]}; do echo , ${feature}; done)} && !Flaky {%- if file != "ci" %} && !Slow {%- endif %}" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
+        {%- if file == "ci" %}
+        env:
+        - name: LATEST_TXT
+          value: latest-fast.txt
+        - name: CI_URL
+          value: https://dl.k8s.io/ci/fast
+        {%- endif %}
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -47,7 +47,7 @@
       testgrid-dashboards: {{testgrid_dashboards}}
       description: {{description}}
       testgrid-alert-email: {{testgrid_alert_email}}
-      {%- if file != "canary" %}
+      {%- if file != "canary" and ( not all_features or file == "presubmit" ) %}
       fork-per-release: "true"
       {%- endif %}
     decorate: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/dra-1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/dra-1.32.yaml
@@ -1,0 +1,234 @@
+periodics:
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-1.32-informing
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  interval: 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+  name: ci-kind-dra-1-32
+  spec:
+    containers:
+    - args:
+      - /bin/bash
+      - -xce
+      - |
+        set -o pipefail
+        # A CI job uses pre-built release artifacts and pulls necessary source files from GitHub.
+        revision=$(curl --fail --silent --show-error --location ${CI_URL}/${LATEST_TXT})
+        # Report what was tested.
+        echo "{\"revision\":\"$revision\"}" >"${ARTIFACTS}/metadata.json"
+        # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
+        hash=${revision/*+/}
+        kind_yaml=$(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
+        kind_node_source="${CI_URL}/$revision/kubernetes-server-linux-amd64.tar.gz"
+        features=( )
+        curl --fail --silent --show-error --location "${CI_URL}/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
+        ginkgo=kubernetes/test/bin/ginkgo
+        e2e_test=kubernetes/test/bin/e2e.test
+        # The latest kind is assumed to work also for older release branches, should this job get forked.
+        curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+        kind build node-image --image=dra/node:latest "${kind_node_source}"
+        GINKGO_E2E_PID=
+        trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+        trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+        # Inject ClusterConfiguration which causes etcd to use /tmp
+        # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+        if ! echo "$kind_yaml" | grep -q '^kubeadmConfigPatches:'; then
+            # Add kubeadmConfigPatches list before node list, there is none at the moment.
+            kind_yaml=$(echo "$kind_yaml" | sed -e '/nodes:/ i\kubeadmConfigPatches:')
+        fi
+        kind_yaml=$(echo "$kind_yaml" | sed -e '/^kubeadmConfigPatches:/ a\- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd')
+        # Additional features are not in kind.yaml, but they can be added at the end.
+        kind create cluster --retain --config <(echo "${kind_yaml}"; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
+        atexit () {
+            kind export logs "${ARTIFACTS}/kind"
+            kind delete cluster
+        }
+        trap atexit EXIT
+        KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Alpha, Beta, DynamicResourceAllocation$(for feature in ${features[@]}; do echo , ${feature}; done)} && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+        GINKGO_E2E_PID=$!
+        wait "${GINKGO_E2E_PID}"
+      command:
+      - runner.sh
+      env:
+      - name: LATEST_TXT
+        value: latest-1.32.txt
+      - name: CI_URL
+        value: https://dl.k8s.io/ci
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-1.32
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o, sig-release-1.32-informing
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  extra_refs:
+  - base_ref: release-1.32
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+    workdir: true
+  - base_ref: master
+    org: kubernetes
+    path_alias: k8s.io/test-infra
+    repo: test-infra
+  interval: 24h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-node-e2e-crio-cgrpv1-dra-1-32
+  spec:
+    containers:
+    - args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-west1-b
+      - --parallelism=1
+      - '--label-filter=Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow'
+      - --timeout=60m
+      - --skip-regex=
+      - '--test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true" --runtime-config=api/beta=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-serial.yaml
+      command:
+      - runner.sh
+      env:
+      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+        value: "1"
+      - name: GOPATH
+        value: /go
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-1.32
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o, sig-release-1.32-informing
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  extra_refs:
+  - base_ref: release-1.32
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+    workdir: true
+  - base_ref: master
+    org: kubernetes
+    path_alias: k8s.io/test-infra
+    repo: test-infra
+  interval: 24h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-node-e2e-crio-cgrpv2-dra-1-32
+  spec:
+    containers:
+    - args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-west1-b
+      - --parallelism=1
+      - '--label-filter=Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow'
+      - --timeout=60m
+      - --skip-regex=
+      - '--test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true" --runtime-config=api/beta=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-serial.yaml
+      command:
+      - runner.sh
+      env:
+      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+        value: "1"
+      - name: GOPATH
+        value: /go
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-1.32
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-containerd, sig-release-1.32-informing
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  extra_refs:
+  - base_ref: release-1.32
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+    workdir: true
+  - base_ref: master
+    org: kubernetes
+    path_alias: k8s.io/test-infra
+    repo: test-infra
+  interval: 24h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-node-e2e-containerd-1-7-dra-1-32
+  spec:
+    containers:
+    - args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-west1-b
+      - --parallelism=1
+      - '--label-filter=Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow'
+      - --timeout=60m
+      - --skip-regex=
+      - '--test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true" --runtime-config=api/beta=true --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+      command:
+      - runner.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-1.32
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+postsubmits: {}
+presubmits: {}


### PR DESCRIPTION
The initial commits prepare the job config for forking. The last commit contains the forked jobs.

Core DRA is beta in 1.32 and became release informing shortly after the release. The same scrutiny makes sense also for future patch releases of 1.32.

/assign @bart0sh 