### PR TITLE
Add dind enable to use docker buildx for aws-ebs-csi-driver CI

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -332,6 +332,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-aws-credential-aws-shared-testing: "true"
+      preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master


### PR DESCRIPTION
This adds the label `preset-dind-enabled: "true"` to pull-aws-ebs-csi-driver-image-test so the job can use `docker buildx`