### PR TITLE
[releng] Add v1.33 and remove v1.29 milestone_applier rules

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -472,10 +472,10 @@ milestone_applier:
     master: v1.33
   kubernetes/kubernetes:
     master: v1.33
+    release-1.33: v1.33
     release-1.32: v1.32
     release-1.31: v1.31
     release-1.30: v1.30
-    release-1.29: v1.29
   kubernetes/org:
     main: v1.33
   kubernetes/release:


### PR DESCRIPTION
 * releng: Add v1.33 and remove v1.29 milestone_applier rules

Pending branch cut:
/hold

/sig release 
/area release-eng
/assign @saschagrunert @cpanato @xmudrii @dims
cc: @kubernetes/release-engineering @mbianchidev 