### PR TITLE
capz: add triggers to run workload upgrade tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -586,6 +586,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
     decorate: true
+    run_if_changed: 'go.mod|templates\/test|^scripts\/|test\/e2e|Makefile'
     optional: true
     always_run: false
     decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -460,6 +460,7 @@ presubmits:
     always_run: false
     optional: false
     decorate: true
+    run_if_changed: 'go.mod|templates\/test|^scripts\/|test\/e2e|Makefile'
     decoration_config:
       timeout: 4h
     branches:


### PR DESCRIPTION
This PR adds file change triggers so that we are better about running the workload upgrade test when we need to.