### PR TITLE
Remove kubelet feature gate KubeletPodResources

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/presets.yaml
@@ -30,8 +30,6 @@ presets:
     value: "true"
   - name: KUBERNETES_NODE_PLATFORM
     value: "windows"
-  - name: KUBELET_TEST_ARGS
-    value: "--feature-gates=KubeletPodResources=false"
   - name: USE_TEST_INFRA_LOG_DUMPING
     value: "true"
 - labels:


### PR DESCRIPTION
Followup of https://github.com/kubernetes/test-infra/pull/34338, the feature gate `KubeletPodResources` was removed in https://github.com/kubernetes/kubernetes/pull/122139 so I'm also removing it in the preset. This is causing the Kubelet to not start at all in the nodes in https://github.com/kubernetes-csi/csi-proxy/pull/369.

/sig windows node
/cc @jsturtevant 