### PR TITLE
Assign etcd integration tests to respective arch dashboards

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -444,7 +444,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-arm64
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-amd64
     testgrid-tab-name: ci-etcd-integration-1-cpu-amd64
   spec:
     containers:
@@ -772,7 +772,7 @@ periodics:
       repo: etcd
       base_ref: release-3.6
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-arm64
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-amd64
     testgrid-tab-name: ci-etcd-integration-1-cpu-release36-amd64
   spec:
     containers:


### PR DESCRIPTION
Assign `ci-etcd-integration-1-cpu-release36-amd64` and `ci-etcd-integration-1-cpu-amd64` to the `sig-etcd-amd64` dashboard. 