### PR TITLE
Add cert-manager enabled e2e testing in LWS

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -146,6 +146,37 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-lws-test-e2e-main-cert-manager
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/lws
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: pull-lws-test-e2e-main-cert-manager
+      description: "Run cert-manager enabled lws end to end tests"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.32.0
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-cert-manager
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-lws-verify-main
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
This PR defines a new CI job for LWS, namely `pull-lws-test-e2e-main-cert-manager` to run the same e2e tests also against a LWS whose cert-manager is enabled and internal cert management is disabled. 

We need this CI job because enabling cert-manager requires many configurational changes and we need to be sure that there is no breakages in each PR.