### PR TITLE
descheduler: update presubmits for 1.33 release 

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -16,7 +16,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23.3
+      - image: public.ecr.aws/docker/library/golang:1.24.2
         command:
         - make
         args:
@@ -43,7 +43,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23.3
+      - image: public.ecr.aws/docker/library/golang:1.24.2
         command:
         - make
         args:
@@ -71,11 +71,49 @@ presubmits:
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23.3
+      - image: public.ecr.aws/docker/library/golang:1.24.2
         command:
         - make
         args:
         - test-unit
+        resources:
+          limits:
+            cpu: 6
+            memory: 4Gi
+          requests:
+            cpu: 6
+            memory: 4Gi
+  - name: pull-descheduler-test-e2e-k8s-master-1-33
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.33
+    decorate: true
+    decoration_config:
+      timeout: 40m
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        env:
+        - name: KUBERNETES_VERSION
+          value: "v1.33.0"
+        - name: KIND_E2E
+          value: "true"
+        args:
+        - make
+        - test-e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
         resources:
           limits:
             cpu: 6
@@ -105,7 +143,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.32.0"
+          value: "v1.32.3"
         - name: KIND_E2E
           value: "true"
         args:
@@ -143,45 +181,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.31.4"
-        - name: KIND_E2E
-          value: "true"
-        args:
-        - make
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 6
-            memory: 4Gi
-          requests:
-            cpu: 6
-            memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-master-1-30
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.30
-    decorate: true
-    decoration_config:
-      timeout: 40m
-    always_run: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    branches:
-    - master
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-master
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        env:
-        - name: KUBERNETES_VERSION
-          value: "v1.30.8"
+          value: "v1.31.6"
         - name: KIND_E2E
           value: "true"
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.33.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.33.yaml
@@ -1,22 +1,22 @@
 # sigs.k8s.io/descheduler presubmits
 presubmits:
   kubernetes-sigs/descheduler:
-  - name: pull-descheduler-verify-release-1-30
+  - name: pull-descheduler-verify-release-1-33
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-verify-release-1.30
+      testgrid-tab-name: pull-descheduler-verify-release-1.33
     decorate: true
     decoration_config:
       timeout: 15m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.30$
+    - ^release-1.33$
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22.7
+      - image: public.ecr.aws/docker/library/golang:1.24.2
         command:
         - make
         args:
@@ -28,22 +28,22 @@ presubmits:
           requests:
             cpu: 8
             memory: 8Gi
-  - name: pull-descheduler-verify-build-release-1-30
+  - name: pull-descheduler-verify-build-release-1-33
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-verify-build-release-1.30
+      testgrid-tab-name: pull-descheduler-verify-build-release-1.33
     decorate: true
     decoration_config:
       timeout: 10m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.30$
+    - ^release-1.33$
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22.7
+      - image: public.ecr.aws/docker/library/golang:1.24.2
         command:
         - make
         args:
@@ -55,23 +55,23 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-unit-test-release-1-30
+  - name: pull-descheduler-unit-test-release-1-33
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-unit-test-release-1.30
+      testgrid-tab-name: pull-descheduler-unit-test-release-1.33
     decorate: true
     decoration_config:
       timeout: 10m
     path_alias: sigs.k8s.io/descheduler
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.30$
+    - ^release-1.33$
     always_run: false
     run_if_changed: '\.go$'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22.7
+      - image: public.ecr.aws/docker/library/golang:1.24.2
         command:
         - make
         args:
@@ -83,11 +83,11 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-release-1-30-1-30
+  - name: pull-descheduler-test-e2e-k8s-release-1-33-1-33
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-30-1.30
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-33-1.33
     decorate: true
     decoration_config:
       timeout: 40m
@@ -96,7 +96,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.30
+    - release-1.33
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-master
@@ -105,7 +105,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.30.4"
+          value: "v1.33.0"
         - name: KIND_E2E
           value: "true"
         args:
@@ -121,11 +121,11 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-release-1-30-1-29
+  - name: pull-descheduler-test-e2e-k8s-release-1-33-1-32
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-30-1.29
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-33-1.32
     decorate: true
     decoration_config:
       timeout: 40m
@@ -134,7 +134,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.30
+    - release-1.33
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-master
@@ -143,7 +143,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.29.4"
+          value: "v1.32.3"
         - name: KIND_E2E
           value: "true"
         args:
@@ -159,11 +159,11 @@ presubmits:
           requests:
             cpu: 6
             memory: 4Gi
-  - name: pull-descheduler-test-e2e-k8s-release-1-30-1-28
+  - name: pull-descheduler-test-e2e-k8s-release-1-33-1-31
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-30-1.28
+      testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-33-1.31
     decorate: true
     decoration_config:
       timeout: 40m
@@ -172,7 +172,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.30
+    - release-1.33
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-master
@@ -181,7 +181,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.28.9"
+          value: "v1.31.6"
         - name: KIND_E2E
           value: "true"
         args:


### PR DESCRIPTION
Similar to https://github.com/kubernetes/test-infra/pull/34045

/cc @seanmalloy @ingvagabund @damemi