### PR TITLE
config/jobs: update go to 1.24 in prometheus-adapter

### DIFF
--- a/config/jobs/kubernetes-sigs/prometheus-adapter/prometheus-adapter-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prometheus-adapter/prometheus-adapter-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: sigs.k8s.io/prometheus-adapter
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:
@@ -29,7 +29,7 @@ presubmits:
     path_alias: sigs.k8s.io/prometheus-adapter
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:


### PR DESCRIPTION
Required by https://github.com/kubernetes-sigs/prometheus-adapter/pull/700

cc: @dgrisonnet @RainbowMango 