### PR TITLE
ensure kind canary jobs select the new nodepool, drop cgroup bind mount on cgroup v2

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -107,7 +107,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -164,7 +163,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -84,6 +84,9 @@ presubmits:
           requests:
             cpu: 7
             memory: 9000Mi
+      # use experimental new nodepool with C4 VM, cgroup v2
+      nodeSelector:
+       cloud.google.com/gke-nodepool: "pool6-20250327232037500200000001"
       tolerations:
         - key: "dedicated"
           operator: "Equal"
@@ -138,6 +141,14 @@ presubmits:
           requests:
             cpu: 4
             memory: 9Gi
+      # use experimental new nodepool with C4 VM, cgroup v2
+      nodeSelector:
+        cloud.google.com/gke-nodepool: "pool6-20250327232037500200000001"
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-testing"
+          effect: "NoSchedule"
     annotations:
       fork-per-release: "true"
       testgrid-num-failures-to-alert: '10'


### PR DESCRIPTION
follow-up https://github.com/kubernetes/test-infra/pull/34761#discussion_r2093789734

I want to see if this is a possible solution for https://github.com/kubernetes/kubernetes/issues/131948