### PR TITLE
remove volume-mount from kind jobs on GKE

### DIFF
--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -36,7 +36,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-etcd-operator-presubmits
       testgrid-tab-name: pull-etcd-operator-test-e2e

--- a/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/alibaba-cloud-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/alibaba-cloud-csi-driver.yaml
@@ -145,7 +145,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     spec:
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250513-98d205aae3-master

--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -68,7 +68,6 @@ presubmits:
     - ^release-.*$
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250513-98d205aae3-master

--- a/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-presubmits.yaml
@@ -9,7 +9,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     always_run: true
     optional: true
     decorate: true
@@ -59,7 +58,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     always_run: true
     optional: true
     decorate: true
@@ -116,7 +114,6 @@ presubmits:
     optional: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decorate: true
     extra_refs:
     - org: kubernetes

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-5.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-5.yaml
@@ -107,7 +107,6 @@ presubmits:
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
         preset-do-credential: "true"
       branches:
         - ^release-1.5$
@@ -140,7 +139,6 @@ presubmits:
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
         preset-do-credential: "true"
       branches:
         - ^release-1.5$
@@ -170,7 +168,6 @@ presubmits:
     - name: pull-cluster-api-provider-digitalocean-e2e-workload-upgrade-release-1-5
       labels:
         preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
         preset-do-credential: "true"
       path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
       branches:
@@ -214,7 +211,6 @@ presubmits:
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
         preset-do-credential: "true"
       branches:
         - ^release-1.5$
@@ -247,7 +243,6 @@ presubmits:
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
         preset-do-credential: "true"
       branches:
         - ^release-1.5$

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-6.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits-release-1-6.yaml
@@ -82,7 +82,6 @@ presubmits:
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
         preset-do-credential: "true"
       branches:
         - ^release-1.6$
@@ -115,7 +114,6 @@ presubmits:
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
         preset-do-credential: "true"
       branches:
         - ^release-1.6$
@@ -145,7 +143,6 @@ presubmits:
     - name: pull-cluster-api-provider-digitalocean-e2e-workload-upgrade-release-1-6
       labels:
         preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
         preset-do-credential: "true"
       path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
       branches:
@@ -189,7 +186,6 @@ presubmits:
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
         preset-do-credential: "true"
       branches:
         - ^release-1.6$
@@ -222,7 +218,6 @@ presubmits:
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
         preset-do-credential: "true"
       branches:
         - ^release-1.6$

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -82,7 +82,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-do-credential: "true"
     branches:
     - ^main$
@@ -115,7 +114,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-do-credential: "true"
     branches:
     - ^main$
@@ -145,7 +143,6 @@ presubmits:
   - name: pull-cluster-api-provider-digitalocean-e2e-workload-upgrade
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-do-credential: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     branches:
@@ -189,7 +186,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-do-credential: "true"
     branches:
     - ^main$
@@ -222,7 +218,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-do-credential: "true"
     branches:
     - ^main$
@@ -258,7 +253,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-do-credential: "true"
     branches:
     - ^main$

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -53,7 +53,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^main$
@@ -112,7 +111,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^main$
@@ -151,7 +149,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^main$
@@ -200,7 +197,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^main$
@@ -239,7 +235,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^main$
@@ -278,7 +273,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^main$

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-7.yaml
@@ -53,7 +53,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.7$
@@ -112,7 +111,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.7$
@@ -148,7 +146,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.7$
@@ -184,7 +181,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.7$
@@ -223,7 +219,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.7$

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-8.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-8.yaml
@@ -112,7 +112,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.8$
@@ -148,7 +147,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.8$
@@ -184,7 +182,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.8$
@@ -223,7 +220,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.8$

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -52,7 +52,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
     skip_if_only_changed: '^(docs/|LICENSE|netlify.toml|OWNERS|OWNERS_ALIASES|SECURITY_CONTACTS|tilt-provider.json|.github/|.gitignore|.golangci.yml)|\\.md$'
     optional: false
@@ -96,7 +95,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
     always_run: false
     optional: true
@@ -143,7 +141,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
     always_run: false
     optional: true

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -80,7 +80,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
     optional: false
     decorate: true
@@ -124,7 +123,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
     optional: false
     decorate: true
@@ -173,7 +171,6 @@ presubmits:
     optional: false
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decorate: true
     extra_refs:
     - org: kubernetes
@@ -219,7 +216,6 @@ presubmits:
     optional: false
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decorate: true
     extra_refs:
     - org: kubernetes
@@ -261,7 +257,6 @@ presubmits:
     optional: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decorate: true
     extra_refs:
     - org: kubernetes
@@ -303,7 +298,6 @@ presubmits:
     optional: false
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decorate: true
     extra_refs:
     - org: kubernetes
@@ -349,7 +343,6 @@ presubmits:
     optional: false
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decorate: true
     extra_refs:
     - org: kubernetes
@@ -395,7 +388,6 @@ presubmits:
     optional: false
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decorate: true
     extra_refs:
     - org: kubernetes
@@ -441,7 +433,6 @@ presubmits:
     optional: false
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decorate: true
     extra_refs:
     - org: kubernetes
@@ -487,7 +478,6 @@ presubmits:
     optional: false
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decorate: true
     extra_refs:
     - org: kubernetes
@@ -542,7 +532,6 @@ presubmits:
       path_alias: k8s.io/kubernetes
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: sigs.k8s.io/kind
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/kube-network-policies/kube-network-policies-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-network-policies/kube-network-policies-presubmits.yaml
@@ -6,7 +6,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     always_run: true
     optional: false
     decorate: true
@@ -52,7 +51,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     always_run: true
     optional: false
     decorate: true

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -693,8 +693,6 @@ presubmits:
       preset-service-account: "true"
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
-      # this is required to make CNI installation to succeed for kind
-      preset-kind-volume-mounts: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250513-98d205aae3-master
@@ -738,8 +736,6 @@ presubmits:
       preset-service-account: "true"
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
-      # this is required to make CNI installation to succeed for kind
-      preset-kind-volume-mounts: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250513-98d205aae3-master
@@ -913,8 +909,6 @@ postsubmits:
       preset-service-account: "true"
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
-      # this is required to make CNI installation to succeed for kind
-      preset-kind-volume-mounts: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250513-98d205aae3-master

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -380,7 +380,6 @@ presubmits:
       - master
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-azure-community: "true"
@@ -433,7 +432,6 @@ presubmits:
       - master
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-azure-community: "true"

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
@@ -5,7 +5,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -42,7 +41,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -114,7 +112,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -151,7 +148,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -242,7 +238,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.25-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.25-config.yaml
@@ -32,7 +32,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -69,7 +68,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -106,7 +104,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.26-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.26-config.yaml
@@ -5,7 +5,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -42,7 +41,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -79,7 +77,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.27-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.27-config.yaml
@@ -5,7 +5,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -42,7 +41,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -79,7 +77,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.28-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.28-config.yaml
@@ -5,7 +5,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -42,7 +41,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -79,7 +77,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -170,7 +167,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.29-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.29-config.yaml
@@ -5,7 +5,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -42,7 +41,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -79,7 +77,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -170,7 +167,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.30-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.30-config.yaml
@@ -5,7 +5,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -42,7 +41,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -79,7 +77,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -170,7 +167,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.31-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.31-config.yaml
@@ -5,7 +5,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -42,7 +41,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -79,7 +77,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:
@@ -170,7 +167,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: "k8s.io/cloud-provider-openstack"
     always_run: false
     branches:

--- a/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
@@ -9,7 +9,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -61,7 +60,6 @@ periodics:
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m

--- a/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
+++ b/config/jobs/kubernetes/sig-auth/sig-auth-encryption-at-rest.yaml
@@ -20,8 +20,6 @@ presubmits:
     labels:
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
-      # this is required to make CNI installation to succeed for kind
-      preset-kind-volume-mounts: "true"
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-auth-encryption-at-rest

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-presubmit.yaml
@@ -18,7 +18,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -82,7 +81,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     path_alias: k8s.io/kubernetes
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -8,7 +8,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -67,7 +66,6 @@ presubmits:
       path_alias: sigs.k8s.io/cloud-provider-kind
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -120,7 +118,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -172,7 +169,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -224,7 +220,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -273,7 +268,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 200m
@@ -318,7 +312,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 200m
@@ -369,7 +362,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -424,7 +416,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -474,7 +465,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -522,7 +512,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -576,7 +565,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -633,7 +621,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -679,7 +666,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -731,7 +717,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -778,7 +763,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -830,7 +814,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -881,7 +864,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -942,7 +924,6 @@ periodics:
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -134,7 +134,6 @@ periodics:
   interval: 24h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-e2e-json-logging-1-30
   spec:
     containers:
@@ -506,7 +505,6 @@ periodics:
   interval: 24h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-e2e-parallel-1-30
   spec:
     containers:
@@ -551,7 +549,6 @@ periodics:
   interval: 24h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-ipv6-e2e-parallel-1-30
   spec:
     containers:
@@ -1750,7 +1747,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-service-account: "true"
     max_concurrency: 8
     name: pull-kubernetes-conformance-kind-ipv6-parallel
@@ -1891,7 +1887,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind
     path_alias: k8s.io/kubernetes
     spec:
@@ -1930,7 +1925,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind-ipv6
     path_alias: k8s.io/kubernetes
     spec:
@@ -1973,7 +1967,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-conformance-kind-ga-only-parallel
     path_alias: k8s.io/kubernetes
     spec:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -135,7 +135,6 @@ periodics:
   interval: 6h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-e2e-json-logging-1-31
   spec:
     containers:
@@ -501,7 +500,6 @@ periodics:
   interval: 6h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-e2e-parallel-1-31
   spec:
     containers:
@@ -546,7 +544,6 @@ periodics:
   interval: 6h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-ipv6-e2e-parallel-1-31
   spec:
     containers:
@@ -1685,7 +1682,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-service-account: "true"
     max_concurrency: 8
     name: pull-kubernetes-conformance-kind-ipv6-parallel
@@ -1826,7 +1822,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind
     path_alias: k8s.io/kubernetes
     spec:
@@ -1865,7 +1860,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind-ipv6
     path_alias: k8s.io/kubernetes
     spec:
@@ -1908,7 +1902,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-conformance-kind-ga-only-parallel
     path_alias: k8s.io/kubernetes
     spec:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -135,7 +135,6 @@ periodics:
   interval: 2h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-e2e-json-logging-1-32
   spec:
     containers:
@@ -501,7 +500,6 @@ periodics:
   interval: 2h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-e2e-parallel-1-32
   spec:
     containers:
@@ -546,7 +544,6 @@ periodics:
   interval: 2h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-ipv6-e2e-parallel-1-32
   spec:
     containers:
@@ -1815,7 +1812,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-service-account: "true"
     max_concurrency: 8
     name: pull-kubernetes-conformance-kind-ipv6-parallel
@@ -1956,7 +1952,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind
     path_alias: k8s.io/kubernetes
     spec:
@@ -1995,7 +1990,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind-ipv6
     path_alias: k8s.io/kubernetes
     spec:
@@ -2038,7 +2032,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-conformance-kind-ga-only-parallel
     path_alias: k8s.io/kubernetes
     spec:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -135,7 +135,6 @@ periodics:
   interval: 1h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-e2e-json-logging-1-33
   spec:
     containers:
@@ -818,7 +817,6 @@ periodics:
   interval: 1h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-e2e-parallel-1-33
   spec:
     containers:
@@ -863,7 +861,6 @@ periodics:
   interval: 1h
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   name: ci-kubernetes-kind-ipv6-e2e-parallel-1-33
   spec:
     containers:
@@ -2455,7 +2452,6 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
       preset-service-account: "true"
     max_concurrency: 8
     name: pull-kubernetes-conformance-kind-ipv6-parallel
@@ -2593,7 +2589,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind
     path_alias: k8s.io/kubernetes
     spec:
@@ -2632,7 +2627,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind-ipv6
     path_alias: k8s.io/kubernetes
     spec:
@@ -2675,7 +2669,6 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     name: pull-kubernetes-conformance-kind-ga-only-parallel
     path_alias: k8s.io/kubernetes
     spec:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -13,7 +13,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decorate: true
     decoration_config:
       timeout: 3h
@@ -61,7 +60,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20250513-98d205aae3-master
@@ -105,7 +103,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 3h
@@ -152,7 +149,6 @@ periodics:
   decorate: true
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   extra_refs:
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -9,7 +9,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -218,7 +217,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 2h20m # allow plenty of time for a serial conformance run
       grace_period: 15m
@@ -258,7 +256,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -307,7 +304,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -357,7 +353,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -406,7 +401,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -451,7 +445,6 @@ presubmits:
     - release-\d+\.\d+ # per-release settings
     labels:
       preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
       grace_period: 15m
@@ -499,7 +492,6 @@ periodics:
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -553,7 +545,6 @@ periodics:
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -603,7 +594,6 @@ periodics:
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m
@@ -720,7 +710,6 @@ periodics:
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
   decorate: true
   decoration_config:
     timeout: 60m


### PR DESCRIPTION
Part of https://github.com/kubernetes/k8s.io/pull/8131
Part of https://github.com/kubernetes/k8s.io/issues/5276
Tested in https://github.com/kubernetes/test-infra/pull/34840

I removed the label from all the kind jobs running on k8s-infra-prow-build cluster.