### PR TITLE
sig-node: move e2e-containerd to dedicated nodepool

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -43,6 +43,11 @@ periodics:
           requests:
             cpu: 4
             memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-node-release-blocking, sig-node-containerd
     testgrid-tab-name: ci-node-e2e

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -99,6 +99,11 @@ presubmits:
           requests:
             cpu: "4"
             memory: "6Gi"
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-e2e-containerd-ec2
     skip_branches:
       - release-\d+\.\d+  # per-release image


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/8004

Use tolerations to schedule e2e-containerd prowjobs to a dedicated nodepool added in https://github.com/kubernetes/k8s.io/pull/8035.