### PR TITLE
CAPZ: Bump resources for upgrade tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -614,11 +614,11 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 9Gi
           requests:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-e2e-upgrade
@@ -657,11 +657,11 @@ presubmits:
             privileged: true
           resources:
             limits:
-              cpu: 2
-              memory: 4Gi
+              cpu: 4
+              memory: 9Gi
             requests:
-              cpu: 2
-              memory: 4Gi
+              cpu: 4
+              memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-apiversion-upgrade-main


### PR DESCRIPTION
These jobs have recently gotten stuck (for as many as tens of hours) in ways that remind me of jobs that were getting OOM killed. That hypothesis at least doesn't disagree with the fact that the tests are getting stuck compiling a large test binary AFAICT. I now have a [PR](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5663) open that's gotten stuck in the same place three times in a row.

The monitoring dashboard also seems to agree, reporting this job consistently getting close to or exceeding the current 4GB memory limit:
https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-sigs&var-repo=cluster-api-provider-azure&var-job=pull-cluster-api-provider-azure-e2e-workload-upgrade&var-build=All&from=1748826996104&to=1748829379115

e.g.
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/5528/pull-cluster-api-provider-azure-e2e-workload-upgrade/1927837379540815872
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/5528/pull-cluster-api-provider-azure-apiversion-upgrade/1927837379595341824

These changes bump the CPU and memory for those jobs to match similar e2e jobs.