### PR TITLE
Add more SIG autoscaling owners and clean up

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/OWNERS
+++ b/config/jobs/kubernetes/sig-autoscaling/OWNERS
@@ -3,12 +3,20 @@
 reviewers:
 - mwielgus
 - maciekpytel
-- bskiba
 - kwiesmueller
 - voelzmo
+- gjtempleton
+- towca
+- raywainman
+- jackfrancis
 approvers:
 - mwielgus
 - maciekpytel
-- bskiba
 - kwiesmueller
 - voelzmo
+- gjtempleton
+- towca
+- raywainman
+- jackfrancis
+emeritus_approvers:
+- bskiba


### PR DESCRIPTION
Get more of the SIG autoscaling approvers on board with the test-infra as well.