### PR TITLE
drop 1.29 from image variants, 1.29 is EOL

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -29,8 +29,3 @@ variants:
     GO_VERSION: 1.23.6
     K8S_RELEASE: latest-1.30
     BAZEL_VERSION: 3.4.1
-  '1.29':
-    CONFIG: '1.29'
-    GO_VERSION: 1.23.6
-    K8S_RELEASE: latest-1.29
-    BAZEL_VERSION: 3.4.1


### PR DESCRIPTION
follow-up to https://github.com/kubernetes/test-infra/pull/34672