### PR TITLE
Set squash as merge method for external-dns

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -797,6 +797,7 @@ tide:
     kubernetes-client/gen: squash
     kubernetes-sigs/cluster-api-provider-digitalocean: squash
     kubernetes-sigs/cluster-api-provider-ibmcloud: squash
+    kubernetes-sigs/external-dns: squash
     kubernetes-sigs/ibm-vpc-block-csi-driver: squash
     kubernetes-sigs/ingate: squash
     kubernetes-sigs/jobset: squash


### PR DESCRIPTION
# Motivation

Avoid having to add manually multiple time the squash label on PRs