### PR TITLE
bump go to 1.24.x for boskos

### DIFF
--- a/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
@@ -7,7 +7,7 @@ postsubmits:
       path_alias: sigs.k8s.io/boskos
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.22.5
+          - image: public.ecr.aws/docker/library/golang:1.24.1
             imagePullPolicy: Always
             command:
               - make

--- a/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       path_alias: sigs.k8s.io/boskos
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.23.4
+          - image: public.ecr.aws/docker/library/golang:1.24.1
             imagePullPolicy: Always
             command:
               - make


### PR DESCRIPTION
Boskos post submits are failing because the go version is too old.