### PR TITLE
block PR on presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-network-policies/kube-network-policies-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-network-policies/kube-network-policies-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     extra_refs:
     - org: kubernetes
@@ -17,7 +17,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     path_alias: sigs.k8s.io/kube-network-policies
     decoration_config:
-      timeout: 40m
+      timeout: 60m
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20250227-3a13bdd784-master
@@ -54,7 +54,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     extra_refs:
     - org: kubernetes
@@ -63,7 +63,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     path_alias: sigs.k8s.io/kube-network-policies
     decoration_config:
-      timeout: 40m
+      timeout: 60m
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20250227-3a13bdd784-master


### PR DESCRIPTION
I didn't realize the jobs were optional, so code merges if is approved without waiting until the job finish

The periodic instability is on SCTP cases , and SCTP has a lot of edges in the kernel so we need to live with it :)

https://testgrid.k8s.io/sig-network-policy-api#kube-network-policies%20conformance,%20master%20(dev)%20%5Bnon-serial%5D&graph-metrics=test-duration-minutes

/assign @BenTheElder @ameukam 