### PR TITLE
Use newer kubekins-e2e image for kubeadm CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-dryrun.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-dryrun.yaml
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -161,7 +161,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -205,7 +205,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -249,7 +249,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"


### PR DESCRIPTION
If you look at:
https://explore.ggcr.dev/?repo=gcr.io/k8s-staging-test-infra/kubekins-e2e

there is no such image with tag:
`v20250227-3a13bdd784-1.33`

so let's just use the newest image:
`v20250411-0688312353-1.33`

Fix for https://github.com/kubernetes/kubernetes/issues/131348