### PR TITLE
[compat-versin] set --emulation-forward-compatible=true inplace during emulation upgrade

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -42,7 +42,7 @@ periodics:
       - name: PARALLEL
         value: "true"
       - name: FEATURE_GATES
-        value: '{"AllBeta":true, "MultiCIDRServiceAllocator":false}'
+        value: '{"AllBeta":true}'
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       # we need privileged mode in order to do docker in docker
@@ -100,7 +100,7 @@ periodics:
       - name: PARALLEL
         value: "true"
       - name: FEATURE_GATES
-        value: '{"AllBeta":true, "MultiCIDRServiceAllocator":false}'
+        value: '{"AllBeta":true}'
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       # we need privileged mode in order to do docker in docker

--- a/experiment/compatibility-versions/common.sh
+++ b/experiment/compatibility-versions/common.sh
@@ -155,12 +155,6 @@ create_cluster() {
     ;;
   esac
 
-  # Conditionally include the emulation-forward-compatible flag based on version
-  emulation_forward_compatible=""
-  if version_gte "${PREV_VERSION}" "1.33"; then
-    emulation_forward_compatible="      \"emulation-forward-compatible\": \"true\""
-  fi
-
   # create the config file
   cat <<EOF > "${ARTIFACTS}/kind-config.yaml"
 # config for 1 control plane node and 2 workers (necessary for conformance)
@@ -186,8 +180,7 @@ kubeadmConfigPatches:
   apiServer:
     extraArgs:
 ${apiServer_extra_args}
-      "emulated-version": "${EMULATED_VERSION}"${emulation_forward_compatible:+
-$emulation_forward_compatible}
+      "emulated-version": "${EMULATED_VERSION}"
   controllerManager:
     extraArgs:
 ${controllerManager_extra_args}


### PR DESCRIPTION
This would make `--emulation-forward-compatible` for all tests and remove dependency on setting `"MultiCIDRServiceAllocator":false`

Tested partially locally.