### PR TITLE
etcd: include pull-etcd-markdown-lint checks

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -861,10 +861,9 @@ presubmits:
             memory: "4Gi"
 
   - name: pull-etcd-markdown-lint
-    optional: true # remove once the job is stable
     cluster: eks-prow-build-cluster
     always_run: false
-    # run_if_changed: '.*\.md$' # uncomment once the job is stable
+    run_if_changed: '.*\.md$'
     branches:
       - main
     decorate: true


### PR DESCRIPTION
`pull-etcd-markdown-lint` appears to be stable, we can include it to our checks. See [job history](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-markdown-lint).

ref: https://github.com/kubernetes/test-infra/pull/34500
