### PR TITLE
sig autoscaling: CA automated image build job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
+++ b/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
@@ -43,3 +43,25 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-autoscaling-gcb
               - --env-passthrough=PULL_BASE_REF
               - vertical-pod-autoscaler
+    - name: post-autoscaler-push-cluster-autoscaler-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-autoscaling-cluster-autoscaler-images, sig-k8s-infra-gcb
+      decorate: true
+      branches:
+        - ^master$
+      run_if_changed: "^cluster-autoscaler/"
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20241224-fe22c549c1
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-autoscaling
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-autoscaling-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - cluster-autoscaler

--- a/config/testgrids/kubernetes/sig-autoscaling/config.yaml
+++ b/config/testgrids/kubernetes/sig-autoscaling/config.yaml
@@ -7,6 +7,7 @@ dashboard_groups:
       - sig-autoscaling-karpenter
       - sig-autoscaling-addon-resizer
       - sig-autoscaling-vpa-images
+      - sig-autoscaling-cluster-autoscaler-images
 
 dashboards:
   - name: sig-autoscaling-cluster-autoscaler
@@ -15,3 +16,4 @@ dashboards:
   - name: sig-autoscaling-karpenter
   - name: sig-autoscaling-addon-resizer
   - name: sig-autoscaling-vpa-images
+  - name: sig-autoscaling-cluster-autoscaler-images


### PR DESCRIPTION
This PR adds a prow job + config to automatically build and publish cluster-autoscaler images.

Refs:

- https://github.com/kubernetes/autoscaler/pull/8042
- https://github.com/kubernetes/autoscaler/pull/8064