### PR TITLE
Update mdtoc jobs to use go 1.24

### DIFF
--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -31,7 +31,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
Required for https://github.com/kubernetes-sigs/mdtoc/pull/73

cc @kubernetes/release-engineering 