### PR TITLE
Upgrade golang 1.24

### DIFF
--- a/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver.yaml
@@ -76,7 +76,7 @@ presubmits:
         - ^main$
       spec:
         containers:
-          - image: 'public.ecr.aws/docker/library/golang:1.23'
+          - image: 'public.ecr.aws/docker/library/golang:1.24'
             command:
               - make
             args:
@@ -102,7 +102,7 @@ presubmits:
         - ^main$
       spec:
         containers:
-          - image: 'public.ecr.aws/docker/library/golang:1.23'
+          - image: 'public.ecr.aws/docker/library/golang:1.24'
             command:
               - make
             args:


### PR DESCRIPTION
Update `ibm-powervs-block-csi-driver` jobs to use the latest go1.24 image.
This affects the test and verify target for the main branch.

Needed for https://github.com/kubernetes-sigs/ibm-powervs-block-csi-driver/pull/876.