### PR TITLE
etcd: enable pull-etcd-verify for release-3.5 branch

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -121,6 +121,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - release-3.5
     - release-3.6
     - release-3.4
     decorate: true


### PR DESCRIPTION
Add `pull-etcd-verify` for branche release-3.5

ref: #32754;

cc @ivanvc @joshjms 