### PR TITLE
etcd: set 60 minute timeout to e2e tests

### DIFF
--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -180,8 +180,6 @@ postsubmits:
     - main
     - release-3.6
     decorate: true
-    decoration_config:
-      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: post-etcd-e2e-amd64
@@ -196,7 +194,7 @@ postsubmits:
         - |
           set -euo pipefail
           make gofail-enable
-          VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
         resources:
           requests:
             cpu: "4"
@@ -211,8 +209,6 @@ postsubmits:
     - main
     - release-3.6
     decorate: true
-    decoration_config:
-      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: post-etcd-e2e-arm64
@@ -226,7 +222,7 @@ postsubmits:
         - -c
         - |
           set -euo pipefail
-          VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
         resources:
           requests:
             cpu: "4"
@@ -243,8 +239,6 @@ postsubmits:
     - main
     - release-3.6
     decorate: true
-    decoration_config:
-      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: post-etcd-e2e-386
@@ -258,7 +252,7 @@ postsubmits:
         - -c
         - |
           set -euo pipefail
-          VERBOSE=1 GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true make test-e2e
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true make test-e2e
         resources:
           requests:
             cpu: "4"

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -188,8 +188,6 @@ presubmits:
     - main
     - release-3.6
     decorate: true
-    decoration_config:
-      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: pull-etcd-e2e-amd64
@@ -204,7 +202,7 @@ presubmits:
         - |
           set -euo pipefail
           make gofail-enable
-          VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
         resources:
           requests:
             cpu: "4"
@@ -220,8 +218,6 @@ presubmits:
     - main
     - release-3.6
     decorate: true
-    decoration_config:
-      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: pull-etcd-e2e-386
@@ -235,7 +231,7 @@ presubmits:
         - -c
         - |
           set -euo pipefail
-          VERBOSE=1 GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true make test-e2e
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true make test-e2e
         resources:
           requests:
             cpu: "4"
@@ -251,8 +247,6 @@ presubmits:
     - main
     - release-3.6
     decorate: true
-    decoration_config:
-      timeout: 60m
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: pull-etcd-e2e-arm64
@@ -266,7 +260,7 @@ presubmits:
         - -c
         - |
           set -euo pipefail
-          VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
Set the `TIMEOUT` environment variable so the tests run with the same timeout defined in the prow job.

/cc @ahrtr 