### PR TITLE
etcd: mark coverage job as blocking

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -831,7 +831,6 @@ presubmits:
         kubernetes.io/arch: arm64
 
   - name: pull-etcd-coverage-report
-    optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
     always_run: true
     branches:


### PR DESCRIPTION
The coverage job has been working fine in the Prow infrastructure. With https://github.com/etcd-io/etcd/pull/19424, in place, we can mark this as blocking.

/cc @jmhbnz @ahrtr 