### PR TITLE
Disable release tests on main until v3.7 prep completed

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -599,7 +599,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     always_run: true
     branches:
-      - main
+      # TODO: Uncomment this once main is prepared for 3.7 development
+      # - main
       - release-3.6
       - release-3.4
     decorate: true


### PR DESCRIPTION
As discussed in https://github.com/etcd-io/etcd/pull/19961#issuecomment-2887083724.

cc @ahrtr, @ivanvc

