### PR TITLE
etcd: Add post-etcd-govulncheck for release-3.4 branch

### DIFF
--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -67,6 +67,7 @@ postsubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-postsubmits


### PR DESCRIPTION
Add govulncheck to postsubmit checks for release-3.4 branch

ref: https://github.com/kubernetes/test-infra/issues/32754

/cc @ivanvc 