### PR TITLE
fix capz-windows-2022-hostprocess test failure

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -741,7 +741,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.17
+        base_ref: release-1.18
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
       - org: kubernetes-sigs
@@ -788,6 +788,8 @@ presubmits:
               value: "v1.30.2"
             - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
+            - name: CLUSTER_TEMPLATE  # CAPZ config
+              value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/refs/heads/release-1.18/templates/test/ci/cluster-template-prow-ci-version.yaml
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
       testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-windows-2022-hostprocess

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -741,7 +741,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.18
+        base_ref: release-1.17
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
       - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -549,7 +549,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.18
+        base_ref: release-1.17
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
       - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -549,7 +549,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.17
+        base_ref: release-1.18
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: true
       - org: kubernetes-sigs
@@ -596,6 +596,8 @@ presubmits:
               value: "v1.32.0"
             - name: WORKER_MACHINE_COUNT
               value: "0" # Don't create any linux worker nodes
+            - name: CLUSTER_TEMPLATE  # CAPZ config
+              value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/refs/heads/release-1.18/templates/test/ci/cluster-template-prow-ci-version.yaml
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver
       testgrid-tab-name: pull-azurefile-csi-driver-e2e-capz-windows-2022-hostprocess


### PR DESCRIPTION
cluster-api-provider-azure release-1.18 does not respect `WINDOWS_SERVER_VERSION` anymore, always creates Windows 2019 node now, this PR reverts to release-1.17 first

```
            - name: WINDOWS_SERVER_VERSION # CAPZ config
              value: "windows-2022"
```