### PR TITLE
Ingress NGINX: Build Controller on `main`.

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -5,6 +5,7 @@ postsubmits:
       annotations:
         testgrid-dashboards: sig-network-ingress-nginx, sig-k8s-infra-gcb
       branches:
+        - ^main$
         - ^release-.+$
       run_if_changed: ^TAG$
       cluster: k8s-infra-prow-build-trusted


### PR DESCRIPTION
Currently Controller builds are only getting triggered from `release-*` branches. This leads to always needing a `release-*` branch for releasing a new minor version, but sadly this makes the comparison between tags and release generation harder.

With this change I'd like to enable us to start new major/minor versions directly from the `main` branch and then split into `release-*` branches after releasing it instead of having to create a `release-*` branch before even publishing the actual release.