### PR TITLE
Add needs-triage labels for secrets-store (csi-driver and sync-controller)

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1141,6 +1141,30 @@ require_matching_label:
     If usage-metrics-collector contributors determine this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
 
     The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+- missing_label: needs-triage
+  org: kubernetes-sigs
+  repo: secrets-store-csi-driver
+  issues: true
+  prs: true
+  regexp: ^triage/
+  missing_comment: |
+    This issue is currently awaiting triage.
+
+    If secrets-store-csi-driver contributors determine this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
+
+    The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+- missing_label: needs-triage
+  org: kubernetes-sigs
+  repo: secrets-store-sync-controller
+  issues: true
+  prs: true
+  regexp: ^triage/
+  missing_comment: |
+    This issue is currently awaiting triage.
+
+    If secrets-store-sync-controller contributors determine this is a relevant issue, they will accept it by applying the `triage/accepted` label and provide further guidance.
+
+    The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
 
 retitle:
   allow_closed_issues: true


### PR DESCRIPTION
Planning to use the `needs-triage` label to auto-populate issues in the [SIG Auth project board](https://github.com/orgs/kubernetes/projects/116) using [sig-auth-tools](https://github.com/kubernetes-sigs/sig-auth-tools).

/cc @enj 