### PR TITLE
Run pull-cluster-api-provider-azure-test on non doc changes

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -2,7 +2,7 @@ presubmits:
   kubernetes-sigs/cluster-api-provider-azure:
   - name: pull-cluster-api-provider-azure-test
     cluster: eks-prow-build-cluster
-    always_run: true
+    skip_if_only_changed: "^docs/|^\\.github/|\\.md$|^(\\.codespellignore|LICENSE|OWNERS|OWNERS_ALIASES|PROJECT|SECURITY_CONTACTS|Tiltfile|Makefile|metadata\\.yaml|netlify\\.toml|tilt-provider\\.json)$"
     optional: false
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"


### PR DESCRIPTION
This PR updates pull-cluster-api-provider-azure-test config to run on non doc changes.