### PR TITLE
block PRs to sample-controller repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -344,6 +344,11 @@ blockades:
   blockregexps:
   - .*
   explanation: "We do not accept changes directly against this repository. Please see `CONTRIBUTING.md` for information on where and how to contribute instead."
+- repos:
+  - kubernetes/sample-controller
+  blockregexps:
+  - .*
+  explanation: "We do not accept changes directly against this repository. Please see `CONTRIBUTING.md` for information on where and how to contribute instead."  
 
 blunderbuss:
   max_request_count: 2


### PR DESCRIPTION
Blocked PRs to sample-controller since it is a staging repo.
Relevant issue: https://github.com/kubernetes/kubernetes/issues/131315