### PR TITLE
Introduce etcd unit and integration tests jobs for ppc64le architecture

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -66,8 +66,6 @@ periodics:
           limits:
             cpu: "4"
             memory: "8Gi"
-    nodeSelector:
-      kubernetes.io/arch: ppc64le
 
 - name: ci-etcd-e2e-amd64
   interval: 4h
@@ -133,6 +131,35 @@ periodics:
           memory: "4Gi"
     nodeSelector:
       kubernetes.io/arch: amd64
+
+- name: ci-etcd-unit-test-ppc64le
+  interval: 4h
+  cluster: k8s-infra-ppc64le-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-unit-test-ppc64le
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250311-73aac21714-master
+        command:
+          - runner.sh
+        args:
+          - make
+          - test-unit
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
 
 - name: ci-etcd-unit-test-arm64
   interval: 4h
@@ -467,6 +494,38 @@ periodics:
           cpu: "2"
           memory: "3Gi"
 
+- name: ci-etcd-integration-1-cpu-ppc64le
+  interval: 24h
+  cluster: k8s-infra-ppc64le-prow-build
+  decorate: true
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le
+    testgrid-tab-name: ci-etcd-integration-1-cpu-ppc64le
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250311-73aac21714-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            make gofail-enable
+            export JUNIT_REPORT_DIR=${ARTIFACTS}
+            GOOS=linux GOARCH=ppc64le CPU=1 make test-integration
+        resources:
+          requests:
+            cpu: "2"
+            memory: "3Gi"
+          limits:
+            cpu: "2"
+            memory: "3Gi"
+
 - name: ci-etcd-integration-1-cpu-arm64
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -533,6 +592,38 @@ periodics:
             cpu: "3"
             memory: "3Gi"
 
+- name: ci-etcd-integration-2-cpu-ppc64le
+  cluster: k8s-infra-ppc64le-prow-build
+  interval: 24h
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-integration-2-cpu-ppc64le
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250311-73aac21714-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            make gofail-enable
+            export JUNIT_REPORT_DIR=${ARTIFACTS}
+            GOOS=linux GOARCH=ppc64le CPU=2 make test-integration
+        resources:
+          requests:
+            cpu: "3"
+            memory: "3Gi"
+          limits:
+            cpu: "3"
+            memory: "3Gi"
+
 - name: ci-etcd-integration-2-cpu-arm64
   cluster: k8s-infra-prow-build
   interval: 24h
@@ -591,6 +682,38 @@ periodics:
             make gofail-enable
             export JUNIT_REPORT_DIR=${ARTIFACTS}
             GOOS=linux GOARCH=amd64 CPU=4 make test-integration
+        resources:
+          requests:
+            cpu: "6"
+            memory: "3Gi"
+          limits:
+            cpu: "6"
+            memory: "3Gi"
+
+- name: ci-etcd-integration-4-cpu-ppc64le
+  cluster: k8s-infra-ppc64le-prow-build
+  interval: 24h
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-integration-4-cpu-ppc64le
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250311-73aac21714-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            make gofail-enable
+            export JUNIT_REPORT_DIR=${ARTIFACTS}
+            GOOS=linux GOARCH=ppc64le CPU=4 make test-integration
         resources:
           requests:
             cpu: "6"


### PR DESCRIPTION
Add prow job configurations to run integration and unit tests periodically against the main branch on the `k8s-infra-ppc64le-prow-build` cluster.

The e2e tests on the ppc64le architecture was added through: https://github.com/kubernetes/test-infra/pull/34503