### PR TITLE
kubekins-e2e-v2 multiarch support for ppc64le

### DIFF
--- a/images/kubekins-e2e-v2/Dockerfile
+++ b/images/kubekins-e2e-v2/Dockerfile
@@ -66,11 +66,13 @@ ARG GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud
 RUN wget -O google-cloud-sdk.tar.gz -q $GCLOUD_SDK_URL && \
     tar xzf google-cloud-sdk.tar.gz -C / && \
     rm google-cloud-sdk.tar.gz && \
-    /google-cloud-sdk/install.sh \
-    --disable-installation-options \
-    --bash-completion=false \
-    --path-update=false \
-    --usage-reporting=false && \
+    if [ "${TARGETARCH}" != "ppc64le" ]; then \
+        /google-cloud-sdk/install.sh \
+        --disable-installation-options \
+        --bash-completion=false \
+        --path-update=false \
+        --usage-reporting=false; \
+    fi && \
     gcloud components install alpha beta && \
     gcloud info | tee /workspace/gcloud-info.txt
 
@@ -128,11 +130,13 @@ RUN mkdir /docker-graph
 # The invocation at the end is to prevent download failures downloads as in the bug.
 # TODO(porridge): bump CFSSL_VERSION to one where cfssljson supports the -version flag and test it as well.
 ARG CFSSL_VERSION
-RUN wget -q -O cfssl "https://github.com/cloudflare/cfssl/releases/download/v${CFSSL_VERSION}/cfssl_${CFSSL_VERSION}_linux_${TARGETARCH}" && \
+RUN if [ "${TARGETARCH}" != "ppc64le" ]; then \
+    wget -q -O cfssl "https://github.com/cloudflare/cfssl/releases/download/v${CFSSL_VERSION}/cfssl_${CFSSL_VERSION}_linux_${TARGETARCH}" && \
     wget -q -O cfssljson "https://github.com/cloudflare/cfssl/releases/download/v${CFSSL_VERSION}/cfssljson_${CFSSL_VERSION}_linux_${TARGETARCH}" && \
     chmod +x cfssl cfssljson && \
     mv cfssl cfssljson /usr/local/bin && \
-    cfssl version
+    cfssl version; \
+    fi
 
 # replace kubectl with one from K8S_RELEASE
 ARG K8S_RELEASE=latest
@@ -156,7 +160,7 @@ RUN wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_
 
 # install kind if a version is provided
 ARG KIND_VERSION
-RUN if [ -n "${KIND_VERSION}" ]; then \
+RUN if [[ ${TARGETARCH} != "ppc64le" && -n "${KIND_VERSION}" ]] ; then \
     wget -q -O /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-${TARGETARCH} && \
     chmod +x /usr/local/bin/kind; \
     fi

--- a/images/kubekins-e2e-v2/README.md
+++ b/images/kubekins-e2e-v2/README.md
@@ -3,7 +3,7 @@
 This is a modernised and lean image of the kubekins-e2e image optimised for the core tools required in an e2e image.
 
 Features:
-- multi-arch, supports both amd64 and arm64
+- multi-arch, supports amd64, arm64 and ppc64le
 - kubetest2
 - kind
 - aws-cli v1

--- a/images/kubekins-e2e-v2/cloudbuild.yaml
+++ b/images/kubekins-e2e-v2/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
     - build
     - --tag=us-central1-docker.pkg.dev/$PROJECT_ID/images/kubekins-e2e:$_GIT_TAG-$_CONFIG
     - --build-arg=IMAGE_ARG=us-central1-docker.pkg.dev/$PROJECT_ID/images/kubekins-e2e:$_GIT_TAG-$_CONFIG
-    - --platform=linux/amd64,linux/arm64
+    - --platform=linux/amd64,linux/arm64,linux/ppc64le
     - --build-arg=CFSSL_VERSION=$_CFSSL_VERSION
     - --build-arg=GO_VERSION=$_GO_VERSION
     - --build-arg=K8S_RELEASE=$_K8S_RELEASE


### PR DESCRIPTION
Fixes #34345
Had to skip below utilities for ppc64le:
- gcloud core install `google-cloud-sdk/install.sh`
- cfssl
- kind