### PR TITLE
test the new GKE nodes with sig-testing canary jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -37,7 +37,7 @@ presubmits:
             cpu: 8
             memory: 20Gi
   - name: pull-kubernetes-integration-canary
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     always_run: false # Only for canary!
     decorate: true
     skip_branches:
@@ -72,6 +72,11 @@ presubmits:
           requests:
             cpu: 8
             memory: 20Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-testing"
+          effect: "NoSchedule"
   - name: pull-kubernetes-integration-go-compatibility
     cluster: k8s-infra-prow-build
     always_run: true
@@ -140,6 +145,11 @@ presubmits:
           requests:
             cpu: 6
             memory: 15Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-testing"
+          effect: "NoSchedule"
 periodics:
 - interval: 1h
   cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -84,6 +84,11 @@ presubmits:
           requests:
             cpu: 7
             memory: 9000Mi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-testing"
+          effect: "NoSchedule"
     annotations:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -28,6 +28,11 @@ periodics:
         requests:
           cpu: 2
           memory: 4Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-testing"
+        effect: "NoSchedule"
   annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: prow
@@ -73,6 +78,11 @@ periodics:
         requests:
           cpu: 2
           memory: 4Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-testing"
+        effect: "NoSchedule"
   annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: node


### PR DESCRIPTION
We deployed faster VMs at https://github.com/kubernetes/k8s.io/pull/7943, so I'm configuring some jobs to run with them.