### PR TITLE
capo: bump CPU for presubmit test job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -40,10 +40,10 @@ presubmits:
         resources:
           requests:
             memory: "8Gi"
-            cpu: "4"
+            cpu: "6"
           limits:
             memory: "8Gi"
-            cpu: "4"
+            cpu: "6"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-test


### PR DESCRIPTION
We go over 4 currently:
https://monitoring-eks.prow.k8s.io/d/53g2x7OZz/jobs?orgId=1&var-org=kubernetes-sigs&var-repo=cluster-api-provider-openstack&var-job=All&from=now-3h&to=now&refresh=30s
