### PR TITLE
Bump golang version for compiling triage to 1.21

### DIFF
--- a/triage/Dockerfile
+++ b/triage/Dockerfile
@@ -16,7 +16,7 @@
 # Cloud SDK, and the resulting files are then used in the second stage.
 
 # Stage 1
-FROM golang:1.18 AS build
+FROM golang:1.21 AS build
 
 # Install the Google Cloud SDK
 RUN curl -o installer https://sdk.cloud.google.com \


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/34876, we started using `atomic.Int64` which is in go1.21 onwards, the go.mod file is up-to-date, but the Dockerfile is stale.

https://prow.k8s.io/log?container=test&id=1928082484776407040&job=post-test-infra-push-triage
```
Step #0: summarize/cluster.go:236:24: undefined: atomic.Int64
Step #0: note: module requires Go 1.21
```