### PR TITLE
Kops - Remove bare-metal e2e tests from required contexts

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -361,7 +361,6 @@ branch-protection:
         kops:
           required_status_checks:
             contexts:
-            - tests-e2e-scenarios-bare-metal
             - build-linux-amd64
             - build-linux-arm64
             - build-macos-amd64


### PR DESCRIPTION
This test has been failing for a while and bare-metal support is still experimental, so we can remove this for now to unblock other PRs

/cc @hakman