### PR TITLE
Add plugins to k-sigs/aws-ebs-csi-driver (release-note & override)

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1472,6 +1472,11 @@ plugins:
     - wip
     - yuks
 
+  kubernetes-sigs/aws-ebs-csi-driver:
+    plugins:
+    - release-note
+    - override
+
   kubernetes-sigs/cloud-provider-azure:
     plugins:
     - milestone


### PR DESCRIPTION
Similar to [other kubernetes-sigs projects](https://github.com/kubernetes/test-infra/blob/50efa469017f8375206e165fc2888728be5e3cda/config/prow/plugins.yaml#L1517-L1521), we the [aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) project would like to add the release-note and override plugins to our Prow config. Thanks!