### PR TITLE
Run windows unit test presubmit job if any windows file or pkg/kubelet file is changed

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/windows-unit.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-unit.yaml
@@ -42,6 +42,9 @@ presubmits:
   kubernetes/kubernetes:
     - name: pull-kubernetes-unit-windows-master
       always_run: false
+      branches:
+        - master
+        - main
       cluster: eks-prow-build-cluster
       decorate: true
       decoration_config:
@@ -57,6 +60,7 @@ presubmits:
           path_alias: sigs.k8s.io/windows-testing
           workdir: true
       path_alias: k8s.io/kubernetes
+      run_if_changed: '.*windows\.go$|pkg/kubelet/.*'
       spec:
         serviceAccountName: azure
         containers:


### PR DESCRIPTION
Part of https://github.com/kubernetes/kubernetes/issues/130149

https://prow.k8s.io/?job=ci-kubernetes-unit-windows-master is stable now so I'm enabling it to run on K/K PRs as optional per discussion in https://kubernetes.slack.com/archives/C2C40FMNF/p1741626380104419

I'd like to run this on kubelet PRs for a while and then expand the scope to other packages over time.

/assign @jsturtevant @BenTheElder 
/sig windows