### PR TITLE
fix branch selection pattern

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.1.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.1
+      - ^release-0.1$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -36,7 +36,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.1
+      - ^release-0.1$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -62,7 +62,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.1
+      - ^release-0.1$
     optional: false
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
@@ -86,7 +86,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.1
+      - ^release-0.1$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.2.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.2
+      - ^release-0.2$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -36,7 +36,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.2
+      - ^release-0.2$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -62,7 +62,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.2
+      - ^release-0.2$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -97,7 +97,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.2
+      - ^release-0.2$
     optional: false
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
@@ -121,7 +121,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.2
+      - ^release-0.2$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.3.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.3
+      - ^release-0.3$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -36,7 +36,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.3
+      - ^release-0.3$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -62,7 +62,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.3
+      - ^release-0.3$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -97,7 +97,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.3
+      - ^release-0.3$
     optional: false
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
@@ -121,7 +121,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.3
+      - ^release-0.3$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
@@ -151,7 +151,7 @@ presubmits:
       preset-service-account: "true"
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.3
+      - ^release-0.3$
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230901-e9e5d470a5-1.24

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.4.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.4.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.4
+      - ^release-0.4$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -36,7 +36,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.4
+      - ^release-0.4$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -62,7 +62,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.4
+      - ^release-0.4$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -97,7 +97,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.4
+      - ^release-0.4$
     optional: false
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
@@ -121,7 +121,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.4
+      - ^release-0.4$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
@@ -150,7 +150,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     branches:
-    - ^release-0.4
+    - ^release-0.4$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231113-7213ea5323-1.25

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.5.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.5
+      - ^release-0.5$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -36,7 +36,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.5
+      - ^release-0.5$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -62,7 +62,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.5
+      - ^release-0.5$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -97,7 +97,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.5
+      - ^release-0.5$
     optional: false
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
@@ -121,7 +121,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.5
+      - ^release-0.5$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
@@ -150,7 +150,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     branches:
-    - ^release-0.5
+    - ^release-0.5$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240405-68dde9badf-1.26

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.6.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.6
+      - ^release-0.6$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -36,7 +36,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.6
+      - ^release-0.6$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -62,7 +62,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.6
+      - ^release-0.6$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -97,7 +97,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.6
+      - ^release-0.6$
     optional: false
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
@@ -121,7 +121,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.6
+      - ^release-0.6$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
@@ -150,7 +150,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     branches:
-    - ^release-0.6
+    - ^release-0.6$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-1164926229-1.27

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.7.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.7
+      - ^release-0.7$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -36,7 +36,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.7
+      - ^release-0.7$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -62,7 +62,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.7
+      - ^release-0.7$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -97,7 +97,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.7
+      - ^release-0.7$
     optional: false
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
@@ -121,7 +121,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.7
+      - ^release-0.7$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
@@ -150,7 +150,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     branches:
-    - ^release-0.7
+    - ^release-0.7$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241125-b4ea3e27a6-1.28

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.8.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.8
+      - ^release-0.8$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -36,7 +36,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.8
+      - ^release-0.8$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -62,7 +62,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.8
+      - ^release-0.8$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -97,7 +97,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.8
+      - ^release-0.8$
     optional: false
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
@@ -121,7 +121,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.8
+      - ^release-0.8$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
@@ -150,7 +150,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     branches:
-    - ^release-0.8
+    - ^release-0.8$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-1.29

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.9.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presubmits-release-0.9.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.9
+      - ^release-0.9$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -36,7 +36,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.9
+      - ^release-0.9$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -62,7 +62,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.9
+      - ^release-0.9$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -97,7 +97,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.9
+      - ^release-0.9$
     optional: false
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
@@ -121,7 +121,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.9
+      - ^release-0.9$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
@@ -150,7 +150,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     branches:
-    - ^release-0.9
+    - ^release-0.9$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-1.30

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presumbits-release-0.10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-presumbits-release-0.10.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.10
+      - ^release-0.10$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -36,7 +36,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.10
+      - ^release-0.10$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -62,7 +62,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.10
+      - ^release-0.10$
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
     labels:
@@ -97,7 +97,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.10
+      - ^release-0.10$
     optional: false
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-ibmcloud
@@ -121,7 +121,7 @@ presubmits:
     always_run: true
     branches:
       # The script this job runs is not in all branches.
-      - ^release-0.10
+      - ^release-0.10$
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-ibmcloud"
@@ -150,7 +150,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     branches:
-    - ^release-0.10
+    - ^release-0.10$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-1.31


### PR DESCRIPTION
fix branch selection pattern

What is happening?
- After the release of v0.10.0 in CAPIBM, we added job configurations for it in test-infra. However, we noticed that the release-0.1 jobs are also being triggered for the release-0.10 branch. This issue occurs because the branch selection pattern for release-0.1 is set to `^release-0.1`, which also matches the release-0.10 string and triggers the checks.

What should happen?
- After fixing the pattern to `^release-0.1$`, we expect the jobs to be triggered only for the release-0.1 branch and not for release-0.10. This change will prevent incorrect checks from being triggered on incoming PRs in case of conflicts in patterns. Additionally, the pattern change will be propagated across all the different release branches to avoid future issues and conflicts.

ref - `release-0.1` job got triggered against PR on `release-0.10` branch
https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/2203