### PR TITLE
[Kjob] Remove e2e tests for k8s v1.29.

### DIFF
--- a/config/jobs/kubernetes-sigs/kjob/kjob-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-periodics-main.yaml
@@ -78,51 +78,6 @@ periodics:
               cpu: "2"
               memory: "4Gi"
   - interval: 12h
-    name: periodic-kjob-test-e2e-main-1-29
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-kjob-test-e2e-main-1-29
-      testgrid-alert-email: kjob-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kjob end to end tests for Kubernetes 1.29"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kjob
-        base_ref: main
-        path_alias: kubernetes-sigs/kjob
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.29.14
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "4"
-              memory: "4Gi"
-            limits:
-              cpu: "4"
-              memory: "4Gi"
-  - interval: 12h
     name: periodic-kjob-test-e2e-main-1-30
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
@@ -78,51 +78,6 @@ periodics:
               cpu: "2"
               memory: "4Gi"
   - interval: 12h
-    name: periodic-kjob-test-e2e-release-0-1-1-29
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-kjob-test-e2e-release-0-1-1-29
-      testgrid-alert-email: kjob-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kjob end to end tests for Kubernetes 1.29"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kjob
-        base_ref: release-0.1
-        path_alias: kubernetes-sigs/kjob
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.29.14
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "4"
-              memory: "4Gi"
-            limits:
-              cpu: "4"
-              memory: "4Gi"
-  - interval: 12h
     name: periodic-kjob-test-e2e-release-0-1-1-30
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-main.yaml
@@ -91,43 +91,6 @@ presubmits:
               limits:
                 cpu: "2"
                 memory: "4Gi"
-    - name: pull-kjob-test-e2e-main-1-29
-      cluster: eks-prow-build-cluster
-      branches:
-        - ^main
-      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-      decorate: true
-      path_alias: sigs.k8s.io/kjob
-      annotations:
-        testgrid-dashboards: sig-apps
-        testgrid-tab-name: pull-kjob-test-e2e-main-1-29
-        description: "Run kjob end to end tests for Kubernetes 1.29"
-      labels:
-        preset-dind-enabled: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-            env:
-              - name: E2E_KIND_VERSION
-                value: kindest/node:v1.29.14
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
-            command:
-              # generic runner script, handles DIND, bazelrc for caching, etc.
-              - runner.sh
-            args:
-              - make
-              - test-e2e
-            # docker-in-docker needs privileged mode
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                cpu: "4"
-                memory: "4Gi"
-              limits:
-                cpu: "4"
-                memory: "4Gi"
     - name: pull-kjob-test-e2e-main-1-30
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-release-0.1.yaml
@@ -91,43 +91,6 @@ presubmits:
               limits:
                 cpu: "2"
                 memory: "4Gi"
-    - name: pull-kjob-test-e2e-release-0-1-1-29
-      cluster: eks-prow-build-cluster
-      branches:
-        - ^release-0.1
-      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-      decorate: true
-      path_alias: sigs.k8s.io/kjob
-      annotations:
-        testgrid-dashboards: sig-apps
-        testgrid-tab-name: pull-kjob-test-e2e-release-0-1-1-29
-        description: "Run kjob end to end tests for Kubernetes 1.29"
-      labels:
-        preset-dind-enabled: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-            env:
-              - name: E2E_KIND_VERSION
-                value: kindest/node:v1.29.14
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
-            command:
-              # generic runner script, handles DIND, bazelrc for caching, etc.
-              - runner.sh
-            args:
-              - make
-              - test-e2e
-            # docker-in-docker needs privileged mode
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                cpu: "4"
-                memory: "4Gi"
-              limits:
-                cpu: "4"
-                memory: "4Gi"
     - name: pull-kjob-test-e2e-release-0-1-1-30
       cluster: eks-prow-build-cluster
       branches:


### PR DESCRIPTION
As mentioned [here](https://github.com/kubernetes/test-infra/commit/2f2c51c8554b89c64be14da29e4ca1137d354797#r154256960) k8s v1.29 is out of support from kubernetes.