### PR TITLE
config: add e2e-certmanager job for kueue

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -356,6 +356,44 @@ presubmits:
             limits:
               cpu: "7"
               memory: "10Gi"
+  - name: pull-kueue-test-e2e-certmanager-main
+    cluster: eks-prow-build-cluster
+    branches:
+      - ^main
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+    decorate: true
+    path_alias: sigs.k8s.io/kueue
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-kueue-test-e2e-certmanager-main
+      description: "Run cert-manager end to end tests"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.31.1
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.24
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-certmanager
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
   - name: pull-kueue-verify-main
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-main.yaml
@@ -437,3 +437,49 @@ periodics:
             limits:
               cpu: "7"
               memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-certmanager-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-certmanager-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic certmanager end to end tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.31.1
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.24
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-certmanager
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"


### PR DESCRIPTION
This PR adds the CI job for running certmanager integration with Kueue. We need this to verify https://github.com/kubernetes-sigs/kueue/pull/4579