### PR TITLE
cluster-autoscaler: update azure E2E to use CAPZ 1.18

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.16
+      base_ref: release-1.18
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:
@@ -42,7 +42,7 @@ presubmits:
           - name: ADDITIONAL_ASO_CRDS
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
-            value: "1.30" # latest available in AKS
+            value: "1.32" # latest available in AKS
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
This PR updates cluster-autoscaler Azure E2E test to use the latest release branch of CAPZ; and also to run on AKS + Kubernetes 1.32