### PR TITLE
Create separate configuration for extended integration tests.

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -30,7 +30,7 @@ presubmits:
           limits:
             cpu: "2"
             memory: "6Gi"
-  - name: pull-kueue-test-integration-main
+  - name: pull-kueue-test-integration-baseline-main
     cluster: eks-prow-build-cluster
     branches:
     - ^main
@@ -39,20 +39,18 @@ presubmits:
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-integration-main
-      description: "Run kueue test-integration"
+      testgrid-tab-name: pull-kueue-test-integration-baseline-main
+      description: "Run kueue test-integration-baseline"
     spec:
       containers:
       - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:
-        - test-integration
+        - test-integration-baseline
         env:
         - name: GOMAXPROCS
           value: "7"
-        - name: INTEGRATION_RUN_ALL
-          value: "false"
         resources:
           requests:
             cpu: "7"
@@ -60,6 +58,34 @@ presubmits:
           limits:
             cpu: "7"
             memory: "10Gi"
+  - name: pull-kueue-test-integration-extended-main
+    cluster: eks-prow-build-cluster
+    branches:
+      - ^main
+    always_run: false
+    decorate: true
+    path_alias: sigs.k8s.io/kueue
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-kueue-test-integration-extended-main
+      description: "Run kueue test-integration-extended"
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.24
+          command:
+            - make
+          args:
+            - test-integration-extended
+          env:
+            - name: GOMAXPROCS
+              value: "7"
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
   - name: pull-kueue-test-integration-multikueue-main
     cluster: eks-prow-build-cluster
     branches:
@@ -81,8 +107,6 @@ presubmits:
         env:
         - name: GOMAXPROCS
           value: "7"
-        - name: INTEGRATION_RUN_ALL
-          value: "false"
         resources:
           requests:
             cpu: "7"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
@@ -30,7 +30,7 @@ presubmits:
           limits:
             cpu: "2"
             memory: "6Gi"
-  - name: pull-kueue-test-integration-release-0-10
+  - name: pull-kueue-test-integration-baseline-release-0-10
     cluster: eks-prow-build-cluster
     branches:
     - ^release-0.10
@@ -39,20 +39,18 @@ presubmits:
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-integration-release-0-10
-      description: "Run kueue test-integration"
+      testgrid-tab-name: pull-kueue-test-integration-baseline-release-0-10
+      description: "Run kueue test-integration-baseline"
     spec:
       containers:
       - image: public.ecr.aws/docker/library/golang:1.23
         command:
         - make
         args:
-        - test-integration
+        - test-integration-baseline
         env:
         - name: GOMAXPROCS
           value: "6"
-        - name: INTEGRATION_RUN_ALL
-          value: "false"
         resources:
           requests:
             cpu: "6"
@@ -60,6 +58,34 @@ presubmits:
           limits:
             cpu: "6"
             memory: "9Gi"
+  - name: pull-kueue-test-integration-extended-release-0-10
+    cluster: eks-prow-build-cluster
+    branches:
+      - ^release-0.10
+    always_run: false
+    decorate: true
+    path_alias: sigs.k8s.io/kueue
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-kueue-test-integration-extended-release-0-10
+      description: "Run kueue test-integration-extended"
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.23
+          command:
+            - make
+          args:
+            - test-integration-extended
+          env:
+            - name: GOMAXPROCS
+              value: "6"
+          resources:
+            requests:
+              cpu: "6"
+              memory: "9Gi"
+            limits:
+              cpu: "6"
+              memory: "9Gi"
   - name: pull-kueue-test-e2e-release-0-10-1-30
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-11.yaml
@@ -30,7 +30,7 @@ presubmits:
           limits:
             cpu: "2"
             memory: "6Gi"
-  - name: pull-kueue-test-integration-release-0-11
+  - name: pull-kueue-test-integration-baseline-release-0-11
     cluster: eks-prow-build-cluster
     branches:
     - ^release-0.11
@@ -39,20 +39,18 @@ presubmits:
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-integration-release-0-11
-      description: "Run kueue test-integration"
+      testgrid-tab-name: pull-kueue-test-integration-baseline-release-0-11
+      description: "Run kueue test-integration-baseline"
     spec:
       containers:
       - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:
-        - test-integration
+        - test-integration-baseline
         env:
         - name: GOMAXPROCS
           value: "7"
-        - name: INTEGRATION_RUN_ALL
-          value: "false"
         resources:
           requests:
             cpu: "7"
@@ -60,7 +58,35 @@ presubmits:
           limits:
             cpu: "7"
             memory: "10Gi"
-  - name: pull-kueue-test-integration-multikueue-release-0-11
+  - name: pull-kueue-test-integration-extended-release-0-11
+    cluster: eks-prow-build-cluster
+    branches:
+      - ^release-0.11
+    always_run: false
+    decorate: true
+    path_alias: sigs.k8s.io/kueue
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-kueue-test-integration-release-0-11
+      description: "Run kueue test-integration-extended"
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.24
+          command:
+            - make
+          args:
+            - test-integration-extended
+          env:
+            - name: GOMAXPROCS
+              value: "7"
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - name: pull-kueue-test-integration-multikueue-baseline-release-0-11
     cluster: eks-prow-build-cluster
     branches:
     - ^release-0.11
@@ -81,8 +107,6 @@ presubmits:
         env:
         - name: GOMAXPROCS
           value: "7"
-        - name: INTEGRATION_RUN_ALL
-          value: "false"
         resources:
           requests:
             cpu: "7"


### PR DESCRIPTION
Create separate configuration for extended integration tests.

Sometimes we miss testing the slow and redundant integration tests before merging to main, which results in errors in periodic tests. This happens because the presubmit integration tests are filtered by the `INTEGRATION_RUN_ALL` flag.

To prevent this, I propose running the extended tests in parallel with the required tests instead of skipping it in presubmit tests. As for the multikueue integration tests, we can run all of them – they only take 6m24s.