### PR TITLE
Add hold plugin for etcd-io projects

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1687,6 +1687,8 @@ plugins:
     - yuks
     - owners-label
     - verify-owners
+    - hold
+    
 
   containerd/containerd:
     plugins:


### PR DESCRIPTION
This PR will add `hold` plugin for etcd-io projects which will allow the reviewers to interact with the PRs via chatops to add `hold` labels.

issue link: [etcd-io/etcd #18110](https://github.com/etcd-io/etcd/issues/18110)