### PR TITLE
etcd: enable verify jobs for release-3.5 branch

### DIFF
--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -29,6 +29,7 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
+    - release-3.5
     - release-3.6
     decorate: true
     annotations:

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -121,6 +121,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.5
     - release-3.6
     decorate: true
     annotations:


### PR DESCRIPTION
Enable the presubmit pull-etcd-verify and the postsubmit post-etcd-verify jobs for the release-3.5 branch.