### PR TITLE
[Kueue] Provide CI_RUN environmental variable

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -1,3 +1,7 @@
+presets:
+- env:
+  - name: CI_RUN
+    value: periodics
 periodics:
   - interval: 12h
     name: periodic-kueue-test-unit-main

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0.10.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0.10.yaml
@@ -1,3 +1,7 @@
+presets:
+- env:
+  - name: CI_RUN
+    value: periodics
 periodics:
   - interval: 12h
     name: periodic-kueue-test-unit-release-0-10

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0.11.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0.11.yaml
@@ -1,3 +1,7 @@
+presets:
+- env:
+  - name: CI_RUN
+    value: periodics
 periodics:
   - interval: 12h
     name: periodic-kueue-test-unit-release-0-11

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -1,3 +1,7 @@
+presets:
+- env:
+  - name: CI_RUN
+    value: presubmits
 presubmits:
   kubernetes-sigs/kueue:
   - name: pull-kueue-test-unit-main

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-10.yaml
@@ -1,3 +1,7 @@
+presets:
+- env:
+  - name: CI_RUN
+    value: presubmits
 presubmits:
   kubernetes-sigs/kueue:
   - name: pull-kueue-test-unit-release-0-10

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-11.yaml
@@ -1,3 +1,7 @@
+presets:
+- env:
+  - name: CI_RUN
+    value: presubmits
 presubmits:
   kubernetes-sigs/kueue:
   - name: pull-kueue-test-unit-release-0-11


### PR DESCRIPTION
Relates to Kueue https://github.com/kubernetes-sigs/kueue/issues/3829

Provide CI_RUN environmental variable to be able to determine what type of CI run it is - presubmits or periodics.