### PR TITLE
Enable the WatchListClient when testing WatchList

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -158,7 +158,7 @@ periodics:
           - --env=CL2_ENABLE_WATCH_LIST_FEATURE=true
           - --env=CONTAINER_IMAGE=registry-sandbox.k8s.io/pause:3.1 #TODO(ameukam): revert when registry.k8s.io is ready
           - --env=KUBE_GCE_PRIVATE_CLUSTER=false #TODO(#29500): revert when private cluster setup is fixed
-          - --env=KUBE_FEATURE_GATES=WatchList=true
+          - --env=KUBE_FEATURE_GATES=WatchList=true,WatchListClient=true
           - --extract=ci/latest
           - --gcp-node-image=gci
           - --gcp-master-size=n2-standard-32


### PR DESCRIPTION
This is slightly different than the previous test prior to https://github.com/kubernetes/kubernetes/pull/131359 because this change enables the streaming list for all kube binaries.  For a test comparing results, this is probably better anyway though.

/assign @wojtek-t @p0lyn0mial 