### PR TITLE
always enable ClusterTrusbBundles feature gates in tests that both focus it and enable all alpha APIs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -463,7 +463,7 @@ presubmits:
         args:
         - --ginkgo-parallel=1
         - --build=quick
-        - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
+        - --env=KUBE_FEATURE_GATES=AllAlpha=true,ClusterTrustBundle=true,ClusterTrustBundleProjection=true,EventedPLEG=false
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
         - --env=KUBE_PROXY_DAEMONSET=true
         - --env=ENABLE_POD_PRIORITY=true
@@ -933,7 +933,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,ClusterTrustBundle=true,ClusterTrustBundleProjection=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -171,7 +171,7 @@ periodics:
             kubetest2 ec2 \
              --stage https://dl.k8s.io/ci/fast/ \
              --version $VERSION \
-             --feature-gates="AllAlpha=true,EventedPLEG=false" \
+             --feature-gates="AllAlpha=true,ClusterTrustBundle=true,ClusterTrustBundleProjection=true,EventedPLEG=false" \
              --runtime-config="api/all=true" \
              --up \
              --down \

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -907,7 +907,7 @@ presubmits:
               kubetest2 ec2 \
                --stage https://dl.k8s.io/ci/fast/ \
                --version $VERSION \
-               --feature-gates="AllAlpha=true,EventedPLEG=false,StorageVersionAPI=true,APIServerIdentity=true" \
+               --feature-gates="AllAlpha=true,ClusterTrustBundle=true,ClusterTrustBundleProjection=true,EventedPLEG=false,StorageVersionAPI=true,APIServerIdentity=true" \
                --runtime-config="api/all=true" \
                --up \
                --down \

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -267,7 +267,7 @@ testSuites:
     - --timeout=180m
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
-    - --env=KUBE_FEATURE_GATES=AllAlpha=true
+    - --env=KUBE_FEATURE_GATES=AllAlpha=true,ClusterTrustBundle=true,ClusterTrustBundleProjection=true
     # Panic if anything mutates a shared informer cache
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true
@@ -280,7 +280,7 @@ testSuites:
     - --timeout=180m
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
-    - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false
+    - --env=KUBE_FEATURE_GATES=AllAlpha=true,EventedPLEG=false,ClusterTrustBundle=true,ClusterTrustBundleProjection=true
     # Panic if anything mutates a shared informer cache
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true


### PR DESCRIPTION
The alpha-features test enables all the APIs but as ClusterTrustBundles move to beta, we explicitly need to enable these FGs.

fixes tests in https://github.com/kubernetes/kubernetes/pull/128499

The PR also explicitly adds CTB featuregates to jobs that focus the CTB tests and enable all alpha APIs.

/cc @enj @liggitt 