### PR TITLE
fix: resolve issue where if k8s git version is bumped but it is alpha0 then there is no n-1 image and it the HEAD version should be treated as n-1

### DIFF
--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -354,7 +354,7 @@ main() {
   # Check if gitVersion contains alpha.0 and increment VERSION_DELTA if needed
   # If the current version is alpha.0, it means the previous *stable* or developed
   # branch is actually n-2 relative to the current minor number for compatibility purposes.
-  if [[ "${GIT_VERSION}" == *alpha.0* ]]; then
+  if [[ "${GIT_VERSION}" == *alpha.0 ]]; then
     echo "Detected alpha.0 in gitVersion (${GIT_VERSION}), incrementing VERSION_DELTA."
     VERSION_DELTA=$((VERSION_DELTA + 1))
     echo "Adjusted VERSION_DELTA: ${VERSION_DELTA}"

--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -350,6 +350,16 @@ main() {
   export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
   mkdir -p "${ARTIFACTS}"
 
+  GIT_VERSION=$(echo "${WORKSPACE_STATUS}" | awk '/^gitVersion/ {print $2}')
+  # Check if gitVersion contains alpha.0 and increment VERSION_DELTA if needed
+  # If the current version is alpha.0, it means the previous *stable* or developed
+  # branch is actually n-2 relative to the current minor number for compatibility purposes.
+  if [[ "${GIT_VERSION}" == *alpha.0* ]]; then
+    echo "Detected alpha.0 in gitVersion (${GIT_VERSION}), incrementing VERSION_DELTA."
+    VERSION_DELTA=$((VERSION_DELTA + 1))
+    echo "Adjusted VERSION_DELTA: ${VERSION_DELTA}"
+  fi
+
   # Get current and n-1 version numbers
   MAJOR_VERSION=$(./hack/print-workspace-status.sh | awk '/STABLE_BUILD_MAJOR_VERSION/ {print $2}')
   MINOR_VERSION=$(./hack/print-workspace-status.sh | awk '/STABLE_BUILD_MINOR_VERSION/ {split($2, minor, "+"); print minor[1]}')

--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -355,7 +355,7 @@ main() {
   # If the current version is alpha.0, it means the previous *stable* or developed
   # branch is actually n-2 relative to the current minor number for compatibility purposes.
   if [[ "${GIT_VERSION}" == *alpha.0 ]]; then
-    echo "Detected alpha.0 in gitVersion (${GIT_VERSION}), incrementing VERSION_DELTA."
+    echo "Detected alpha.0 in gitVersion (${GIT_VERSION}), treating as still the previous minor version."
     VERSION_DELTA=$((VERSION_DELTA + 1))
     echo "Adjusted VERSION_DELTA: ${VERSION_DELTA}"
   fi


### PR DESCRIPTION
Currently the ci-kubernetes-e2e-kind-compatibility-versions-n-minus-1 is failing:

https://testgrid.k8s.io/sig-testing-kind#compatibility-version-test-n-minus-1
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-compatibility-versions-n-minus-1/1915039549864546304

```
DEBUG: docker/images.go:67] Pulling image: kindest/node:v1.33.0 ...
DEBUG: docker/images.go:73] Trying again to pull image: "kindest/node:v1.33.0" ... command "docker pull kindest/node:v1.33.0" failed with error: exit status 1
DEBUG: docker/images.go:73] Trying again to pull image: "kindest/node:v1.33.0" ... command "docker pull kindest/node:v1.33.0" failed with error: exit status 1
DEBUG: docker/images.go:73] Trying again to pull image: "kindest/node:v1.33.0" ... command "docker pull kindest/node:v1.33.0" failed with error: exit status 1
DEBUG: docker/images.go:73] Trying again to pull image: "kindest/node:v1.33.0" ... command "docker pull kindest/node:v1.33.0" failed with error: exit status 1
```

This is occuring as the k8s branch was bumped from v1.33 -> v1.34:
aprindle@aprindle-ssd ~/kubernetes  [master]./hack/print-workspace-status.sh
aprindle@aprindle-ssd ~/kubernetes  [master]./hack/print-workspace-status.sh
STABLE_BUILD_GIT_COMMIT 9ba7dcecc39274f3acf4064d572996ecdbc96f10
STABLE_BUILD_SCM_STATUS clean
STABLE_BUILD_SCM_REVISION v1.34.0-alpha.0.31+9ba7dcecc39274
STABLE_BUILD_MAJOR_VERSION 1
STABLE_BUILD_MINOR_VERSION 34+
STABLE_DOCKER_TAG v1.34.0-alpha.0.31_9ba7dcecc39274
STABLE_DOCKER_REGISTRY registry.k8s.io
STABLE_DOCKER_PUSH_REGISTRY staging-k8s.gcr.io
gitCommit 9ba7dcecc39274f3acf4064d572996ecdbc96f10
gitTreeState clean
gitVersion v1.34.0-alpha.0.31+9ba7dcecc39274
gitMajor 1
gitMinor 34+
buildDate 2025-04-23T19:40:29Z


The issue is that in this "alpha.0" state - gitVersion v1.34.0-alpha.0.31+9ba7dcecc39274-dirty the branch is not ready to be considered v1.34 and should be considered v1.33.  The issue currently is there is no kind image at v1.33 so the test failures.  This PR makes it so that if "alpha.0" is found in the git version the HEAD branch still treated as n-1