### PR TITLE
descheduler: bump timeout from 40m to 60m

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -90,7 +90,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.32
     decorate: true
     decoration_config:
-      timeout: 40m
+      timeout: 60m
     always_run: true
     labels:
       preset-dind-enabled: "true"
@@ -128,7 +128,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.31
     decorate: true
     decoration_config:
-      timeout: 40m
+      timeout: 60m
     always_run: true
     labels:
       preset-dind-enabled: "true"
@@ -166,7 +166,7 @@ presubmits:
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.30
     decorate: true
     decoration_config:
-      timeout: 40m
+      timeout: 60m
     always_run: true
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
There has been recently many timeouts. Bumping it to see if it helps. Or, whether there's a different problem. E.g. slower infrastructure, bigger images to pull, etc.