### PR TITLE
[Kueue] Remove e2e tests for k8s v1.29.

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -90,44 +90,6 @@ presubmits:
           limits:
             cpu: "7"
             memory: "10Gi"
-  - name: pull-kueue-test-e2e-main-1-29
-    cluster: eks-prow-build-cluster
-    branches:
-      - ^main
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-main-1-29
-      description: "Run kueue end to end tests for Kubernetes 1.29"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.29.14
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10"
-              memory: "10Gi"
-            limits:
-              cpu: "10"
-              memory: "10Gi"
   - name: pull-kueue-test-e2e-main-1-30
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
@@ -60,44 +60,6 @@ presubmits:
           limits:
             cpu: "6"
             memory: "9Gi"
-  - name: pull-kueue-test-e2e-release-0-10-1-29
-    cluster: eks-prow-build-cluster
-    branches:
-      - ^release-0.10
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-release-0-10-1-29
-      description: "Run kueue end to end tests for Kubernetes 1.29"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.29.14
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10"
-              memory: "10Gi"
-            limits:
-              cpu: "10"
-              memory: "10Gi"
   - name: pull-kueue-test-e2e-release-0-10-1-30
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-11.yaml
@@ -90,44 +90,6 @@ presubmits:
           limits:
             cpu: "7"
             memory: "10Gi"
-  - name: pull-kueue-test-e2e-release-0-11-1-29
-    cluster: eks-prow-build-cluster
-    branches:
-      - ^release-0.11
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-release-0-11-1-29
-      description: "Run kueue end to end tests for Kubernetes 1.29"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.29.14
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10"
-              memory: "10Gi"
-            limits:
-              cpu: "10"
-              memory: "10Gi"
   - name: pull-kueue-test-e2e-release-0-11-1-30
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.10.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.10.yaml
@@ -116,52 +116,6 @@ periodics:
               cpu: "6"
               memory: "9Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-release-0-10-1-29
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-release-0-10-1-29
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue end to end tests for Kubernetes 1.29"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: release-0.10
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.29.14
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.23
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10"
-              memory: "10Gi"
-            limits:
-              cpu: "10"
-              memory: "10Gi"
-  - interval: 12h
     name: periodic-kueue-test-e2e-release-0-10-1-30
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.11.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.11.yaml
@@ -116,52 +116,6 @@ periodics:
               cpu: "6"
               memory: "9Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-release-0-11-1-29
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-release-0-11-1-29
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue end to end tests for Kubernetes 1.29"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: release-0.11
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.29.14
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10"
-              memory: "10Gi"
-            limits:
-              cpu: "10"
-              memory: "10Gi"
-  - interval: 12h
     name: periodic-kueue-test-e2e-release-0-11-1-30
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-main.yaml
@@ -116,52 +116,6 @@ periodics:
               cpu: "6"
               memory: "9Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-main-1-29
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-main-1-29
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue end to end tests for Kubernetes 1.29"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: main
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.29.14
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "10"
-              memory: "10Gi"
-            limits:
-              cpu: "10"
-              memory: "10Gi"
-  - interval: 12h
     name: periodic-kueue-test-e2e-main-1-30
     cluster: eks-prow-build-cluster
     annotations:


### PR DESCRIPTION
k8s v1.29 is out of support from kubernetes.

Follow up for https://github.com/kubernetes/test-infra/pull/34605#issuecomment-2751383292.