### PR TITLE
[Kjob] Fix release-0.1 tests.

### DIFF
--- a/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
@@ -103,7 +103,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.29.14
+              value: kindest/node:v1.29.12
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -148,7 +148,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.30.10
+              value: kindest/node:v1.30.8
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -193,7 +193,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.31.6
+              value: kindest/node:v1.31.4
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -238,7 +238,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
+              value: kindest/node:v1.32.0
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:

--- a/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-release-0.1.yaml
@@ -109,7 +109,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
             env:
               - name: E2E_KIND_VERSION
-                value: kindest/node:v1.29.14
+                value: kindest/node:v1.29.12
               - name: BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang:1.24
             command:
@@ -146,7 +146,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
             env:
               - name: E2E_KIND_VERSION
-                value: kindest/node:v1.30.10
+                value: kindest/node:v1.30.8
               - name: BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang:1.24
             command:
@@ -183,7 +183,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
             env:
               - name: E2E_KIND_VERSION
-                value: kindest/node:v1.31.6
+                value: kindest/node:v1.31.4
               - name: BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang:1.24
             command:
@@ -220,7 +220,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
             env:
               - name: E2E_KIND_VERSION
-                value: kindest/node:v1.32.3
+                value: kindest/node:v1.32.0
               - name: BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang:1.24
             command:


### PR DESCRIPTION
We have an error:
```
ERROR: failed to detect containerd snapshotter
```

For more details, see https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-kjob-test-e2e-release-0-1-1-32/1904326141368340480.

This happens due to incompatible versions between the Kind binary and Kind image.