### PR TITLE
Kueue: remove E2E_KIND_VERSION variable

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -109,8 +109,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.30"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -149,8 +147,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.31"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -189,8 +185,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -229,8 +223,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -269,8 +261,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -309,8 +299,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -349,8 +337,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -389,8 +375,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
@@ -79,8 +79,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.30"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.23
           command:
@@ -119,8 +117,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.31"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.23
           command:
@@ -159,8 +155,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.23
           command:
@@ -199,8 +193,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.23
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-11.yaml
@@ -109,8 +109,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.30"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -149,8 +147,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.31"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -189,8 +185,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -229,8 +223,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -269,8 +261,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -309,8 +299,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -349,8 +337,6 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.10.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.10.yaml
@@ -142,8 +142,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.30"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.23
           command:
@@ -190,8 +188,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.31"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.23
           command:
@@ -238,8 +234,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.23
           command:
@@ -286,8 +280,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.23
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.11.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-0.11.yaml
@@ -142,8 +142,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.30"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -190,8 +188,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.31"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -238,8 +234,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -286,8 +280,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -334,8 +326,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -382,8 +372,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -430,8 +418,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-release-blocking-main.yaml
@@ -142,8 +142,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.30"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.30.10
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -190,8 +188,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.31"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.31.6
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -238,8 +234,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -286,8 +280,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -334,8 +326,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -382,8 +372,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:
@@ -430,8 +418,6 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.3
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:


### PR DESCRIPTION
This PR removes the E2E_KIND_VERSION env variable from jobs config. Fixes https://github.com/kubernetes-sigs/kueue/issues/4729