### PR TITLE
Update pull-etcd-release-tests to use make test-release

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -616,20 +616,8 @@ presubmits:
           - bash
           - -c
           - |
-            gpg --batch --gen-key <<EOF
-            %no-protection
-            Key-Type: 1
-            Key-Length: 2048
-            Subkey-Type: 1
-            Subkey-Length: 2048
-            Name-Real: Prow
-            Name-Email: ci-robot@k8s.io
-            Expire-Date: 0
-            EOF
-            # Add the origin remote as the remote is unnamed in the prow infra.
-            git remote add origin https://github.com/etcd-io/etcd.git
-            DRY_RUN=true ./scripts/release.sh --no-upload --no-docker-push --no-gh-release --in-place 3.6.99
-            VERSION=3.6.99 ./scripts/test_images.sh
+            export CI=true
+            make test-release
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
Port `pull-etcd-release-tests` shell scripts to `test.sh`. Make Prow job call `make test-release`.

wait for https://github.com/etcd-io/etcd/pull/19815 to be reviewed and merged.
ref: https://github.com/kubernetes/test-infra/issues/32754

/cc @ivanvc @jmhbnz 