### PR TITLE
Re-enable etcd release tests on main

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -599,8 +599,7 @@ presubmits:
     cluster: k8s-infra-prow-build
     always_run: true
     branches:
-      # TODO: Uncomment this once main is prepared for 3.7 development
-      # - main
+      - main
       - release-3.6
       - release-3.4
     decorate: true


### PR DESCRIPTION
Main branch is now prepared for 3.7 development, refer https://github.com/etcd-io/etcd/pull/19961

v3.7.x will be dynamically retrieved by the release tests scripts here: https://github.com/etcd-io/etcd/blob/main/scripts/test.sh#L570-L573

cc @ivanvc, @joshjms, @ahrtr 