### PR TITLE
fix: change to downloading the prev k/k repo in a tmp dir instead of into the workdir

### DIFF
--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -343,7 +343,8 @@ upgrade_cluster_components() {
 
 main() {
   # create temp dir and setup cleanup
-  TMP_DIR=$(mktemp -d)
+  TMP_DIR=$(mktemp -d -p /tmp kind-e2e-XXXXXX)
+  echo "Created temporary directory: ${TMP_DIR}"
 
   # ensure artifacts (results) directory exists when not in CI
   export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
@@ -386,10 +387,13 @@ main() {
   # Clone the previous versions Kubernetes release branch
   # TODO(aaron-prindle) extend the branches to test from n-1 -> n-1..3 as more k8s releases are done that support compatibility versions
   export PREV_RELEASE_BRANCH="release-${EMULATED_VERSION}"
-  git clone --filter=blob:none --single-branch --branch "${PREV_RELEASE_BRANCH}" https://github.com/kubernetes/kubernetes.git "${PREV_RELEASE_BRANCH}"
+  # Define the path within the temp directory for the cloned repo
+  PREV_RELEASE_REPO_PATH="${TMP_DIR}/prev-release-k8s"
+  echo "Cloning branch ${PREV_RELEASE_BRANCH} into ${PREV_RELEASE_REPO_PATH}"
+  git clone --filter=blob:none --single-branch --branch "${PREV_RELEASE_BRANCH}" https://github.com/kubernetes/kubernetes.git "${PREV_RELEASE_REPO_PATH}"
 
-  # enter the release branch and run tests
-  pushd "${PREV_RELEASE_BRANCH}"
+  # enter the cloned prev repo branch (in temp) and run tests
+  pushd "${PREV_RELEASE_REPO_PATH}"
   run_tests || res=$?
   popd
 


### PR DESCRIPTION
Recently seeing testgrid failures for the n-2 test:
https://testgrid.k8s.io/sig-testing-kind#compatibility-version-test-n-minus-2

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-compatibility-versions-n-minus-2/1914858605782241280

```
Kubernetes e2e suite: [It] [sig-network] ServiceCIDR and IPAddress API should support ServiceCIDR API operations [Conformance] expand_less | 1s
-- | --
{ failed [FAILED] unexpected error getting default ServiceCIDR: the server could not find the requested resource In [It] at: k8s.io/kubernetes/test/e2e/network/service_cidrs.go:167 @ 04/23/25 02:06:08.413 }
```

This is related to a recent change in integration tests:
https://github.com/kubernetes/kubernetes/compare/44c230bf5...b53b9fb55 

This should not have changed this test though as it should be using the n-<1..3> version.   This PR attempts to fix this issue by moving the pulled down n-<1..3> version repo to be located in /tmp instead of nested in the workdir