### PR TITLE
Job configuration to push aws-encryption-provider container

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cloud-provider-aws.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cloud-provider-aws.yaml
@@ -92,3 +92,38 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-provider-aws-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+  kubernetes-sigs/aws-encryption-provider:
+    - name: aws-encryption-provider-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: provider-aws-encryption-provider, sig-k8s-infra-gcb
+        testgrid-tab-name: aws-encryption-provider-image-pushes
+      decorate: true
+      branches:
+        # For publishing canary images.
+        - ^master$
+        - ^release-
+        # For publishing tagged images. Those will only get built once, i.e.
+        # existing images are not getting overwritten. A new tag must be set to
+        # trigger another image build. Images are only built for tags that follow
+        # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20241224-fe22c549c1
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-provider-aws
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-provider-aws-gcb
+              - --env-passthrough=PULL_BASE_REF,REGISTRY
+              - .
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
+              - name: REGISTRY
+                value: "us-central1-docker.pkg.dev/k8s-staging-images/aws-encryption-provider"


### PR DESCRIPTION
Adding job configurations to build aws-encryption-provider containers. 

Corresponding cloud-build configuration PR in [aws-encryption-provider](https://github.com/kubernetes-sigs/aws-encryption-provider/pull/136)

Pushes images to existing repo created from [PR](https://github.com/kubernetes/k8s.io/pull/7587)