### PR TITLE
Revert "chore: [compat version] remove exception of MultiCIDRServiceAllocator feature

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -42,7 +42,7 @@ periodics:
       - name: PARALLEL
         value: "true"
       - name: FEATURE_GATES
-        value: '{"AllBeta":true}'
+        value: '{"AllBeta":true, "MultiCIDRServiceAllocator":false}'
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
This reverts commit a1bbc994c435b6e8d79d58d6d5d7f8f118ae78b9.

According to https://github.com/kubernetes/test-infra/blob/b1cafe446cfb116424d25ece9d6a1e6b76c61453/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh#L363-L367, we are still testing version 1.32 in this test right now. So `MultiCIDRServiceAllocator` still cannot be set to true because `emulation-forward-compatible` flag is only available from 1.33

The exception of MultiCIDRServiceAllocator feature can only be removed after 1.34.alpha.1 tag has been added.