### PR TITLE
Fix path bug in SIG Scalability Azure 100 node perf test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
@@ -16,6 +16,10 @@ periodics:
       preset-azure-community: "true"
     extra_refs:
     - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: main
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    - org: kubernetes-sigs
       repo: cloud-provider-azure
       base_ref: master
       path_alias: sigs.k8s.io/cloud-provider-azure
@@ -38,6 +42,7 @@ periodics:
         - bash
         - -c
         - >-
+          sleep 300 &&
           cd ${GOPATH}/src/k8s.io/perf-tests/ &&
           ./run-e2e.sh cluster-loader2
           --nodes=100 \


### PR DESCRIPTION
Forgot to clone CAPZ repo in the job, causing a file not found error.