### PR TITLE
Add aws-ebs-csi-driver security presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -288,6 +288,35 @@ presubmits:
       testgrid-tab-name: pull-external-test-fips
       description: kubernetes/kubernetes external test on pull requests on release branch for fips image
       testgrid-num-columns-recent: '30'
+  - name: pull-aws-ebs-csi-driver-security
+    cluster: eks-prow-build-cluster
+    decorate: true
+    optional: false
+    branches:
+      - ^release-.*$
+    skip_if_only_changed: "^docs/|^examples/|.md$|OWNERS$|^.github/"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250513-98d205aae3-master
+          command:
+            - runner.sh
+          args:
+            - make
+            - security
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+    annotations:
+      testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
+      testgrid-tab-name: pull-security
+      description: Scans release branch for any known vulnerabilities
+      testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-external-test-eks
     cluster: eks-prow-build-cluster
     decorate: true


### PR DESCRIPTION
[EBS CSI Driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) adding govulncheck presubmit for our release PRs. [Etcd has similar presubmit](https://github.com/kubernetes/test-infra/blob/aadea71dc0081825bc931936bdc43427a7095519/config/jobs/etcd/etcd-presubmits.yaml#L157). 

/assign @ElijahQuinones 
/assign @ConnorJC3 
/cc @torredil 