### PR TITLE
Fix the URL for the ghproxy cmd location

### DIFF
--- a/ghproxy/README.md
+++ b/ghproxy/README.md
@@ -1,5 +1,5 @@
 # ghProxy
 
-ghProxy has been moved with Prow to the [kubernetes-sigs/prow](https://github.com/kubernetes-sigs/prow) repository. Specifically you can find its source code [here](https://github.com/kubernetes-sigs/prow/tree/main/ghproxy).
+ghProxy has been moved with Prow to the [kubernetes-sigs/prow](https://github.com/kubernetes-sigs/prow) repository. Specifically you can find its source code [here](https://github.com/kubernetes-sigs/prow/tree/main/cmd/ghproxy).
 
 If you depend on the ghProxy source code and need to update your references, please follow the [same instructions](../prow/README.md) provided for the Prow source code.


### PR DESCRIPTION
Fix the broken link for the ghproxy command