### PR TITLE
CI: Fix issue with cleanup not being called for upgrade on compatibility version tests

### DIFF
--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -391,7 +391,12 @@ main() {
   UPGRADE_SCRIPT="${UPGRADE_SCRIPT:-${PWD}/../test-infra/experiment/compatibility-versions/kind-upgrade.sh}"
   echo "Upgrading cluster with ${UPGRADE_SCRIPT}"
 
-  upgrade_cluster_components
+  upgrade_cluster_components || res=$?
+  # If upgrade fails, we shouldn't run tests but should still clean up.
+  if [[ "$res" -ne 0 ]]; then
+    cleanup
+    exit $res
+  fi
 
   # Clone the previous versions Kubernetes release branch
   # TODO(aaron-prindle) extend the branches to test from n-1 -> n-1..3 as more k8s releases are done that support compatibility versions


### PR DESCRIPTION
Fix a small bug that causes the kind cluster to not get properly cleaned up when upgrade fails in compatibility version testing. Trap the exit code instead and clean up. We still shouldn't run the tests in this case but it is useful to get the artifacts  of the kind cluster which cleanup provides.