### PR TITLE
Update Cluster API milestone applier

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -512,7 +512,8 @@ milestone_applier:
     release-1.17: v1.17
     release-1.16: v1.16
   kubernetes-sigs/cluster-api:
-    main: v1.10
+    main: v1.11
+    release-1.10: v1.10
     release-1.9: v1.9
     release-1.8: v1.8
     release-1.7: v1.7


### PR DESCRIPTION
cluster-api: update milestone applier after the creation of the release 1.10 branch