### PR TITLE
[sig-windows] Set skip for private registry test

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows-presubmits.yaml
@@ -46,6 +46,9 @@ presubmits:
           limits:
             cpu: "2"
             memory: 9Gi
+        env:
+          - name: GINKGO_SKIP
+            value: \[LinuxOnly\]|\[Serial\]|\[Slow\]|\[Excluded:WindowsDocker\]|\[Feature:DynamicResourceAllocation\]|Networking.Granular.Checks(.*)node-pod.communication|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute(.*)http.hook.properly|\[sig-api-machinery\].Garbage.collector|pull.from.private.registry.with.secret
         securityContext:
           privileged: true
     annotations:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.29-windows.yaml
@@ -59,6 +59,9 @@ periodics:
         limits:
           cpu: "2"
           memory: 9Gi
+      env:
+        - name: GINKGO_SKIP
+          value: \[LinuxOnly\]|\[Serial\]|\[Slow\]|\[Excluded:WindowsDocker\]|\[Feature:DynamicResourceAllocation\]|Networking.Granular.Checks(.*)node-pod.communication|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute(.*)http.hook.properly|\[sig-api-machinery\].Garbage.collector|pull.from.private.registry.with.secret
       securityContext:
         privileged: true
 - name: ci-kubernetes-e2e-capz-1-29-windows-serial-slow


### PR DESCRIPTION
This requires using all the skips that are defaulted in our sig windows scripts.

Fixes failure at https://testgrid.k8s.io/sig-windows-signal#capz-windows-1.29

After https://github.com/kubernetes-sigs/windows-testing/pull/481, the test was enabled but the nodes are properly configured in k8s <1.30 in our testing sub. 

1.29 is EOL today but still on the dashboard for a little while longer.

/sig windows
/assign @marosset 