### PR TITLE
Add test infra for pod autoscaling alpha/beta features.

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -366,7 +366,7 @@ periodics:
       - --gcp-node-image=gci
       - --extract=ci/latest
       - --timeout=240m
-      - --test_args=--ginkgo.focus=\[Feature:HPA\]
+      - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Alpha\]|\[Beta\]
         --minStartupPods=8
       - --ginkgo-parallel=1
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
@@ -382,3 +382,41 @@ periodics:
     # TODO: add to release blocking dashboards once run is successful
     testgrid-dashboards: sig-autoscaling-hpa
     testgrid-tab-name: gce-cos-autoscaling-hpa-cpu
+- interval: 30m
+  name: ci-kubernetes-e2e-autoscaling-hpa-cpu-alpha-beta
+  cluster: k8s-infra-prow-build
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  decorate: true
+  decoration_config:
+    timeout: 260m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --check-leaked-resources
+      - --provider=gce
+      - --gcp-zone=us-west1-b
+      - --gcp-node-image=gci
+      - --extract=ci/latest
+      - --timeout=240m
+      - --env=KUBE_FEATURE_GATES=HPAConfigurableTolerance=true
+      - --test_args=--ginkgo.focus=\[Feature:HPAConfigurableTolerance\]
+        --minStartupPods=8
+      - --ginkgo-parallel=1
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
+
+  annotations:
+    # TODO: add to release blocking dashboards once run is successful
+    testgrid-dashboards: sig-autoscaling-hpa
+    testgrid-tab-name: gce-cos-autoscaling-hpa-cpu-alpha-beta

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -88,7 +88,53 @@ presubmits:
         - --provider=gce
         - --gcp-zone=us-west1-b
         - --gcp-node-image=gci
-        - --test_args=--ginkgo.focus=\[Feature:HPA\] --minStartupPods=8
+        - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Alpha\]|\[Beta\] --minStartupPods=8
+        - --ginkgo-parallel=1
+        - --timeout=300m
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
+
+  - name: pull-kubernetes-e2e-autoscaling-hpa-cpu-alpha-beta
+    cluster: k8s-infra-prow-build
+    annotations:
+      testgrid-dashboards: sig-autoscaling-hpa
+      testgrid-tab-name: gci-gce-autoscaling-hpa-cpu-alpha-beta-pull
+    # TODO: set `optional: false` once tests not flaky
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 310m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: release
+      base_ref: master
+      path_alias: k8s.io/release
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --build=quick
+        - --check-leaked-resources
+        - --provider=gce
+        - --gcp-zone=us-west1-b
+        - --gcp-node-image=gci
+        - --env=KUBE_FEATURE_GATES=HPAConfigurableTolerance=true
+        - --test_args=--ginkgo.focus=\[Feature:HPAConfigurableTolerance\] --minStartupPods=8
         - --ginkgo-parallel=1
         - --timeout=300m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master


### PR DESCRIPTION
Adds testing infrastructure to run pod autoscaling tests targeting features gated by alpha and beta feature gates.

For the moment, the only feature in scope is Configurable Tolerance (see [PR](https://github.com/kubernetes/kubernetes/pull/130797)).