### PR TITLE
Increase timeout of addon-resizer build job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
+++ b/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
@@ -5,6 +5,8 @@ postsubmits:
       annotations:
         testgrid-dashboards: sig-autoscaling-addon-resizer, sig-k8s-infra-gcb
       decorate: true
+      decoration_config:
+        timeout: 180m
       branches:
         - ^addon-resizer-release-1.8$
       spec:


### PR DESCRIPTION
The current addon-resizer build job is taking just over 2 hours to complete (this is a slow process due to it building 5 different images) which is much slower in a Cloud Build environment than locally.

The [default timeout is 2 hours](https://github.com/kubernetes-sigs/prow/blob/e8fa16f56508b4209238eb956d0d02143dd0d56b/pkg/entrypoint/run.go#L58).

Looking to override this to 3 hours to give the job enough time to finish.

See https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-autoscaler-push-addon-resizer-images/1892289674458697728 for a recent failure.

This work is part of the onboarding of this repo into automatic builds, see https://github.com/kubernetes/autoscaler/issues/7615.