### PR TITLE
etcd: add post-etcd-coverage-report job

### DIFF
--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -322,3 +322,32 @@ postsubmits:
             memory: "3Gi"
       nodeSelector:
         kubernetes.io/arch: arm64
+
+  - name: post-etcd-coverage-report
+    cluster: eks-prow-build-cluster
+    branches:
+    - main
+    - release-3.6
+    decorate: true
+    decoration_config:
+      timeout: 60m
+    annotations:
+      testgrid-dashboards: sig-etcd-postsubmits
+      testgrid-tab-name: post-etcd-coverage-report
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250311-73aac21714-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            make upload-coverage-report
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"


### PR DESCRIPTION
Add a Codecov post-submit job, to avoid false reporting in coverage difference (https://github.com/etcd-io/etcd/pull/19659#issuecomment-2750605288)

Needs: https://github.com/etcd-io/etcd/pull/19676