### PR TITLE
Revert "CAPO: Increase resource limits for -test presubmit"

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -39,10 +39,10 @@ presubmits:
         - "./scripts/ci-test.sh"
         resources:
           requests:
-            memory: "8Gi"
+            memory: "6Gi"
             cpu: "4"
           limits:
-            memory: "8Gi"
+            memory: "6Gi"
             cpu: "4"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack


### PR DESCRIPTION
Reverts kubernetes/test-infra#34455
Solved with https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2448