### PR TITLE
etcd: don't run pull-etcd-markdown-lint while we fine tune it

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -861,10 +861,10 @@ presubmits:
             memory: "4Gi"
 
   - name: pull-etcd-markdown-lint
-    optional: true
+    optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
     always_run: false
-    run_if_changed: '.*\.md$'
+    # run_if_changed: '.*\.md$' # uncomment once the job is stable
     branches:
       - main
     decorate: true


### PR DESCRIPTION
The `run_if_changed` rule overrides `always_run`. Commenting it while we fine-tune the job/ensure it works.

Fixes etcd-io/etcd#19604.

/cc @ahrtr 