### PR TITLE
[ci-kubernetes-e2e-kind-dependencies] install jq needed by script

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -567,6 +567,9 @@ periodics:
         export PATH=$PATH:$GOPATH/bin
         mkdir -p "${WORKDIR}"
 
+        # needed by gomod_staleness.py
+        apt update && apt -y install jq
+
         # Update each dependency to the latest version
         ./../test-infra/experiment/dependencies/gomod_staleness.py
 


### PR DESCRIPTION
`gomod_staleness.py` needs `jq`