### PR TITLE
etcd: add robustness test periodics for release-3.6

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -282,6 +282,96 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: arm64
 
+- name: ci-etcd-robustness-release36-amd64
+  interval: 24h
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 210m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-create-test-group: 'true'
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250422-9d0e6fd518-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        result=0
+        apt-get -o APT::Update::Error-Mode=any update && apt-get --yes install cmake libfuse3-dev libfuse3-3 fuse3
+        sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+        make install-lazyfs
+        set -euo pipefail
+        GO_TEST_FLAGS="-v --count 120 --timeout '200m' --run TestRobustnessExploratory"
+        VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/data/results make test-robustness-release-3.6 || result=$?
+        if [ -d /data/results ]; then
+          zip -r ${ARTIFACTS}/results.zip /data/results
+        fi
+        exit $result
+      resources:
+        requests:
+          cpu: "7"
+          memory: "14Gi"
+        limits:
+          cpu: "7"
+          memory: "14Gi"
+      # fuse needs privileged mode
+      securityContext:
+        privileged: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+
+- name: ci-etcd-robustness-release36-arm64
+  interval: 24h
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 210m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-create-test-group: 'true'
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250422-9d0e6fd518-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        result=0
+        apt-get -o APT::Update::Error-Mode=any update && apt-get --yes install cmake libfuse3-dev libfuse3-3 fuse3
+        sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+        make install-lazyfs
+        set -euo pipefail
+        GO_TEST_FLAGS="-v --count 120 --timeout '200m' --run TestRobustnessExploratory"
+        VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=8 EXPECT_DEBUG=true GO_TEST_FLAGS=${GO_TEST_FLAGS} RESULTS_DIR=/data/results make test-robustness-release-3.6 || result=$?
+        if [ -d /data/results ]; then
+          zip -r ${ARTIFACTS}/results.zip /data/results
+        fi
+        exit $result
+      resources:
+        requests:
+          cpu: "7"
+          memory: "14Gi"
+        limits:
+          cpu: "7"
+          memory: "14Gi"
+      # fuse needs privileged mode
+      securityContext:
+        privileged: true
+    nodeSelector:
+      kubernetes.io/arch: arm64
+
 - name: ci-etcd-robustness-release35-amd64
   interval: 24h
   cluster: k8s-infra-prow-build

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -50,6 +50,32 @@ dashboards:
           value: <test-url>
         - key: etcdVersion
           value: v3.6
+    - name: ci-etcd-robustness-release36-amd64
+      test_group_name: ci-etcd-robustness-release36-amd64
+      file_bug_template:
+        url: https://github.com/etcd-io/etcd/issues/new
+        options:
+        - key: template
+          value: bug-report.yml
+        - key: title
+          value: '[robustness tests] 3.6-amd64: <test-name>'
+        - key: problem
+          value: <test-url>
+        - key: etcdVersion
+          value: v3.6
+    - name: ci-etcd-robustness-release36-arm64
+      test_group_name: ci-etcd-robustness-release36-arm64
+      file_bug_template:
+        url: https://github.com/etcd-io/etcd/issues/new
+        options:
+        - key: template
+          value: bug-report.yml
+        - key: title
+          value: '[robustness tests] 3.6-arm64: <test-name>'
+        - key: problem
+          value: <test-url>
+        - key: etcdVersion
+          value: v3.6
     - name: ci-etcd-robustness-release35-amd64
       test_group_name: ci-etcd-robustness-release35-amd64
       file_bug_template:


### PR DESCRIPTION
Adds periodic jobs to run robustness test on branch release-3.6

Ref: https://github.com/etcd-io/etcd/pull/19945

/cc @ivanvc @serathius 