### PR TITLE
[CAPZ] Use k8s version v1.30.8 instead of v1.30.11

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -207,7 +207,7 @@ periodics:
           - name: GINKGO_FOCUS
             value: "API Version Upgrade"
           - name: KUBERNETES_VERSION
-            value: "v1.30.11"
+            value: "v1.30.5"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -207,7 +207,7 @@ periodics:
           - name: GINKGO_FOCUS
             value: "API Version Upgrade"
           - name: KUBERNETES_VERSION
-            value: "v1.30.5"
+            value: "v1.30.8"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -651,7 +651,7 @@ presubmits:
             - name: GINKGO_FOCUS
               value: "API Version Upgrade"
             - name: KUBERNETES_VERSION
-              value: "v1.30.5"
+              value: "v1.30.8"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -651,7 +651,7 @@ presubmits:
             - name: GINKGO_FOCUS
               value: "API Version Upgrade"
             - name: KUBERNETES_VERSION
-              value: "v1.30.11"
+              value: "v1.30.5"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -118,7 +118,7 @@ presubmits:
             - name: GINKGO_FOCUS
               value: "API Version Upgrade"
             - name: KUBERNETES_VERSION
-              value: "v1.30.5"
+              value: "v1.30.8"
           resources:
             limits:
               cpu: 6

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -118,7 +118,7 @@ presubmits:
             - name: GINKGO_FOCUS
               value: "API Version Upgrade"
             - name: KUBERNETES_VERSION
-              value: "v1.30.11"
+              value: "v1.30.5"
           resources:
             limits:
               cpu: 6


### PR DESCRIPTION
Seems like we do not publish (test) VM images for K8s `v1.30.11` yet. So moving over to `v1.30.8` as per the error message in [pull-cluster-api-provider-azure-apiversion-upgrade-v1beta1](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/5591/pull-cluster-api-provider-azure-apiversion-upgrade-v1beta1/1916925101207457792)

```bash
[SynchronizedBeforeSuite] [FAILED] [14.162 seconds]
[SynchronizedBeforeSuite] 
/home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/e2e_suite_test.go:64
   Timeline >>
  STEP: Loading the e2e test configuration from "/home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/config/azure-dev-envsubst.yaml" @ 04/28/25 18:50:30.318
  Apr 28 18:50:30.323: INFO: Getting versions for image "capi-ubun2-2404" in community gallery "ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019" in location "uksouth"
  Apr 28 18:50:31.930: INFO: Getting versions for image "capi-win-2019-containerd" in community gallery "ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019" in location "uksouth"
  Apr 28 18:50:33.011: INFO: Finding Flatcar images and versions in community gallery "flatcar4capi-742ef0cb-dcaa-4ecb-9cb0-bfd2e43dccc0" in location "uksouth"
  [FAILED] in [SynchronizedBeforeSuite] - /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/helpers.go:815 @ 04/28/25 18:50:44.479
  << Timeline
   [FAILED] Provided Kubernetes version v1.30.11 does not have a corresponding VM image in the "capi offer"
  Expected
      <semver.Versions | len:15, cap:17>: [
          {Major: 1, Minor: 30, Patch: 5, Pre: nil, Build: nil},
          {Major: 1, Minor: 27, Patch: 16, Pre: nil, Build: nil},
          {Major: 1, Minor: 28, Patch: 10, Pre: nil, Build: nil},
          {Major: 1, Minor: 32, Patch: 0, Pre: nil, Build: nil},
          {Major: 1, Minor: 29, Patch: 11, Pre: nil, Build: nil},
          {Major: 1, Minor: 29, Patch: 12, Pre: nil, Build: nil},
          {Major: 1, Minor: 31, Patch: 3, Pre: nil, Build: nil},
          {Major: 1, Minor: 31, Patch: 4, Pre: nil, Build: nil},
          {Major: 1, Minor: 29, Patch: 10, Pre: nil, Build: nil},
          {Major: 1, Minor: 28, Patch: 15, Pre: nil, Build: nil},
          {Major: 1, Minor: 31, Patch: 2, Pre: nil, Build: nil},
          {Major: 1, Minor: 30, Patch: 6, Pre: nil, Build: nil},
          {Major: 1, Minor: 30, Patch: 7, Pre: nil, Build: nil},
          {Major: 1, Minor: 30, Patch: 8, Pre: nil, Build: nil},
          {Major: 1, Minor: 31, Patch: 1, Pre: nil, Build: nil},
      ]
  to contain element matching
      <semver.Version>: {Major: 1, Minor: 30, Patch: 11, Pre: nil, Build: nil}
  In [SynchronizedBeforeSuite] at: /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/helpers.go:815 @ 04/28/25 18:50:44.479
```