### PR TITLE
Prepare for blixt image pushing

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-blixt.yaml
+++ b/config/jobs/image-pushing/k8s-staging-blixt.yaml
@@ -1,0 +1,23 @@
+postsubmits:
+  kubernetes-sigs/blixt:
+    # Blixt Images
+    - name: post-blixt-images
+      annotations:
+        testgrid-dashboards: sig-network-blixt, sig-k8s-infra-gcb
+      branches:
+        - ^main$
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20241224-fe22c549c1
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-images
+              - --scratch-bucket=gs://k8s-staging-images-gcb
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
+              - --build-dir=.
+              - --with-git-dir
+              - .

--- a/config/testgrids/kubernetes/sig-network/config.yaml
+++ b/config/testgrids/kubernetes/sig-network/config.yaml
@@ -1,6 +1,7 @@
 dashboard_groups:
 - name: sig-network
   dashboard_names:
+    - sig-network-blixt
     - sig-network-dns
     - sig-network-external-dns
     - sig-network-gce
@@ -17,6 +18,7 @@ dashboard_groups:
     - sig-network-nat64
 
 dashboards:
+- name: sig-network-blixt
 - name: sig-network-dns
 - name: sig-network-external-dns
 - name: sig-network-gce


### PR DESCRIPTION
This change adds the required jobs for (blixt)[https://github.com/kubernetes-sigs/blixt] image promotion

Please hold until https://github.com/kubernetes/k8s.io/pull/7875 is merged