### PR TITLE
remove stale unit test experimental job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -75,43 +75,6 @@ presubmits:
             requests:
               cpu: 4
               memory: "36Gi"
-  - name: pull-kubernetes-unit-experimental
-    # try clonerefs with preclone
-    decoration_config:
-      utility_images:
-        clonerefs: "gcr.io/spiffxp-gke-dev/clonerefs-k8s-preclone:latest"
-    annotations:
-      testgrid-dashboards: sig-testing-misc
-    decorate: true
-    cluster: k8s-infra-prow-build
-    skip_branches:
-    - release-\d+.\d+ # per-release job
-    optional: true
-    always_run: false
-    path_alias: k8s.io/kubernetes
-    spec:
-      # unit tests have no business requiring root or doing privileged operations
-      securityContext:
-        # NOTE: these are arbitrary non-root values. They don't exist in the
-        # image and don't need to, the unit tests should only write to TMPDIR
-        runAsUser: 2001
-        runAsGroup: 2010
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master
-          imagePullPolicy: Always
-          securityContext:
-            allowPrivilegeEscalation: false
-          command:
-            - make
-            - test
-          # TODO: direct copy from pull-kubernetes-bazel-test, tune these
-          resources:
-            limits:
-              cpu: 4
-              memory: "36Gi"
-            requests:
-              cpu: 4
-              memory: "36Gi"
   - name: pull-kubernetes-unit-go-canary
     annotations:
       testgrid-num-failures-to-alert: '10'


### PR DESCRIPTION
deleting a stale "experimental" job using an experiment we had for speeding up clones that is now obsolete.

This job isn't actually running, just bloating the config.