### PR TITLE
don't override KUBE_INTEGRATION_TEST_MAX_CONCURRENCY in 1.33+

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -22,8 +22,6 @@ presubmits:
         command:
         - runner.sh
         env:
-        - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
-          value: "8"
         - name: KUBE_TIMEOUT
           value: "-timeout=1h30m"
         args:
@@ -60,8 +58,6 @@ presubmits:
         command:
         - runner.sh
         env:
-        - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
-          value: "8"
         - name: KUBE_TIMEOUT
           value: "-timeout=1h30m"
         args:


### PR DESCRIPTION
currently this has no impact on older branches, for 1.33+ it does, though _currently_ it matches the automatic default, but that's fragile

see: https://github.com/kubernetes/kubernetes/issues/126202#issuecomment-2720469788