### PR TITLE
Update OWNERS for sig-autoscaling testgrid directory

### DIFF
--- a/config/testgrids/kubernetes/sig-autoscaling/OWNERS
+++ b/config/testgrids/kubernetes/sig-autoscaling/OWNERS
@@ -1,10 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- mwielgus
-- maciekpytel
-- bskiba
+- sig-autoscaling-leads
 approvers:
-- mwielgus
-- maciekpytel
-- bskiba
+- sig-autoscaling-leads


### PR DESCRIPTION
Update OWNERS to canonical group to prevent list of folks getting stale.