### PR TITLE
[VPA] Temporarily stop requiring e2e vpa tests in PRs while we fix tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -204,6 +204,7 @@ presubmits:
       testgrid-tab-name: autoscaling-vpa-full-presubmits
     optional: true
     decorate: true
+    always_run: false  # Temporary until tests using GCR are fixed (https://github.com/kubernetes/autoscaler/issues/7946)
     decoration_config:
       timeout: 120m
     run_if_changed: '^vertical-pod-autoscaler\/'


### PR DESCRIPTION
See https://github.com/kubernetes/autoscaler/issues/7946.

We agreed to turn off these e2e tests as part of PR submission flow temporarily while these tests are being fixed.

We will of course run them again before the next release and work on re-instating this ASAP.