### PR TITLE
[sig-windows] Checkout the csi-driver repo 

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -20,6 +20,11 @@ periodics:
     base_ref: master
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
+  - org: kubernetes-sigs
+    repo: azuredisk-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/azuredisk-csi-driver
+    workdir: false
   spec:
     serviceAccountName: azure
     containers:
@@ -58,8 +63,8 @@ periodics:
           - name: WORKER_MACHINE_COUNT # CAPZ config
             value: "0" # Don't create any linux worker nodes
   annotations:
-    testgrid-dashboards: provider-azure-azuredisk-csi-driver
-    testgrid-tab-name: pci-azuredisk-csi-driver-e2e-capz-windows
+    testgrid-dashboards: provider-azure-azuredisk-csi-driver, sig-windows-master-release, sig-windows-signal
+    testgrid-tab-name: ci-azuredisk-csi-driver-e2e-capz-windows
     description: "Run E2E tests on a capz Windows 2022 cluster for Azure Disk CSI driver."
     testgrid-num-columns-recent: '30'
 presubmits:


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/34402/files is failing with:

```
bash: line 1: cd: /home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver: No such file or directory
```

This checks it out and also adds the job to sig-windows dashboards so we can monitor it.

/sig-windows
/assign @andyzhangx @marosset 