### PR TITLE
Drop explicit ClusterTrustBundle focus from alpha-only jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -474,7 +474,7 @@ presubmits:
         - --gcp-region=us-central1
         - --provider=gce
         - --runtime-config=api/all=true
-        - --test_args=--ginkgo.focus=\[Feature:(WatchList|InPlacePodVerticalScaling|APIServerTracing|SidecarContainers|StorageVersionAPI|PodPreset|ClusterTrustBundle|ClusterTrustBundleProjection|PodLifecycleSleepAction|RecoverVolumeExpansionFailure)\] --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0|\[KubeUp\] --minStartupPods=8
+        - --test_args=--ginkgo.focus=\[Feature:(WatchList|InPlacePodVerticalScaling|APIServerTracing|SidecarContainers|StorageVersionAPI|PodPreset|PodLifecycleSleepAction|RecoverVolumeExpansionFailure)\] --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0|\[KubeUp\] --minStartupPods=8
         - --timeout=180m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
         resources:
@@ -942,7 +942,7 @@ periodics:
       - --gcp-region=us-central1
       - --provider=gce
       - --runtime-config=api/all=true
-      - --test_args=--ginkgo.focus=\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|ClusterTrustBundle|ClusterTrustBundleProjection)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Example)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Example)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
       - --timeout=180m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
       resources:

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -181,7 +181,7 @@ periodics:
              --test-package-url=https://dl.k8s.io/ \
              --test-package-dir=ci/fast \
              --test-package-marker=latest-fast.txt \
-             --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|ClusterTrustBundle|ClusterTrustBundleProjection)\]|Networking" \
+             --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking" \
              --skip-regex="\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Example)\]|IPv6|csi-hostpath-v0" \
              --parallel=25
         env:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -917,7 +917,7 @@ presubmits:
                --test-package-url=https://dl.k8s.io/ \
                --test-package-dir=ci/fast \
                --test-package-marker=latest-fast.txt \
-               --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|ClusterTrustBundle|ClusterTrustBundleProjection)\]|Networking" \
+               --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking" \
                --skip-regex="\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0" \
                --parallel=25
           env:

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -271,7 +271,7 @@ testSuites:
     # Panic if anything mutates a shared informer cache
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true
-    - --test_args=--ginkgo.focus=\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|ClusterTrustBundle|ClusterTrustBundleProjection)\]|Networking
+    - --test_args=--ginkgo.focus=\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking
       --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Example)\]|IPv6|csi-hostpath-v0
       --minStartupPods=8
     cluster: k8s-infra-prow-build
@@ -284,7 +284,7 @@ testSuites:
     # Panic if anything mutates a shared informer cache
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true
-    - --test_args=--ginkgo.focus=\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC|ClusterTrustBundle|ClusterTrustBundleProjection)\]|Networking
+    - --test_args=--ginkgo.focus=\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking
       --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Example)\]|IPv6|csi-hostpath-v0
       --minStartupPods=8
     cluster: k8s-infra-prow-build


### PR DESCRIPTION
This is step 1 of transitioning ClusterTrustBundle from alpha to beta. Promotion from alpha to beta will turn these alpha-only jobs which explicitly focus on the ClusterTrustBundle tests red. It was questionable to structure these this way in the first place.

Step 2 will get these tests added to run in the kind-alpha / kind-alpha-beta jobs in a follow-up (will likely require both test-infra and k/k PRs).

Step 3 will promote CTB to beta and ensure that the tests run in the kind-alpha-beta / kind-beta jobs (will ideally only require a k/k PR).

cc @stlaz @pohly @aojea 

context:
* https://github.com/kubernetes/kubernetes/pull/128499#issuecomment-2695298639
* https://github.com/kubernetes/test-infra/pull/34451
* https://github.com/kubernetes/test-infra/pull/34456
* https://github.com/kubernetes/kubernetes/pull/130567
* https://github.com/kubernetes/kubernetes/pull/130572
* https://github.com/kubernetes/kubernetes/pull/130580