### PR TITLE
Fix pull-aws-ebs-csi-driver-image-test

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -339,7 +339,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - test-image
+        - test-images
         resources:
           requests:
             cpu: "2"


### PR DESCRIPTION
Fixes slight typo Makefile target is `test-images` not `test-image`