### PR TITLE
Try ci-kubernetes-gce-conformance-latest-kubetest2 without k/k git clone

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -98,3 +98,61 @@ periodics:
           --test-package-dir=ci \;
           --test-package-marker=$MARKER_VERSION \;
           --focus-regex='\[Conformance\]'
+- interval: 3h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-gce-conformance-latest-kubetest2-without-git-clone
+  annotations:
+    fork-per-release: "true"
+    fork-per-release-replacements: "MARKER_VERSION=latest.txt -> MARKER_VERSION=latest-{{.Version}}.txt"
+    testgrid-dashboards: sig-release-master-blocking, conformance-all, conformance-gce
+    testgrid-tab-name: Conformance - Clone - GCE - master - kubetest2
+    description: Runs conformance tests using kubetest2 against kubernetes master on GCE
+    testgrid-num-failures-to-alert: '1'
+    testgrid-alert-stale-results-hours: '24'
+    testgrid-num-columns-recent: '3'
+    testgrid-alert-email: release-team@kubernetes.io
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 220m
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: 4
+          memory: 14Gi
+        requests:
+          cpu: 4
+          memory: 14Gi
+      command:
+      - runner.sh
+      args:
+      - "/bin/bash"
+      - "-c"
+      - set -o errexit;
+        set -o nounset;
+        set -o pipefail;
+        set -o xtrace;
+        export GO111MODULE=on;
+        go install sigs.k8s.io/kubetest2@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+        go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+        MARKER_VERSION=latest.txt;
+        kubetest2 gce \;
+          --v=9 \;
+          --legacy-mode \;
+          --up \;
+          --down \;
+          --kubernetes-version=https://dl.k8s.io/ci/$MARKER_VERSION \;
+          --test=ginkgo \;
+          -- \;
+          --test-package-url=https://dl.k8s.io \;
+          --test-package-dir=ci \;
+          --test-package-marker=$MARKER_VERSION \;
+          --focus-regex='\[Conformance\]'


### PR DESCRIPTION
The job [ci-kubernetes-gce-conformance-latest-kubetest2](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml#L59-L62) uses pre-built artifacts from https://dl.k8s.io/ci and doesn't appear to build Kubernetes locally. So seems cloning k/k is not required.
Hence adding a clone job to test the theory and shall cleanup if we don't really need the cloning of k/k
Ref: https://kubernetes.slack.com/archives/C6WB33KNJ/p1744110199840459?thread_ts=1744108967.712789&cid=C6WB33KNJ