### PR TITLE
Enable KubeletPSI feature gate in API server

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -510,7 +510,7 @@ presubmits:
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/image-config.yaml
         - --deployment=node
         - --gcp-zone=us-central1-b
-        - '--node-test-args=--feature-gates=AllAlpha=true,ImageVolume=true,EventedPLEG=false --service-feature-gates=ProcMountType=true,UserNamespacesSupport=true,ImageVolume=true,ResourceHealthStatus=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
+        - '--node-test-args=--feature-gates=AllAlpha=true,ImageVolume=true,EventedPLEG=false --service-feature-gates=ProcMountType=true,UserNamespacesSupport=true,ImageVolume=true,ResourceHealthStatus=true,KubeletPSI=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
         - --node-tests=true
         - --provider=gce
         - --test_args=--nodes=8 --focus="\[Feature:.+\]" --skip="\[Flaky\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]"


### PR DESCRIPTION
The feature gate controls kubelet behavior, and has already been enabled in kubelet through --node-test-args.

However, our E2E test also needs to check the feature gate to change the test behavior. And it's actually checking the feature gate from API server (through using k8s.io/apiserver/pkg/util/feature package).

To make the E2E test behave correctly. We are enabling the feature gate in API server through the --service-feature-gates flag. This has no effect on API server behavior; it only affects test code behavior.

/cc @kannon92 