### PR TITLE
Job to run E2E default tests on IBM powervs

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
@@ -293,3 +293,82 @@ periodics:
 
               [ -z "${BOSKOS_HOST:-}" ] || release_account >> "$ARTIFACTS/boskos.log" 2>&1
               [ $rc != 0 ] && echo "ERROR: alpha-enabled-default tests exited with code: $rc"; exit $rc
+  - name: ci-kubernetes-e2e-ppc64le-default
+    interval: 8h
+    cluster: k8s-infra-ppc64le-prow-build
+    labels:
+      preset-ibmcloud-cred: "true"
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    extra_refs:
+      - base_ref: main
+        org: kubernetes-sigs
+        repo: provider-ibmcloud-test-infra
+        workdir: true
+    annotations:
+      description: Runs e2e tests with against kubernetes ci latest on IBM powervs
+      testgrid-dashboards: ibm-k8s-e2e-default
+      testgrid-tab-name: ci-kubernetes-e2e-ppc64le-default
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250422-9d0e6fd518-master
+          env:
+            - name: "BOSKOS_HOST"
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: "USER"
+              value: "ci-kubernetes-ppc64le-e2e-default"
+          resources:
+            requests:
+              cpu: 2
+              memory: "6Gi"
+            limits:
+              cpu: 2
+              memory: "6Gi"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              export PATH=$GOPATH/bin:$PATH
+              export GO111MODULE=on
+              RESOURCE_TYPE="powervs"
+              #Call to boskos to checkout resource
+              source "./hack/boskos.sh"
+
+              #Setup of kubetest2 tf deployer and ginkgo tester
+              make install-deployer-tf
+              go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
+
+              #Install ansible required to bring up k8s cluster on infra
+              apt-get update && apt-get install -y ansible
+
+              K8S_BUILD_VERSION=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+
+              TIMESTAMP=$(date +%s)
+
+              set +o errexit
+              set -o xtrace
+              kubetest2 tf --powervs-image-name CentOS-Stream-9 \
+                --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
+                --powervs-service-id ${BOSKOS_RESOURCE_ID} \
+                --powervs-ssh-key k8s-prow-sshkey \
+                --ssh-private-key /etc/secret-volume/ssh-privatekey \
+                --build-version $K8S_BUILD_VERSION \
+                --release-marker $K8S_BUILD_VERSION \
+                --cluster-name e2e-default-$TIMESTAMP \
+                --workers-count 2 \
+                --up --down --auto-approve --retry-on-tf-failure 3 \
+                --break-kubetest-on-upfail true \
+                --powervs-memory 32 \
+                --test=ginkgo -- --parallel 25 --test-package-dir ci --test-package-marker latest.txt \
+                --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|KubeProxy.should.update.metric"; rc=$?
+
+              [ -z "${BOSKOS_HOST:-}" ] || release_account >> "$ARTIFACTS/boskos.log" 2>&1
+              [ $rc != 0 ] && echo "ERROR: E2e default tests exited with code: $rc"; exit $rc

--- a/config/testgrids/kubernetes/sig-cloud-provider/ibm/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/ibm/config.yaml
@@ -4,6 +4,7 @@ dashboard_groups:
     - ibm-k8s-conformance-ppc64le
     - ibm-k8s-unit-tests-ppc64le
     - ibm-k8s-e2e-node-ppc64le
+    - ibm-k8s-e2e-default
     - ibm-k8s-e2e-alpha-enabled-default
     - ibm-etcd-tests-ppc64le
     - ibm-presubmits
@@ -12,6 +13,7 @@ dashboards:
 - name: ibm-k8s-unit-tests-ppc64le
 - name: ibm-k8s-conformance-ppc64le
 - name: ibm-k8s-e2e-node-ppc64le
+- name: ibm-k8s-e2e-default
 - name: ibm-k8s-e2e-alpha-enabled-default
 - name: ibm-presubmits
 - name: ibm-etcd-tests-ppc64le


### PR DESCRIPTION
Ref: https://kubernetes.slack.com/archives/C09QZ4DQB/p1742225363263569?thread_ts=1742221592.280199&cid=C09QZ4DQB

Mapping to [gci-gce-alpha-enabled-default](https://testgrid.k8s.io/google-gce#gci-gce-alpha-enabled-default) 