### PR TITLE
etcd: Add unit tests for branch release-3.4

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -1037,6 +1037,66 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: arm64
 
+- name: ci-etcd-unit-test-release34-amd64
+  interval: 4h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.4
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-unit-test-release34-amd64
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250527-1b2b10e804-master
+      command:
+      - runner.sh
+      args:
+      - make
+      - test-unit
+      resources:
+        requests:
+          cpu: "4"
+          memory: "4Gi"
+        limits:
+          cpu: "4"
+          memory: "4Gi"
+
+- name: ci-etcd-unit-test-release34-386
+  interval: 4h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.4
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-unit-test-release34-386
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250527-1b2b10e804-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        GOOS=linux GOARCH=386 CPU=1 GO_TEST_FLAGS='-p=4' make test-unit
+      resources:
+        requests:
+          cpu: "4"
+          memory: "4Gi"
+        limits:
+          cpu: "4"
+          memory: "4Gi"
+
 - name: ci-etcd-integration-1-cpu-release36-amd64
   interval: 24h
   cluster: eks-prow-build-cluster

--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -95,6 +95,7 @@ postsubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-postsubmits
@@ -153,6 +154,7 @@ postsubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-postsubmits

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -33,6 +33,7 @@ presubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
@@ -93,6 +94,7 @@ presubmits:
     branches:
     - main
     - release-3.6
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits


### PR DESCRIPTION
Adds presubmits, postsubmits, and periodics for amd64 and 386.

Ref: https://github.com/kubernetes/test-infra/issues/32754

/cc @ivanvc @abdurrehman107