### PR TITLE
CAPO: Update periodics

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.12.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.12.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-provider-openstack-e2e-test-release-0-9
+- name: periodic-cluster-api-provider-openstack-e2e-test-release-0-12
   cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
@@ -12,7 +12,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-openstack
-    base_ref: release-0.9
+    base_ref: release-0.12
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
   max_concurrency: 1
   spec:
@@ -41,7 +41,7 @@ periodics:
           cpu: 2000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
-    testgrid-tab-name: periodic-e2e-test-release-0.9
+    testgrid-tab-name: periodic-e2e-test-release-0.12
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-openstack-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
     testgrid-alert-stale-results-hours: "72"
@@ -53,7 +53,7 @@ periodics:
       - aborted
       - error
       report_template: ':alert: Failed periodic job: {{.Status.State}}. <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-openstack|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'
-- name: periodic-cluster-api-provider-openstack-e2e-full-test-release-0-9
+- name: periodic-cluster-api-provider-openstack-e2e-full-test-release-0-12
   cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
@@ -66,7 +66,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-openstack
-    base_ref: release-0.9
+    base_ref: release-0.12
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
   spec:
     containers:
@@ -101,7 +101,7 @@ periodics:
           cpu: 2000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
-    testgrid-tab-name: periodic-e2e-full-test-release-0.9
+    testgrid-tab-name: periodic-e2e-full-test-release-0.12
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-openstack-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
     testgrid-alert-stale-results-hours: "72"


### PR DESCRIPTION
With release v0.12 out we are adding periodics for this release branch and removing them for release v0.9.