### PR TITLE
Increase memory limit for PDCSI container

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -23,10 +23,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: "8Gi"
+            memory: "10Gi"
           requests:
             cpu: 2
-            memory: "8Gi"
+            memory: "10Gi"
     annotations:
       testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
       testgrid-tab-name: presubmit-gcp-compute-persistent-disk-csi-driver-e2e


### PR DESCRIPTION
E2E tests are expanded to add more instances and test cases which is causing E2E failures due to OOM
![image](https://github.com/user-attachments/assets/31270b82-c719-4110-ab88-6cc958647d15)


Test failure [link]( https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_gcp-compute-persistent-disk-csi-driver/1932/pull-gcp-compute-persistent-disk-csi-driver-e2e/1891917919453974528)