### PR TITLE
etcd: enable pull-etcd-verify for release-3.4 branch

### DIFF
--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -30,6 +30,7 @@ postsubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-postsubmits

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -122,6 +122,7 @@ presubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits


### PR DESCRIPTION
Enable pull-etcd-verify for release-3.4 branch.

No change is needed to emulate the behavior in Github Actions
Reference: https://github.com/kubernetes/test-infra/issues/32754

/cc @ivanvc