### PR TITLE
etcd: enable pull-etcd-govulncheck for release-3.4 branch

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -159,6 +159,7 @@ presubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits


### PR DESCRIPTION
Add `pull-etcd-govulncheck` for branches release-3.4 and release-3.5

ref: https://github.com/kubernetes/test-infra/issues/32754; 

- [x] https://github.com/etcd-io/etcd/pull/19810

/cc @abdurrehman107 @ivanvc 