### PR TITLE
Add pull-kubernetes-e2e-storage-kind-alpha-beta-features-slow job

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
@@ -97,6 +97,50 @@ presubmits:
             cpu: "2"
             memory: "6Gi"
 
+  # This jobs runs e2e.test with a focus on slow tests for all alpha/beta storage features on a kind cluster
+  - name: pull-kubernetes-e2e-storage-kind-alpha-beta-features-slow
+    cluster: eks-prow-build-cluster
+    decorate: true
+    always_run: false
+    skip_branches:
+    - release-\d+\.\d+
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: k8s.io/kubernetes
+    annotations:
+      testgrid-dashboards: presubmits-kubernetes-nonblocking
+      testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
+      description: Run storage long running tests for alpha/beta features in a KIND cluster.
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20250422-9d0e6fd518-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"VolumeAttributesClass":true}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
+        - name: LABEL_FILTER
+          value: "FeatureGate:VolumeAttributesClass && Slow"
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "2"
+            memory: "6Gi"
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+
 periodics:
   # This jobs runs storage tests that need Kubernetes In Docker (kind).
   - name: ci-kubernetes-e2e-storage-kind-disruptive


### PR DESCRIPTION
Discussed in May 12th [sig-storage meeting](https://docs.google.com/document/d/1_hvq3nleqQEYatH9V_Gfep39jMzaFJRSN2ioA0PFq-Q/edit?tab=t.0#heading=h.6zlb4lqhd6fj), run https://github.com/kubernetes/kubernetes/pull/129918 in presubmits as a periodically check. 

/assign @msau42 
/assign @carlory 