### PR TITLE
fix: resolve issue where WORKSPACE_STATUS was not properly set in compatibility versions test and fix alpha.0 regex

### DIFF
--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -350,20 +350,21 @@ main() {
   export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
   mkdir -p "${ARTIFACTS}"
 
-  GIT_VERSION=$(echo "${WORKSPACE_STATUS}" | awk '/^gitVersion/ {print $2}')
+  export VERSION_DELTA=${VERSION_DELTA:-1}
+
+  WORKSPACE_STATUS=$(./hack/print-workspace-status.sh)
+  GIT_VERSION=$(echo "$WORKSPACE_STATUS" | awk '/^gitVersion / {print $2}')
   # Check if gitVersion contains alpha.0 and increment VERSION_DELTA if needed
   # If the current version is alpha.0, it means the previous *stable* or developed
   # branch is actually n-2 relative to the current minor number for compatibility purposes.
-  if [[ "${GIT_VERSION}" == *alpha.0 ]]; then
+  if [[ "${GIT_VERSION}" == *alpha.0* ]]; then
     echo "Detected alpha.0 in gitVersion (${GIT_VERSION}), treating as still the previous minor version."
     VERSION_DELTA=$((VERSION_DELTA + 1))
     echo "Adjusted VERSION_DELTA: ${VERSION_DELTA}"
   fi
 
-  # Get current and n-1 version numbers
-  MAJOR_VERSION=$(./hack/print-workspace-status.sh | awk '/STABLE_BUILD_MAJOR_VERSION/ {print $2}')
-  MINOR_VERSION=$(./hack/print-workspace-status.sh | awk '/STABLE_BUILD_MINOR_VERSION/ {split($2, minor, "+"); print minor[1]}')
-  export VERSION_DELTA=${VERSION_DELTA:-1}
+  MAJOR_VERSION=$(echo "$WORKSPACE_STATUS" | awk '/^STABLE_BUILD_MAJOR_VERSION / {print $2}')
+  MINOR_VERSION=$(echo "$WORKSPACE_STATUS" | awk '/^STABLE_BUILD_MINOR_VERSION / {split($2, minor, "+"); print minor[1]}')
   export CURRENT_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}"
   export PREV_VERSION="${MAJOR_VERSION}.$((MINOR_VERSION - VERSION_DELTA))"
   export EMULATED_VERSION="${PREV_VERSION}"


### PR DESCRIPTION
Fixes issues with https://github.com/kubernetes/test-infra/pull/34713 due to git state not being synced.  This PR now sets the WORKSPACE_STATUS and fixes the alpha.0 check