### PR TITLE
[triage] bump timeout to 5 hrs for update_summaries script

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -136,7 +136,7 @@ periodics:
       command:
       - timeout
       args:
-      - "10800"
+      - "18000"
       - /update_summaries.sh
       # When changing CPUs, also change NUM_WORKERS above
       resources:


### PR DESCRIPTION
missed a spot in https://github.com/kubernetes/test-infra/pull/34890