### PR TITLE
[CAPZ] Bump up min K8s upgrade versions in CAPZ upgrade tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -1,111 +1,5 @@
 periodics:
 
-- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-27-1-28-main
-  cluster: eks-prow-build-cluster
-  minimum_interval: 24h
-  decorate: true
-  decoration_config:
-    timeout: 4h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-community: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    serviceAccountName: azure
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250409-f52ea67ed6-1.29
-      args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-      env:
-        - name: KUBERNETES_VERSION_UPGRADE_FROM
-          value: "stable-1.27"
-        - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "stable-1.28"
-        - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.9-0"
-        - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.10.1"
-        - name: GINKGO_FOCUS
-          value: "\\[K8s-Upgrade\\]"
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        limits:
-          cpu: 4
-          memory: 4Gi
-        requests:
-          cpu: 4
-          memory: 4Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capi-periodic-upgrade-main-1-27-1-28
-    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: "Runs Kubernetes upgrade tests from v1.27 to v1.28 on CAPZ main branch"
-
-- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-28-1-29-main
-  cluster: eks-prow-build-cluster
-  minimum_interval: 24h
-  decorate: true
-  decoration_config:
-    timeout: 4h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-community: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    serviceAccountName: azure
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250409-f52ea67ed6-1.29
-      args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-      env:
-        - name: KUBERNETES_VERSION_UPGRADE_FROM
-          value: "stable-1.28"
-        - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "stable-1.29"
-        - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.10-0"
-        - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.11.1"
-        - name: GINKGO_FOCUS
-          value: "\\[K8s-Upgrade\\]"
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        limits:
-          cpu: 4
-          memory: 4Gi
-        requests:
-          cpu: 4
-          memory: 4Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capi-periodic-upgrade-main-1-28-1-29
-    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: "Runs Kubernetes upgrade tests from v1.28 to v1.29 on CAPZ main branch"
-
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-29-1-30-main
   cluster: eks-prow-build-cluster
   minimum_interval: 24h
@@ -138,9 +32,9 @@ periodics:
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.30"
         - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.12-0"
+          value: "3.5.9-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.11.1"
+          value: "v1.10.1"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -158,3 +52,109 @@ periodics:
     testgrid-tab-name: capi-periodic-upgrade-main-1-29-1-30
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
     description: "Runs Kubernetes upgrade tests from v1.29 to v1.30 on CAPZ main branch"
+
+- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-30-1-31-main
+  cluster: eks-prow-build-cluster
+  minimum_interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250409-f52ea67ed6-1.29
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.30"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.31"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.5.10-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "v1.11.1"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: 4
+          memory: 4Gi
+        requests:
+          cpu: 4
+          memory: 4Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capi-periodic-upgrade-main-1-30-1-31
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: "Runs Kubernetes upgrade tests from v1.30 to v1.31 on CAPZ main branch"
+
+- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-31-1-32-main
+  cluster: eks-prow-build-cluster
+  minimum_interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250409-f52ea67ed6-1.29
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.31"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.32"
+        - name: ETCD_VERSION_UPGRADE_TO
+          value: "3.5.12-0"
+        - name: COREDNS_VERSION_UPGRADE_TO
+          value: "v1.11.1"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: 4
+          memory: 4Gi
+        requests:
+          cpu: 4
+          memory: 4Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capi-periodic-upgrade-main-1-31-1-32
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: "Runs Kubernetes upgrade tests from v1.31 to v1.32 on CAPZ main branch"


### PR DESCRIPTION
Based off of widely supported K8s version for an AKS clusters in a popular region like `eastus`, we are updating the upgrade tests to reflect latest supported K8s versions.

```bash
❯ az aks get-versions --location eastus --output table
KubernetesVersion    Upgrades                                                                                                                                          SupportPlan
-------------------  ------------------------------------------------------------------------------------------------------------------------------------------------  --------------------------------------
1.32.3               None available                                                                                                                                    KubernetesOfficial
1.32.2               1.32.3                                                                                                                                            KubernetesOfficial
1.32.1               1.32.2, 1.32.3                                                                                                                                    KubernetesOfficial
1.32.0               1.32.1, 1.32.2, 1.32.3                                                                                                                            KubernetesOfficial
1.31.7               1.32.0, 1.32.1, 1.32.2, 1.32.3                                                                                                                    KubernetesOfficial
1.31.6               1.31.7, 1.32.0, 1.32.1, 1.32.2, 1.32.3                                                                                                            KubernetesOfficial
1.31.5               1.31.6, 1.31.7, 1.32.0, 1.32.1, 1.32.2, 1.32.3                                                                                                    KubernetesOfficial
1.31.4               1.31.5, 1.31.6, 1.31.7, 1.32.0, 1.32.1, 1.32.2, 1.32.3                                                                                            KubernetesOfficial
1.31.3               1.31.4, 1.31.5, 1.31.6, 1.31.7, 1.32.0, 1.32.1, 1.32.2, 1.32.3                                                                                    KubernetesOfficial
1.31.2               1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7, 1.32.0, 1.32.1, 1.32.2, 1.32.3                                                                            KubernetesOfficial
1.31.1               1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7, 1.32.0, 1.32.1, 1.32.2, 1.32.3                                                                    KubernetesOfficial
1.30.11              1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7                                                                                            KubernetesOfficial, AKSLongTermSupport
1.30.10              1.30.11, 1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7                                                                                   KubernetesOfficial, AKSLongTermSupport
1.30.9               1.30.10, 1.30.11, 1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7                                                                          KubernetesOfficial, AKSLongTermSupport
1.30.8               1.30.9, 1.30.10, 1.30.11, 1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7                                                                  KubernetesOfficial, AKSLongTermSupport
1.30.7               1.30.8, 1.30.9, 1.30.10, 1.30.11, 1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7                                                          KubernetesOfficial, AKSLongTermSupport
1.30.6               1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11, 1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7                                                  KubernetesOfficial, AKSLongTermSupport
1.30.5               1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11, 1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7                                          KubernetesOfficial, AKSLongTermSupport
1.30.4               1.30.5, 1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11, 1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7                                  KubernetesOfficial, AKSLongTermSupport
1.30.3               1.30.4, 1.30.5, 1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11, 1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7                          KubernetesOfficial, AKSLongTermSupport
1.30.2               1.30.3, 1.30.4, 1.30.5, 1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11, 1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7                  KubernetesOfficial, AKSLongTermSupport
1.30.1               1.30.2, 1.30.3, 1.30.4, 1.30.5, 1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11, 1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7          KubernetesOfficial, AKSLongTermSupport
1.30.0               1.30.1, 1.30.2, 1.30.3, 1.30.4, 1.30.5, 1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11, 1.31.1, 1.31.2, 1.31.3, 1.31.4, 1.31.5, 1.31.6, 1.31.7  KubernetesOfficial, AKSLongTermSupport
1.29.15              1.30.0, 1.30.1, 1.30.2, 1.30.3, 1.30.4, 1.30.5, 1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11                                                  AKSLongTermSupport
1.29.14              1.29.15, 1.30.0, 1.30.1, 1.30.2, 1.30.3, 1.30.4, 1.30.5, 1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11                                         AKSLongTermSupport
1.28.100             1.29.14, 1.29.15, 1.30.0, 1.30.1, 1.30.2, 1.30.3, 1.30.4, 1.30.5, 1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11                                AKSLongTermSupport
1.28.15              1.28.100, 1.29.14, 1.29.15, 1.30.0, 1.30.1, 1.30.2, 1.30.3, 1.30.4, 1.30.5, 1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11                      AKSLongTermSupport
1.27.102             1.28.15, 1.28.100, 1.29.14, 1.29.15, 1.30.0, 1.30.1, 1.30.2, 1.30.3, 1.30.4, 1.30.5, 1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11             AKSLongTermSupport
1.27.101             1.27.102, 1.28.15, 1.28.100, 1.29.14, 1.29.15, 1.30.0, 1.30.1, 1.30.2, 1.30.3, 1.30.4, 1.30.5, 1.30.6, 1.30.7, 1.30.8, 1.30.9, 1.30.10, 1.30.11   AKSLongTermSupport
```