### PR TITLE
CAPI: also build latest-ci in presubmit lastestk8s

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -456,6 +456,9 @@ presubmits:
           value: "true"
         - name: GINKGO_LABEL_FILTER
           value: "!Conformance"
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION_LATEST_CI"
         - name: KUBERNETES_VERSION_MANAGEMENT
           value: ci/latest-1.33
         - name: KUBERNETES_VERSION

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
@@ -490,6 +490,9 @@ presubmits:
         - name: GINKGO_LABEL_FILTER
           value: "!Conformance"
 {{- end }}
+        # Ensure required kind images get built.
+        - name: KIND_BUILD_IMAGES
+          value: "KUBERNETES_VERSION_LATEST_CI"
         - name: KUBERNETES_VERSION_MANAGEMENT
           value: {{ index (index $.versions ((last $.config.Upgrades).To)) "k8sRelease" }}
         - name: KUBERNETES_VERSION


### PR DESCRIPTION
Fixes: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api/11904/pull-cluster-api-e2e-latestk8s-main/1894730572488511488

We forgot to set this when setting it for the periodic job.