### PR TITLE
fix: resolve test failures by adding back MultiCIDRServiceAllocator:false to E2E compatibility versions tests

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -42,7 +42,7 @@ periodics:
       - name: PARALLEL
         value: "true"
       - name: FEATURE_GATES
-        value: '{"AllBeta":true}'
+        value: '{"AllBeta":true, "MultiCIDRServiceAllocator":false}'
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       # we need privileged mode in order to do docker in docker
@@ -100,7 +100,7 @@ periodics:
       - name: PARALLEL
         value: "true"
       - name: FEATURE_GATES
-        value: '{"AllBeta":true}'
+        value: '{"AllBeta":true, "MultiCIDRServiceAllocator":false}'
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
Reverts change made in: https://github.com/kubernetes/test-infra/pull/34523

Currently ci-kubernetes-e2e-kind-compatibility-versions-* tests are failing:
https://testgrid.k8s.io/sig-testing-kind#compatibility-version-test-n-minus-1
https://testgrid.k8s.io/sig-testing-kind#compatibility-version-test-n-minus-2

Currently the E2E compatibility version tests require the apiserver configuration be identical across across the 2 step upgrade.  This means that it is non-trivial to have a new feature gate (`emulation-forward-compatible`) not set in a previous version and then set in the upgraded version the test uses (eg: 1.32 `emulation-forward-compatible` doesn't exist -> 1.33 `emulation-forward-compatible` does exist).  This change can be made but for now reverting this change to get tests passing again and coverage