### PR TITLE
prow: allow more contexts for kOps

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -363,9 +363,11 @@ branch-protection:
             contexts:
             - tests-e2e-scenarios-bare-metal
             - build-linux-amd64
+            - build-linux-arm64
             - build-macos-amd64
             - build-windows-amd64
-            - verify
+            - verify-amd64
+            - verify-arm64
         kubelet:
           restrictions:
             users: []


### PR DESCRIPTION
Add more contexts added in:
  - https://github.com/kubernetes/kops/pull/17286