### PR TITLE
update k/release jobs to use go1.24

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -101,7 +101,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -127,7 +127,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -152,7 +152,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -177,7 +177,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
needed for https://github.com/kubernetes/release/pull/3990


/assign @puerco @xmudrii @saschagrunert 
cc @kubernetes/release-managers 