### PR TITLE
etcd: enable pull-etcd-release-tests for release-3.4 branch

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -600,6 +600,7 @@ presubmits:
     branches:
       - main
       - release-3.6
+      - release-3.4
     decorate: true
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Enable `pull-etcd-release-tests` for `release-3.4` branch.

The PR for the workflow is merged: https://github.com/etcd-io/etcd/pull/19855
Reference: https://github.com/kubernetes/test-infra/issues/32754

/cc @ivanvc 