### PR TITLE
Replace CRI-O eviction jobs with their kubetest2 variants

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2671,57 +2671,6 @@ presubmits:
             memory: 6Gi
   - name: pull-crio-cgroupv1-node-e2e-eviction
     cluster: k8s-infra-prow-build
-    skip_branches:
-      - release-\d+\.\d+  # per-release image
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    optional: true
-    always_run: false
-    max_concurrency: 12
-    decorate: true
-    decoration_config:
-      timeout: 320m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        args:
-        - --deployment=node
-        - --env=KUBE_SSH_USER=core
-        - --gcp-zone=us-west1-b
-        - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-        - --node-tests=true
-        - --provider=gce
-        - --test_args=--nodes=1 --focus="\[Feature:Eviction\]" --timeout=300m
-        - --timeout=300m
-        - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
-        env:
-        - name: GOPATH
-          value: /go
-        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-          value: "1"
-        resources:
-          requests:
-            cpu: 4
-            memory: 6Gi
-          limits:
-            cpu: 4
-            memory: 6Gi
-    annotations:
-      testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgroupv1-node-e2e-eviction
-  - name: pull-crio-cgroupv1-node-e2e-eviction-kubetest2
-    cluster: k8s-infra-prow-build
-    # explicitly needs /test pull-crio-cgroupv1-node-e2e-eviction-kubetest2 to run
     always_run: false
     optional: true
     max_concurrency: 12
@@ -2744,7 +2693,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgroupv1-node-e2e-eviction-kubetest2
+      testgrid-tab-name: pr-crio-cgroupv1-node-e2e-eviction
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
@@ -2779,57 +2728,6 @@ presubmits:
             value: "1"
   - name: pull-crio-cgroupv2-node-e2e-eviction
     cluster: k8s-infra-prow-build
-    skip_branches:
-      - release-\d+\.\d+  # per-release image
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-    optional: true
-    always_run: false
-    max_concurrency: 12
-    decorate: true
-    decoration_config:
-      timeout: 320m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        args:
-        - --deployment=node
-        - --env=KUBE_SSH_USER=core
-        - --gcp-zone=us-west1-b
-        - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-        - --node-tests=true
-        - --provider=gce
-        - --test_args=--nodes=1 --focus="\[Feature:Eviction\]" --timeout=300m
-        - --timeout=300m
-        - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2.yaml
-        env:
-        - name: GOPATH
-          value: /go
-        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-          value: "1"
-        resources:
-          requests:
-            cpu: 4
-            memory: 6Gi
-          limits:
-            cpu: 4
-            memory: 6Gi
-    annotations:
-      testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgroupv2-node-e2e-eviction
-  - name: pull-crio-cgroupv2-node-e2e-eviction-kubetest2
-    cluster: k8s-infra-prow-build
-    # explicitly needs /test pull-crio-cgroupv2-node-e2e-eviction-kubetest2 to run
     always_run: false
     optional: true
     max_concurrency: 12
@@ -2852,7 +2750,7 @@ presubmits:
       preset-pull-kubernetes-e2e-gce: "true"
     annotations:
       testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-      testgrid-tab-name: pr-crio-cgroupv2-node-e2e-eviction-kubetest2
+      testgrid-tab-name: pr-crio-cgroupv2-node-e2e-eviction
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master


### PR DESCRIPTION
Replaced 2 CRI-O eviction jobs with their -kubetest2 variants. Both jobs were successfully tested in [my test PR](https://github.com/kubernetes/kubernetes/pull/130241).

Ref: https://github.com/kubernetes/test-infra/issues/32567

/sig-node
/cc @kannon92 @elieser1101