### PR TITLE
Kueue: Upgrade Go version to 1.24

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -13,7 +13,7 @@ presubmits:
       description: "Run kueue unit tests"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         env:
         - name: GO_TEST_FLAGS
           value: "-race -count 3"
@@ -43,7 +43,7 @@ presubmits:
       description: "Run kueue test-integration"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:
@@ -73,7 +73,7 @@ presubmits:
       description: "Run kueue test-multikueue-integration"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:
@@ -110,7 +110,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.29.4
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -148,7 +148,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -186,7 +186,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -224,7 +224,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -262,7 +262,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.2
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -300,7 +300,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.1
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -338,7 +338,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.1
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -418,7 +418,7 @@ presubmits:
         - name: GOMAXPROCS
           value: "2"
         - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.23
+          value: public.ecr.aws/docker/library/golang:1.24
         resources:
           requests:
             cpu: "2"
@@ -439,7 +439,7 @@ presubmits:
       description: "Run kueue test-scheduling-perf"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-main.yaml
@@ -22,7 +22,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.23
+        - image: public.ecr.aws/docker/library/golang:1.24
           env:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
@@ -62,7 +62,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.23
+        - image: public.ecr.aws/docker/library/golang:1.24
           command:
             - make
           args:
@@ -100,7 +100,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.23
+        - image: public.ecr.aws/docker/library/golang:1.24
           command:
             - make
           args:
@@ -143,7 +143,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.29.4
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -189,7 +189,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -235,7 +235,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -281,7 +281,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -327,7 +327,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.2
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -373,7 +373,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.1
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -419,7 +419,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.1
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh


### PR DESCRIPTION
/assign @mimowo 

`kubekins` has already supported 1.24.

```shell
docker run -it --entrypoint bash --platform linux/amd64 gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
root@9fd7c2fa86dc:/workspace# go version 
go version go1.24.0 linux/amd64
```