### PR TITLE
containerd: update jobs for containerd 2.1 release

### DIFF
--- a/config/jobs/containerd/containerd/containerd-periodic-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-periodic-jobs.yaml
@@ -245,6 +245,76 @@ periodics:
     testgrid-tab-name: ci-containerd-arm64-build-2.0
     description: "builds release/2.0 branch of upstream containerd (arm64)"
 
+- name: ci-containerd-build-2-1
+  cron: "0 8,21 * * *" # Run twice a day - ensure this is the same time as ci-containerd-arm64-build-2-1
+  labels:
+    preset-service-account: "true"
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+    - org: containerd
+      repo: containerd
+      base_ref: release/2.1
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-master
+        command:
+          - runner.sh
+        args:
+          - test/build.sh
+        env:
+          - name: DEPLOY_DIR
+            value: release-2.1
+          - name: DEPLOY_BUCKET
+            value: k8s-staging-cri-tools
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+  annotations:
+    testgrid-dashboards: sig-node-containerd,containerd-periodic
+    testgrid-tab-name: ci-containerd-build-2.1
+    description: "builds release/2.1 branch of upstream containerd"
+
+- name: ci-containerd-arm64-build-2-1
+  cron: "0 8,21 * * *" # Run twice a day - ensure this is the same time as ci-containerd-build-2-1
+  labels:
+    preset-service-account: "true"
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+    - org: containerd
+      repo: containerd
+      base_ref: release/2.1
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250422-9d0e6fd518-master
+        command:
+          - runner.sh
+        args:
+          - test/build.sh
+        env:
+          - name: DEPLOY_DIR
+            value: release-2.1
+          - name: DEPLOY_BUCKET
+            value: k8s-staging-cri-tools
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+    nodeSelector:
+      kubernetes.io/arch: arm64
+  annotations:
+    testgrid-dashboards: sig-node-containerd,containerd-periodic
+    testgrid-tab-name: ci-containerd-arm64-build-2.1
+    description: "builds release/2.1 branch of upstream containerd (arm64)"
+
 - name: ci-containerd-build-test-images
   interval: 24h
   labels:

--- a/config/jobs/containerd/containerd/containerd-postsubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-postsubmit-jobs.yaml
@@ -125,6 +125,38 @@ postsubmits:
         testgrid-tab-name: post-containerd-build-2.0
         description: "builds release/2.0 branch of upstream containerd"
 
+    - name: post-containerd-build-2-1
+      labels:
+        preset-service-account: "true"
+      cluster: k8s-infra-prow-build
+      decorate: true
+      branches:
+        - release/2.1
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250422-9d0e6fd518-master
+            command:
+              - runner.sh
+            args:
+              - test/build.sh
+            env:
+              - name: DEPLOY_DIR
+                value: release-2.1
+              - name: DEPLOY_BUCKET
+                value: k8s-staging-cri-tools
+            resources:
+              limits:
+                cpu: 4
+                memory: 6Gi
+              requests:
+                cpu: 4
+                memory: 6Gi
+      annotations:
+        testgrid-dashboards: sig-node-containerd,containerd-postsubmits
+        testgrid-tab-name: post-containerd-build-2.1
+        description: "builds release/2.1 branch of upstream containerd"
+
+
     - name: post-containerd-build-test-images
       labels:
         preset-service-account: "true"

--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -8,6 +8,7 @@ presubmits:
     - release/1.6
     - release/1.7
     - release/2.0
+    - release/2.1
     decorate: true
     annotations:
       testgrid-dashboards: sig-node-containerd,containerd-presubmits
@@ -42,6 +43,7 @@ presubmits:
     branches:
     - main
     - release/2.0
+    - release/2.1
     decoration_config:
       timeout: 100m
     extra_refs:
@@ -331,6 +333,7 @@ presubmits:
     - main
     - release/1.7
     - release/2.0
+    - release/2.1
     annotations:
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"

--- a/jobs/e2e_node/containerd/containerd-release-2.1/env
+++ b/jobs/e2e_node/containerd/containerd-release-2.1/env
@@ -1,0 +1,9 @@
+CONTAINERD_TEST: 'true'
+CONTAINERD_LOG_LEVEL: 'debug'
+CONTAINERD_DEPLOY_PATH: 'k8s-staging-cri-tools/containerd/release-2.1'
+CONTAINERD_PKG_PREFIX: 'containerd-cni'
+
+CONTAINERD_EXTRA_RUNTIME_HANDLER: 'test-handler'
+CONTAINERD_EXTRA_RUNTIME_OPTIONS: |
+  BinaryName = "/home/containerd/usr/local/sbin/runc"
+CONTAINERD_SYSTEMD_CGROUP: 'true'

--- a/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
@@ -1,0 +1,9 @@
+images:
+  ubuntu:
+    image: ubuntu-gke-2204-1-24-v20220623
+    project: ubuntu-os-gke-cloud
+    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/env"
+  cos-stable:
+    image_family: cos-beta
+    project: cos-cloud
+    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
This is based on https://github.com/kubernetes/test-infra/pull/33758, https://github.com/kubernetes/test-infra/pull/33768, https://github.com/kubernetes/test-infra/pull/33769, and the subsequent arm64 additions.