### PR TITLE
Update CAPZ jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -2,8 +2,10 @@ periodics:
 
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-27-1-28-main
   cluster: eks-prow-build-cluster
-  interval: 24h
+  minimum_interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 4h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -48,11 +50,15 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capi-periodic-upgrade-main-1-27-1-28
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: "Runs Kubernetes upgrade tests from v1.27 to v1.28 on CAPZ main branch"
 
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-28-1-29-main
   cluster: eks-prow-build-cluster
-  interval: 24h
+  minimum_interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 4h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -97,11 +103,15 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capi-periodic-upgrade-main-1-28-1-29
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: "Runs Kubernetes upgrade tests from v1.28 to v1.29 on CAPZ main branch"
 
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-29-1-30-main
   cluster: eks-prow-build-cluster
-  interval: 24h
+  minimum_interval: 24h
   decorate: true
+  decoration_config:
+    timeout: 4h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -146,3 +156,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capi-periodic-upgrade-main-1-29-1-30
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: "Runs Kubernetes upgrade tests from v1.29 to v1.30 on CAPZ main branch"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -4,7 +4,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 48h
+  minimum_interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -36,13 +36,13 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-conformance-main
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: Runs conformance & node conformance tests on a stable k8s version with latest cluster-api-provider-azure
+    description: Runs conformance & node conformance tests on latest kubernetes master with cluster-api-provider-azure
 - name: periodic-cluster-api-provider-azure-conformance-with-ci-artifacts-main
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 48h
+  minimum_interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -82,14 +82,14 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-conformance-k8s-ci-main
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
     description: Runs conformance & node conformance tests on latest kubernetes master with cluster-api-provider-azure
 - name: periodic-cluster-api-provider-azure-conformance-with-ci-artifacts-dra-main
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 2h # TODO: increase this to 48h when we're confident it's stable
+  minimum_interval: 4h # TODO: increase this to 48h when we're confident it's stable
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -142,7 +142,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 48h
+  minimum_interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -179,12 +179,13 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-capi-e2e-main
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs Cluster API E2E tests on latest cluster-api-provider-azure
 - name: periodic-cluster-api-provider-azure-apiversion-upgrade-main
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 48h
+  minimum_interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -223,7 +224,7 @@ periodics:
     description: This job creates clusters using supported older api versions (v1alpha4), and verifies that the clusters continue to operate properly after the api version is upgraded to the latest (v1beta1).
 - name: periodic-cluster-api-provider-azure-coverage
   cluster: eks-prow-build-cluster
-  interval: 12h
+  minimum_interval: 12h
   decorate: true
   path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   extra_refs:
@@ -267,7 +268,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 48h
+  minimum_interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -304,12 +305,13 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-e2e-main
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs workload cluster creation E2E tests on latest cluster-api-provider-azure
 - name: periodic-cluster-api-provider-azure-e2e-aks-main
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 48h
+  minimum_interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -346,12 +348,13 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-e2e-aks-main
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs managed Kubernetes E2E tests on latest cluster-api-provider-azure
 - name: periodic-cluster-api-provider-azure-100-nodes
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 3h
-  interval: 24h
+  minimum_interval: 24h
   path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   labels:
     preset-dind-enabled: "true"
@@ -448,3 +451,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-100-nodes-k8s-master
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs scalability tests with 100 nodes on latest cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.17.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.17.yaml
@@ -4,7 +4,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  minimum_interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -42,7 +42,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  minimum_interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -89,7 +89,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  minimum_interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -126,12 +126,13 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-17
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs Cluster API E2E tests on cluster-api-provider-azure release-1.17 (v1beta1)
 - name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-17
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  minimum_interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -168,12 +169,13 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-17
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs Cluster API Provider Azure E2E tests on cluster-api-provider-azure release-1.17 (v1beta1)
 - name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-17
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  minimum_interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -210,3 +212,4 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-17
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs managed Kubernetes E2E tests on cluster-api-provider-azure release-1.17 (v1beta1)

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.18.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.18.yaml
@@ -4,7 +4,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  minimum_interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -42,7 +42,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  minimum_interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -89,7 +89,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  minimum_interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -126,12 +126,13 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-18
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs Cluster API E2E tests on cluster-api-provider-azure release-1.18 (v1beta1)
 - name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-18
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  minimum_interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -168,12 +169,13 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-18
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs workload cluster creation E2E tests on cluster-api-provider-azure release-1.18 (v1beta1)
 - name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-18
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 4h
-  interval: 72h
+  minimum_interval: 72h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -210,3 +212,4 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-18
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs managed Kubernetes E2E tests on cluster-api-provider-azure release-1.18 (v1beta1)

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -40,10 +40,13 @@ presubmits:
           requests:
             cpu: 6
             memory: 16Gi
+    decoration_config:
+      timeout: 2h
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-test-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Runs unit tests and generates code coverage reports for the main branch.
   - name: pull-cluster-api-provider-azure-build
     cluster: eks-prow-build-cluster
     always_run: true
@@ -64,10 +67,13 @@ presubmits:
           requests:
             cpu: 6
             memory: 8Gi
+    decoration_config:
+      timeout: 1h
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-build-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Builds the project to ensure there are no compilation errors on the main branch.
   - name: pull-cluster-api-provider-azure-e2e
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
@@ -104,10 +110,13 @@ presubmits:
         securityContext:
           privileged: true
       serviceAccountName: azure
+    decoration_config:
+      timeout: 4h
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Executes end-to-end tests to validate the functionality of the main branch.
   - name: pull-cluster-api-provider-azure-e2e-optional
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
@@ -150,6 +159,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-optional-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Runs optional end-to-end tests that are not required for every PR.
   - name: pull-cluster-api-provider-azure-e2e-aks
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
@@ -192,6 +202,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-aks-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Tests the integration with Azure Kubernetes Service (AKS) for the main branch.
   - name: pull-cluster-api-provider-azure-capi-e2e
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
@@ -235,6 +246,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-capi-e2e-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Runs Cluster API end-to-end tests to ensure compatibility with the main branch.
   - name: pull-cluster-api-provider-azure-verify
     cluster: eks-prow-build-cluster
     always_run: true
@@ -743,6 +755,8 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-custom-k8s-main
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Validates conformance with a custom Kubernetes build on the main branch.
   - name: pull-cluster-api-provider-azure-windows-custom-builds
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
@@ -798,6 +812,8 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-windows-containerd-upstream-custom-k8s-main
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Tests Windows support with custom builds on the main branch.
   - name: pull-cluster-api-provider-azure-load-test-custom-builds
     cluster: eks-prow-build-cluster
     decorate: true
@@ -898,6 +914,8 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-scalability-100-node-k8s-main
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Conducts load testing with custom builds to assess scalability on the main branch.
   - name: pull-cluster-api-provider-azure-apiserver-ilb
     cluster: eks-prow-build-cluster
     labels:
@@ -938,4 +956,5 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apiserver-ilb-main
-      description: This job creates a vanilla CAPZ cluster with an ILB for the API server and verifies that the cluster is functional.
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Verifies the functionality of a cluster with an internal load balancer for the API server.

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -24,6 +24,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-test-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Runs unit tests for the v1beta1 release branch.
   - name: pull-cluster-api-provider-azure-build-v1beta1
     cluster: eks-prow-build-cluster
     always_run: true
@@ -48,9 +49,11 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-build-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Builds the project to ensure there are no compilation errors for the v1beta1 release branch.
   - name: pull-cluster-api-provider-azure-e2e-v1beta1
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    always_run: false
     optional: false
     decorate: true
     skip_if_only_changed: "^docs/|^\\.github/|\\.md$|^(\\.codespellignore|LICENSE|OWNERS|OWNERS_ALIASES|PROJECT|SECURITY_CONTACTS|Tiltfile|metadata\\.yaml|netlify\\.toml|tilt-provider\\.json)$"
@@ -88,9 +91,11 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Executes end-to-end tests for the v1beta1 release branch.
   - name: pull-cluster-api-provider-azure-apiversion-upgrade-v1beta1
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    always_run: false
     optional: false
     decorate: true
     skip_if_only_changed: "^docs/|^\\.github/|\\.md$|^(\\.codespellignore|LICENSE|OWNERS|OWNERS_ALIASES|PROJECT|SECURITY_CONTACTS|Tiltfile|Makefile|metadata\\.yaml|netlify\\.toml|tilt-provider\\.json)$"
@@ -171,9 +176,11 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-optional-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Runs optional end-to-end tests for the v1beta1 release branch.
   - name: pull-cluster-api-provider-azure-e2e-aks-v1beta1
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    always_run: false
     optional: false
     decorate: true
     decoration_config:
@@ -213,6 +220,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-aks-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Tests integration with Azure Kubernetes Service (AKS) for the v1beta1 release branch.
   - name: pull-cluster-api-provider-azure-capi-e2e-v1beta1
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
@@ -256,6 +264,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-capi-e2e-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Runs Cluster API end-to-end tests for the v1beta1 release branch.
   - name: pull-cluster-api-provider-azure-verify-v1beta1
     cluster: eks-prow-build-cluster
     always_run: true
@@ -287,6 +296,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-verify-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Verifies code quality and style for the v1beta1 release branch.
   - name: pull-cluster-api-provider-azure-conformance-v1beta1
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
@@ -324,6 +334,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-v1beta1
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Validates conformance for the v1beta1 release branch.
   - name: pull-cluster-api-provider-azure-apidiff-v1beta1
     cluster: k8s-infra-prow-build
     decorate: true
@@ -351,9 +362,12 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apidiff-v1beta1
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Checks for API differences in the v1beta1 release branch.
   - name: pull-cluster-api-provider-azure-ci-entrypoint-v1beta1
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    always_run: false
     optional: false
     decorate: true
     skip_if_only_changed: "^docs/|^\\.github/|\\.md$|^(\\.codespellignore|LICENSE|OWNERS|OWNERS_ALIASES|PROJECT|SECURITY_CONTACTS|Tiltfile|metadata\\.yaml|netlify\\.toml|tilt-provider\\.json)$"
@@ -435,6 +449,8 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-conformance-k8s-ci-v1beta1
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Runs conformance tests with CI artifacts for the v1beta1 release branch.
   - name: pull-cluster-api-provider-azure-e2e-workload-upgrade-v1beta1
     cluster: eks-prow-build-cluster
     labels:
@@ -477,3 +493,5 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-upgrade-v1beta1
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Tests workload cluster upgrades for the v1beta1 release branch.


### PR DESCRIPTION
This PR
- Adds `description` to the jobs.
- Adds `testgrid-email` field to the jobs. 
- Adds missing `always_run` field to the jobs.
- `interval` has been deprecated. Updated `interval` with `minimum_interval`. Reference: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Periodic