### PR TITLE
switch most kind CI jobs for the kubernetes master branch to ginkgo v2 label filter and no* hardcoded skips

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -193,8 +193,8 @@ presubmits:
         - -c
         - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
         env:
-        - name: FOCUS
-          value: \[Conformance\]|IPv6DualStack
+        - name: LABEL_FILTER
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
         - name: IP_FAMILY
@@ -239,10 +239,8 @@ presubmits:
         - -c
         - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
         env:
-        - name: FOCUS
-          value: "."
-        - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing
+        - name: LABEL_FILTER
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -23,11 +23,8 @@ presubmits:
         - -c
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
-        - name: FOCUS
-          value: "."
-        # TODO(bentheelder): reduce the skip list further
-        - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
+        - name: LABEL_FILTER
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -116,11 +113,8 @@ presubmits:
         - -c
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
-        - name: FOCUS
-          value: "."
-        # TODO(bentheelder): reduce the skip list further
-        - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing
+        - name: LABEL_FILTER
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
         # enable IPV6 in bootstrap image
@@ -513,7 +507,7 @@ periodics:
       # ListFromCacheSnapshot does not implement the compaction behavior for watch cache defined in "Servers with support for API chunking should support continue listing from the last key if the original version has been compacted away" conformance test so it flakes
       # Ref: https://issues.k8s.io/131011
       - name: SKIP
-        value: PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity|Servers.with.support.for.API.chunking.should.support.continue.listing.from.the.last.key.if.the.original.version.has.been.compacted.away
+        value: Servers.with.support.for.API.chunking.should.support.continue.listing.from.the.last.key.if.the.original.version.has.been.compacted.away
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -564,8 +558,6 @@ periodics:
         value: '{"api/beta":"true", "api/ga":"true"}'
       - name: LABEL_FILTER
         value: "Feature: isSubsetOf OffByDefault && !Alpha && !Deprecated && !Slow && !Disruptive && !Flaky"
-      - name: SKIP
-        value: PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -619,7 +611,7 @@ periodics:
       # ListFromCacheSnapshot does not implement the compaction behavior for watch cache defined in "Servers with support for API chunking should support continue listing from the last key if the original version has been compacted away" conformance test so it flakes
       # Ref: https://issues.k8s.io/131011
       - name: SKIP
-        value: PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity|Servers.with.support.for.API.chunking.should.support.continue.listing.from.the.last.key.if.the.original.version.has.been.compacted.away
+        value: Servers.with.support.for.API.chunking.should.support.continue.listing.from.the.last.key.if.the.original.version.has.been.compacted.away
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -728,10 +720,8 @@ periodics:
       - -c
       - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-arm64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
-      - name: FOCUS
-        value: "."
-      - name: SKIP
-        value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
+      - name: LABEL_FILTER
+        value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -448,10 +448,8 @@ presubmits:
           value: '{"EventedPLEG":true}'
         - name: RUNTIME_CONFIG
           value: '{"api/alpha":"true", "api/ga":"true"}'
-        - name: FOCUS
-          value: "."
-        - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
+        - name: LABEL_FILTER
+          value: "Feature: isSubsetOf EventedPLEG && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
We still have the hardcoded skip for https://github.com/kubernetes/kubernetes/issues/131011 in some alpha/beta jobs, discussing there.
/hold
Wait for https://github.com/kubernetes/kubernetes/pull/131462 before merging