### PR TITLE
Bump kubekins image for main to 1.33

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-upgrades.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -81,7 +81,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -138,7 +138,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -195,7 +195,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -252,7 +252,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -309,7 +309,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
       command:
       - runner.sh
       - ./scripts/ci-test.sh
@@ -50,7 +50,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
       command:
       - runner.sh
       - ./scripts/ci-test.sh
@@ -100,7 +100,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -152,7 +152,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -212,7 +212,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -261,7 +261,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -311,7 +311,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -43,7 +43,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         resources:
           requests:
             cpu: 6000m
@@ -68,7 +68,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         command:
         - "runner.sh"
         - ./scripts/ci-verify.sh
@@ -96,7 +96,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -122,7 +122,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -166,7 +166,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         args:
         - runner.sh
         - ./scripts/ci-e2e.sh
@@ -220,7 +220,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -263,7 +263,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -309,7 +309,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -359,7 +359,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -402,7 +402,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -446,7 +446,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33
         args:
         - runner.sh
         - ./scripts/ci-e2e.sh

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-prowjob-gen.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-prowjob-gen.yaml
@@ -32,7 +32,7 @@
 prow_ignored:
   branches:
     main:
-      testImage: "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.32"
+      testImage: "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-1.33"
       interval: "3h"
       upgradesInterval: "24h"
       kubernetesVersionManagement: "v1.30.10"


### PR DESCRIPTION
part of https://github.com/kubernetes-sigs/cluster-api/issues/11642

Bumps kubekins for the tests running agains the main branch of CAPI to 1.33