### PR TITLE
Clean up feature labels for resource managers (#130579)

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -909,7 +909,7 @@ periodics:
           - --deployment=node
           - --gcp-zone=us-west1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
-          - '--node-test-args=--feature-gates=RequiresNUMA=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
           - --test_args=--nodes=1 --skip="" --focus="\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]"

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -730,6 +730,7 @@ periodics:
     testgrid-tab-name: node-kubelet-containerd-standalone-mode
     description: "Runs kubelet in standalone mode"
 
+# DEPRECATED: This job is being replaced by ci-kubernetes-node-kubelet-serial-resource-managers
 - name: ci-kubernetes-node-kubelet-serial-topology-manager
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -778,6 +779,7 @@ periodics:
             cpu: 4
             memory: 6Gi
 
+# DEPRECATED: This job is being replaced by ci-kubernetes-node-kubelet-serial-resource-managers
 - name: ci-kubernetes-node-kubelet-serial-cpu-manager
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -826,6 +828,7 @@ periodics:
             cpu: 4
             memory: 6Gi
 
+# DEPRECATED: This job is being replaced by ci-kubernetes-node-kubelet-serial-resource-managers
 - name: ci-kubernetes-node-kubelet-serial-memory-manager
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -862,6 +865,54 @@ periodics:
           - --node-tests=true
           - --provider=gce
           - --test_args=--nodes=1 --skip="" --focus="\[Feature:MemoryManager\]"
+          - --timeout=180m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+
+- name: ci-kubernetes-node-kubelet-serial-resource-managers
+  interval: 4h
+  cluster: k8s-infra-prow-build
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    testgrid-tab-name: kubelet-serial-gce-e2e-resource-managers
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 240m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --deployment=node
+          - --gcp-zone=us-west1-b
+          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+          - '--node-test-args=--feature-gates=RequiresNUMA=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=1 --skip="" --focus="\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]"
           - --timeout=180m
         env:
           - name: GOPATH

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -293,6 +293,12 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
+    - color: 0052cc
+      description: "Indicates features requiring NUMA architecture support"
+      name: RequiresNUMA
+      target: both
+      prowPlugin: label
+      addedBy: anyone
     - color: f7c6c7
       description: Categorizes issue or PR as related to a flaky test.
       name: kind/flake


### PR DESCRIPTION
---

## What type of PR is this?

<!--
Add one of the following kinds:
/kind api-change
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind flake
-->
/kind cleanup

---

## What this PR does / why we need it

- **Introduces a new feature label** `RequiresNUMA` to replace `CPUManager`, `MemoryManager`, and `TopologyManager`.  
- **Deprecates existing jobs** (`ci-kubernetes-node-kubelet-serial-topology-manager`, `ci-kubernetes-node-kubelet-serial-cpu-manager`, `ci-kubernetes-node-kubelet-serial-memory-manager`) and consolidates them into **one job**: `ci-kubernetes-node-kubelet-serial-resource-managers`.  
- **Updates test configuration** to reflect the new `RequiresNUMA` label and reduce duplication across the resource manager tests.

This change makes our labeling strategy more consistent and easier to maintain, while still supporting the same e2e tests for NUMA-related features.

---

## Which issue(s) this PR fixes

[Fixes #130579
](https://github.com/kubernetes/kubernetes/issues/130579)

- References [#129296](https://github.com/kubernetes/kubernetes/pull/129296#issuecomment-2700038459)

---

## Special notes for your reviewer

- The **new label** is defined in `label_sync/labels.yaml` with a description that indicates NUMA architecture support.  
- The **new job** is located in `config/jobs/kubernetes/sig-node/node-kubelet.yaml` and uses the same `[Feature:CPUManager]`, `[Feature:MemoryManager]`, `[Feature:TopologyManager]` focus until those test tags can be updated.  
- The **old jobs** are marked as deprecated with comments to highlight that they will be replaced and eventually removed.

If there’s anything I’ve missed or if additional documentation is needed, please let me know.

---

## Does this PR introduce a user-facing change?

```release-note
Renamed CPUManager, MemoryManager, and TopologyManager feature labels to a single RequiresNUMA label.
Replaced three node e2e jobs with one consolidated job ci-kubernetes-node-kubelet-serial-resource-managers.
```

---

## Additional documentation, e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A

---

/sig node
/cc @dims @SergeyKanzhelev @mrunalp
/assign @klueska


<!--  
Use /assign @person and /cc @person to request reviews.
Add /hold if you want to prevent automatic merging until you're ready.
/hold
-->