### PR TITLE
Fix cluster autoscaler pull-kubernetes-e2e-autoscaling-ca-build test, try 2

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -208,8 +208,10 @@ presubmits:
       containers:
       - command:
         - runner.sh
+        args:
         - make
-        - -C cluster-autoscaler
+        - -C
+        - cluster-autoscaler
         - test-build-tags
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
         securityContext:


### PR DESCRIPTION
Follow-up to #34486 which fails with:

```
Docker in Docker enabled, initializing...
================================================================================
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.all.forwarding = 1
Starting Docker: docker.
Waiting for docker to be ready, sleeping for 1 seconds.
================================================================================
Done setting up docker in docker.
+ WRAPPED_COMMAND_PID=[2](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/autoscaler/7906/pull-kubernetes-e2e-autoscaling-ca-build/1899601915285606400#1:build-log.txt%3A2)29
+ wait 229
+ make '-C cluster-autoscaler' test-build-tags
make: ***  cluster-autoscaler: No such file or directory.  Stop.
+ EXIT_VALUE=2
+ set +o xtrace
Cleaning up after docker in docker.
================================================================================
Waiting [3](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/autoscaler/7906/pull-kubernetes-e2e-autoscaling-ca-build/1899601915285606400#1:build-log.txt%3A3)0 seconds for pods stopped with terminationGracePeriod:30
Cleaning up after docker
Waiting for docker to stop for 30 seconds
Stopping Docker: dockerProgram process in pidfile '/var/run/docker-ssd.pid', 1 process(es), refused to die.
================================================================================
Done cleaning up after docker in docker.
```

See https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/autoscaler/7906/pull-kubernetes-e2e-autoscaling-ca-build/1899601915285606400 for an example of the failure