### PR TITLE
chore: [compat version] remove exception of MultiCIDRServiceAllocator feature for N-1 test

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -42,7 +42,7 @@ periodics:
       - name: PARALLEL
         value: "true"
       - name: FEATURE_GATES
-        value: '{"AllBeta":true, "MultiCIDRServiceAllocator":false}'
+        value: '{"AllBeta":true}'
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
move https://github.com/kubernetes/test-infra/pull/34537 forward for N-1 test

This should fix `compatibility-version-test-n-minus-1`