### PR TITLE
node: kubetest2: clear usage of skip-regex

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1091,7 +1091,7 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --parallelism=1
         - '--label-filter=Feature: containsAny CPUManager && !Flaky'
-        - --skip-regex=\[Flaky\]|\[Slow\]
+        - --skip-regex=""
         - --test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --cgroup-driver=systemd"
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
   - name: pull-kubernetes-node-kubelet-serial-topology-manager
@@ -1197,7 +1197,7 @@ presubmits:
         - --repo-root=.
         - --gcp-zone=us-west1-b
         - --parallelism=1
-        - --skip-regex=\[Flaky\]|\[Slow\]
+        - --skip-regex=""
         - '--label-filter=Feature: containsAny TopologyManager && !Flaky'
         - --test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --cgroup-driver=systemd"
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
@@ -1845,7 +1845,7 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --parallelism=1
         - --focus-regex=\[Feature:HugePages\]
-        - --skip-regex=
+        - --skip-regex=""
         - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-hugepages.yaml
         resources:
@@ -1904,7 +1904,7 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --parallelism=1
         - --focus-regex=\[Feature:HugePages\]
-        - --skip-regex=
+        - --skip-regex=""
         - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-hugepages.yaml
         resources:
@@ -1963,7 +1963,7 @@ presubmits:
         - --repo-root=.
         - --gcp-zone=us-west1-b
         - --parallelism=1
-        - --skip-regex=
+        - --skip-regex=""
         - '--label-filter=Feature: isSubsetOf { CPUManager, MemoryManager, TopologyManager }'
         - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-resource-managers.yaml
@@ -2023,7 +2023,7 @@ presubmits:
         - --repo-root=.
         - --gcp-zone=us-west1-b
         - --parallelism=1
-        - --skip-regex=
+        - --skip-regex=""
         - '--label-filter=Feature: isSubsetOf { CPUManager, MemoryManager, TopologyManager }'
         - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-resource-managers.yaml


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/34563 reminded us about the skip regex defaults of the `kubetest2` `node` tester:

Turns out that the `kubetest2` node tester, which we need to use in these lanes, has a `SkipRegex` default setting which include the `Serial` tag.

Problem: all the e2e_node suites are serial, because they need to mutate the node, which is a giant shared piece of state.

As followup, we take care to initialize the `skip-regex` option to empty value and we demand to the label filter which test to run, avoiding sources of conflicts.