### PR TITLE
fix: update compatibility version kind configuration YAML to be valid YAML

### DIFF
--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -174,7 +174,7 @@ kubeadmConfigPatches:
     extraArgs:
 ${apiServer_extra_args}
       "emulated-version": "${EMULATED_VERSION}"
-      "emulation-forward-compatible": true
+      "emulation-forward-compatible": "true"
   controllerManager:
     extraArgs:
 ${controllerManager_extra_args}


### PR DESCRIPTION
Fixes an issue where in a recent PR the kind config YAML was invalid using a bool vs a string.  This PR fixes that

PR that changed the configuration: https://github.com/kubernetes/test-infra/pull/34523

Related comment: https://github.com/kubernetes/test-infra/pull/34523

Comment Inlined below:

... https://github.com/kubernetes/test-infra/pull/34523 may have inadvertently broke the the related integration tests:

https://testgrid.k8s.io/sig-testing-kind#compatibility-version-test-n-minus-1
https://testgrid.k8s.io/sig-testing-kind#compatibility-version-test-n-minus-2

![image](https://github.com/user-attachments/assets/4f979650-f02d-4172-a110-01fe7b538f5b)


https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-compatibility-versions-n-minus-1/1901808198633918464
```
Command Output: I0318 01:36:13.658875     218 initconfiguration.go:261] loading configuration from "/kind/kubeadm.conf"
W0318 01:36:13.659695     218 common.go:101] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration"). Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
W0318 01:36:13.660410     218 initconfiguration.go:332] error unmarshaling configuration schema.GroupVersionKind{Group:"kubeadm.k8s.io", Version:"v1beta3", Kind:"ClusterConfiguration"}: json: cannot unmarshal bool into Go struct field APIServer.apiServer.extraArgs of type string
json: cannot unmarshal bool into Go struct field APIServer.apiServer.extraArgs of type string
````

I believe the issue is that the `true` here should be quoted  so it is a YAMl string vs a bool:
```
"emulation-forward-compatible": true
```