### PR TITLE
[sig-windows] Adding Windows GCE jobs back

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-gce.yaml
@@ -1,0 +1,115 @@
+periodics:
+- name: ci-kubernetes-e2e-windows-containerd-gce-master
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator|\[Driver:.windows-gcepd\]
+      - --test-cmd-args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator|\[Driver:.windows-gcepd\]
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce
+    testgrid-tab-name: gce-windows-2019-containerd-master
+    description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
+- name: ci-kubernetes-e2e-windows-win2022-containerd-gce-master
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-windows-repo-list: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/latest
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh
+      - --test_args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator|\[Driver:.windows-gcepd\]
+      - --test-cmd-args=--node-os-distro=windows -prepull-images=true --ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[alpha\]|\[Slow\]|\[GMSA\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|\[sig-api-machinery\].Aggregator|\[Driver:.windows-gcepd\]
+      - --ginkgo-parallel=4
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: NO_LINUX_POOL_TAINT
+        value: "true"
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2022"
+      - name: NODE_SIZE
+        value: "n1-standard-4"
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241230-3006692a6f-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows-gce
+    testgrid-tab-name: gce-windows-2022-containerd-master
+    description: Runs tests on a Kubernetes cluster with Windows Server 2022 containerd nodes on GCE

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -8,6 +8,7 @@ dashboard_groups:
     - sig-windows-1.32-release
     - sig-windows-master-release
     - sig-windows-presubmit
+    - sig-windows-gce
     - sig-windows-networking
     - sig-windows-containerd-runtime-signal
     - sig-windows-push-images
@@ -20,6 +21,7 @@ dashboards:
 - name: sig-windows-1.32-release
 - name: sig-windows-master-release
 - name: sig-windows-presubmit
+- name: sig-windows-gce
 - name: sig-windows-push-images
 - name: sig-windows-networking
   dashboard_tab:


### PR DESCRIPTION
GKE will have resources to maintain Windows. Adding previously removed Windows job https://github.com/kubernetes/test-infra/pull/34103 back  