### PR TITLE
Add privileged sec context to image test container for aws-ebs-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -341,6 +341,8 @@ presubmits:
         args:
         - make
         - test-images
+        securityContext:
+          privileged: true
         resources:
           requests:
             cpu: "2"


### PR DESCRIPTION
In order for DinD to work successfully you need privileged securityContext to be set or you get the following error 

```
sysctl: permission denied on key "net.ipv6.conf.all.disable_ipv6"
sysctl: permission denied on key "net.ipv6.conf.all.forwarding"
```