### PR TITLE
Set IP_FAMILY to `ipv6` in pull-cluster-api-provider-azure-conformance-ipv6-with-ci-artifacts

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -393,7 +393,7 @@ presubmits:
             - name: E2E_ARGS
               value: "-kubetest.use-ci-artifacts"
             - name: IP_FAMILY
-              value: "IPv6"
+              value: "ipv6"
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
- Set IP_FAMILY to `ipv6` in pull-cluster-api-provider-azure-conformance-ipv6-with-ci-artifacts