### PR TITLE
🌱 Enable periodic GH Bug Triage project board syncing for v1.34

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -26,7 +26,7 @@ periodics:
             secretKeyRef:
               name: k8s-release-enhancements-triage-github-token
               key: token
-- name: periodic-sync-bug-triage-github-project-beta-1-33
+- name: periodic-sync-bug-triage-github-project-beta-1-34
   interval: 3h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
@@ -47,7 +47,7 @@ periodics:
         - name: PROJECT_NUMBER
           value: "80"
         - name: MILESTONE
-          value: "v1.33"
+          value: "v1.34"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Updated the milestone for the periodic prow job as per the instruction at https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/release-signal/project-boards.md#setting-up-the-bug-triage-project-board
/assign @Vyom-Yadav 
/cc @wendy-ha18 