### PR TITLE
Revert "[VPA] Temporarily stop requiring e2e vpa tests in PRs while we fix tests"

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -204,7 +204,6 @@ presubmits:
       testgrid-tab-name: autoscaling-vpa-full-presubmits
     optional: true
     decorate: true
-    always_run: false  # Temporary until tests using GCR are fixed (https://github.com/kubernetes/autoscaler/issues/7946)
     decoration_config:
       timeout: 120m
     run_if_changed: '^vertical-pod-autoscaler\/'


### PR DESCRIPTION
Reverts kubernetes/test-infra#34578 as tests are now working as expected.