### PR TITLE
inference-extension: Add PULL_BASE_SHA to the env list

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-inference-extension.yaml
+++ b/config/jobs/image-pushing/k8s-staging-inference-extension.yaml
@@ -19,5 +19,5 @@ postsubmits:
             args:
               - --project=k8s-staging-images
               - --scratch-bucket=gs://k8s-staging-images-gcb
-              - --env-passthrough=PULL_BASE_REF
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
               - .


### PR DESCRIPTION
The release pipeline in the inference extension can use PULL_BASE_SHA to get the git commit SHA.