### PR TITLE
pull-kubernetes-integration: split into Go and cmd testing, for real

### DIFF
--- a/config/jobs/kubernetes/sig-testing/cmd.yaml
+++ b/config/jobs/kubernetes/sig-testing/cmd.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   # this replaces the bootstrap / scenario based job going forward
-  - name: pull-kubernetes-integration
+  - name: pull-kubernetes-cmd
     cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
@@ -25,9 +25,9 @@ presubmits:
         - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
           value: "8"
         - name: KUBE_TIMEOUT
-          value: "-timeout=1h30m"
+          value: "-timeout=30m"
         args:
-        - ./hack/jenkins/test-integration-dockerized.sh
+        - ./hack/jenkins/test-cmd-dockerized.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -38,7 +38,7 @@ presubmits:
           requests:
             cpu: 8
             memory: 20Gi
-  - name: pull-kubernetes-integration-canary
+  - name: pull-kubernetes-cmd-canary
     cluster: eks-prow-build-cluster
     always_run: false # Only for canary!
     decorate: true
@@ -63,9 +63,9 @@ presubmits:
         - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
           value: "8"
         - name: KUBE_TIMEOUT
-          value: "-timeout=1h30m"
+          value: "-timeout=30m"
         args:
-        - ./hack/jenkins/test-integration-dockerized.sh
+        - ./hack/jenkins/test-cmd-dockerized.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ presubmits:
           requests:
             cpu: 8
             memory: 20Gi
-  - name: pull-kubernetes-integration-go-compatibility
+  - name: pull-kubernetes-cmd-go-compatibility
     cluster: k8s-infra-prow-build
     always_run: true
     decorate: true
@@ -102,7 +102,7 @@ presubmits:
         - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
           value: auto
         args:
-        - ./hack/jenkins/test-integration-dockerized.sh
+        - ./hack/jenkins/test-cmd-dockerized.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -113,7 +113,7 @@ presubmits:
           requests:
             cpu: 6
             memory: 15Gi
-  - name: pull-kubernetes-integration-go-canary
+  - name: pull-kubernetes-cmd-go-canary
     cluster: k8s-infra-prow-build
     always_run: false
     skip_report: false
@@ -133,7 +133,7 @@ presubmits:
         command:
         - runner.sh
         args:
-        - ./hack/jenkins/test-integration-dockerized.sh
+        - ./hack/jenkins/test-cmd-dockerized.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -147,7 +147,7 @@ presubmits:
 periodics:
 - interval: 1h
   cluster: eks-prow-build-cluster
-  name: ci-kubernetes-integration-master
+  name: ci-kubernetes-cmd-master
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -161,16 +161,16 @@ periodics:
     fork-per-release: "true"
     fork-per-release-periodic-interval: 2h 2h 6h 24h
     testgrid-dashboards: sig-release-master-blocking
-    testgrid-tab-name: integration-master
+    testgrid-tab-name: cmd-master
     testgrid-alert-email: release-team@kubernetes.io
-    description: "Ends up running: make test-integration"
+    description: "Ends up running: make test-cmd"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250212-16f67660c2-master
       command:
       - runner.sh
       args:
-      - ./hack/jenkins/test-integration-dockerized.sh
+      - ./hack/jenkins/test-cmd-dockerized.sh
       env:
       - name: SHORT
         value: --short=false

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -33,6 +33,12 @@ dashboards:
   - name: pull-kubernetes-node-e2e-containerd
     test_group_name: pull-kubernetes-node-e2e-containerd
     base_options: width=10
+  - name: pull-kubernetes-cmd
+    test_group_name: pull-kubernetes-cmd
+    base_options: width=10
+  - name: pull-kubernetes-cmd-go-compatibility
+    test_group_name: pull-kubernetes-cmd-go-compatibility
+    base_options: width=10
   - name: pull-kubernetes-integration
     test_group_name: pull-kubernetes-integration
     base_options: width=10

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -24,6 +24,8 @@ jobs:
   - ci-kubernetes-kubemark-500-gce
   - ci-kubernetes-verify-master
   kubernetes-jenkins/pr-logs/directory/:
+  - pull-kubernetes-cmd
+  - pull-kubernetes-cmd-go-compatibility
   - pull-kubernetes-conformance-kind-ga-only-parallel
   - pull-kubernetes-dependencies
   - pull-kubernetes-e2e-ec2


### PR DESCRIPTION
It's annoying that pull-kubernetes-integration also runs "make test-cmd" because it makes the job run longer (which is a problem because it is one of the slowest, thus delaying merging of PRs) and because of the additional, confusing output produced by the shell scripts which test commands.

A trial run with canary jobs was successful. However, the [test scripts](https://github.com/kubernetes/kubernetes/pull/130337) then got renamed with an additional "test-" prefix. This has been taken account when modifying the actual jobs.

/hold

Let's merge during normal work hours (Monday?) when @aojea and I are around in case that something breaks.
We can also wait for @BenTheElder.
