### PR TITLE
Replace CRI-O resource managers jobs with their kubetest2 variants

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1923,62 +1923,6 @@ presubmits:
     optional: true
     skip_report: false
     skip_branches:
-      - release-\d+\.\d+  # per-release image
-    annotations:
-      testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgroupv1-node-e2e-resource-managers
-      description: "Executes CPU, Memory and Topology manager e2e tests for crio"
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    decorate: true
-    decoration_config:
-      timeout: 240m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
-      path_alias: k8s.io/release
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-          command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-          args:
-            - --deployment=node
-            - --env=KUBE_SSH_USER=core
-            - --gcp-zone=us-west1-b
-            - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-            - --node-tests=true
-            - --provider=gce
-            - --test_args=--nodes=1 --focus="\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]"
-            - --timeout=90m
-            - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-resource-managers.yaml
-          env:
-          - name: GOPATH
-            value: /go
-          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-            value: "1"
-          resources:
-            limits:
-              cpu: 4
-              memory: 6Gi
-            requests:
-              cpu: 4
-              memory: 6Gi
-  - name: pull-crio-cgroupv1-node-e2e-resource-managers-kubetest2
-    cluster: k8s-infra-prow-build
-    # explicitly needs /test pull-crio-cgroupv1-node-e2e-resource-managers-kubetest2 to run
-    always_run: false
-    optional: true
-    skip_report: false
-    skip_branches:
     - release-\d+\.\d+  # per-release image
     decorate: true
     path_alias: k8s.io/kubernetes
@@ -2000,7 +1944,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgroupv1-node-e2e-resource-managers-kubetest2
+      testgrid-tab-name: pr-crio-cgroupv1-node-e2e-resource-managers
       description: "Executes CPU, Memory and Topology manager e2e tests for crio"
     spec:
       containers:
@@ -2039,62 +1983,6 @@ presubmits:
     optional: true
     skip_report: false
     skip_branches:
-      - release-\d+\.\d+  # per-release image
-    annotations:
-      testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgroupv2-node-e2e-resource-managers
-      description: "Executes CPU, Memory and Topology manager e2e tests for crio"
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    decorate: true
-    decoration_config:
-      timeout: 240m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
-      path_alias: k8s.io/release
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-          command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-          args:
-            - --deployment=node
-            - --env=KUBE_SSH_USER=core
-            - --gcp-zone=us-west1-b
-            - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-            - --node-tests=true
-            - --provider=gce
-            - --test_args=--nodes=1 --focus="\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]"
-            - --timeout=90m
-            - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-resource-managers.yaml
-          env:
-          - name: GOPATH
-            value: /go
-          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-            value: "1"
-          resources:
-            limits:
-              cpu: 4
-              memory: 6Gi
-            requests:
-              cpu: 4
-              memory: 6Gi
-  - name: pull-crio-cgroupv2-node-e2e-resource-managers-kubetest2
-    cluster: k8s-infra-prow-build
-    # explicitly needs /test pull-crio-cgroupv2-node-e2e-resource-managers-kubetest2 to run
-    always_run: false
-    optional: true
-    skip_report: false
-    skip_branches:
     - release-\d+\.\d+  # per-release image
     decorate: true
     path_alias: k8s.io/kubernetes
@@ -2116,7 +2004,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgroupv2-node-e2e-resource-managers-kubetest2
+      testgrid-tab-name: pr-crio-cgroupv2-node-e2e-resource-managers
       description: "Executes CPU, Memory and Topology manager e2e tests for crio"
     spec:
       containers:


### PR DESCRIPTION
Both jobs work the same as their old variants. They're failing 2 test cases, but [the fix](https://github.com/kubernetes/kubernetes/pull/130163) is underway. All 4 jobs have been [successfully tested](https://github.com/kubernetes/kubernetes/pull/130163#issuecomment-2671517684) in the fix PR.

Ref: https://github.com/kubernetes/test-infra/issues/32567

/sig-node
/cc @kannon92 @SergeyKanzhelev