### PR TITLE
Kueue: Add E2E_K8S_VERSION env variable to jobs config

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -107,6 +107,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.30"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
@@ -145,6 +147,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.31"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
@@ -183,6 +187,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -221,6 +227,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -259,6 +267,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -297,6 +307,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -335,6 +347,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -373,6 +387,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
@@ -77,6 +77,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.30"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
@@ -115,6 +117,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.31"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
@@ -153,6 +157,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -191,6 +197,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-11.yaml
@@ -107,6 +107,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.30"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
@@ -145,6 +147,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.31"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
@@ -183,6 +187,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -221,6 +227,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -259,6 +267,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -297,6 +307,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -335,6 +347,8 @@ presubmits:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.10.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.10.yaml
@@ -140,6 +140,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.30"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
@@ -186,6 +188,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.31"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
@@ -232,6 +236,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -278,6 +284,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.11.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.11.yaml
@@ -140,6 +140,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.30"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
@@ -186,6 +188,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.31"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
@@ -232,6 +236,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -278,6 +284,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -324,6 +332,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -370,6 +380,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -416,6 +428,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-main.yaml
@@ -140,6 +140,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.30"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
@@ -186,6 +188,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.31"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
@@ -232,6 +236,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -278,6 +284,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -324,6 +332,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -370,6 +380,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
@@ -416,6 +428,8 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-master
           env:
+            - name: E2E_K8S_VERSION
+              value: "1.32"
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE


### PR DESCRIPTION
This PR adds the `E2E_K8S_VERSION` env variable to jobs config as part of https://github.com/kubernetes-sigs/kueue/issues/4729