### PR TITLE
fix usernamespace failures in ec2 jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd-presubmit.yaml
@@ -176,7 +176,7 @@ presubmits:
               - name: IMAGE_CONFIG_FILE
                 value: aws-instance.yaml
               - name: SKIP
-                value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+                value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:UserNamespacesSupport\]
               - name: TEST_ARGS
                 value: '--kubelet-flags="--cgroup-driver=systemd"'
             resources:
@@ -219,7 +219,7 @@ presubmits:
               - name: FOCUS
                 value: \[Serial\]
               - name: SKIP
-                value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+                value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:UserNamespacesSupport\]
               - name: BUILD_EKS_AMI
                 value: "true"
               - name: IMAGE_CONFIG_DIR
@@ -267,7 +267,7 @@ presubmits:
               - name: FOCUS
                 value: \[Serial\]
               - name: SKIP
-                value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+                value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:UserNamespacesSupport\]
               - name: USE_DOCKERIZED_BUILD
                 value: "true"
               - name: TARGET_BUILD_ARCH

--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -364,7 +364,7 @@ periodics:
             - name: FOCUS
               value: \[Serial\]
             - name: SKIP
-              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:UserNamespacesSupport\]
             - name: USE_DOCKERIZED_BUILD
               value: "true"
             - name: TARGET_BUILD_ARCH
@@ -421,7 +421,7 @@ periodics:
             - name: IMAGE_CONFIG_FILE
               value: aws-instance.yaml
             - name: SKIP
-              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:UserNamespacesSupport\]
             - name: TEST_ARGS
               value: '--kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd"'
           resources:
@@ -464,7 +464,7 @@ periodics:
             - name: FOCUS
               value: \[Serial\]
             - name: SKIP
-              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:UserNamespacesSupport\]
             - name: BUILD_EKS_AMI
               value: "true"
             - name: IMAGE_CONFIG_DIR
@@ -513,7 +513,7 @@ periodics:
             - name: FOCUS
               value: \[Serial\]
             - name: SKIP
-              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:UserNamespacesSupport\]
             - name: BUILD_EKS_AMI
               value: "true"
             - name: BUILD_EKS_AMI_ARCH
@@ -570,7 +570,7 @@ periodics:
             - name: FOCUS
               value: \[Serial\]
             - name: SKIP
-              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:UserNamespacesSupport\]
             - name: BUILD_EKS_AMI
               value: "true"
             - name: BUILD_EKS_AMI_OS
@@ -621,7 +621,7 @@ periodics:
             - name: FOCUS
               value: \[Serial\]
             - name: SKIP
-              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+              value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:UserNamespacesSupport\]
             - name: BUILD_EKS_AMI
               value: "true"
             - name: BUILD_EKS_AMI_OS


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cgroupv2-containerd-node-arm64-e2e-serial-ec2/1901281724340375552

/kind failing-test

We filter out these tests in most lanes due to some custom enablement in the kernel.

This started from 3/12 but I think it should be excluded.

cc @rata @haircommander @dims 

