### PR TITLE
Avoid running VPA tests when the enhancements directory changes

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -207,7 +207,7 @@ presubmits:
     always_run: false  # Temporary until tests using GCR are fixed (https://github.com/kubernetes/autoscaler/issues/7946)
     decoration_config:
       timeout: 120m
-    run_if_changed: '^vertical-pod-autoscaler\/'
+    run_if_changed: '^vertical-pod-autoscaler\/(?!enhancements\/).*'
     path_alias: k8s.io/autoscaler
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
It's a waste to re-run the tests when enhancements changes, so stop doing that.