### PR TITLE
Fix typo in ci-kubernetes-ppc64le-e2e-node-latest-kubetest2 job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
@@ -215,7 +215,7 @@ periodics:
                 --build-version $K8S_BUILD_VERSION --retry-on-tf-failure 3 \
                 --break-kubetest-on-upfail true --powervs-memory 32 \
                 --playbook k8s-node-remote.yml
-              EXTERNAL_IP=`grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/config3-$TIMESTAMP/hosts`
+              EXTERNAL_IP=`grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/config2-$TIMESTAMP/hosts`
               # Skipping test due to https://github.com/kubernetes/kubernetes/issues/131132 and
               # Related to https://github.com/kubernetes/kubernetes/issues/124791
               kubetest2 tf --test=exec -- ssh -i /etc/secret-volume/ssh-privatekey root@$EXTERNAL_IP \


### PR DESCRIPTION
https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-ppc64le-e2e-node-latest-kubetest2/1909549862572003328 job failed with below error:
```
grep: /home/prow/go/src/github.com/kubernetes-sigs/provider-ibmcloud-test-infra/config3-1744108606/hosts: No such file or directory
I0408 10:50:12.244242   34252 app.go:61] The files in RunDir shall not be part of Artifacts
I0408 10:50:12.244258   34252 app.go:62] pass rundir-in-artifacts flag True for RunDir to be part of Artifacts
I0408 10:50:12.244290   34252 app.go:64] RunDir for this run: "/home/prow/go/src/github.com/kubernetes-sigs/provider-ibmcloud-test-infra/_rundir/e07ec5de-7595-47b1-a0cd-1ec7e26ffc0d"
I0408 10:50:12.245081   34252 app.go:136] ID for this run: "e07ec5de-7595-47b1-a0cd-1ec7e26ffc0d"
ssh: Could not resolve hostname : Name or service not known
F0408 10:50:12.254803   34270 exec.go:100] failed to run exec tester: exit status 255
Error: exit status 255
ssh: Could not resolve hostname : Name or service not known
scp: Connection closed
```