### PR TITLE
Temporarily bump ci-test-infra-triage timeout/interval

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -94,11 +94,11 @@ periodics:
       - --jq=/usr/bin/jq
 
 - name: ci-test-infra-triage
-  interval: 4h
+  interval: 6h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   decoration_config:
-    timeout: 3h
+    timeout: 5h
   max_concurrency: 1
   annotations:
     testgrid-num-failures-to-alert: '18'


### PR DESCRIPTION
While i work on longer term mitigation, let's see if a small bump in time is enough to tide us over. We are flying blind at the moment.

xref: https://github.com/kubernetes/test-infra/issues/34863