### PR TITLE
Specify the node image for manual scalability tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -372,6 +372,7 @@ presubmits:
         # memory usage regression.
         - --env=KUBE_DNS_MEMORY_LIMIT=300Mi
         - --extract=local
+        - --gcp-node-image=gci
         - --gcp-nodes=5000
         - --gcp-project-type=scalability-scale-project
         - --gcp-zone=us-east1-b


### PR DESCRIPTION
Hoping to fix the following error:
```
2025/03/20 15:45:16 main.go:326: Something went wrong: failed to acquire k8s binaries: open /home/prow/go/src/k8s.io/kubernetes/_output/gcs-stage: no such file or directory
Traceback (most recent call last):
  File "/workspace/scenarios/kubernetes_e2e.py", line 391, in <module>
    main(parse_args())
  File "/workspace/scenarios/kubernetes_e2e.py", line 307, in main
    mode.start(runner_args)
  File "/workspace/scenarios/kubernetes_e2e.py", line 136, in start
    check_env(env, self.command, *args)
  File "/workspace/scenarios/kubernetes_e2e.py", line 57, in check_env
    subprocess.check_call(cmd, env=env)
  File "/usr/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '('kubetest', '--dump=/logs/artifacts', '--gcp-service-account=/etc/service-account/service-account.json', '--build=quick', '--up', '--down', '--provider=gce', '--cluster=gce-scale-cluster', '--gcp-network=gce-scale-cluster', '--extract=local', '--gcp-nodes=5000', '--gcp-project-type=scalability-scale-project', '--gcp-zone=us-east1-b', '--metadata-sources=cl2-metadata.json', '--test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh', '--test-cmd-args=cluster-loader2', '--test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true', '--test-cmd-args=--experimental-prometheus-disk-snapshot-name=pull-kubernetes-e2e-gce-scale-performance-manual-1902744459217473536', '--test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true', '--test-cmd-args=--nodes=5000', '--test-cmd-args=--prometheus-scrape-node-exporter', '--test-cmd-args=--provider=gce', '--test-cmd-args=--report-dir=/logs/artifacts', '--test-cmd-args=--testconfig=testing/load/config.yaml', '--test-cmd-args=--testconfig=testing/huge-service/config.yaml', '--test-cmd-args=--testconfig=testing/access-tokens/config.yaml', '--test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml', '--test-cmd-args=--testoverrides=./testing/experiments/ignore_known_gce_container_restarts.yaml', '--test-cmd-args=--testoverrides=./testing/overrides/5000_nodes.yaml', '--test-cmd-name=ClusterLoaderV2', '--timeout=420m', '--logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/pull-kubernetes-e2e-gce-scale-performance-manual/1902744459217473536')' returned non-zero exit status 1.
```
From https://github.com/kubernetes/kubernetes/pull/130583#issuecomment-2742603480

This is the only missing argument from the test when compared to other tests that build locally.

/assign @wojtek-t @mborsz 