### PR TITLE
do not run sctp connectivity tests on kind jobs on COS

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-periodic.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-periodic.yaml
@@ -26,7 +26,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv6|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
+        value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv6|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|SCTPConnectivity
       command:
         - wrapper.sh
         - bash
@@ -80,7 +80,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv4|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|Internet.connection|loadbalancer.source.ranges
+        value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv4|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|Internet.connection|loadbalancer.source.ranges|SCTPConnectivity
       command:
         - wrapper.sh
         - bash

--- a/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv6|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
+          value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv6|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|SCTPConnectivity
         command:
         - wrapper.sh
         - bash
@@ -85,7 +85,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv4|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|Internet.connection|loadbalancer.source.ranges
+          value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv4|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|Internet.connection|loadbalancer.source.ranges|SCTPConnectivity
         command:
         - wrapper.sh
         - bash
@@ -136,7 +136,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|Networking-IPv6|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service
+          value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|Networking-IPv6|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|SCTPConnectivity
         - name: PARALLEL
           value: "true"
         - name: IP_FAMILY


### PR DESCRIPTION
Seen in https://testgrid.k8s.io/sig-testing-kind#cloud-provider-kind%20(IPv6),%20master%20(dev)%20%5Bnon-serial%5D

COS does not support SCTP module yet so all SCTPConnectivity tests fail, we need to skip them in the meantime