### PR TITLE
Update milestone applier for k/website dev-1.34 release branch

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -562,7 +562,7 @@ milestone_applier:
   kubernetes-sigs/boskos:
     master: v1.23
   kubernetes/website:
-    dev-1.32: 1.32
+    dev-1.34: 1.34
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
Update the k/website milestone applier for the `dev-1.34` branch to automatically apply the 1.34 milestone for PRs created against the `dev-1.34` branch.

/hold for review from @kubernetes/sig-docs-leads 