### PR TITLE
kubespray/branch protection: exclude checksum auto update

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -597,6 +597,8 @@ branch-protection:
             gh-pages:
               protect: false
         kubespray:
+          exclude:
+            - "^component_hash_update/" # don't protect PR branches from the checksums updater
           required_status_checks:
             contexts:
             - Kubespray CI Pipeline


### PR DESCRIPTION
Kubespray updates the checksums of binaries it deploys with a github
workflow which makes a pull request.

Unprotect the branch used for that purpose.

workflow: https://github.com/kubernetes-sigs/kubespray/blob/master/.github/workflows/upgrade-patch-versions.yml

(branch naming is updated by the pending PR kubernetes-sigs/kubespray#12097)

updating script: https://github.com/kubernetes-sigs/kubespray/blob/master/scripts/component_hash_update/src/component_hash_update/download.py
