### PR TITLE
etcd: upload coverage report even with failures

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -856,7 +856,10 @@ presubmits:
           - bash
           - -c
           - |
+            return_code=0
+            make test-coverage || return_code=$?
             make upload-coverage-report
+            exit $return_code
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
Restore the previous behavior. Always upload the coverage results even if the tests have failures.

I found this while working on https://github.com/etcd-io/etcd/pull/19424, and by the workflow failure on etcd-io/etcd#19450.

/cc @jmhbnz 