### PR TITLE
'Feature: isSubsetOf {Alpha, Beta}' does not filter Alpha/Beta test cases correctly in kubernetes-kind.yaml

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -311,7 +311,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/alpha":"true", "api/ga":"true"}'
         - name: LABEL_FILTER
-          value: "!Slow && !Disruptive && !Flaky && Feature: isSubsetOf Alpha"
+          value: "!Slow && !Disruptive && !Flaky && Feature: containsAny Alpha"
         - name: SKIP
           value: PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
         - name: PARALLEL
@@ -359,7 +359,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/beta":"true", "api/ga":"true"}'
         - name: LABEL_FILTER
-          value: "!Slow && !Disruptive && !Flaky && Feature: isSubsetOf Beta"
+          value: "!Slow && !Disruptive && !Flaky && Feature: containsAny Beta"
         - name: SKIP
           value: PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
         - name: PARALLEL
@@ -408,7 +408,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/all":"true"}'
         - name: LABEL_FILTER
-          value: "!Slow && !Disruptive && !Flaky && Feature: isSubsetOf { Alpha, Beta }"
+          value: "!Slow && !Disruptive && !Flaky && Feature: containsAny { Alpha, Beta }"
         - name: SKIP
           value: PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
         - name: PARALLEL
@@ -509,7 +509,7 @@ periodics:
       - name: RUNTIME_CONFIG
         value: '{"api/alpha":"true", "api/ga":"true"}'
       - name: LABEL_FILTER
-        value: "!Slow && !Disruptive && !Flaky && Feature: isSubsetOf Alpha"
+        value: "!Slow && !Disruptive && !Flaky && Feature: containsAny Alpha"
       - name: SKIP
         value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
       - name: PARALLEL
@@ -561,7 +561,7 @@ periodics:
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       - name: LABEL_FILTER
-        value: "!Slow && !Disruptive && !Flaky && Feature: isSubsetOf { Beta }"
+        value: "!Slow && !Disruptive && !Flaky && Feature: containsAny { Beta }"
       - name: SKIP
         value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
       - name: PARALLEL
@@ -613,7 +613,7 @@ periodics:
       - name: RUNTIME_CONFIG
         value: '{"api/all":"true"}'
       - name: LABEL_FILTER
-        value: "!Slow && !Disruptive && !Flaky && Feature: isSubsetOf { Alpha, Beta }"
+        value: "!Slow && !Disruptive && !Flaky && Feature: containsAny { Alpha, Beta }"
       - name: SKIP
         value: PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
       - name: PARALLEL


### PR DESCRIPTION
In my PR (https://github.com/kubernetes/kubernetes/pull/130210), I face that [my e2e test cases](https://github.com/kubernetes/kubernetes/blob/74c7c7ab4dade1d5e30333573cf49ec18154f1e1/test/e2e/common/node/security_context.go#L642-L644) are strangely skipped in [pull-kubernetes-e2e-kind-alpha-beta-features](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/130210/pull-kubernetes-e2e-kind-alpha-beta-features/1891853902811238400) even though those are marked with ginkgo label `[Feature:Beta]`.

The [affected test cases](https://github.com/kubernetes/kubernetes/blob/74c7c7ab4dade1d5e30333573cf49ec18154f1e1/test/e2e/common/node/security_context.go#L642-L644
) are:
```golang
// this generates ginkgo labels:
//   [Feature:SupplementalGroupsPolicy] [FeatureGate:SupplementalGroupsPolicy] [Feature:Beta]
f.Context("SupplementalGroupsPolicy [LinuxOnly]", feature.SupplementalGroupsPolicy, framework.WithFeatureGate(features.SupplementalGroupsPolicy), func() {
```

After my survey, according to [the official docs](https://onsi.github.io/ginkgo/#label-sets), the [specified ginkgo label filter `Feature: isSubsetOf {Alpha,Beta}`](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml#L411) does not match ginkgo label set `[Feature:SupplementalGroupsPolicy] [Feature:Beta]`. It is because `Feature`'s label set value is `{SupplementalGroupsPolicy, Beta}` that is NOT a subset of {Alpha, Beta}`.

I think the filter was expected to be `Feature: containsAny {Alpha,Beta}`

This PR replaces only below cases in kubernetes-kind.yaml
- `Feature: isSubsetOf Alpha` ==> `Feature: containsAny Alpha`
- `Feature: isSubsetOf Beta` ==> `Feature: containsAny Beta`
- `Feature: isSubsetOf {Beta}` ==> `Feature: containsAny {Beta}`
- `Feature: isSubsetOf {Alpha,Beta}` ==> `Feature: containsAny {Alpha,Beta}`