### PR TITLE
Use standard settings for aws-vpc-cni for e2e-kops-aws-cni-amazon-vpc CI job

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1492,10 +1492,17 @@ def generate_network_plugins():
         networking_arg = plugin.replace('amazon-vpc', 'amazonvpc').replace('kuberouter', 'kube-router')
         k8s_version = 'stable'
         distro = 'u2404'
+        extra_flags = ['--node-size=t3.large']
         if plugin in ['kuberouter']:
             k8s_version = 'ci'
         if plugin in ['cilium-eni', 'amazon-vpc']:
             distro = 'u2204' # pinned to 22.04 because of network issues with 24.04 and these CNIs
+        if plugin in ['amazon-vpc']:
+            extra_flags += [
+                "--set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true",
+                "--set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80",
+                "--set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10",
+            ]
         results.append(
             build_test(
                 distro=distro,
@@ -1503,7 +1510,7 @@ def generate_network_plugins():
                 kops_channel='alpha',
                 name_override=f"kops-aws-cni-{plugin}",
                 networking=networking_arg,
-                extra_flags=['--node-size=t3.large'],
+                extra_flags=extra_flags,
                 extra_dashboards=['kops-network-plugins'],
                 runs_per_day=3,
             )

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -2,7 +2,7 @@
 # 9 jobs, total of 189 runs per week
 periodics:
 
-# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "amazonvpc"}
+# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "amazonvpc"}
 - name: e2e-kops-aws-cni-amazon-vpc
   cron: '15 3-23/8 * * *'
   labels:
@@ -32,7 +32,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250305' --channel=alpha --networking=amazonvpc --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250305' --channel=alpha --networking=amazonvpc --node-size=t3.large --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -57,7 +57,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2204
-    test.kops.k8s.io/extra_flags: --node-size=t3.large --discovery-store=s3://k8s-kops-prow/discovery
+    test.kops.k8s.io/extra_flags: --node-size=t3.large --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --discovery-store=s3://k8s-kops-prow/discovery
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest


### PR DESCRIPTION
We missed a spot, we use ENABLE_PREFIX_DELEGATION/MINIMUM_IP_TARGET/WARM_IP_TARGET in other vpc-cni jobs. let's use the same for `e2e-kops-aws-cni-amazon-vpc` as well.

possibly helps with flakiness we see in https://github.com/kubernetes/kubernetes/issues/131071

Specifically see:
https://storage.googleapis.com/k8s-triage/index.html?text=%22aws-cni%22&job=e2e-kops-aws-cni-amazon-vpc