### PR TITLE
prow: add milestone applier config for CAPV v1.14

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -547,7 +547,8 @@ milestone_applier:
     release-0.4: v0.4
     release-0.3: v0.3
   kubernetes-sigs/cluster-api-provider-vsphere:
-    main: v1.13
+    main: v1.14
+    release-1.13: v1.13
     release-1.12: v1.12
     release-1.11: v1.11
     release-1.10: v1.10


### PR DESCRIPTION
We branched off the release-1.13 branch, thus new issues assigning to v1.14 milestone.