### PR TITLE
sig-testing: move canaries tests to dedicated nodepool

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -1,80 +1,88 @@
 periodics:
-- name: ci-test-infra-benchmark-demo
-  cluster: k8s-infra-prow-build
-  interval: 24h
-  decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/benchmarkjunit:latest
-      command:
-      - /benchmarkjunit
-      args:
-      - --log-file=$(ARTIFACTS)/benchmark-log.txt
-      - --output=$(ARTIFACTS)/junit_benchmarks.xml
-      - --pass-on-error
-      - ./experiment/dummybenchmarks/...
-      resources:
-        limits:
-          cpu: 2
-          memory: 4Gi
-        requests:
-          cpu: 2
-          memory: 4Gi
-  annotations:
-    testgrid-alert-email: colew@google.com
-    testgrid-dashboards: sig-testing-canaries
-    testgrid-tab-name: benchmark-demo
-    description: Demoing JUnit golang benchmark results.
-- interval: 1h
-  name: ci-test-infra-multiple-container-test
-  cluster: k8s-infra-prow-build
-  decorate: true
-  spec:
-    containers:
-    - name: test-1
-      image: alpine
-      command: ["/bin/echo"]
-      args: ["I am first"]
-      resources:
-        requests:
-          memory: "256Mi"
-          cpu: "500m"
-        limits:
-          memory: "256Mi"
-          cpu: "500m"
-    - name: test-2
-      image: alpine
-      command: ["/bin/sh"]
-      args:
-      - -c
-      - "sleep 60 && echo I && sleep 60 && echo am && sleep 60 && echo second"
-      resources:
-        requests:
-          memory: "256Mi"
-          cpu: "500m"
-        limits:
-          memory: "256Mi"
-          cpu: "500m"
-    - name: test-3
-      image: alpine
-      command: ["/bin/sh"]
-      args:
-      - -c
-      - "sleep 120 && echo I && sleep 120 && echo am && sleep 120 && echo third"
-      resources:
-        requests:
-          memory: "256Mi"
-          cpu: "500m"
-        limits:
-          memory: "256Mi"
-          cpu: "500m"
-  annotations:
-    testgrid-alert-email: anthonytong@google.com
-    testgrid-dashboards: sig-testing-canaries
-    testgrid-tab-name: multiple-container-test
-    description: echo at different times from three different containers
+  - name: ci-test-infra-benchmark-demo
+    cluster: k8s-infra-prow-build
+    interval: 24h
+    decorate: true
+    extra_refs:
+      - org: kubernetes
+        repo: test-infra
+        base_ref: master
+        path_alias: k8s.io/test-infra
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/benchmarkjunit:latest
+          command:
+            - /benchmarkjunit
+          args:
+            - --log-file=$(ARTIFACTS)/benchmark-log.txt
+            - --output=$(ARTIFACTS)/junit_benchmarks.xml
+            - --pass-on-error
+            - ./experiment/dummybenchmarks/...
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 2
+              memory: 4Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-testing"
+          effect: "NoSchedule"
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
+      testgrid-tab-name: benchmark-demo
+      description: Demoing JUnit golang benchmark results.
+  - interval: 1h
+    name: ci-test-infra-multiple-container-test
+    cluster: k8s-infra-prow-build
+    decorate: true
+    spec:
+      containers:
+        - name: test-1
+          image: alpine
+          command: ["/bin/echo"]
+          args: ["I am first"]
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "500m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+        - name: test-2
+          image: alpine
+          command: ["/bin/sh"]
+          args:
+            - -c
+            - "sleep 60 && echo I && sleep 60 && echo am && sleep 60 && echo second"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "500m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+        - name: test-3
+          image: alpine
+          command: ["/bin/sh"]
+          args:
+            - -c
+            - "sleep 120 && echo I && sleep 120 && echo am && sleep 120 && echo third"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "500m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-testing"
+          effect: "NoSchedule"
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
+      testgrid-tab-name: multiple-container-test
+      description: echo at different times from three different containers


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/7943