### PR TITLE
increase resource overhead for cluster-autoscaler build test

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -264,8 +264,8 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 4
+            memory: 8Gi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 4
+            memory: 8Gi


### PR DESCRIPTION
Seeing lots of test flakes for the cluster-autoscaler build tags test:

- https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-kubernetes-e2e-autoscaling-ca-build?buildId=1909884638956883968

This PR increases resource overhead to avoid flakes.