### PR TITLE
etcd: Add unit, integration and e2e test jobs against release-3.6 for ppc64le

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -880,6 +880,38 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: arm64
 
+- name: ci-etcd-e2e-release36-ppc64le
+  interval: 4h
+  cluster: k8s-infra-ppc64le-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.6
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le
+    testgrid-tab-name: ci-etcd-e2e-release36-ppc64le
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250513-98d205aae3-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            VERBOSE=1 GOOS=linux GOARCH=ppc64le CPU=4 EXPECT_DEBUG=true make test-e2e-release
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
+
 - name: ci-etcd-e2e-release36-amd64
   interval: 4h
   cluster: eks-prow-build-cluster
@@ -945,6 +977,35 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: amd64
 
+- name: ci-etcd-unit-test-release36-ppc64le
+  interval: 4h
+  cluster: k8s-infra-ppc64le-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.6
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-unit-test-release36-ppc64le
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250513-98d205aae3-master
+        command:
+          - runner.sh
+        args:
+          - make
+          - test-unit
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
+
 - name: ci-etcd-unit-test-release36-arm64
   interval: 4h
   cluster: k8s-infra-prow-build
@@ -1007,6 +1068,38 @@ periodics:
         limits:
           cpu: "2"
           memory: "3Gi"
+
+- name: ci-etcd-integration-1-cpu-release36-ppc64le
+  interval: 24h
+  cluster: k8s-infra-ppc64le-prow-build
+  decorate: true
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.6
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le
+    testgrid-tab-name: ci-etcd-integration-1-cpu-release36-ppc64le
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250513-98d205aae3-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            make gofail-enable
+            export JUNIT_REPORT_DIR=${ARTIFACTS}
+            GOOS=linux GOARCH=ppc64le CPU=1 make test-integration
+        resources:
+          requests:
+            cpu: "2"
+            memory: "3Gi"
+          limits:
+            cpu: "2"
+            memory: "3Gi"
 
 - name: ci-etcd-integration-1-cpu-release36-arm64
   interval: 24h
@@ -1074,6 +1167,38 @@ periodics:
             cpu: "3"
             memory: "3Gi"
 
+- name: ci-etcd-integration-2-cpu-release36-ppc64le
+  cluster: k8s-infra-ppc64le-prow-build
+  interval: 24h
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.6
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-integration-2-cpu-release36-ppc64le
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250513-98d205aae3-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            make gofail-enable
+            export JUNIT_REPORT_DIR=${ARTIFACTS}
+            GOOS=linux GOARCH=ppc64le CPU=2 make test-integration
+        resources:
+          requests:
+            cpu: "3"
+            memory: "3Gi"
+          limits:
+            cpu: "3"
+            memory: "3Gi"
+
 - name: ci-etcd-integration-2-cpu-release36-arm64
   cluster: k8s-infra-prow-build
   interval: 24h
@@ -1132,6 +1257,38 @@ periodics:
             make gofail-enable
             export JUNIT_REPORT_DIR=${ARTIFACTS}
             GOOS=linux GOARCH=amd64 CPU=4 make test-integration
+        resources:
+          requests:
+            cpu: "6"
+            memory: "3Gi"
+          limits:
+            cpu: "6"
+            memory: "3Gi"
+
+- name: ci-etcd-integration-4-cpu-release36-ppc64le
+  cluster: k8s-infra-ppc64le-prow-build
+  interval: 24h
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.6
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-integration-4-cpu-release36-ppc64le
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250513-98d205aae3-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            make gofail-enable
+            export JUNIT_REPORT_DIR=${ARTIFACTS}
+            GOOS=linux GOARCH=ppc64le CPU=4 make test-integration
         resources:
           requests:
             cpu: "6"


### PR DESCRIPTION
This PR adds job configurations to run unit, e2e and integration tests (1,2, and 4 CPU modes) from release-3.6 branch against the ppc64le build cluster. This is done to improve coverage extensively. 

cc @ivanvc @ahrtr 