### PR TITLE
Revert "swap-conformance lanes: add eviction tests to swap serial lanes"

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -509,7 +509,7 @@ periodics:
           - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
+          - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
           - --timeout=180m
         env:
           - name: GOPATH
@@ -558,7 +558,7 @@ periodics:
       - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=1 --timeout=4h --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
+      - --test_args=--nodes=1 --timeout=4h --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
       - --timeout=270m
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
       resources:

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -509,7 +509,7 @@ periodics:
           - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
+          - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]" --skip="\[Flaky\]|\[Slow\]|\[Benchmark\]|\[Feature:Eviction\]"
           - --timeout=180m
         env:
           - name: GOPATH
@@ -558,7 +558,7 @@ periodics:
       - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=1 --timeout=4h --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
+      - --test_args=--nodes=1 --timeout=4h --focus="\[Feature:NodeSwap\]" --skip="\[Flaky\]|\[Slow\]|\[Benchmark\]|\[Feature:Eviction\]"
       - --timeout=270m
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
       resources:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2294,7 +2294,7 @@ presubmits:
             - '--node-test-args=--feature-gates=NodeSwap=true --service-feature-gates=NodeSwap=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
             - --provider=gce
-            - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
+            - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]" --skip="\[Flaky\]|\[Slow\]|\[Benchmark\]|\[Feature:Eviction\]"
             - --timeout=180m
           env:
             - name: GOPATH
@@ -2345,7 +2345,7 @@ presubmits:
         - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
+        - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]" --skip="\[Flaky\]|\[Slow\]|\[Benchmark\]|\[Feature:Eviction\]"
         - --timeout=180m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
         resources:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2294,7 +2294,7 @@ presubmits:
             - '--node-test-args=--feature-gates=NodeSwap=true --service-feature-gates=NodeSwap=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
             - --provider=gce
-            - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
+            - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
             - --timeout=180m
           env:
             - name: GOPATH
@@ -2345,7 +2345,7 @@ presubmits:
         - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
+        - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
         - --timeout=180m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
         resources:


### PR DESCRIPTION
This reverts adding memory eviction tests to the swap-conformance lanes, that were done as part of https://github.com/kubernetes/test-infra/pull/34507.

The reason is that it causes the lane to become flaky.
Eviction tests are very delicate and fragile. They stress out the node entirely, and depend on many delicate factors like the amount of total/free memory on the node, etc. Even if swap is disabled for Kubernetes workloads, the fact it's enabled on the node might easily cause these tests to become flaky. The swap-conformance stress tests are designed to run on this lane and they are very stable.