### PR TITLE
Add missing ResourceHealthStatus feature gate for API server

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -510,7 +510,7 @@ presubmits:
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/image-config.yaml
         - --deployment=node
         - --gcp-zone=us-central1-b
-        - '--node-test-args=--feature-gates=AllAlpha=true,ImageVolume=true,EventedPLEG=false --service-feature-gates=ProcMountType=true,UserNamespacesSupport=true,ImageVolume=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
+        - '--node-test-args=--feature-gates=AllAlpha=true,ImageVolume=true,EventedPLEG=false --service-feature-gates=ProcMountType=true,UserNamespacesSupport=true,ImageVolume=true,ResourceHealthStatus=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
         - --node-tests=true
         - --provider=gce
         - --test_args=--nodes=8 --focus="\[Feature:.+\]" --skip="\[Flaky\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]"


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/130618 introduced a new dependency on the ResourceHealthStatus feature gate in the API server when updating Pods' `status`. Without that flag enabled, Pods' `status.containerStatuses[].allocatedResourcesStatus` fields get dropped which was causing the failures described by https://github.com/kubernetes/kubernetes/issues/130829. https://github.com/kubernetes/kubernetes/pull/130843 shows the job [failing before](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/130843/pull-kubernetes-node-e2e-containerd-alpha-features/1900986992347320320) and [passing after](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/130843/pull-kubernetes-node-e2e-containerd-alpha-features/1901008133111681024) hardcoding this feature flag.

Fixes https://github.com/kubernetes/kubernetes/issues/130829
Closes https://github.com/kubernetes/kubernetes/pull/130843