### PR TITLE
etcd bbolt: set a 60 minute timeout for jobs

### DIFF
--- a/config/jobs/etcd/etcd-bbolt-presubmits.yaml
+++ b/config/jobs/etcd/etcd-bbolt-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
         - main
         - release-1.4
       decorate: true
+      decoration_config:
+        timeout: 60m
       annotations:
         testgrid-dashboards: sig-etcd-bbolt-presubmits
         testgrid-tab-name: pull-bbolt-test-1-cpu-arm64
@@ -37,6 +39,8 @@ presubmits:
         - main
         - release-1.4
       decorate: true
+      decoration_config:
+        timeout: 60m
       annotations:
         testgrid-dashboards: sig-etcd-bbolt-presubmits
         testgrid-tab-name: pull-bbolt-test-2-cpu-arm64
@@ -66,6 +70,8 @@ presubmits:
         - main
         - release-1.4
       decorate: true
+      decoration_config:
+        timeout: 60m
       annotations:
         testgrid-dashboards: sig-etcd-bbolt-presubmits
         testgrid-tab-name: pull-bbolt-test-4-cpu-arm64
@@ -95,6 +101,8 @@ presubmits:
         - main
         - release-1.4
       decorate: true
+      decoration_config:
+        timeout: 60m
       annotations:
         testgrid-dashboards: sig-etcd-bbolt-presubmits
         testgrid-tab-name: pull-bbolt-test-4-cpu-race-arm64


### PR DESCRIPTION
These jobs have configured a 30 minute timeout. Due to the Go v1.24 upgrade the tests are hanging. Setting it to 60 minutes, should be enough for the jobs to finish, and we don't keep the jobs running indefinitely (they timeout after 48 hours).

Link to: https://github.com/etcd-io/bbolt/pull/907

/cc @ahrtr 