### PR TITLE
Update sig-node presubmit focus regex to match SeparateDisk tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2923,7 +2923,7 @@ presubmits:
         - --repo-root=.
         - --gcp-zone=us-west1-b
         - --parallelism=1
-        - --focus-regex=SeparateDiskTest
+        - --focus-regex=SeparateDisk
         - --skip-regex=""
         - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-imagefs.yaml


### PR DESCRIPTION
Updates the focus regex from "SeparateDiskTest" to "SeparateDisk" in the sig-node presubmit test configuration.

This change aligns with the label modification made in this [PR](https://github.com/kubernetes/kubernetes/pull/129574) ("Separate SeparateDiskTests from eviction"), ensuring consistent test selection.