### PR TITLE
Drop kops 1.29 grid jobs, add kops 1.31

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -442,16 +442,16 @@ distro_options = [
 ]
 
 k8s_versions = [
-    "1.28",
     "1.29",
     "1.30",
     "1.31",
+    "1.32",
 ]
 
 kops_versions = [
     None, # maps to latest
-    "1.29",
     "1.30",
+    "1.31",
 ]
 
 

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -2,195 +2,6 @@
 # 331 jobs, total of 975 runs per week
 periodics:
 
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-al2023-k28
-  cron: '49 7 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-al2023-k28
-
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-al2023-k28-ko29
-  cron: '7 23 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-al2023-k28-ko29
-
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-al2023-k28-ko30
-  cron: '42 10 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-al2023-k28-ko30
-
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-al2023-k29
   cron: '11 17 * * 3'
@@ -254,69 +65,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k29
 
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-al2023-k29-ko29
-  cron: '34 18 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-al2023-k29-ko29
-
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-al2023-k29-ko30
   cron: '15 7 * * 4'
@@ -379,6 +127,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k29-ko30
+
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k29-ko31
+  cron: '1 17 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-al2023-k29-ko31
 
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-al2023-k30
@@ -506,6 +317,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k30-ko30
 
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k30-ko31
+  cron: '25 5 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-al2023-k30-ko31
+
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-al2023-k31
   cron: '16 2 * * 0'
@@ -569,9 +443,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-al2023-k31
 
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb12-k28
-  cron: '20 22 * * 6'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k31-ko31
+  cron: '0 0 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -599,19 +473,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: admin
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -623,140 +497,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-al2023-k31-ko31
+
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-al2023-k32
+  cron: '2 8 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb12-k28
-
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb12-k28-ko29
-  cron: '48 15 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb12-k28-ko29
-
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb12-k28-ko30
-  cron: '41 18 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb12-k28-ko30
+    testgrid-tab-name: kops-grid-kubenet-al2023-k32
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-deb12-k29
@@ -821,69 +632,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k29
 
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-deb12-k29-ko29
-  cron: '57 18 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-deb12-k29-ko29
-
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-deb12-k29-ko30
   cron: '44 23 * * 5'
@@ -946,6 +694,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k29-ko30
+
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k29-ko31
+  cron: '58 17 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-deb12-k29-ko31
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-deb12-k30
@@ -1073,6 +884,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k30-ko30
 
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k30-ko31
+  cron: '2 21 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-deb12-k30-ko31
+
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-deb12-k31
   cron: '49 19 * * 4'
@@ -1136,9 +1010,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-deb12-k31
 
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-flatcar-k28
-  cron: '25 9 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k31-ko31
+  cron: '59 0 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -1166,20 +1040,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: core
+        value: admin
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -1191,142 +1064,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-deb12-k31-ko31
+
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-deb12-k32
+  cron: '39 9 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-flatcar-k28
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-flatcar-k28-ko29
-  cron: '6 17 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-flatcar-k28-ko29
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-flatcar-k28-ko30
-  cron: '19 4 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.30, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-flatcar-k28-ko30
+    testgrid-tab-name: kops-grid-kubenet-deb12-k32
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-flatcar-k29
@@ -1392,70 +1200,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k29
 
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-flatcar-k29-ko29
-  cron: '7 20 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-flatcar-k29-ko29
-
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-flatcar-k29-ko30
   cron: '34 17 * * 1'
@@ -1519,6 +1263,70 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k29-ko30
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-flatcar-k29-ko31
+  cron: '28 7 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-flatcar-k29-ko31
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-flatcar-k30
@@ -1648,6 +1456,70 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k30-ko30
 
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-flatcar-k30-ko31
+  cron: '36 11 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-flatcar-k30-ko31
+
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-flatcar-k31
   cron: '20 4 * * 1'
@@ -1712,9 +1584,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-flatcar-k31
 
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-rhel8-k28
-  cron: '28 10 * * 5'
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-flatcar-k31-ko31
+  cron: '21 14 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -1742,19 +1614,20 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ec2-user
+        value: core
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -1766,140 +1639,78 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-flatcar-k31-ko31
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-flatcar-k32
+  cron: '50 22 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-rhel8-k28
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-rhel8-k28-ko29
-  cron: '49 6 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-rhel8-k28-ko29
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-rhel8-k28-ko30
-  cron: '0 3 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-rhel8-k28-ko30
+    testgrid-tab-name: kops-grid-kubenet-flatcar-k32
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-rhel8-k29
@@ -1964,69 +1775,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k29
 
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-rhel8-k29-ko29
-  cron: '52 19 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-rhel8-k29-ko29
-
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-rhel8-k29-ko30
   cron: '5 22 * * 1'
@@ -2089,6 +1837,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k29-ko30
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-rhel8-k29-ko31
+  cron: '15 16 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-rhel8-k29-ko31
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-rhel8-k30
@@ -2216,6 +2027,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k30-ko30
 
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-rhel8-k30-ko31
+  cron: '51 12 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-rhel8-k30-ko31
+
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-rhel8-k31
   cron: '45 7 * * 1'
@@ -2279,9 +2153,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-rhel8-k31
 
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-u2004-k28
-  cron: '42 8 * * *'
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-rhel8-k31-ko31
+  cron: '42 1 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -2309,19 +2183,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -2333,140 +2207,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-rhel8-k31-ko31
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-rhel8-k32
+  cron: '15 21 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-u2004-k28
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-u2004-k28-ko29
-  cron: '59 16 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-u2004-k28-ko29
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-u2004-k28-ko30
-  cron: '2 21 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-u2004-k28-ko30
+    testgrid-tab-name: kops-grid-kubenet-rhel8-k32
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-u2004-k29
@@ -2531,69 +2342,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k29
 
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-u2004-k29-ko29
-  cron: '26 13 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-u2004-k29-ko29
-
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-u2004-k29-ko30
   cron: '31 0 * * *'
@@ -2656,6 +2404,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k29-ko30
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-u2004-k29-ko31
+  cron: '57 22 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-u2004-k29-ko31
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-u2004-k30
@@ -2783,6 +2594,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k30-ko30
 
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-u2004-k30-ko31
+  cron: '57 2 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-u2004-k30-ko31
+
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-u2004-k31
   cron: '27 5 * * *'
@@ -2846,9 +2720,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2004-k31
 
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-u2204-k28
-  cron: '23 9 * * 4'
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-u2004-k31-ko31
+  cron: '8 15 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -2876,13 +2750,13 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
@@ -2900,140 +2774,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-u2004-k31-ko31
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-u2004-k32
+  cron: '5 23 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-u2204-k28
-
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-u2204-k28-ko29
-  cron: '24 23 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-u2204-k28-ko29
-
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-u2204-k28-ko30
-  cron: '57 2 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-u2204-k28-ko30
+    testgrid-tab-name: kops-grid-kubenet-u2004-k32
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-u2204-k29
@@ -3098,69 +2909,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k29
 
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kubenet"}
-- name: e2e-kops-grid-kubenet-u2204-k29-ko29
-  cron: '21 10 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kubenet" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kubenet-u2204-k29-ko29
-
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-u2204-k29-ko30
   cron: '24 7 * * 3'
@@ -3223,6 +2971,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k29-ko30
+
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-u2204-k29-ko31
+  cron: '2 17 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-u2204-k29-ko31
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-u2204-k30
@@ -3350,6 +3161,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k30-ko30
 
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-u2204-k30-ko31
+  cron: '18 13 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-u2204-k30-ko31
+
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-kubenet-u2204-k31
   cron: '34 4 * * 2'
@@ -3413,9 +3287,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kubenet-u2204-k31
 
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-al2023-k28
-  cron: '28 14 * * 0'
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-u2204-k31-ko31
+  cron: '11 8 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -3443,19 +3317,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ec2-user
+        value: ubuntu
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -3467,140 +3341,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kubenet-u2204-k31-ko31
+
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-kubenet-u2204-k32
+  cron: '0 14 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kubenet" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-al2023-k28
-
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-al2023-k28-ko29
-  cron: '9 10 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-al2023-k28-ko29
-
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
-- name: e2e-kops-grid-calico-al2023-k28-ko30
-  cron: '32 7 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-al2023-k28-ko30
+    testgrid-tab-name: kops-grid-kubenet-u2204-k32
 
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-al2023-k29
@@ -3665,69 +3476,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k29
 
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-al2023-k29-ko29
-  cron: '0 7 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-al2023-k29-ko29
-
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
 - name: e2e-kops-grid-calico-al2023-k29-ko30
   cron: '25 10 * * 0'
@@ -3790,6 +3538,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k29-ko30
+
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k29-ko31
+  cron: '59 4 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-al2023-k29-ko31
 
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-al2023-k30
@@ -3917,6 +3728,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k30-ko30
 
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k30-ko31
+  cron: '55 8 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-al2023-k30-ko31
+
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-al2023-k31
   cron: '1 11 * * 6'
@@ -3980,9 +3854,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-al2023-k31
 
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb12-k28
-  cron: '47 9 * * 5'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k31-ko31
+  cron: '30 21 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4010,19 +3884,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: admin
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -4034,140 +3908,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-al2023-k31-ko31
+
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-al2023-k32
+  cron: '19 1 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb12-k28
-
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb12-k28-ko29
-  cron: '47 12 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb12-k28-ko29
-
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb12-k28-ko30
-  cron: '10 9 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb12-k28-ko30
+    testgrid-tab-name: kops-grid-calico-al2023-k32
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb12-k29
@@ -4232,69 +4043,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k29
 
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb12-k29-ko29
-  cron: '2 17 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-deb12-k29-ko29
-
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb12-k29-ko30
   cron: '27 20 * * 5'
@@ -4357,6 +4105,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k29-ko30
+
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k29-ko31
+  cron: '1 2 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb12-k29-ko31
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb12-k30
@@ -4484,6 +4295,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k30-ko30
 
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k30-ko31
+  cron: '25 6 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb12-k30-ko31
+
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb12-k31
   cron: '2 12 * * 3'
@@ -4547,9 +4421,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-deb12-k31
 
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k28
-  cron: '48 10 * * 0'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k31-ko31
+  cron: '24 19 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -4577,20 +4451,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: core
+        value: admin
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -4602,142 +4475,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-deb12-k31-ko31
+
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb12-k32
+  cron: '0 14 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k28
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k28-ko29
-  cron: '50 22 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k28-ko29
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k28-ko30
-  cron: '31 19 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.30, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k28-ko30
+    testgrid-tab-name: kops-grid-calico-deb12-k32
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k29
@@ -4803,70 +4611,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k29
 
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k29-ko29
-  cron: '35 3 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-flatcar-k29-ko29
-
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k29-ko30
   cron: '22 6 * * 4'
@@ -4930,6 +4674,70 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k29-ko30
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k29-ko31
+  cron: '28 16 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k29-ko31
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k30
@@ -5059,6 +4867,70 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k30-ko30
 
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k30-ko31
+  cron: '32 4 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k30-ko31
+
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k31
   cron: '21 15 * * 4'
@@ -5123,9 +4995,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-flatcar-k31
 
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k28
-  cron: '51 21 * * 3'
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k31-ko31
+  cron: '29 17 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -5153,19 +5025,20 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ec2-user
+        value: core
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -5177,140 +5050,78 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-flatcar-k31-ko31
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k32
+  cron: '59 21 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k28
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k28-ko29
-  cron: '34 13 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k28-ko29
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k28-ko30
-  cron: '3 16 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k28-ko30
+    testgrid-tab-name: kops-grid-calico-flatcar-k32
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k29
@@ -5375,69 +5186,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k29
 
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k29-ko29
-  cron: '27 0 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-rhel8-k29-ko29
-
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k29-ko30
   cron: '58 13 * * 3'
@@ -5500,6 +5248,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k29-ko30
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k29-ko31
+  cron: '8 11 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k29-ko31
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k30
@@ -5627,6 +5438,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k30-ko30
 
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k30-ko31
+  cron: '32 7 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k30-ko31
+
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k31
   cron: '14 8 * * 1'
@@ -5690,9 +5564,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-rhel8-k31
 
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k28
-  cron: '53 23 * * *'
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k31-ko31
+  cron: '5 2 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -5720,19 +5594,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -5744,140 +5618,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-rhel8-k31-ko31
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k32
+  cron: '4 2 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k28
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k28-ko29
-  cron: '40 3 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k28-ko29
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k28-ko30
-  cron: '49 6 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k28-ko30
+    testgrid-tab-name: kops-grid-calico-rhel8-k32
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k29
@@ -5942,69 +5753,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k29
 
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k29-ko29
-  cron: '45 14 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2004-k29-ko29
-
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k29-ko30
   cron: '52 3 * * *'
@@ -6067,6 +5815,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k29-ko30
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k29-ko31
+  cron: '6 21 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k29-ko31
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k30
@@ -6194,6 +6005,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k30-ko30
 
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k30-ko31
+  cron: '2 17 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k30-ko31
+
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k31
   cron: '36 2 * * *'
@@ -6257,9 +6131,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2004-k31
 
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k28
-  cron: '12 22 * * 3'
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k31-ko31
+  cron: '55 12 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -6287,13 +6161,13 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
@@ -6311,140 +6185,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2004-k31-ko31
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k32
+  cron: '6 8 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k28
-
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k28-ko29
-  cron: '43 12 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k28-ko29
-
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k28-ko30
-  cron: '26 17 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k28-ko30
+    testgrid-tab-name: kops-grid-calico-u2004-k32
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2204-k29
@@ -6509,69 +6320,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k29
 
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2204-k29-ko29
-  cron: '22 9 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=calico" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-calico-u2204-k29-ko29
-
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2204-k29-ko30
   cron: '35 20 * * 3'
@@ -6634,6 +6382,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k29-ko30
+
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k29-ko31
+  cron: '1 18 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k29-ko31
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2204-k30
@@ -6761,6 +6572,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k30-ko30
 
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k30-ko31
+  cron: '49 22 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k30-ko31
+
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2204-k31
   cron: '57 19 * * 6'
@@ -6824,9 +6698,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-calico-u2204-k31
 
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-al2023-k28
-  cron: '47 9 * * 4'
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k31-ko31
+  cron: '0 3 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -6854,19 +6728,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ec2-user
+        value: ubuntu
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -6878,140 +6752,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-calico-u2204-k31-ko31
+
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2204-k32
+  cron: '7 9 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=calico" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-al2023-k28
-
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-al2023-k28-ko29
-  cron: '37 22 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-al2023-k28-ko29
-
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-al2023-k28-ko30
-  cron: '28 19 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-al2023-k28-ko30
+    testgrid-tab-name: kops-grid-calico-u2204-k32
 
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-al2023-k29
@@ -7076,69 +6887,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k29
 
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-al2023-k29-ko29
-  cron: '28 3 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-al2023-k29-ko29
-
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-al2023-k29-ko30
   cron: '49 6 * * 0'
@@ -7201,6 +6949,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k29-ko30
+
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k29-ko31
+  cron: '11 16 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-al2023-k29-ko31
 
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-al2023-k30
@@ -7328,6 +7139,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k30-ko30
 
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k30-ko31
+  cron: '15 4 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-al2023-k30-ko31
+
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-al2023-k31
   cron: '50 4 * * 5'
@@ -7391,9 +7265,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-al2023-k31
 
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb12-k28
-  cron: '21 19 * * 2'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k31-ko31
+  cron: '50 17 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -7421,19 +7295,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: admin
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -7445,140 +7319,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-al2023-k31-ko31
+
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-al2023-k32
+  cron: '24 6 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb12-k28
-
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb12-k28-ko29
-  cron: '55 8 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb12-k28-ko29
-
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb12-k28-ko30
-  cron: '54 21 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb12-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-al2023-k32
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb12-k29
@@ -7643,69 +7454,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k29
 
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb12-k29-ko29
-  cron: '54 21 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-deb12-k29-ko29
-
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb12-k29-ko30
   cron: '27 0 * * 3'
@@ -7768,6 +7516,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k29-ko30
+
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k29-ko31
+  cron: '45 22 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb12-k29-ko31
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb12-k30
@@ -7895,6 +7706,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k30-ko30
 
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k30-ko31
+  cron: '29 18 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb12-k30-ko31
+
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb12-k31
   cron: '32 6 * * 1'
@@ -7958,9 +7832,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-deb12-k31
 
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k28
-  cron: '51 13 * * 0'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k31-ko31
+  cron: '20 7 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -7988,20 +7862,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: core
+        value: admin
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -8013,142 +7886,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-deb12-k31-ko31
+
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb12-k32
+  cron: '50 20 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k28
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k28-ko29
-  cron: '40 4 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k28-ko29
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k28-ko30
-  cron: '53 17 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.30, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-deb12-k32
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k29
@@ -8214,70 +8022,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k29
 
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k29-ko29
-  cron: '33 17 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-flatcar-k29-ko29
-
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k29-ko30
   cron: '28 20 * * 2'
@@ -8341,6 +8085,70 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k29-ko30
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k29-ko31
+  cron: '10 10 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k29-ko31
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k30
@@ -8470,6 +8278,70 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k30-ko30
 
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k30-ko31
+  cron: '46 14 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k30-ko31
+
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k31
   cron: '10 0 * * 0'
@@ -8534,9 +8406,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-flatcar-k31
 
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k28
-  cron: '5 15 * * 2'
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k31-ko31
+  cron: '27 19 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -8564,19 +8436,20 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ec2-user
+        value: core
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -8588,140 +8461,78 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-flatcar-k31-ko31
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k32
+  cron: '56 18 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k28
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k28-ko29
-  cron: '34 1 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k28-ko29
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k28-ko30
-  cron: '31 20 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-flatcar-k32
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k29
@@ -8786,69 +8597,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k29
 
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k29-ko29
-  cron: '11 12 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-rhel8-k29-ko29
-
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k29-ko30
   cron: '2 17 * * 4'
@@ -8911,6 +8659,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k29-ko30
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k29-ko31
+  cron: '48 23 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k29-ko31
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k30
@@ -9038,6 +8849,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k30-ko30
 
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k30-ko31
+  cron: '44 11 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k30-ko31
+
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k31
   cron: '44 10 * * 5'
@@ -9101,9 +8975,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-rhel8-k31
 
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k28
-  cron: '51 13 * * *'
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k31-ko31
+  cron: '37 22 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9131,19 +9005,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -9155,140 +9029,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-rhel8-k31-ko31
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k32
+  cron: '18 16 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k28
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k28-ko29
-  cron: '16 15 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k28-ko29
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k28-ko30
-  cron: '1 10 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-rhel8-k32
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k29
@@ -9353,69 +9164,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k29
 
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k29-ko29
-  cron: '25 10 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2004-k29-ko29
-
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k29-ko30
   cron: '40 23 * * *'
@@ -9478,6 +9226,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k29-ko30
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k29-ko31
+  cron: '18 1 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k29-ko31
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k30
@@ -9605,6 +9416,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k30-ko30
 
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k30-ko31
+  cron: '42 5 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k30-ko31
+
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k31
   cron: '46 16 * * *'
@@ -9668,9 +9542,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2004-k31
 
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2204-k28
-  cron: '46 12 * * 0'
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k31-ko31
+  cron: '31 8 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -9698,13 +9572,13 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
@@ -9722,140 +9596,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2004-k31-ko31
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k32
+  cron: '24 2 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2204-k28
-
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2204-k28-ko29
-  cron: '27 0 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2204-k28-ko29
-
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2204-k28-ko30
-  cron: '46 13 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2204-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-u2004-k32
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2204-k29
@@ -9920,69 +9731,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k29
 
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2204-k29-ko29
-  cron: '22 13 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-u2204-k29-ko29
-
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2204-k29-ko30
   cron: '15 0 * * 3'
@@ -10045,6 +9793,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k29-ko30
+
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2204-k29-ko31
+  cron: '41 22 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2204-k29-ko31
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2204-k30
@@ -10172,6 +9983,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k30-ko30
 
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2204-k30-ko31
+  cron: '37 18 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2204-k30-ko31
+
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2204-k31
   cron: '11 1 * * 0'
@@ -10235,9 +10109,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-u2204-k31
 
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-al2023-k28
-  cron: '53 14 * * 4'
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2204-k31-ko31
+  cron: '56 23 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -10265,19 +10139,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ec2-user
+        value: ubuntu
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -10289,140 +10163,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-u2204-k31-ko31
+
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2204-k32
+  cron: '9 11 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k28
-
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-al2023-k28-ko29
-  cron: '39 11 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k28-ko29
-
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-al2023-k28-ko30
-  cron: '50 14 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-u2204-k32
 
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-al2023-k29
@@ -10487,69 +10298,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k29
 
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-al2023-k29-ko29
-  cron: '30 14 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k29-ko29
-
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-al2023-k29-ko30
   cron: '59 3 * * 2'
@@ -10612,6 +10360,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k29-ko30
+
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k29-ko31
+  cron: '45 13 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k29-ko31
 
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-al2023-k30
@@ -10739,6 +10550,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k30-ko30
 
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k30-ko31
+  cron: '41 1 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k30-ko31
+
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-al2023-k31
   cron: '28 3 * * 5'
@@ -10802,9 +10676,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-al2023-k31
 
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb12-k28
-  cron: '31 4 * * 1'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k31-ko31
+  cron: '4 12 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -10832,19 +10706,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: admin
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -10856,140 +10730,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k31-ko31
+
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-al2023-k32
+  cron: '58 9 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k28
-
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb12-k28-ko29
-  cron: '2 11 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k28-ko29
-
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb12-k28-ko30
-  cron: '7 22 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-etcd-al2023-k32
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb12-k29
@@ -11054,69 +10865,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k29
 
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-deb12-k29-ko29
-  cron: '59 6 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k29-ko29
-
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb12-k29-ko30
   cron: '30 11 * * 5'
@@ -11179,6 +10927,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k29-ko30
+
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k29-ko31
+  cron: '36 5 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k29-ko31
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb12-k30
@@ -11306,6 +11117,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k30-ko30
 
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k30-ko31
+  cron: '48 1 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k30-ko31
+
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-deb12-k31
   cron: '22 1 * * 3'
@@ -11369,9 +11243,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-deb12-k31
 
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k28
-  cron: '18 6 * * 5'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k31-ko31
+  cron: '9 20 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -11399,20 +11273,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: core
+        value: admin
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -11424,142 +11297,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k31-ko31
+
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-deb12-k32
+  cron: '24 19 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k28
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k28-ko29
-  cron: '46 9 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k28-ko29
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k28-ko30
-  cron: '39 12 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.30, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-etcd-deb12-k32
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-flatcar-k29
@@ -11625,70 +11433,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k29
 
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-flatcar-k29-ko29
-  cron: '59 12 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k29-ko29
-
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-flatcar-k29-ko30
   cron: '14 1 * * 3'
@@ -11752,6 +11496,70 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k29-ko30
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k29-ko31
+  cron: '28 23 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k29-ko31
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-flatcar-k30
@@ -11881,6 +11689,70 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k30-ko30
 
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k30-ko31
+  cron: '52 11 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k30-ko31
+
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-flatcar-k31
   cron: '47 11 * * 5'
@@ -11945,9 +11817,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k31
 
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k28
-  cron: '23 8 * * 3'
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k31-ko31
+  cron: '37 6 * * 0'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -11975,19 +11847,20 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ec2-user
+        value: core
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -11999,140 +11872,78 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k31-ko31
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-flatcar-k32
+  cron: '5 9 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k28
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k28-ko29
-  cron: '47 18 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k28-ko29
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k28-ko30
-  cron: '26 23 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-etcd-flatcar-k32
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k29
@@ -12197,69 +12008,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k29
 
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-rhel8-k29-ko29
-  cron: '26 15 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k29-ko29
-
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k29-ko30
   cron: '7 10 * * 2'
@@ -12322,6 +12070,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k29-ko30
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k29-ko31
+  cron: '21 4 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k29-ko31
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k30
@@ -12449,6 +12260,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k30-ko30
 
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k30-ko31
+  cron: '13 0 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k30-ko31
+
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-rhel8-k31
   cron: '42 5 * * 2'
@@ -12512,9 +12386,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k31
 
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k28
-  cron: '45 18 * * *'
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k31-ko31
+  cron: '36 13 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -12542,19 +12416,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -12566,140 +12440,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k31-ko31
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-rhel8-k32
+  cron: '28 23 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k28
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k28-ko29
-  cron: '29 20 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k28-ko29
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k28-ko30
-  cron: '0 1 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-etcd-rhel8-k32
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k29
@@ -12764,69 +12575,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k29
 
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2004-k29-ko29
-  cron: '52 9 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k29-ko29
-
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k29-ko30
   cron: '29 4 * * *'
@@ -12889,6 +12637,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k29-ko30
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k29-ko31
+  cron: '39 10 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k29-ko31
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k30
@@ -13016,6 +12827,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k30-ko30
 
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k30-ko31
+  cron: '23 22 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k30-ko31
+
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2004-k31
   cron: '36 7 * * *'
@@ -13079,9 +12953,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2004-k31
 
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k28
-  cron: '32 3 * * 5'
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k31-ko31
+  cron: '30 19 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13109,13 +12983,13 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
@@ -13133,140 +13007,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k31-ko31
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2004-k32
+  cron: '6 5 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k28
-
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k28-ko29
-  cron: '50 3 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k28-ko29
-
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k28-ko30
-  cron: '11 22 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-etcd-u2004-k32
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2204-k29
@@ -13331,69 +13142,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k29
 
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-etcd"}
-- name: e2e-kops-grid-cilium-etcd-u2204-k29-ko29
-  cron: '31 22 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-etcd" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-etcd
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k29-ko29
-
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2204-k29-ko30
   cron: '50 3 * * 2'
@@ -13456,6 +13204,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k29-ko30
+
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k29-ko31
+  cron: '28 5 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k29-ko31
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2204-k30
@@ -13583,6 +13394,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k30-ko30
 
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k30-ko31
+  cron: '4 9 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k30-ko31
+
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
 - name: e2e-kops-grid-cilium-etcd-u2204-k31
   cron: '41 14 * * 4'
@@ -13646,9 +13520,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-etcd-u2204-k31
 
-# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-al2023-k28
-  cron: '13 10 * * 5'
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k31-ko31
+  cron: '5 12 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -13676,19 +13550,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ec2-user
+        value: ubuntu
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -13700,143 +13574,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k31-ko31
+
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-etcd"}
+- name: e2e-kops-grid-cilium-etcd-u2204-k32
+  cron: '55 4 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-etcd" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    test.kops.k8s.io/networking: cilium-etcd
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-al2023-k28
-
-# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-al2023-k28-ko29
-  cron: '46 3 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-al2023-k28-ko29
-
-# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-al2023-k28-ko30
-  cron: '7 14 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-al2023-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-etcd-u2204-k32
 
 # {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-al2023-k29
@@ -13902,70 +13710,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k29
 
-# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-al2023-k29-ko29
-  cron: '23 22 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-al2023-k29-ko29
-
 # {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-al2023-k29-ko30
   cron: '26 19 * * 4'
@@ -14029,6 +13773,70 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k29-ko30
+
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k29-ko31
+  cron: '16 13 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k29-ko31
 
 # {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-al2023-k30
@@ -14158,6 +13966,70 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k30-ko30
 
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k30-ko31
+  cron: '56 1 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k30-ko31
+
 # {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-al2023-k31
   cron: '36 7 * * 1'
@@ -14222,9 +14094,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-al2023-k31
 
-# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb12-k28
-  cron: '42 7 * * 6'
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k31-ko31
+  cron: '37 4 * * 4'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14252,19 +14124,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: admin
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -14276,143 +14148,79 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/distro: al2023
     test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k31-ko31
+
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=t3.large", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-al2023-k32
+  cron: '46 13 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb12-k28
-
-# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb12-k28-ko29
-  cron: '8 14 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb12-k28-ko29
-
-# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb12-k28-ko30
-  cron: '5 11 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb12-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-eni-al2023-k32
 
 # {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb12-k29
@@ -14478,70 +14286,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k29
 
-# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-deb12-k29-ko29
-  cron: '1 11 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-deb12-k29-ko29
-
 # {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb12-k29-ko30
   cron: '40 22 * * 4'
@@ -14605,6 +14349,70 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k29-ko30
+
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k29-ko31
+  cron: '58 0 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k29-ko31
 
 # {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb12-k30
@@ -14734,6 +14542,70 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k30-ko30
 
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k30-ko31
+  cron: '58 20 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k30-ko31
+
 # {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-deb12-k31
   cron: '51 10 * * 1'
@@ -14798,9 +14670,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-deb12-k31
 
-# {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-flatcar-k28
-  cron: '49 18 * * 5'
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k31-ko31
+  cron: '7 9 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14828,20 +14700,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: core
+        value: admin
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -14853,145 +14724,79 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/distro: deb12
     test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k31-ko31
+
+# {"cloud": "aws", "distro": "deb12", "extra_flags": "--node-size=t3.large", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-deb12-k32
+  cron: '57 8 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-flatcar-k28
-
-# {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-flatcar-k28-ko29
-  cron: '10 2 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-flatcar-k28-ko29
-
-# {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-flatcar-k28-ko30
-  cron: '35 15 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.30, kops-distro-flatcar, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-flatcar-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-eni-deb12-k32
 
 # {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k29
@@ -15058,71 +14863,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k29
 
-# {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-flatcar-k29-ko29
-  cron: '51 7 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --validation-wait=20m \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: flatcar
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-flatcar-k29-ko29
-
 # {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k29-ko30
   cron: '50 18 * * 2'
@@ -15187,6 +14927,71 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k29-ko30
+
+# {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-flatcar-k29-ko31
+  cron: '24 12 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-flatcar-k29-ko31
 
 # {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k30
@@ -15318,6 +15123,71 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k30-ko30
 
+# {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-flatcar-k30-ko31
+  cron: '4 16 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-flatcar-k30-ko31
+
 # {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-flatcar-k31
   cron: '36 15 * * 5'
@@ -15383,9 +15253,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-flatcar-k31
 
-# {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-rhel8-k28
-  cron: '22 19 * * 0'
+# {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-flatcar-k31-ko31
+  cron: '41 13 * * 5'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15413,19 +15283,20 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
+          --validation-wait=20m \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ec2-user
+        value: core
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -15437,143 +15308,80 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/distro: flatcar
     test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-flatcar, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-flatcar-k31-ko31
+
+# {"cloud": "aws", "distro": "flatcar", "extra_flags": "--node-size=t3.large", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-flatcar-k32
+  cron: '10 21 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='075585003325/Flatcar-beta-4186.1.1-hvm' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --validation-wait=20m \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-flatcar, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-rhel8-k28
-
-# {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-rhel8-k28-ko29
-  cron: '9 23 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-rhel8-k28-ko29
-
-# {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-rhel8-k28-ko30
-  cron: '12 2 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-rhel8-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-eni-flatcar-k32
 
 # {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k29
@@ -15639,70 +15447,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k29
 
-# {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-rhel8-k29-ko29
-  cron: '56 18 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-rhel8-k29-ko29
-
 # {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k29-ko30
   cron: '13 15 * * 4'
@@ -15766,6 +15510,70 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k29-ko30
+
+# {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-rhel8-k29-ko31
+  cron: '31 17 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-rhel8-k29-ko31
 
 # {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k30
@@ -15895,6 +15703,70 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k30-ko30
 
+# {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-rhel8-k30-ko31
+  cron: '31 21 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-rhel8-k30-ko31
+
 # {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-rhel8-k31
   cron: '19 6 * * 0'
@@ -15959,9 +15831,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-rhel8-k31
 
-# {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-u2004-k28
-  cron: '0 17 * * *'
+# {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-rhel8-k31-ko31
+  cron: '10 0 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15989,19 +15861,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -16013,143 +15885,79 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/distro: rhel8
     test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-rhel8-k31-ko31
+
+# {"cloud": "aws", "distro": "rhel8", "extra_flags": "--node-size=t3.large", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-rhel8-k32
+  cron: '13 20 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-u2004-k28
-
-# {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-u2004-k28-ko29
-  cron: '11 9 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-u2004-k28-ko29
-
-# {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-u2004-k28-ko30
-  cron: '6 20 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-u2004-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-eni-rhel8-k32
 
 # {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k29
@@ -16215,70 +16023,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k29
 
-# {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-u2004-k29-ko29
-  cron: '10 20 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-u2004-k29-ko29
-
 # {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k29-ko30
   cron: '23 1 * * *'
@@ -16342,6 +16086,70 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k29-ko30
+
+# {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-u2004-k29-ko31
+  cron: '33 23 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-u2004-k29-ko31
 
 # {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k30
@@ -16471,6 +16279,70 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k30-ko30
 
+# {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-u2004-k30-ko31
+  cron: '13 11 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-u2004-k30-ko31
+
 # {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2004-k31
   cron: '45 12 * * *'
@@ -16535,9 +16407,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2004-k31
 
-# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-u2204-k28
-  cron: '29 0 * * 4'
+# {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-u2004-k31-ko31
+  cron: '24 6 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -16565,13 +16437,13 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
@@ -16589,143 +16461,79 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-u2004-k31-ko31
+
+# {"cloud": "aws", "distro": "u2004", "extra_flags": "--node-size=t3.large", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-u2004-k32
+  cron: '35 22 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-u2204-k28
-
-# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-u2204-k28-ko29
-  cron: '44 6 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-u2204-k28-ko29
-
-# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-u2204-k28-ko30
-  cron: '41 19 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-u2204-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-eni-u2004-k32
 
 # {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k29
@@ -16791,70 +16599,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k29
 
-# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "cilium-eni"}
-- name: e2e-kops-grid-cilium-eni-u2204-k29-ko29
-  cron: '37 11 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-cilium-eni-u2204-k29-ko29
-
 # {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k29-ko30
   cron: '20 22 * * 3'
@@ -16918,6 +16662,70 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k29-ko30
+
+# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-u2204-k29-ko31
+  cron: '10 0 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-u2204-k29-ko31
 
 # {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k30
@@ -17047,6 +16855,70 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k30-ko30
 
+# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-u2204-k30-ko31
+  cron: '46 20 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-u2204-k30-ko31
+
 # {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-grid-cilium-eni-u2204-k31
   cron: '0 21 * * 1'
@@ -17111,9 +16983,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-cilium-eni-u2204-k31
 
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-al2023-k28
-  cron: '13 3 * * 0'
+# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-u2204-k31-ko31
+  cron: '39 17 * * 2'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17141,19 +17013,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ec2-user
+        value: ubuntu
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -17165,140 +17037,79 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-cilium-eni-u2204-k31-ko31
+
+# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+- name: e2e-kops-grid-cilium-eni-u2204-k32
+  cron: '38 15 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    test.kops.k8s.io/networking: cilium-eni
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-al2023-k28
-
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-al2023-k28-ko29
-  cron: '15 12 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-al2023-k28-ko29
-
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-al2023-k28-ko30
-  cron: '30 9 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-al2023-k28-ko30
+    testgrid-tab-name: kops-grid-cilium-eni-u2204-k32
 
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-al2023-k29
@@ -17363,69 +17174,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k29
 
-# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-al2023-k29-ko29
-  cron: '34 9 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.29, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-al2023-k29-ko29
-
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-al2023-k29-ko30
   cron: '43 12 * * 3'
@@ -17488,6 +17236,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k29-ko30
+
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k29-ko31
+  cron: '49 2 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-al2023-k29-ko31
 
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-al2023-k30
@@ -17615,6 +17426,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k30-ko30
 
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k30-ko31
+  cron: '37 6 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-al2023-k30-ko31
+
 # {"cloud": "aws", "distro": "al2023", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-al2023-k31
   cron: '4 14 * * 2'
@@ -17678,9 +17552,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-al2023-k31
 
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb12-k28
-  cron: '30 16 * * 4'
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k31-ko31
+  cron: '36 11 * * 6'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -17708,19 +17582,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: admin
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -17732,140 +17606,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-al2023, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-al2023-k31-ko31
+
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-al2023-k32
+  cron: '22 4 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='137112412989/al2023-ami-2023.6.20250211.0-kernel-6.1-x86_64' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: al2023
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-al2023, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb12-k28
-
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb12-k28-ko29
-  cron: '20 19 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb12-k28-ko29
-
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb12-k28-ko30
-  cron: '49 14 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb12-k28-ko30
+    testgrid-tab-name: kops-grid-kopeio-al2023-k32
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb12-k29
@@ -17930,69 +17741,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k29
 
-# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb12-k29-ko29
-  cron: '45 6 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: admin
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: deb12
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.29, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-deb12-k29-ko29
-
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb12-k29-ko30
   cron: '40 11 * * 2'
@@ -18055,6 +17803,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k29-ko30
+
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k29-ko31
+  cron: '34 21 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-deb12-k29-ko31
 
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb12-k30
@@ -18182,6 +17993,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k30-ko30
 
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k30-ko31
+  cron: '30 1 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-deb12-k30-ko31
+
 # {"cloud": "aws", "distro": "deb12", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb12-k31
   cron: '19 5 * * 6'
@@ -18245,9 +18119,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-deb12-k31
 
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k28
-  cron: '58 20 * * 6'
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k31-ko31
+  cron: '11 20 * * 3'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -18275,19 +18149,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ec2-user
+        value: admin
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -18299,140 +18173,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-deb12, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-deb12-k31-ko31
+
+# {"cloud": "aws", "distro": "deb12", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb12-k32
+  cron: '13 7 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='136693071363/debian-12-amd64-20250210-2019' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: admin
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: deb12
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-deb12, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k28
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k28-ko29
-  cron: '21 2 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k28-ko29
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k28-ko30
-  cron: '56 7 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k28-ko30
+    testgrid-tab-name: kops-grid-kopeio-deb12-k32
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k29
@@ -18497,69 +18308,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k29
 
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k29-ko29
-  cron: '40 7 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ec2-user
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: rhel8
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.29, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k29-ko29
-
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k29-ko30
   cron: '45 10 * * 0'
@@ -18622,6 +18370,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k29-ko30
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k29-ko31
+  cron: '35 12 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k29-ko31
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k30
@@ -18749,6 +18560,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k30-ko30
 
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k30-ko31
+  cron: '47 0 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k30-ko31
+
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k31
   cron: '23 9 * * 1'
@@ -18812,9 +18686,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-rhel8-k31
 
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k28
-  cron: '44 14 * * *'
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k31-ko31
+  cron: '26 5 * * 1'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -18842,19 +18716,19 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: ec2-user
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -18866,140 +18740,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-rhel8, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k31-ko31
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k32
+  cron: '33 19 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='309956199498/RHEL-8.9.0_HVM-20240327-x86_64-4-Hourly2-GP3' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ec2-user
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-rhel8, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k28
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k28-ko29
-  cron: '11 20 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k28-ko29
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k28-ko30
-  cron: '22 1 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k28-ko30
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k32
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k29
@@ -19064,69 +18875,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k29
 
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k29-ko29
-  cron: '54 17 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.29, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2004-k29-ko29
-
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k29-ko30
   cron: '35 4 * * *'
@@ -19189,6 +18937,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k29-ko30
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k29-ko31
+  cron: '37 18 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-u2004-k29-ko31
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k30
@@ -19316,6 +19127,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k30-ko30
 
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k30-ko31
+  cron: '1 6 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-u2004-k30-ko31
+
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k31
   cron: '33 3 * * *'
@@ -19379,9 +19253,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2004-k31
 
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k28
-  cron: '53 15 * * 3'
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k31-ko31
+  cron: '56 11 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -19409,13 +19283,13 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
@@ -19433,140 +19307,77 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-u2004, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-u2004-k31-ko31
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k32
+  cron: '3 17 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250218.1' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2004, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k28
-
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k28-ko29
-  cron: '52 19 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k28-ko29
-
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k28-ko30
-  cron: '1 14 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.28'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.30'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.28, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k28-ko30
+    testgrid-tab-name: kops-grid-kopeio-u2004-k32
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2204-k29
@@ -19631,69 +19442,6 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k29
 
-# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.29", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2204-k29-ko29
-  cron: '33 6 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kopeio" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.29.txt \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/k8s_version: '1.29'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: '1.29'
-    test.kops.k8s.io/networking: kopeio
-    testgrid-dashboards: kops-1.29, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-kopeio-u2204-k29-ko29
-
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.30", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2204-k29-ko30
   cron: '44 3 * * 4'
@@ -19756,6 +19504,69 @@ periodics:
     testgrid-dashboards: kops-1.30, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k29-ko30
+
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2204-k29-ko31
+  cron: '42 5 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.29.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.29.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.29'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.29, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-u2204-k29-ko31
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2204-k30
@@ -19883,6 +19694,69 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k30-ko30
 
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2204-k30-ko31
+  cron: '50 1 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.30.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.30'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.30, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-u2204-k30-ko31
+
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2204-k31
   cron: '52 2 * * 3'
@@ -19946,12 +19820,14 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-kopeio-u2204-k31
 
-# {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
-- name: e2e-kops-grid-gce-kubenet-u2004-k28
-  cron: '2 1-23/8 * * *'
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.31", "kops_channel": "alpha", "kops_version": "1.31", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2204-k31-ko31
+  cron: '59 12 * * 0'
   labels:
-    preset-k8s-ssh: "true"
-  cluster: k8s-infra-prow-build
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
   decorate: true
   decoration_config:
     timeout: 90m
@@ -19962,7 +19838,6 @@ periodics:
     workdir: true
     path_alias: k8s.io/kops
   spec:
-    serviceAccountName: k8s-kops-test
     containers:
     - command:
       - runner.sh
@@ -19974,21 +19849,20 @@ periodics:
         kubetest2 kops \
           -v 2 \
           --up --down \
-          --cloud-provider=gce \
-          --admin-access=0.0.0.0/0 \
-          --create-args="--channel=alpha --networking=kubenet --gce-service-account=default" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.31/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.31.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.31.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
-        value: /etc/ssh-key-secret/ssh-private
+        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
-        value: prow
+        value: ubuntu
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       imagePullPolicy: Always
       resources:
@@ -19999,16 +19873,78 @@ periodics:
           cpu: "4"
           memory: 6Gi
   annotations:
-    test.kops.k8s.io/cloud: gce
-    test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --gce-service-account=default
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.31'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: '1.31'
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-1.31, kops-distro-u2204, kops-grid, kops-k8s-1.31, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-kopeio-u2204-k31-ko31
+
+# {"cloud": "aws", "distro": "u2204", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2204-k32
+  cron: '18 8 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250211' --channel=alpha --networking=kopeio" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: kubenet
-    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    test.kops.k8s.io/networking: kopeio
+    testgrid-dashboards: kops-distro-u2204, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-kubenet-u2004-k28
+    testgrid-tab-name: kops-grid-kopeio-u2204-k32
 
 # {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
 - name: e2e-kops-grid-gce-kubenet-u2004-k29
@@ -20202,9 +20138,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-kubenet-u2004-k31
 
-# {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-grid-gce-calico-u2004-k28
-  cron: '52 5-23/8 * * *'
+# {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "kubenet"}
+- name: e2e-kops-grid-gce-kubenet-u2004-k32
+  cron: '53 6-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   cluster: k8s-infra-prow-build
@@ -20232,13 +20168,13 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--channel=alpha --networking=calico --gce-service-account=default" \
+          --create-args="--channel=alpha --networking=kubenet --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.32.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
@@ -20258,13 +20194,13 @@ periodics:
     test.kops.k8s.io/cloud: gce
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/extra_flags: --gce-service-account=default
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    test.kops.k8s.io/networking: kubenet
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-calico-u2004-k28
+    testgrid-tab-name: kops-grid-gce-kubenet-u2004-k32
 
 # {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-grid-gce-calico-u2004-k29
@@ -20458,9 +20394,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-calico-u2004-k31
 
-# {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
-- name: e2e-kops-grid-gce-cilium-u2004-k28
-  cron: '22 7-23/8 * * *'
+# {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-grid-gce-calico-u2004-k32
+  cron: '31 2-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   cluster: k8s-infra-prow-build
@@ -20488,13 +20424,13 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--channel=alpha --networking=cilium --gce-service-account=default" \
+          --create-args="--channel=alpha --networking=calico --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.32.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
@@ -20514,13 +20450,13 @@ periodics:
     test.kops.k8s.io/cloud: gce
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/extra_flags: --gce-service-account=default
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: cilium
-    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-cilium-u2004-k28
+    testgrid-tab-name: kops-grid-gce-calico-u2004-k32
 
 # {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-grid-gce-cilium-u2004-k29
@@ -20714,9 +20650,9 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-cilium-u2004-k31
 
-# {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.28", "kops_channel": "alpha", "kops_version": "latest", "networking": "gce"}
-- name: e2e-kops-grid-gce-gce-u2004-k28
-  cron: '55 5-23/8 * * *'
+# {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+- name: e2e-kops-grid-gce-cilium-u2004-k32
+  cron: '29 0-23/8 * * *'
   labels:
     preset-k8s-ssh: "true"
   cluster: k8s-infra-prow-build
@@ -20744,13 +20680,13 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--channel=alpha --networking=gce --gce-service-account=default" \
+          --create-args="--channel=alpha --networking=cilium --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.28.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.28.txt \
+          --test-package-marker=stable-1.32.txt \
           --parallel=25
       env:
       - name: KUBE_SSH_KEY_PATH
@@ -20770,13 +20706,13 @@ periodics:
     test.kops.k8s.io/cloud: gce
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/extra_flags: --gce-service-account=default
-    test.kops.k8s.io/k8s_version: '1.28'
+    test.kops.k8s.io/k8s_version: '1.32'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: gce
-    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.28, kops-latest, sig-cluster-lifecycle-kops
+    test.kops.k8s.io/networking: cilium
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
-    testgrid-tab-name: kops-grid-gce-gce-u2004-k28
+    testgrid-tab-name: kops-grid-gce-cilium-u2004-k32
 
 # {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.29", "kops_channel": "alpha", "kops_version": "latest", "networking": "gce"}
 - name: e2e-kops-grid-gce-gce-u2004-k29
@@ -20969,3 +20905,67 @@ periodics:
     testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.31, kops-latest, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-gce-gce-u2004-k31
+
+# {"cloud": "gce", "distro": "u2004", "extra_flags": "--gce-service-account=default", "k8s_version": "1.32", "kops_channel": "alpha", "kops_version": "latest", "networking": "gce"}
+- name: e2e-kops-grid-gce-gce-u2004-k32
+  cron: '48 2-23/8 * * *'
+  labels:
+    preset-k8s-ssh: "true"
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    serviceAccountName: k8s-kops-test
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=gce \
+          --admin-access=0.0.0.0/0 \
+          --create-args="--channel=alpha --networking=gce --gce-service-account=default" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.32.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.32.txt \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/ssh-key-secret/ssh-private
+      - name: KUBE_SSH_USER
+        value: prow
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: gce
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --gce-service-account=default
+    test.kops.k8s.io/k8s_version: '1.32'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: latest
+    test.kops.k8s.io/networking: gce
+    testgrid-dashboards: kops-distro-u2004, kops-gce, kops-grid, kops-k8s-1.32, kops-latest, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '90'
+    testgrid-tab-name: kops-grid-gce-gce-u2004-k32


### PR DESCRIPTION
The 1.29 release markers have been deleted by the bucket's lifecycle policy:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-calico-al2023-k28-ko29/1890342701237276672

`Error: init failed to download kops from url: https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.29/latest-ci-updown-green.txt returned 404`

With kops 1.31.0 released we can update the grid to test kops 1.31, as well as k8s 1.32 with kops master

/cc @hakman