### PR TITLE
cosi: raise cpu for presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface.yaml
@@ -22,11 +22,11 @@ presubmits:
         - build
         resources:
           limits:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 6Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -54,11 +54,11 @@ presubmits:
         - ./hack/prow-test.sh
         resources:
           limits:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 6Gi
         env:
         - name: GOMAXPROCS # workaround for go not respecting cgroup resource limits/requests
           valueFrom:
@@ -83,11 +83,11 @@ presubmits:
         - ./hack/prow-lint.sh
         resources:
           limits:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 6Gi
         env:
         - name: GOMAXPROCS # workaround for go not respecting cgroup resource limits/requests
           valueFrom:
@@ -112,11 +112,11 @@ presubmits:
         - ./hack/prow-check-generate.sh
         resources:
           limits:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 6Gi
         env:
         - name: GOMAXPROCS # workaround for go not respecting cgroup resource limits/requests
           valueFrom:


### PR DESCRIPTION
Setting GOMAXPROCS seems to be effective at capping the CPUs used by Go lint and unit tests, but those jobs are still regularly taking over 6 minutes and time out after 8.

Most of the length is due to having 3 golang submodules to lint. Giving more CPU and memory should help ensure there aren't risks of CI flakes.