### PR TITLE
Skip disabled features in crio splitfs job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1397,7 +1397,7 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]|\[Feature:.+\]|\[Feature\]
-        - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
+        - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport\]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]
         - --timeout=3h
         - '--test-args=--ginkgo.timeout=3h --service-feature-gates="KubeletSeparateDiskGC=true" --feature-gates="KubeletSeparateDiskGC=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-splitfs.yaml


### PR DESCRIPTION
This job enables only `KubeletSeparateDiskGC`. Then, it needs to skip tests for features that are not enabled like other similar jobs.

Fixes kubernetes/kubernetes#130670
