### PR TITLE
chore: [compat version] remove exception of MultiCIDRServiceAllocator feature.

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -42,7 +42,7 @@ periodics:
       - name: PARALLEL
         value: "true"
       - name: FEATURE_GATES
-        value: '{"AllBeta":true, "MultiCIDRServiceAllocator":false}'
+        value: '{"AllBeta":true}'
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       # we need privileged mode in order to do docker in docker
@@ -100,7 +100,7 @@ periodics:
       - name: PARALLEL
         value: "true"
       - name: FEATURE_GATES
-        value: '{"AllBeta":true, "MultiCIDRServiceAllocator":false}'
+        value: '{"AllBeta":true}'
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       # we need privileged mode in order to do docker in docker

--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -174,6 +174,7 @@ kubeadmConfigPatches:
     extraArgs:
 ${apiServer_extra_args}
       "emulated-version": "${EMULATED_VERSION}"
+      "emulation-forward-compatible": true
   controllerManager:
     extraArgs:
 ${controllerManager_extra_args}


### PR DESCRIPTION
With the merge of https://github.com/kubernetes/kubernetes/pull/130354
we don't need the exception in https://github.com/kubernetes/test-infra/pull/34206 anymore. 