### PR TITLE
migrate critical kind jobs to the new nodepool

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
@@ -12,7 +12,6 @@ periodics:
     fork-per-release-periodic-interval: 1h 2h 6h 24h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -49,6 +48,13 @@ periodics:
           # this is mostly for building kubernetes
           memory: 9Gi
           cpu: 7
+    nodeSelector:
+      cloud.google.com/machine-family: c4
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-testing"
+        effect: "NoSchedule"
 - interval: 1h
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-kind-ipv6-e2e-parallel
@@ -62,7 +68,6 @@ periodics:
     fork-per-release-periodic-interval: 1h 2h 6h 24h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -106,3 +111,10 @@ periodics:
           memory: 9Gi
           # during the tests more like 3-20m is used
           cpu: 7
+    nodeSelector:
+      cloud.google.com/machine-family: c4
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-testing"
+        effect: "NoSchedule"

--- a/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
@@ -9,7 +9,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -42,6 +41,13 @@ presubmits:
           requests:
             cpu: 7
             memory: 9000Mi
+      nodeSelector:
+        cloud.google.com/machine-family: c4
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-testing"
+          effect: "NoSchedule"
     annotations:
       testgrid-dashboards: sig-arch-code-organization
       testgrid-tab-name: pull-kind-master-dependencies
@@ -61,7 +67,6 @@ periodics:
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -97,3 +102,10 @@ periodics:
         requests:
           cpu: 7
           memory: 9000Mi
+    nodeSelector:
+      cloud.google.com/machine-family: c4
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-testing"
+        effect: "NoSchedule"

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -9,7 +9,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -37,6 +36,13 @@ presubmits:
           requests:
             cpu: 7
             memory: 9000Mi
+      nodeSelector:
+        cloud.google.com/machine-family: c4
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-testing"
+          effect: "NoSchedule"
     annotations:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
@@ -85,7 +91,7 @@ presubmits:
             memory: 9000Mi
       # use experimental new nodepool with C4 VM, cgroup v2
       nodeSelector:
-       cloud.google.com/gke-nodepool: "pool6-20250327232037500200000001"
+       cloud.google.com/machine-family: c4
       tolerations:
         - key: "dedicated"
           operator: "Equal"
@@ -141,7 +147,7 @@ presubmits:
             memory: 9000Mi
       # use experimental new nodepool with C4 VM, cgroup v2
       nodeSelector:
-        cloud.google.com/gke-nodepool: "pool6-20250327232037500200000001"
+        cloud.google.com/machine-family: c4
       tolerations:
         - key: "dedicated"
           operator: "Equal"
@@ -198,7 +204,7 @@ presubmits:
             memory: 9000Mi
       # use experimental new nodepool with C4 VM, cgroup v2
       nodeSelector:
-        cloud.google.com/gke-nodepool: "pool6-20250327232037500200000001"
+        cloud.google.com/machine-family: c4
       tolerations:
         - key: "dedicated"
           operator: "Equal"
@@ -499,7 +505,6 @@ periodics:
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -541,6 +546,13 @@ periodics:
           # this is mostly for building kubernetes
           memory: 9Gi
           cpu: 7
+    nodeSelector:
+      cloud.google.com/machine-family: c4
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-testing"
+        effect: "NoSchedule"
 
 - interval: 4h
   cluster: k8s-infra-prow-build
@@ -553,7 +565,6 @@ periodics:
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -591,6 +602,13 @@ periodics:
           # this is mostly for building kubernetes
           memory: 9Gi
           cpu: 7
+    nodeSelector:
+      cloud.google.com/machine-family: c4
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-testing"
+        effect: "NoSchedule"
 
 - interval: 4h
   cluster: k8s-infra-prow-build
@@ -603,7 +621,6 @@ periodics:
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -645,6 +662,13 @@ periodics:
           # this is mostly for building kubernetes
           memory: 9Gi
           cpu: 7
+    nodeSelector:
+      cloud.google.com/machine-family: c4
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "sig-testing"
+        effect: "NoSchedule"
 - interval: 24h
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-e2e-kind-rootless


### PR DESCRIPTION
/cc @BenTheElder @aojea @pacoxu 

Part of https://github.com/kubernetes/k8s.io/issues/5276
Tested in https://github.com/kubernetes/kubernetes/issues/131948 and https://github.com/kubernetes/test-infra/pull/34840

tl;dr: There is a bad kernel update in Ubuntu(the underlying OS of the GKE nodes) and it was fixed in a newer version but hasn't been rolled out yet. This change migrates to a nodepool with groups v2 + faster VMs + Container Optimised OS
