### PR TITLE
etcd: Add etcd integration prow jobs for release-3.4

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -1330,3 +1330,99 @@ periodics:
             memory: "3Gi"
     nodeSelector:
       kubernetes.io/arch: arm64
+
+- name: ci-etcd-integration-1-cpu-release34-amd64
+  interval: 24h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.4
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-amd64
+    testgrid-tab-name: ci-etcd-integration-1-cpu-release34-amd64
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250513-98d205aae3-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        make gofail-enable
+        export JUNIT_REPORT_DIR=${ARTIFACTS}
+        GOOS=linux GOARCH=amd64 CPU=1 make test-integration
+      resources:
+        requests:
+          cpu: "2"
+          memory: "3Gi"
+        limits:
+          cpu: "2"
+          memory: "3Gi"
+
+- name: ci-etcd-integration-2-cpu-release34-amd64
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.4
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-integration-2-cpu-release34-amd64
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250513-98d205aae3-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            make gofail-enable
+            export JUNIT_REPORT_DIR=${ARTIFACTS}
+            GOOS=linux GOARCH=amd64 CPU=2 make test-integration
+        resources:
+          requests:
+            cpu: "3"
+            memory: "3Gi"
+          limits:
+            cpu: "3"
+            memory: "3Gi"
+
+- name: ci-etcd-integration-4-cpu-release34-amd64
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.4
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-integration-4-cpu-release34-amd64
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250513-98d205aae3-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            make gofail-enable
+            export JUNIT_REPORT_DIR=${ARTIFACTS}
+            GOOS=linux GOARCH=amd64 CPU=4 make test-integration
+        resources:
+          requests:
+            cpu: "6"
+            memory: "3Gi"
+          limits:
+            cpu: "6"
+            memory: "3Gi"

--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -268,6 +268,7 @@ postsubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-postsubmits

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -280,6 +280,7 @@ presubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -345,6 +346,7 @@ presubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -410,6 +412,7 @@ presubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits


### PR DESCRIPTION
Adds etcd-integration for pull, post, and periodics.

Successful on `pj-on-kind`. 