### PR TITLE
Changed powervs-ssh-key value used by ibm conformance job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
@@ -118,7 +118,7 @@ periodics:
               kubetest2 tf --powervs-image-name CentOS-Stream-9 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} \
-                --powervs-ssh-key k8s-pvs-sshkey \
+                --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
                 --build-version $K8S_BUILD_VERSION \
                 --release-marker $K8S_BUILD_VERSION \


### PR DESCRIPTION
Changing `--powervs-ssh-key` value passed to `kubetest2 tf` command as the ssh key was changed in the infra to match other naming conventions.

Faced below error in https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-ppc64le-conformance-latest-kubetest2/1905912861452931072
```
[31m│[0m [0m[1m[31mError: [0m[0m[1mfailed to provision: failed to Create PVM Instance :[POST /pcloud/v1/cloud-instances/{cloud_instance_id}/pvm-instances][404] pcloudPvminstancesPostNotFound {"description":"SSH key k8s-pvs-sshkey does not exist. Check the details and try again or contact support for help, id: k8s-pvs-sshkey","error":"SSH key k8s-pvs-sshkey not found"}[0m
```