### PR TITLE
Updating capz branch used in Windows jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-1.30
     decorate: true
     extra_refs:
-    - base_ref: release-1.16
+    - base_ref: release-1.19
       org: kubernetes-sigs
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.30-windows.yaml
@@ -23,7 +23,7 @@ periodics:
   decoration_config:
     timeout: 8h0m0s
   extra_refs:
-  - base_ref: release-1.16
+  - base_ref: release-1.19
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -78,7 +78,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.16
+    base_ref: release-1.19
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.31-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.31-windows-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-1.31
     decorate: true
     extra_refs:
-    - base_ref: release-1.16
+    - base_ref: release-1.19
       org: kubernetes-sigs
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.31-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.31-windows.yaml
@@ -9,7 +9,7 @@ periodics:
   decoration_config:
     timeout: 4h0m0s
   extra_refs:
-  - base_ref: main
+  - base_ref: release-1.19
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -65,7 +65,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.16
+    base_ref: release-1.19
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.32-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.32-windows.yaml
@@ -9,7 +9,7 @@ periodics:
   decoration_config:
     timeout: 4h0m0s
   extra_refs:
-  - base_ref: main
+  - base_ref: release-1.19
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -65,7 +65,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.16
+    base_ref: release-1.19
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -718,7 +718,7 @@ presubmits:
       workdir: false
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.16
+      base_ref: main
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: false
     - org: kubernetes-sigs


### PR DESCRIPTION
- Updating all of the release branches to use CAPZ @v1.19.x (most were on v1.16.x)
- Updating all k/k master jobs to use CAPZ @main (most already were)

/kind cleanup
/sig windows
/assign @jsturtevant @aravindhp @zylxjtu 