### PR TITLE
[Kjob] Sync resources between presubmits and periodic tests.

### DIFF
--- a/config/jobs/kubernetes-sigs/kjob/kjob-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-periodics-main.yaml
@@ -117,8 +117,8 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "7"
-              memory: "10Gi"
+              cpu: "4"
+              memory: "4Gi"
             limits:
-              cpu: "7"
-              memory: "10Gi"
+              cpu: "4"
+              memory: "4Gi"

--- a/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
@@ -117,8 +117,8 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "7"
-              memory: "10Gi"
+              cpu: "4"
+              memory: "4Gi"
             limits:
-              cpu: "7"
-              memory: "10Gi"
+              cpu: "4"
+              memory: "4Gi"

--- a/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-main.yaml
@@ -123,8 +123,8 @@ presubmits:
               privileged: true
             resources:
               requests:
-                cpu: "2"
+                cpu: "4"
                 memory: "4Gi"
               limits:
-                cpu: "2"
+                cpu: "4"
                 memory: "4Gi"

--- a/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-release-0.1.yaml
@@ -123,8 +123,8 @@ presubmits:
               privileged: true
             resources:
               requests:
-                cpu: "2"
+                cpu: "4"
                 memory: "4Gi"
               limits:
-                cpu: "2"
+                cpu: "4"
                 memory: "4Gi"


### PR DESCRIPTION
I propose to use the same resources on presubmit and periodic tests.

Currently in resources on presubmits we have

https://github.com/kubernetes/test-infra/blob/f908520b9ce38085332050acfd319225ca8e3dbf/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-main.yaml#L124-L130

and resources on periodic we have

https://github.com/kubernetes/test-infra/blob/f908520b9ce38085332050acfd319225ca8e3dbf/config/jobs/kubernetes-sigs/kjob/kjob-periodics-main.yaml#L118-L124