### PR TITLE
Update image for build jobs for cluster-api-provider-cloudstack

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
@@ -66,7 +66,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-1164926229-1.27
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.32
         command:
         - bash
         - -c
@@ -98,7 +98,7 @@ presubmits:
       automountServiceAccountToken: false
       containers:
       - name: build-container
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-1164926229-1.27
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.32
         command:
         - bash
         - -c
@@ -131,7 +131,7 @@ presubmits:
       hostNetwork: true
       containers:
       - name: build-container
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-1164926229-1.27
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250411-0688312353-1.32
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-cloudstack/capi-provider-cloudstack-presumbit.yaml
@@ -74,10 +74,10 @@ presubmits:
         resources:
           requests:
             memory: "8Gi"
-            cpu: "1024m"
+            cpu: 2
           limits:
             memory: "8Gi"
-            cpu: "1024m"
+            cpu: 2
   - name: capi-provider-cloudstack-presubmit-unit-test
     cluster: eks-prow-build-cluster
     labels:
@@ -106,10 +106,10 @@ presubmits:
         resources:
           requests:
             memory: "8Gi"
-            cpu: "1024m"
+            cpu: 2
           limits:
             memory: "8Gi"
-            cpu: "1024m"
+            cpu: 2
   - name: capi-provider-cloudstack-presubmit-e2e-smoke-test
     cluster: eks-prow-build-cluster
     labels:
@@ -137,13 +137,12 @@ presubmits:
         args:
         - make
         - run-e2e-smoke
-        # docker-in-docker needs privileged mode
-        securityContext:
+        securityContext: # docker-in-docker needs privileged mode
           privileged: true
         resources:
           requests:
             memory: "8Gi"
-            cpu: "1024m"
+            cpu: 2
           limits:
             memory: "8Gi"
-            cpu: "1024m"
+            cpu: 2


### PR DESCRIPTION
Update `kubekins-e2e` image tag & increased CPU for jobs from 1 to 2.

Tested locally.