### PR TITLE
remove recently deleted featuregates from test configs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1363,7 +1363,7 @@ def generate_misc():
                        "--set=spec.kubeAPIServer.runtimeConfig=api/all=true",
                        "--gce-service-account=default",
                    ],
-                   kubernetes_feature_gates="AllAlpha,DisableCloudProviders,DisableKubeletCloudCredentialProviders,-EventedPLEG",
+                   kubernetes_feature_gates="AllAlpha,-EventedPLEG",
                    focus_regex=r'\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking',
                    skip_regex=r'\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0',
                    test_timeout_minutes=240,

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -3479,7 +3479,7 @@ periodics:
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
           --create-args="--channel=alpha --networking=kubenet --image=cos-cloud/cos-105-17412-370-67 --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --set=spec.kubeAPIServer.runtimeConfig=api/all=true --gce-service-account=default" \
-          --kubernetes-feature-gates=AllAlpha,DisableCloudProviders,DisableKubeletCloudCredentialProviders,-EventedPLEG \
+          --kubernetes-feature-gates=AllAlpha,-EventedPLEG \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://storage.googleapis.com/k8s-release-dev/ci/latest.txt \
           --test=kops \

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -105,7 +105,7 @@ periodics:
             kubetest2 ec2 \
              --stage https://dl.k8s.io/ci/fast/ \
              --version $VERSION \
-             --feature-gates="AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false" \
+             --feature-gates="AllAlpha=true,EventedPLEG=false" \
              --runtime-config="api/all=true" \
              --external-cloud-provider true \
              --up \
@@ -171,7 +171,7 @@ periodics:
             kubetest2 ec2 \
              --stage https://dl.k8s.io/ci/fast/ \
              --version $VERSION \
-             --feature-gates="AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false" \
+             --feature-gates="AllAlpha=true,EventedPLEG=false" \
              --runtime-config="api/all=true" \
              --up \
              --down \

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -907,7 +907,7 @@ presubmits:
               kubetest2 ec2 \
                --stage https://dl.k8s.io/ci/fast/ \
                --version $VERSION \
-               --feature-gates="AllAlpha=true,DisableCloudProviders=true,DisableKubeletCloudCredentialProviders=true,EventedPLEG=false,StorageVersionAPI=true,APIServerIdentity=true" \
+               --feature-gates="AllAlpha=true,EventedPLEG=false,StorageVersionAPI=true,APIServerIdentity=true" \
                --runtime-config="api/all=true" \
                --up \
                --down \


### PR DESCRIPTION
k/k master recently got rid of the DisableCloudProviders, DisableKubeletCloudCredentialProviders feature gates. Remove them from job configs to fix the jobs.

k/k change that broke these: https://github.com/kubernetes/kubernetes/pull/130162

Fixes permafails in:
https://testgrid.k8s.io/amazon-ec2#ci-kubernetes-e2e-ec2-alpha-enabled-default
https://testgrid.k8s.io/amazon-ec2#ci-kubernetes-e2e-ec2-alpha-features
https://testgrid.k8s.io/kops-gce#ci-kubernetes-e2e-cos-gce-alpha-features
https://testgrid.k8s.io/sig-node-presubmits#pr-kubelet-gce-cluster-e2e-credential-provider