### PR TITLE
add kind repo presubmit for 1.33

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -299,6 +299,52 @@ presubmits:
             cpu: "7"
             memory: 9000Mi
   # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
+  - name: pull-kind-e2e-kubernetes-1-33
+    cluster: k8s-infra-prow-build
+    skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
+    optional: false
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: release-1.33
+      path_alias: k8s.io/kubernetes
+    path_alias: sigs.k8s.io/kind
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20250409-f52ea67ed6-1.33
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
+        env:
+        - name: FOCUS
+          value: "."
+        # TODO(bentheelder): reduce the skip list further
+        # NOTE: changes should filter down to pull-kubernetes-e2e-kind-canary
+        # and then pull-kubernetes-e2e-kind
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+  # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
   - name: pull-kind-e2e-kubernetes-1-32
     cluster: k8s-infra-prow-build
     skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'


### PR DESCRIPTION
/cc @stmcginnis @aojea 

note: more generally we are careful to keep these relatively in sync with kubernetes/kubernetes, and to try changes in the "-canary" job before filtering them into both repos

I specially ensured when forking the job here that we didn't need to repeat #34673, by checking the `pull-kubernetes-e2e-kind` job for 1.33