### PR TITLE
Revert "Use the kubemark staging registry for testing ci-golang-tip-k…

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -91,7 +91,6 @@ periodics:
       - --env=KUBEMARK_SCHEDULER_TEST_ARGS=--authorization-always-allow-paths=/healthz,/readyz,/livez,/metrics --profiling --contention-profiling --kube-api-qps=200 --kube-api-burst=200
       - --env=DEPLOY_GCI_DRIVER=false
       - --env=PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/gce-pd
-      - --env=KUBEMARK_IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images
       - --extract=gs://k8s-infra-scale-golang-builds/ci/latest.txt
       - --gcp-master-size=n2-standard-4
       - --gcp-node-size=e2-standard-8


### PR DESCRIPTION
…8s-master"

This reverts commit c0b789d1294de0818f27174a9c969a18dddddef6.

since https://github.com/kubernetes/k8s.io/pull/8102#issuecomment-2882815673 was marked as done