### PR TITLE
update golang to 1.24 for jobset ci

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -56,7 +56,7 @@ periodics:
     decorate: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:
@@ -92,7 +92,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -132,7 +132,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -43,7 +43,7 @@ presubmits:
       description: "Run jobset integration tests"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:
@@ -73,7 +73,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -108,7 +108,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -143,7 +143,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
+              value: public.ecr.aws/docker/library/golang:1.24
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh


### PR DESCRIPTION
Update jobset to use go 1.24 in our CI.

Related: https://github.com/kubernetes-sigs/jobset/pull/841