### PR TITLE
Fix ci-crio-cgroupv2-userns-e2e-serial failure

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -796,6 +796,11 @@ periodics:
   path_alias: k8s.io/kubernetes
   extra_refs:
     - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+    - org: kubernetes
       repo: test-infra
       base_ref: master
       path_alias: k8s.io/test-infra


### PR DESCRIPTION
Following up https://github.com/kubernetes/test-infra/pull/34531 .
The periodic CI keeps failing. It fails probably because it doesn't set `extra_refs`.

cf. https://docs.prow.k8s.io/docs/jobs/#how-to-configure-new-jobs

> ```
> periodics:
> - name: foo-job         # Names need not be unique, but must match the regex ^[A-Za-z0-9-._]+$
>   decorate: true        # Enable Pod Utility decoration. (see below)
>   interval: 1h          # Anything that can be parsed by time.ParseDuration.
>   # Alternatively use a cron instead of an interval, for example:
>   # cron: "05 15 * * 1-5"  # Run at 7:05 PST (15:05 UTC) every M-F
>   extra_refs:            # Periodic job doesn't clone any repo by default, needs to be added explicitly
>   - org: org
>     repo: repo
>     base_ref: main
>   spec: {}              # Valid Kubernetes PodSpec.
> ```