### PR TITLE
Remove the command of downloading kind binary

### DIFF
--- a/config/jobs/etcd/etcd-operator-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-postsubmits.yaml
@@ -47,8 +47,6 @@ postsubmits:
         - bash
         - -c
         - |
-          # We can't remove the line below for now, because the e2e test needs the kind binary present
-          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           make test-e2e
         # docker-in-docker needs privileged mode
         securityContext:

--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -49,8 +49,6 @@ presubmits:
         - bash
         - -c
         - |
-          # We can't remove the line below for now, because the e2e test needs the kind binary present
-          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           make test-e2e
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/34332

With the merge of https://github.com/etcd-io/etcd-operator/pull/76, we don't need to download the kind binary anymore.

cc @ivanvc 