### PR TITLE
update zeitgeist jobs to use go1.24

### DIFF
--- a/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/zeitgeist/zeitgeist-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -31,7 +31,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
         imagePullPolicy: Always
         command:
         - make
@@ -55,7 +55,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
/assign @saschagrunert @puerco @Verolop 
cc @kubernetes/release-managers  
