### PR TITLE
sig-node: move more tests to dedicated nodepool

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -100,6 +100,11 @@ periodics:
         requests:
           cpu: 4
           memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
   annotations:
     testgrid-dashboards: sig-node-release-blocking
     testgrid-tab-name: node-kubelet-serial-containerd
@@ -150,6 +155,11 @@ periodics:
         requests:
           cpu: 4
           memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-kubelet-containerd-flaky
@@ -319,6 +329,11 @@ periodics:
           requests:
             cpu: 4
             memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
 
 - name: ci-kubernetes-node-swap-fedora
   cluster: k8s-infra-prow-build
@@ -423,6 +438,11 @@ periodics:
           requests:
             cpu: 4
             memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
 
 - name: ci-kubernetes-node-swap-fedora-serial
   interval: 4h
@@ -526,6 +546,11 @@ periodics:
           requests:
             cpu: 4
             memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
 
 - name: ci-kubernetes-node-swap-conformance-fedora-serial
   interval: 4h
@@ -627,6 +652,11 @@ periodics:
           requests:
             cpu: 4
             memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
 
 
 - name: ci-kubernetes-node-e2e-containerd-standalone-mode-all-alpha
@@ -677,6 +707,11 @@ periodics:
         limits:
           cpu: 4
           memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
   annotations:
     testgrid-dashboards: sig-node-release-blocking
     testgrid-tab-name: node-kubelet-containerd-standalone-mode-all-alpha
@@ -730,6 +765,11 @@ periodics:
         limits:
           cpu: 4
           memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
   annotations:
     testgrid-dashboards: sig-node-release-blocking
     testgrid-tab-name: node-kubelet-containerd-standalone-mode
@@ -782,6 +822,11 @@ periodics:
           requests:
             cpu: 4
             memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
 
 - name: ci-kubernetes-node-kubelet-serial-cpu-manager
   interval: 24h
@@ -830,6 +875,11 @@ periodics:
           requests:
             cpu: 4
             memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
 
 - name: ci-kubernetes-node-kubelet-serial-memory-manager
   interval: 24h
@@ -878,6 +928,11 @@ periodics:
           requests:
             cpu: 4
             memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
 
 - name: ci-kubernetes-node-e2e-cri-proxy-serial
   interval: 24h
@@ -932,6 +987,11 @@ periodics:
           limits:
             cpu: 4
             memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
 - name: ci-kubernetes-e2e-relaxed-environment-variable-validation
   interval: 24h
   cluster: k8s-infra-prow-build
@@ -979,6 +1039,11 @@ periodics:
           requests:
             cpu: 4
             memory: 6Gi
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-node"
+        effect: "NoSchedule"
 
 # TODO: migrate performance special config tests to containerd/cri-o
 #- name: ci-kubernetes-node-kubelet-performance-test

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -53,6 +53,11 @@ presubmits:
             memory: "6Gi"
         securityContext:
           privileged: true
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-e2e-containerd
     skip_branches:
       - release-\d+\.\d+  # per-release image
@@ -319,6 +324,11 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-e2e-containerd-kubetest2
     cluster: k8s-infra-prow-build
     always_run: false
@@ -368,6 +378,11 @@ presubmits:
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
         - '--test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-e2e-containerd-features
     cluster: k8s-infra-prow-build
     branches:
@@ -421,6 +436,11 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-e2e-containerd-features-kubetest2
     cluster: k8s-infra-prow-build
     # explicitly needs /test pull-kubernetes-node-e2e-containerd-features-kubetest2 to run
@@ -476,6 +496,11 @@ presubmits:
         - --skip-regex=\[Flaky\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]
         - '--test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/image-config.yaml
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-e2e-containerd-alpha-features
     cluster: k8s-infra-prow-build
     branches:
@@ -530,6 +555,11 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-e2e-containerd-kubelet-psi
     cluster: k8s-infra-prow-build
     branches:
@@ -584,6 +614,11 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
 
   - name: pull-kubernetes-node-kubelet-serial-containerd
     cluster: k8s-infra-prow-build
@@ -632,6 +667,11 @@ presubmits:
             requests:
               cpu: 4
               memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-kubelet-containerd-flaky
     always_run: false
     cluster: k8s-infra-prow-build
@@ -679,6 +719,11 @@ presubmits:
             requests:
               cpu: 4
               memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-kubelet-serial-containerd-alpha-features
     cluster: k8s-infra-prow-build
     always_run: false
@@ -728,6 +773,11 @@ presubmits:
             requests:
               cpu: 4
               memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-kubelet-serial-containerd-sidecar-containers
     cluster: k8s-infra-prow-build
     always_run: false
@@ -775,6 +825,11 @@ presubmits:
             requests:
               cpu: 4
               memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-kubelet-serial-containerd-kubetest2
     cluster: k8s-infra-prow-build
     # explicitly needs /test pull-kubernetes-node-kubelet-serial-containerd-kubetest2 to run
@@ -827,6 +882,11 @@ presubmits:
         - --skip-regex=\[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
         - '--test-args=--ginkgo.timeout=3h --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-kubelet-serial-podresources
     cluster: k8s-infra-prow-build
     always_run: false
@@ -879,6 +939,11 @@ presubmits:
           env:
             - name: GOPATH
               value: /go
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-e2e-alpha-ec2
     # duplicate job of ci-kubernetes-e2e-ec2-alpha-features to test changes in provider-aws-test-infra
     cluster: eks-prow-build-cluster
@@ -940,6 +1005,11 @@ presubmits:
             requests:
               cpu: 8
               memory: 10Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-kubelet-serial-cpu-manager
     cluster: k8s-infra-prow-build
     always_run: false
@@ -991,6 +1061,11 @@ presubmits:
           env:
             - name: GOPATH
               value: /go
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-kubelet-serial-cpu-manager-kubetest2
     cluster: k8s-infra-prow-build
     # explicitly needs /test pull-kubernetes-node-kubelet-serial-cpu-manager-kubetest2 to run
@@ -1047,6 +1122,11 @@ presubmits:
         - --skip-regex=""
         - --test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --cgroup-driver=systemd"
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-kubelet-serial-topology-manager
     cluster: k8s-infra-prow-build
     always_run: false
@@ -1098,6 +1178,11 @@ presubmits:
           env:
             - name: GOPATH
               value: /go
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-kubelet-serial-topology-manager-kubetest2
     cluster: k8s-infra-prow-build
     # explicitly needs /test pull-kubernetes-node-kubelet-serial-topology-manager-kubetest2 to run
@@ -1154,6 +1239,11 @@ presubmits:
         - '--label-filter=Feature: containsAny TopologyManager && !Flaky'
         - --test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --cgroup-driver=systemd"
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-kubelet-serial-hugepages
     cluster: k8s-infra-prow-build
     always_run: false
@@ -1205,6 +1295,11 @@ presubmits:
           env:
             - name: GOPATH
               value: /go
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-crio-cgrpv2-imagefs-e2e
     cluster: k8s-infra-prow-build
     always_run: false
@@ -2046,6 +2141,11 @@ presubmits:
           env:
             - name: GOPATH
               value: /go
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-crio-node-memoryqos-cgrpv2
     cluster: k8s-infra-prow-build
     # explicitly needs /test pull-kubernetes-crio-node-memoryqos-cgrpv2 to run
@@ -2205,6 +2305,11 @@ presubmits:
             requests:
               cpu: 4
               memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
 
   - name: pull-kubernetes-node-swap-fedora-serial
     cluster: k8s-infra-prow-build
@@ -2313,6 +2418,11 @@ presubmits:
             requests:
               cpu: 4
               memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
 
   - name: pull-kubernetes-node-swap-conformance-fedora-serial
     cluster: k8s-infra-prow-build
@@ -2416,6 +2526,11 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
 
   - name: pull-kubernetes-e2e-gce-kubelet-credential-provider
     cluster: k8s-infra-prow-build
@@ -2472,6 +2587,11 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-cos-cgroupv2-containerd-node-e2e-features
     skip_branches:
       - release-\d+\.\d+  # per-release image
@@ -2523,6 +2643,11 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-cos-cgroupv2-containerd-node-e2e
     skip_branches:
       - release-\d+\.\d+  # per-release image
@@ -2574,6 +2699,11 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-cos-cgroupv2-containerd-node-e2e-serial
     skip_branches:
       - release-\d+\.\d+  # per-release image
@@ -2625,6 +2755,11 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-cos-cgroupv2-containerd-node-e2e-eviction
     skip_branches:
       - release-\d+\.\d+  # per-release image
@@ -2676,6 +2811,11 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-crio-cgroupv1-node-e2e-eviction
     cluster: k8s-infra-prow-build
     always_run: false
@@ -3059,6 +3199,11 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
 
   - name: pull-kubernetes-node-e2e-containerd-standalone-mode
     cluster: k8s-infra-prow-build
@@ -3114,6 +3259,11 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
 
   - name: pull-kubernetes-node-e2e-resource-health-status
     cluster: k8s-infra-prow-build
@@ -3163,6 +3313,11 @@ presubmits:
           limits:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
 
   - name: pull-kubernetes-node-e2e-containerd-serial-ec2
     skip_branches:
@@ -3318,6 +3473,11 @@ presubmits:
             limits:
               cpu: 4
               memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-e2e-relaxed-environment-variable-validation
     cluster: k8s-infra-prow-build
     always_run: false
@@ -3372,3 +3532,8 @@ presubmits:
           requests:
             cpu: 4
             memory: 6Gi
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/8004
  
  Targeting some containerd's related jobs only.