### PR TITLE
[ci-kubernetes-e2e-kind-dependencies] remove hardcoded vendor packages

### DIFF
--- a/experiment/dependencies/gomod_staleness.py
+++ b/experiment/dependencies/gomod_staleness.py
@@ -71,6 +71,10 @@ def source(pkg, old, new):
         return "github.com/golang" + pkg[len("golang.org/x"):], old, new
     elif pkg.startswith("go.uber.org/"):
         return "github.com/uber-go" + pkg[len("go.uber.org"):], old, new
+    elif pkg.startswith("sigs.k8s.io/"):
+        return "github.com/kubernetes-sigs" + pkg[len("sigs.k8s.io"):], old, new
+    elif pkg.startswith("cel.dev/"):
+        return "github.com/google/cel-spec", old, new
     elif pkg.startswith("go.starlark.net"):
         return "github.com/google/starlark-go", old, new
     elif pkg.startswith("gopkg.in"):


### PR DESCRIPTION
pick up the packages to skip from hack/unwanted-dependencies.json being added in:
https://github.com/kubernetes/kubernetes/pull/131871

- also updated the generated comparison urls for cel and sigs.k8s.io packages

/hold