### PR TITLE
replace eventedpleg crio job with kubetest2 variant

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1415,57 +1415,7 @@ presubmits:
             value: "1"
   - name: pull-kubernetes-node-crio-cgrpv1-evented-pleg-e2e
     cluster: k8s-infra-prow-build
-    skip_branches:
-      - release-\d+\.\d+  # per-release image
-    annotations:
-      testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgrpv1-evented-pleg-gce-e2e
-    always_run: false
-    optional: true
-    max_concurrency: 12
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
-    decorate: true
-    decoration_config:
-      timeout: 240m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-          command:
-            - runner.sh
-            - /workspace/scenarios/kubernetes_e2e.py
-          args:
-            - --deployment=node
-            - --env=KUBE_SSH_USER=core
-            - --gcp-zone=us-west1-b
-            - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --feature-gates=EventedPLEG=true --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-            - --node-tests=true
-            - --provider=gce
-            - --test_args=--nodes=8 --focus="\[NodeConformance\]|\[Feature:.+\]|\[Feature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport\]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]"
-            - --timeout=180m
-            - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-evented-pleg.yaml
-          resources:
-            limits:
-              cpu: 4
-              memory: 6Gi
-            requests:
-              cpu: 4
-              memory: 6Gi
-          env:
-            - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-              value: "1"
-  - name: pull-kubernetes-node-crio-cgrpv1-evented-pleg-e2e-kubetest2
-    cluster: k8s-infra-prow-build
-    # explicitly needs /test pull-kubernetes-node-crio-cgrpv1-evented-pleg-e2e-kubetest2 to run
+    # explicitly needs /test pull-kubernetes-node-crio-cgrpv1-evented-pleg-e2e to run
     always_run: false
     optional: true
     skip_branches:
@@ -1486,7 +1436,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgrpv1-evented-pleg-gce-e2e-kubetest2
+      testgrid-tab-name: pr-crio-cgrpv1-evented-pleg-gce-e2e
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master


### PR DESCRIPTION
runs from feb 13th, [kubetest2](https://testgrid.k8s.io/sig-node-cri-o#pr-crio-cgrpv1-evented-pleg-gce-e2e-kubetest2) variant seem to behave as the [original](https://testgrid.k8s.io/sig-node-cri-o#pr-crio-cgrpv1-evented-pleg-gce-e2e) one.

NOTE: https://github.com/kubernetes/kubernetes/pull/127865 seem to solve current broken runs.

ref: https://github.com/kubernetes/test-infra/issues/32567
cc: @bart0sh @kannon92 