### PR TITLE
kubekins-e2e-v2 multiarch support for s390x

### DIFF
--- a/images/kubekins-e2e-v2/Dockerfile
+++ b/images/kubekins-e2e-v2/Dockerfile
@@ -66,7 +66,7 @@ ARG GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud
 RUN wget -O google-cloud-sdk.tar.gz -q $GCLOUD_SDK_URL && \
     tar xzf google-cloud-sdk.tar.gz -C / && \
     rm google-cloud-sdk.tar.gz && \
-    if [ "${TARGETARCH}" != "ppc64le" ]; then \
+    if [ "${TARGETARCH}" != "ppc64le" ] && [ "${TARGETARCH}" != "s390x" ]; then \
         /google-cloud-sdk/install.sh \
         --disable-installation-options \
         --bash-completion=false \
@@ -160,7 +160,7 @@ RUN wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_
 
 # install kind if a version is provided
 ARG KIND_VERSION
-RUN if [ "${TARGETARCH}" != "ppc64le" ] && [ -n "${KIND_VERSION}" ]; then \
+RUN if [ "${TARGETARCH}" != "ppc64le" ] && [ "${TARGETARCH}" != "s390x" ] && [ -n "${KIND_VERSION}" ]; then \
     wget -q -O /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-${TARGETARCH} && \
     chmod +x /usr/local/bin/kind; \
     fi

--- a/images/kubekins-e2e-v2/README.md
+++ b/images/kubekins-e2e-v2/README.md
@@ -3,7 +3,7 @@
 This is a modernised and lean image of the kubekins-e2e image optimised for the core tools required in an e2e image.
 
 Features:
-- multi-arch, supports amd64, arm64 and ppc64le
+- multi-arch, supports amd64, arm64 , ppc64le and s390x
 - kubetest2
 - kind
 - aws-cli v1

--- a/images/kubekins-e2e-v2/cloudbuild.yaml
+++ b/images/kubekins-e2e-v2/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
     - build
     - --tag=us-central1-docker.pkg.dev/$PROJECT_ID/images/kubekins-e2e:$_GIT_TAG-$_CONFIG
     - --build-arg=IMAGE_ARG=us-central1-docker.pkg.dev/$PROJECT_ID/images/kubekins-e2e:$_GIT_TAG-$_CONFIG
-    - --platform=linux/amd64,linux/arm64,linux/ppc64le
+    - --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
     - --build-arg=CFSSL_VERSION=$_CFSSL_VERSION
     - --build-arg=GO_VERSION=$_GO_VERSION
     - --build-arg=K8S_RELEASE=$_K8S_RELEASE


### PR DESCRIPTION
Fixes #34646

Had to skip below utilities for s390x:
gcloud core install `google-cloud-sdk/install.sh`
kind