### PR TITLE
VPA: enable InPlaceOrRecreate feature gate in tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -87,6 +87,9 @@ periodics:
         requests:
           cpu: 2
           memory: 6Gi
+      env:
+      - name: FEATURE_GATES
+        value: "InPlaceOrRecreate=true"
 
   annotations:
     testgrid-dashboards: sig-autoscaling-vpa
@@ -133,6 +136,9 @@ periodics:
         requests:
           cpu: 2
           memory: 6Gi
+      env:
+      - name: FEATURE_GATES
+        value: "InPlaceOrRecreate=true"
 
   annotations:
     testgrid-dashboards: sig-autoscaling-vpa
@@ -179,6 +185,9 @@ periodics:
         requests:
           cpu: 2
           memory: 6Gi
+      env:
+      - name: FEATURE_GATES
+        value: "InPlaceOrRecreate=true"
 
   annotations:
     testgrid-dashboards: sig-autoscaling-vpa
@@ -225,6 +234,9 @@ periodics:
         requests:
           cpu: 2
           memory: 6Gi
+      env:
+      - name: FEATURE_GATES
+        value: "InPlaceOrRecreate=true"
 
   annotations:
     testgrid-dashboards: sig-autoscaling-vpa

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -237,6 +237,9 @@ presubmits:
           requests:
             cpu: 2
             memory: 6Gi
+        env:
+        - name: FEATURE_GATES
+          value: "InPlaceOrRecreate=true"
   - name: pull-kubernetes-e2e-autoscaling-ca-build
     cluster: k8s-infra-prow-build
     annotations:


### PR DESCRIPTION
Enables the `InPlaceOrRecreate` feature gate by default in all periodic and pre-submit VPA tests.