### PR TITLE
CAPV: Bump prowjob-gen config to v1.33

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-prowjob-gen.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-prowjob-gen.yaml
@@ -13,14 +13,14 @@ prow_ignored:
       # interval for coverage job
       interval: "24h"
       upgrades:
-      - from: "1.29"
-        to: "1.30"
       - from: "1.30"
         to: "1.31"
       - from: "1.31"
         to: "1.32"
       - from: "1.32"
         to: "1.33"
+      - from: "1.33"
+        to: "1.34"
     release-1.13:
       testImage: "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.32"
       upgrades:
@@ -85,4 +85,6 @@ prow_ignored:
     "1.32":
       k8sRelease: "stable-1.32"
     "1.33":
-      k8sRelease: "ci/latest-1.33"
+      k8sRelease: "stable-1.33"
+    "1.34":
+      k8sRelease: "ci/latest-1.34"


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/3307

Due to GA release of v1.33

Does not change any upstream jobs but to keep it in sync for future.