### PR TITLE
new gcsweb directory download instructions

### DIFF
--- a/gcsweb/cmd/gcsweb/gcsweb_test.go
+++ b/gcsweb/cmd/gcsweb/gcsweb_test.go
@@ -356,6 +356,8 @@ func TestHandleDirectory(t *testing.T) {
 	<div style="padding: 1em">
 		You can download this directory by running the following <a href="https://cloud.google.com/storage/docs/gsutil">gsutil</a> command:
 		<pre>gsutil -m cp -r gs://test-bucket/pr-logs/12345/ .</pre>
+		Or using the <a href="https://cloud.google.com/sdk/docs/install">gcloud storage</a> command:
+		<pre>gcloud storage cp -r gs://test-bucket/pr-logs/12345/ .</pre>
 	</div>
 </details>
 </body></html>`,

--- a/gcsweb/cmd/gcsweb/templates.go
+++ b/gcsweb/cmd/gcsweb/templates.go
@@ -116,6 +116,8 @@ const tmplContentFooterText = `</ul>
 	<div style="padding: 1em">
 		You can download this directory by running the following <a href="https://cloud.google.com/storage/docs/gsutil">gsutil</a> command:
 		<pre>gsutil -m cp -r gs://{{.ProwPath.FullPath}}/ .</pre>
+		Or using the <a href="https://cloud.google.com/sdk/docs/install">gcloud storage</a> command:
+		<pre>gcloud storage cp -r gs://{{.ProwPath.FullPath}}/ .</pre>
 	</div>
 </details>
 {{- end }}


### PR DESCRIPTION
See 77eee46449eb927fda8f270fdcdeefddb0dfa85f (https://github.com/kubernetes/test-infra/pull/26978) for context

This commit updates the instructions to also suggest the `gcloud storage` CLI instead of just the `gsutil` CLI. The `gsutil` CLI seems like it's losing support? It doesn't work on Python 3.13 anymore and it doesn't seem clear when it will.