### PR TITLE
Add PR job to verify winsylink removal with azuredisk csi driver in a  K8s cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -367,6 +367,78 @@ presubmits:
       testgrid-dashboards: sig-windows-presubmit
       testgrid-tab-name: pull-master-windows-nodelogquery
       testgrid-num-columns-recent: '30'
+  - name: pull-windows-winsymlink-azuredisk
+    always_run: false
+    optiona: true
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    path_alias: sigs.k8s.io/azuredisk-csi-driver
+    branches:
+    - master
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-containerd-1-7-latest: "true"
+      preset-azure-community: "true"
+      preset-capz-windows-2022: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api-provider-azure
+        base_ref: release-1.17
+        path_alias: sigs.k8s.io/cluster-api-provider-azure
+        workdir: true
+      - org: kubernetes-sigs
+        repo: cloud-provider-azure
+        base_ref: master
+        path_alias: sigs.k8s.io/cloud-provider-azure
+        workdir: false
+      - org: kubernetes-sigs
+        repo: azuredisk-csi-driver
+        base_ref: master
+        path_alias: sigs.k8s.io/azuredisk-csi-driver
+        workdir: false
+      - org: marosset
+        repo: windows-testing
+        base_ref: run-capz-e2e-entrypoint
+        path_alias: k8s.io/windows-testing
+        workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250205-f1f3519e6b-master
+          command:
+            - runner.sh
+            - ./capz/run-capz-e2e.sh
+          args:
+            - bash
+            - -c
+            - >-
+              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+              make e2e-test
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 4
+              memory: 8Gi
+            requests:
+              cpu: 4
+              memory: 8Gi
+          env:
+            - name: WINDOWS # azuredisk-csi-driver config
+              value: "true"
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
+              value: "true"
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
+              value: "true"
+    annotations:
+      testgrid-dashboards: sig-windows-presubmit
+      testgrid-tab-name: pull-windows-winsymlink-azuredisk
+      description: "Run azuredisk E2E tests on a capz Windows 2022 cluster to verify winsymlink behavior"
+      testgrid-num-columns-recent: '30'
   kubernetes-sigs/windows-testing:
   - name: pull-e2e-capz-windows-2022-extension
     cluster: k8s-infra-prow-build


### PR DESCRIPTION
Adds a PR job to build a windows cluster with `run-capz-e2e.sh` and then run the azuredisk-csi-driver e2e test

This targets a fork for run-capz-e2e.sh with https://github.com/marosset/windows-testing/commit/f5bbb638edeeb32efcadce1383d342e8c4b158c6 so we can run the azuredisk-csi-driver e2e tests instead of k/k e2e tests like the script normally runs.

I will merge the changes into k-sigs/windows-testing after we do some additional validation

/sig windows
/assign @jsturtevant 