### PR TITLE
kind canaries: use `Feature: isEmpty`

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -285,7 +285,7 @@ presubmits:
         - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isSubsetOf OffByDefault && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -74,7 +74,7 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isSubsetOf OffByDefault && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/34599#discussion_r2011048552

Tentatively there will be only one failing test case after this, and the resulting filter is pretty reasonable ... 🤞 

/cc @aojea @pohly @stmcginnis 

My goal is to get to where we can use something like this in 1.34 and avoid the current:
https://github.com/kubernetes/test-infra/blob/754fa8f9d783bde6e7904093954c5be896369947/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml#L30

(and not need anything like it for the alpha/beta/... jobs either)

xref: https://github.com/kubernetes/kubernetes/issues/131040