### PR TITLE
kubekins-e2e-v2: Add back kind for amd64/amd64

### DIFF
--- a/images/kubekins-e2e-v2/Dockerfile
+++ b/images/kubekins-e2e-v2/Dockerfile
@@ -160,7 +160,7 @@ RUN wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_
 
 # install kind if a version is provided
 ARG KIND_VERSION
-RUN if [[ ${TARGETARCH} != "ppc64le" && -n "${KIND_VERSION}" ]] ; then \
+RUN if [ "${TARGETARCH}" != "ppc64le" ] && [ -n "${KIND_VERSION}" ]; then \
     wget -q -O /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-${TARGETARCH} && \
     chmod +x /usr/local/bin/kind; \
     fi


### PR DESCRIPTION
Use only sh syntax in Dockerfile. No bash.

Fixes #34416
cc @Rajalakshmi-Girish @upodroid

Fixes https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_alibaba-cloud-csi-driver/1272/pull-alibaba-cloud-csi-driver-verify-helm/1899428740237103104