### PR TITLE
[CAPZ] Use k8s version v1.30.3 instead of v1.30.8

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -207,7 +207,7 @@ periodics:
           - name: GINKGO_FOCUS
             value: "API Version Upgrade"
           - name: KUBERNETES_VERSION
-            value: "v1.30.8"
+            value: "v1.30.3"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -651,7 +651,7 @@ presubmits:
             - name: GINKGO_FOCUS
               value: "API Version Upgrade"
             - name: KUBERNETES_VERSION
-              value: "v1.30.8"
+              value: "v1.30.3"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -118,7 +118,7 @@ presubmits:
             - name: GINKGO_FOCUS
               value: "API Version Upgrade"
             - name: KUBERNETES_VERSION
-              value: "v1.30.8"
+              value: "v1.30.3"
           resources:
             limits:
               cpu: 6


### PR DESCRIPTION
Earlier [PR 34747](https://github.com/kubernetes/test-infra/pull/34747) upgraded the k8s version to v1.30.8.
This PR is downgrading the min K8s version in CAPZ tests to `v1.30.3` to address the errors CAPZ is seeing in `pull-cluster-api-provider-azure-apiversion-upgrade-v1beta1` logs. 

```bash
E0428 23:07:38.283612       1 controller.go:324] "Reconciler error" err="failed to init machine scope cache: failed to get default image: no VM image found for publisher \"cncf-upstream\" offer \"capi\" sku \"ubuntu-2204-gen1\" with Kubernetes version \"v1.30.8\"" controller="azuremachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AzureMachine" AzureMachine="clusterctl-upgrade/clusterctl-upgrade-workload-wyoa4b-control-plane-h6jtd" namespace="clusterctl-upgrade" name="clusterctl-upgrade-workload-wyoa4b-control-plane-h6jtd" reconcileID="33609f28-d630-44b9-9631-5fab6e44d16b"
```