### PR TITLE
Update prow plugin with CAPZ release 1.20

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -534,9 +534,9 @@ milestone_applier:
     release-0.7: v0.7.x
     release-0.6: v0.6.x
   kubernetes-sigs/cluster-api-provider-azure:
-    main: v1.18
-    release-1.17: v1.17
-    release-1.16: v1.16
+    main: v1.20
+    release-1.19: v1.19
+    release-1.18: v1.18
   kubernetes-sigs/cluster-api-provider-digitalocean:
     main: v1.1.0
     release-1.0: v1.0.0


### PR DESCRIPTION
Updates the current milestone and supported branches for CAPZ to 1.20