### PR TITLE
Fix cluster autoscaler pull-kubernetes-e2e-autoscaling-ca-build test

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -209,6 +209,7 @@ presubmits:
       - command:
         - runner.sh
         - make
+        - -C cluster-autoscaler
         - test-build-tags
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
         securityContext:


### PR DESCRIPTION
The test currently fails with
```
Docker in Docker enabled, initializing...
================================================================================
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.all.forwarding = 1
Starting Docker: docker.
Waiting for docker to be ready, sleeping for 1 seconds.
================================================================================
Done setting up docker in docker.
+ WRAPPED_COMMAND_PID=[2](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/autoscaler/7906/pull-kubernetes-e2e-autoscaling-ca-build/1899595641911250944#1:build-log.txt%3A2)38
+ wait 238
+ make test-build-tags
make: *** No rule to make target 'test-build-tags'.  Stop.
+ EXIT_VALUE=2
+ set +o xtrace
Cleaning up after docker in docker.
================================================================================
Waiting [3](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/autoscaler/7906/pull-kubernetes-e2e-autoscaling-ca-build/1899595641911250944#1:build-log.txt%3A3)0 seconds for pods stopped with terminationGracePeriod:30
Cleaning up after docker
Waiting for docker to stop for 30 seconds
Stopping Docker: dockerProgram process in pidfile '/var/run/docker-ssd.pid', 1 process(es), refused to die.
================================================================================
Done cleaning up after docker in docker.
```
(For example, https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/autoscaler/7906/pull-kubernetes-e2e-autoscaling-ca-build/1899595641911250944 )

I assume it's because the test needs to first enter the `cluster-autoscaler` directory. I'm hoping this repo has a way to rehearse jobs before merging them.