### PR TITLE
replace crio hugepages jobs with kubetest2

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1801,61 +1801,6 @@ presubmits:
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
   - name: pull-crio-cgroupv1-node-e2e-hugepages
     cluster: k8s-infra-prow-build
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    annotations:
-      testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-kubelet-crio-cgroupv1-node-e2e-hugepages
-    always_run: false
-    optional: true
-    skip_report: false
-    skip_branches:
-      - release-\d+\.\d+  # per-release image
-    decorate: true
-    decoration_config:
-      timeout: 240m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
-      path_alias: k8s.io/release
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-        command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-        args:
-          - --deployment=node
-          - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-west1-b
-          - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-          - --node-tests=true
-          - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Feature:HugePages\]"
-          - --timeout=90m
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-hugepages.yaml
-        env:
-          - name: GOPATH
-            value: /go
-          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-            value: "1"
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
-  - name: pull-crio-cgroupv1-node-e2e-hugepages-kubetest2
-    cluster: k8s-infra-prow-build
-    # explicitly needs /test pull-crio-cgroupv1-node-e2e-hugepages-kubetest2 to run
     always_run: false
     optional: true
     skip_report: false
@@ -1881,7 +1826,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-kubelet-crio-cgroupv1-node-e2e-hugepages-kubetest2
+      testgrid-tab-name: pr-kubelet-crio-cgroupv1-node-e2e-hugepages
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
@@ -1915,61 +1860,6 @@ presubmits:
             value: "1"
   - name: pull-crio-cgroupv2-node-e2e-hugepages
     cluster: k8s-infra-prow-build
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    annotations:
-      testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-kubelet-crio-cgroupv2-node-e2e-hugepages
-    always_run: false
-    optional: true
-    skip_report: false
-    skip_branches:
-      - release-\d+\.\d+  # per-release image
-    decorate: true
-    decoration_config:
-      timeout: 240m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
-      path_alias: k8s.io/release
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-        command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-        args:
-          - --deployment=node
-          - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-west1-b
-          - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-          - --node-tests=true
-          - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Feature:HugePages\]"
-          - --timeout=90m
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-hugepages.yaml
-        env:
-          - name: GOPATH
-            value: /go
-          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-            value: "1"
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
-  - name: pull-crio-cgroupv2-node-e2e-hugepages-kubetest2
-    cluster: k8s-infra-prow-build
-    # explicitly needs /test pull-crio-cgroupv2-node-e2e-hugepages-kubetest2 to run
     always_run: false
     optional: true
     skip_report: false
@@ -1995,7 +1885,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-kubelet-crio-cgroupv2-node-e2e-hugepages-kubetest2
+      testgrid-tab-name: pr-kubelet-crio-cgroupv2-node-e2e-hugepages
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master


### PR DESCRIPTION
The jobs worked just fine in my test PR, here are links to the test grid for both jobs:
- https://testgrid.k8s.io/sig-node-cri-o#pr-kubelet-crio-cgroupv1-node-e2e-hugepages-kubetest2
- https://testgrid.k8s.io/sig-node-cri-o#pr-kubelet-crio-cgroupv2-node-e2e-hugepages-kubetest2

Ref: https://github.com/kubernetes/test-infra/issues/32567

/sig-node
/cc @kannon92 @SergeyKanzhelev