### PR TITLE
[releng] 1.33: Update kubekins-e2e variants.yaml with 1.33 config

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -9,6 +9,11 @@ variants:
     GO_VERSION: 1.24.0
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
+  '1.33':
+    CONFIG: '1.33'
+    GO_VERSION: 1.24.0
+    K8S_RELEASE: latest-1.33
+    BAZEL_VERSION: 3.4.1
   '1.32':
     CONFIG: '1.32'
     GO_VERSION: 1.23.6


### PR DESCRIPTION
Update kubekins-e2e variant with 1.33 config.

/sig release
/area release-eng
/hold

cc @kubernetes/release-engineering @mbianchidev  