### PR TITLE
Run k8s unit tests on ppc64le

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/OWNERS
@@ -1,0 +1,14 @@
+
+reviewers:
+- mkumatag
+- Prajyot-Parab
+- Rajalakshmi-Girish
+- kishen-v
+approvers:
+- mkumatag
+- Prajyot-Parab
+- Rajalakshmi-Girish
+- kishen-v
+labels:
+- sig/cloud-provider
+- area/provider/ppc64le

--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
@@ -1,0 +1,34 @@
+periodics:
+  - name: ci-kubernetes-unit-ppc64le
+    interval: 1h
+    cluster: k8s-infra-ppc64le-prow-build
+    decorate: true
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    annotations:
+      testgrid-dashboards: ibm-k8s-unit-tests-ppc64le
+      testgrid-tab-name: ci-kubernetes-unit-ppc64le
+    spec:
+      # unit tests have no business requiring root or doing privileged operations
+      securityContext:
+        # NOTE: these are arbitrary non-root values. They don't exist in the
+        # image and don't need to, the unit tests should only write to TMPDIR
+        runAsGroup: 2010
+        runAsUser: 2001
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250227-3a13bdd784-master
+          command:
+            - make
+            - test
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 6
+              memory: "28Gi"
+            limits:
+              cpu: 6
+              memory: "28Gi"

--- a/config/testgrids/kubernetes/sig-cloud-provider/ibm/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/ibm/config.yaml
@@ -7,16 +7,12 @@ dashboard_groups:
     - ibm-etcd-tests-ppc64le
 
 dashboards:
+- name: ibm-k8s-unit-tests-ppc64le
 - name: ibm-k8s-conformance-ppc64le
   dashboard_tab:
     - name: periodic-k8s-conformance-ppc64le-containerd
       description: Runs conformance tests using kubetest2 against latest kubernetes nightly release on ibm ppc64le architecture with containerd as runtime
       test_group_name: ppc64le-conformance-containerd
-- name: ibm-k8s-unit-tests-ppc64le
-  dashboard_tab:
-    - name: periodic-k8s-unit-tests-ppc64le
-      description: Runs unit tests on ibm ppc64le architecture
-      test_group_name: ppc64le-unit
 - name: ibm-k8s-e2e-node-ppc64le
   dashboard_tab:
     - name: periodic-k8s-e2e-node-ppc64le
@@ -35,8 +31,6 @@ test_groups:
   days_of_results: 7
   column_header:
   - configuration_value: k8s-build-version
-- name: ppc64le-unit
-  gcs_prefix: ppc64le-kubernetes/logs/periodic-kubernetes-unit-test-ppc64le
 - name: k8s-e2e-node
   gcs_prefix:  ppc64le-kubernetes/logs/periodic-kubernetes-containerd-e2e-node-tests-ppc64le
 - name: ppc64le-etcd-tests


### PR DESCRIPTION
This is to add a periodic ci job to run k8s UT on ppc64le cluster.
Replacing testgrid at https://testgrid.k8s.io/ibm-k8s-unit-tests-ppc64le#periodic-k8s-unit-tests-ppc64le with results from this new job.