### PR TITLE
Add Windows 2022 tests to CI of PDCSI driver.

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
@@ -44,7 +44,53 @@ periodics:
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: ci-windows-2019-provider-gcp-compute-persistent-disk-csi-driver
-    description: Kubernetes Integration tests for Kubernetes Master branch and Driver latest
+    description: Kubernetes Integration tests for Kubernetes Master branch and Driver latest on Windows 2019 nodes
+- name: ci-gce-pd-csi-driver-latest-k8s-master-windows-2022
+  cluster: k8s-infra-prow-build
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: gcp-compute-persistent-disk-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    workdir: true
+  interval: 4h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 360m
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
+      command:
+      - runner.sh
+      args:
+      - "test/run-windows-k8s-integration.sh"
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2022"
+      - name: PREPULL_YAML
+        value: "prepull-head.yaml"
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: 2
+          memory: "6Gi"
+        requests:
+          cpu: 2
+          memory: "6Gi"
+  annotations:
+    testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
+    testgrid-tab-name: ci-windows-2022-provider-gcp-compute-persistent-disk-csi-driver
+    description: Kubernetes Integration tests for Kubernetes Master branch and Driver latest on Windows 2022 nodes
 presubmits:
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
   - name: pull-gcp-compute-persistent-disk-csi-driver-e2e-windows-2019
@@ -92,5 +138,50 @@ presubmits:
     annotations:
       testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
       testgrid-tab-name: windows-2019-presubmit-gcp-compute-persistent-disk-csi-driver
-      description: Kubernetes Integration Windows tests for Kubernetes Master branch and Driver latest build
-      testgrid-alert-email: jinxu@google.com
+      description: Presubmit Kubernetes Integration tests for Kubernetes Master branch on Windows 2019 nodes
+  - name: pull-gcp-compute-persistent-disk-csi-driver-e2e-windows-2022
+    cluster: k8s-infra-prow-build
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+      preset-common-gce-windows: "true"
+      preset-e2e-gce-windows: "true"
+      preset-e2e-gce-windows-containerd: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 180m
+    path_alias: sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
+        command:
+        - runner.sh
+        args:
+        - "test/run-windows-k8s-integration.sh"
+        env:
+        - name: WINDOWS_NODE_OS_DISTRIBUTION
+          value: "win2022"
+        - name: PREPULL_YAML
+          value: "prepull-head.yaml"
+        - name: GCE_PD_OVERLAY_NAME
+          value: "dev"
+        - name: GCE_PD_DO_DRIVER_BUILD
+          value: "true"
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: "6Gi"
+          requests:
+            cpu: 2
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
+      testgrid-tab-name: windows-2022-presubmit-gcp-compute-persistent-disk-csi-driver
+      description: Presubmit Kubernetes Integration tests for Kubernetes Master branch on Windows 2022 nodes


### PR DESCRIPTION
Relevant changes for PDCSI is being made in https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1999