### PR TITLE
Fix node-e2e-containerd-2-0-dra job failure

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -327,6 +327,9 @@ presubmits:
       repo: test-infra
       base_ref: master
       path_alias: k8s.io/test-infra
+    - org: containerd
+      repo: containerd
+      base_ref: release/2.0
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -73,6 +73,11 @@
       repo: test-infra
       base_ref: master
       path_alias: k8s.io/test-infra
+    {%- if "containerd-2-0" in job_name %}
+    - org: containerd
+      repo: containerd
+      base_ref: release/2.0
+    {%- endif %}
     {%- endif %}
     spec:
       containers:


### PR DESCRIPTION
Added containerd repo to the node-e2e-containerd-2-0-dra to fix the following error:
```
Failed to read metadata file "/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml":
open /home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml: no such file or directory
```

[example of failing test run](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/130241/pull-kubernetes-node-e2e-containerd-2-0-dra-canary/1903738667860496384)

/sig node
/cc @pohly @kannon92 