### PR TITLE
build kind image before kueue-viz

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -382,6 +382,7 @@ presubmits:
             - runner.sh
           args:
             - make
+            - kind-image-build
             - test-e2e-kueueviz
           # docker-in-docker needs privileged mode
           securityContext:


### PR DESCRIPTION
As I was testing kueue-viz I found out that it was not taking the local image.

This builds the image before running e2e tests.

This will only be used once https://github.com/kubernetes-sigs/kueue/pull/5059 merges. 

This PR should still go first because it doesn't actually hurt anything (image will build but not be used. no harm no foul). 