### PR TITLE
Change test-infra owners for fsx openzfs

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-fsx-openzfs-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/aws-fsx-openzfs-csi-driver/OWNERS
@@ -1,7 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- jacobwolfaws
+- dims
 
 approvers:
-- jacobwolfaws
+- dims


### PR DESCRIPTION
Moving the test-infra owners to be the owners of the fsx openzfs csi driver