### PR TITLE
CAPO: Increase resource limits for -test presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -39,10 +39,10 @@ presubmits:
         - "./scripts/ci-test.sh"
         resources:
           requests:
-            memory: "6Gi"
+            memory: "8Gi"
             cpu: "4"
           limits:
-            memory: "6Gi"
+            memory: "8Gi"
             cpu: "4"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack


### PR DESCRIPTION
Tests are almost perma failing. We're again getting OOM killed, going
slightly over the memory:
https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?orgId=1&var-org=kubernetes-sigs&var-repo=cluster-api-provider-openstack&var-job=All&from=now-3h&to=now
