### PR TITLE
remove the rest of DisableCloudProviders, DisableKubeletCloudCredentialProviders featuregates

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1465,7 +1465,7 @@ periodics:
           - --deployment=node
           - --gcp-zone=us-west1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
-          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--feature-gates=DisableKubeletCloudCredentialProviders=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
           - --test_args=--nodes=1 --focus="\[Feature:KubeletCredentialProviders\]" --skip="\[Flaky\]|\[Serial\]"
@@ -1507,7 +1507,6 @@ periodics:
         - --check-leaked-resources
         - --cluster=
         - --env=ENABLE_AUTH_PROVIDER_GCP=true
-        - --env=KUBE_FEATURE_GATES=DisableKubeletCloudCredentialProviders=true
         - --extract=ci/latest
         - --gcp-zone=us-west1-b
         - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2394,7 +2394,7 @@ presubmits:
           - --deployment=node
           - --gcp-zone=us-west1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
-          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--feature-gates=DisableKubeletCloudCredentialProviders=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
           - --test_args=--nodes=1 --focus="\[Feature:KubeletCredentialProviders\]" --skip="\[Flaky\]|\[Serial\]"
@@ -2446,7 +2446,6 @@ presubmits:
           - --build=quick
           - --cluster=
           - --env=ENABLE_AUTH_PROVIDER_GCP=true
-          - --env=KUBE_FEATURE_GATES=DisableKubeletCloudCredentialProviders=true
           - --gcp-zone=us-west1-b
           - --gcp-node-image=gci
           - --gcp-nodes=1


### PR DESCRIPTION
There were a couple more removed featuregates being set in the tests that I missed in https://github.com/kubernetes/test-infra/pull/34374. These did not follow the original pattern.

The last few occurrences of these featuregates appear in:
- config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml and definitions for lower versions
- experiment/compatibility-versions/validate-compatibility-versions-feature-gates.sh - I don't know what this is, but the FG is in a comment anyway
- releng/test_config.yaml - I don't know what this is and whether the FG should be removed from there, too.

Fixes: https://github.com/kubernetes/kubernetes/pull/130162