### PR TITLE
Add e2e tests for fips and a1compat images for aws-ebs-csi-driver

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -33,6 +33,40 @@ presubmits:
       testgrid-tab-name: test-e2e-external-eks-windows
       description: aws ebs csi driver External Storage tests for Windows on pull request
       testgrid-num-columns-recent: '30'
+  - name: pull-aws-ebs-csi-driver-test-e2e-external-eks-windows-fips
+    cluster: eks-prow-build-cluster
+    decorate: true
+    optional: true
+    skip_report: true
+    branches:
+      - ^release-.*$
+    skip_if_only_changed: "^docs/|^examples/|.md$|OWNERS$|^.github/"
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-credential-aws-shared-testing: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-e2e-external-eks-windows-fips
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "2"
+            memory: "4Gi"
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+    annotations:
+      testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
+      testgrid-tab-name: test-e2e-external-eks-windows-fips
+      description: aws ebs csi driver External Storage tests for Windows fips image on release branch pull requests
+      testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-test-helm-chart
     cluster: eks-prow-build-cluster
     decorate: true
@@ -221,6 +255,74 @@ presubmits:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-external-test
       description: kubernetes/kubernetes external test on pull request
+      testgrid-num-columns-recent: '30'
+  - name: pull-aws-ebs-csi-driver-external-test-a1
+    cluster: eks-prow-build-cluster
+    decorate: true
+    optional: true
+    skip_report: true
+    branches:
+      - ^release-.*$
+    skip_if_only_changed: "^docs/|^examples/|.md$|OWNERS$|^.github/"
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-credential-aws-shared-testing: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-external-a1
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+    annotations:
+      testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
+      testgrid-tab-name: pull-external-test-a1
+      description: kubernetes/kubernetes external test on pull requests on release branch for a1compat image
+      testgrid-num-columns-recent: '30'
+  - name: pull-aws-ebs-csi-driver-external-test-fips
+    cluster: eks-prow-build-cluster
+    decorate: true
+    optional: true
+    skip_report: true
+    branches:
+      - ^release-.*$
+    skip_if_only_changed: "^docs/|^examples/|.md$|OWNERS$|^.github/"
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-aws-credential-aws-shared-testing: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-external-fips
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+    annotations:
+      testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
+      testgrid-tab-name: pull-external-test-fips
+      description: kubernetes/kubernetes external test on pull requests on release branch for fips image
       testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-external-test-eks
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
This Cr introduces 3 new CI jobs

`pull-aws-ebs-csi-driver-test-e2e-external-eks-windows-fips`
`pull-aws-ebs-csi-driver-external-test-a1`
`pull-aws-ebs-csi-driver-external-test-fips`

Which test the `fips` and `a1compat` images when a PR is cut to any of the release branches to make sure that they are working properly prior to a release. 

They are currently `optional` and will `skip_report`ing to github as is [best practice](https://docs.prow.k8s.io/docs/build-test-update/#how-to-test-a-prowjob) for new prow jobs 