### PR TITLE
bump kubernetes unit test jobs on master branch to use whole machine

### DIFF
--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -27,14 +27,13 @@ presubmits:
           command:
             - make
             - test
-          # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7.2
+              memory: "43Gi"
             requests:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7.2
+              memory: "43Gi"
   - name: pull-kubernetes-unit-go-compatibility
     annotations:
       fork-per-release: "true"
@@ -183,8 +182,8 @@ periodics:
           # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7.2
+              memory: "43Gi"
             requests:
-              cpu: 4
-              memory: "36Gi"
+              cpu: 7.2
+              memory: "43Gi"


### PR DESCRIPTION
we might as well run them faster and then free up the machine, at 4 cores we already can only schedule another job with <4 cores (the machine has 7.91 schedulable with say another 1-200m consumed by daemonsets)

these run with excellent parallelism and would happily use more cores.

NOTE: they're not using all of the memory at all, but we're requesting all of the cores anyhow