### PR TITLE
Switching to Kubekins Image for Tests

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-lib-external-provisioner/sig-storage-lib-external-provisioner.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Build test in sig-storage-lib-external-provisioner repo.
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250422-9d0e6fd518-master
         command:
         # Plain make runs also verify
         - make


### PR DESCRIPTION
**Description:**

Bumping sig-storage-lib-external-provisioner go version to 1.23.1 or this [PR](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/pull/186) and because of that the CI job also needs the go version bumped as it is currently 1.22.12. 

 Switching to kubekins image so that image is automatically bumped in the future and does not become outdated.