### PR TITLE
Add ci-test-infra-triage to releng-informing

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -103,7 +103,7 @@ periodics:
   annotations:
     testgrid-num-failures-to-alert: '18'
     testgrid-alert-stale-results-hours: '12'
-    testgrid-dashboards: sig-testing-misc, sig-k8s-infra-prow
+    testgrid-dashboards: sig-release-releng-informing, sig-testing-misc, sig-k8s-infra-prow
     testgrid-tab-name: triage
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-alerts@kubernetes.io
     description: Runs BigQuery queries, summarizes results into clusters, and uploads to GCS for go.k8s.io/triage


### PR DESCRIPTION
When `ci-test-infra-triage` fails as it did recently, we fly blind.
https://github.com/kubernetes/test-infra/issues/34863

As that job generates the data that is used for our triage dashboard:
https://storage.googleapis.com/k8s-triage/index.html

We have to keep an eye on this job to make sure it works fine as it is likely to affect our release process (find flakes, find broken jobs, lose ci signal basically) as we don't really have or want to have all jobs tracked by release folks in blocking or informing boards. Several of us keep track of this job, but it is better to signal everyone in release team that this is important as the release team turns over every cycle.

thanks,
Dims