### PR TITLE
Remove Image push jobs from sig-release-master-informing

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
@@ -3,7 +3,7 @@ postsubmits:
     - name: post-kpromo-push-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-release-releng-blocking, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-release-releng-blocking, sig-release-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io, release-team@kubernetes.io
         testgrid-num-failures-to-alert: '1'
       decorate: true

--- a/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
@@ -3,7 +3,7 @@ postsubmits:
     - name: post-release-push-image-debian-base
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
       decorate: true
       run_if_changed: '^images\/build\/debian-base\/'
@@ -35,7 +35,7 @@ postsubmits:
     - name: post-release-push-image-distroless-iptables
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
       decorate: true
       run_if_changed: '^images\/build\/distroless-iptables\/'
@@ -67,7 +67,7 @@ postsubmits:
     - name: post-release-push-image-go-runner
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
       decorate: true
       decoration_config:
@@ -102,7 +102,7 @@ postsubmits:
     - name: post-release-push-image-kube-cross
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
       decorate: true
       decoration_config:
@@ -137,7 +137,7 @@ postsubmits:
     - name: post-release-push-image-setcap
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
       decorate: true
       run_if_changed: '^images\/build\/setcap\/'

--- a/config/jobs/image-pushing/releng/k8s-staging-kubernetes.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-kubernetes.yaml
@@ -3,7 +3,7 @@ postsubmits:
     - name: post-kubernetes-push-image-etcd
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
       decorate: true
       run_if_changed: '^cluster\/images\/etcd\/'
@@ -32,7 +32,7 @@ postsubmits:
     - name: post-kubernetes-push-image-pause
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
       decorate: true
       run_if_changed: '^build\/pause\/'


### PR DESCRIPTION
The image pushes shouldn't be listed in [sig-release-master-informing](https://testgrid.k8s.io/sig-release-master-informing) dashboard. They're built adhoc and mostly not from k/k.
They are also listed in a different dedicated tab [sig-release-image-pushes](https://testgrid.k8s.io/sig-release-image-pushes)
Hence this change is to remove below jobs from [sig-release-master-informing](https://testgrid.k8s.io/sig-release-master-informing) dashboard:

- post-kpromo-push-image
- post-kubernetes-push-image-etcd
- post-kubernetes-push-image-pause
- post-release-push-image-debian-base
- post-release-push-image-distroless-iptables
- post-release-push-image-go-runner
- post-release-push-image-kube-cross
- post-release-push-image-setcap

Ref [Slack Thread](https://kubernetes.slack.com/archives/C2C40FMNF/p1748076703194349)
Ref: https://github.com/kubernetes/test-infra/pull/34548#discussion_r2010698786 