### PR TITLE
speed up e2e-gce

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -286,11 +286,13 @@ presubmits:
           image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           resources:
             limits:
-              cpu: 4
-              memory: "14Gi"
+              cpu: 7.2
+              # NOTE: we don't need this much memory, but we're using ~all of the cores anyhow
+              # and this isn't even 2 GB / core ...
+              memory: "20Gi"
             requests:
-              cpu: 4
-              memory: "14Gi"
+              cpu: 7.2
+              memory: "20Gi"
           securityContext:
             privileged: true
 


### PR DESCRIPTION
note: e2e-ec2 is using cpu: 10, we spend ~18m in "build" currently https://testgrid.k8s.io/presubmits-kubernetes-blocking#pull-kubernetes-e2e-gce&graph-metrics=test-duration-minutes