### PR TITLE
Nominate ivanvc as an approver for sig-etcd test infra

### DIFF
--- a/config/jobs/etcd/OWNERS
+++ b/config/jobs/etcd/OWNERS
@@ -9,6 +9,7 @@ reviewers:
 
 approvers:
   - ahrtr
+  - ivanvc
   - jmhbnz
   - serathius
   - wenjiaswe


### PR DESCRIPTION
Nominate @ivanvc as an approver for sig-etcd test infra.

@ivanvc is the release lead of sig-etcd.  He is also the de-fact lead, also the leading contributor, of sig-etcd test infra/workflow.

cc @ArkaSaha30 @jmhbnz @serathius