### PR TITLE
Add prow job config for building and pushing vpa images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
+++ b/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
@@ -21,3 +21,25 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-autoscaling-gcb
               - --env-passthrough=PULL_BASE_REF
               - addon-resizer
+    - name: post-autoscaler-push-vpa-images
+        cluster: k8s-infra-prow-build-trusted
+        annotations:
+          testgrid-dashboards: sig-autoscaling-vpa, sig-k8s-infra-gcb
+        decorate: true
+        branches:
+          - ^master$
+        run_if_changed: "^vertical-pod-autoscaler/"
+        spec:
+          serviceAccountName: gcb-builder
+          containers:
+            - image: gcr.io/k8s-staging-test-infra/image-builder:v20241224-fe22c549c1
+              command:
+                - /run.sh
+              args:
+                # this is the project GCB will run in, which is the same as the GCR
+                # images are pushed to.
+                - --project=k8s-staging-autoscaling
+                # This is the same as above, but with -gcb appended.
+                - --scratch-bucket=gs://k8s-staging-autoscaling-gcb
+                - --env-passthrough=PULL_BASE_REF
+                - vertical-pod-autoscaler

--- a/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
+++ b/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
@@ -24,7 +24,7 @@ postsubmits:
     - name: post-autoscaler-push-vpa-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-autoscaling-vpa, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-autoscaling-vpa-images, sig-k8s-infra-gcb
       decorate: true
       branches:
         - ^master$

--- a/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
+++ b/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
@@ -22,24 +22,24 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF
               - addon-resizer
     - name: post-autoscaler-push-vpa-images
-        cluster: k8s-infra-prow-build-trusted
-        annotations:
-          testgrid-dashboards: sig-autoscaling-vpa, sig-k8s-infra-gcb
-        decorate: true
-        branches:
-          - ^master$
-        run_if_changed: "^vertical-pod-autoscaler/"
-        spec:
-          serviceAccountName: gcb-builder
-          containers:
-            - image: gcr.io/k8s-staging-test-infra/image-builder:v20241224-fe22c549c1
-              command:
-                - /run.sh
-              args:
-                # this is the project GCB will run in, which is the same as the GCR
-                # images are pushed to.
-                - --project=k8s-staging-autoscaling
-                # This is the same as above, but with -gcb appended.
-                - --scratch-bucket=gs://k8s-staging-autoscaling-gcb
-                - --env-passthrough=PULL_BASE_REF
-                - vertical-pod-autoscaler
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-autoscaling-vpa, sig-k8s-infra-gcb
+      decorate: true
+      branches:
+        - ^master$
+      run_if_changed: "^vertical-pod-autoscaler/"
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20241224-fe22c549c1
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-autoscaling
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-autoscaling-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - vertical-pod-autoscaler

--- a/config/testgrids/kubernetes/sig-autoscaling/config.yaml
+++ b/config/testgrids/kubernetes/sig-autoscaling/config.yaml
@@ -6,7 +6,7 @@ dashboard_groups:
       - sig-autoscaling-vpa
       - sig-autoscaling-karpenter
       - sig-autoscaling-addon-resizer
-      - sig-autoscaling-vpa
+      - sig-autoscaling-vpa-images
 
 dashboards:
   - name: sig-autoscaling-cluster-autoscaler
@@ -14,4 +14,4 @@ dashboards:
   - name: sig-autoscaling-vpa
   - name: sig-autoscaling-karpenter
   - name: sig-autoscaling-addon-resizer
-  - name: sig-autoscaling-vpa
+  - name: sig-autoscaling-vpa-images

--- a/config/testgrids/kubernetes/sig-autoscaling/config.yaml
+++ b/config/testgrids/kubernetes/sig-autoscaling/config.yaml
@@ -6,6 +6,7 @@ dashboard_groups:
       - sig-autoscaling-vpa
       - sig-autoscaling-karpenter
       - sig-autoscaling-addon-resizer
+      - sig-autoscaling-vpa
 
 dashboards:
   - name: sig-autoscaling-cluster-autoscaler
@@ -13,3 +14,4 @@ dashboards:
   - name: sig-autoscaling-vpa
   - name: sig-autoscaling-karpenter
   - name: sig-autoscaling-addon-resizer
+  - name: sig-autoscaling-vpa


### PR DESCRIPTION
Add a prow job to build and push VPA images as part of https://github.com/kubernetes/autoscaler/issues/7902.

This is following the [published instructions](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md) and a continuation of the previous work we did to onboard a separate binary in the repo (see [addon-resizer](https://github.com/kubernetes/autoscaler/issues/7615)).