### PR TITLE
[triage] Revert timeout to 3 hours + Bump CPU/Memory

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -94,11 +94,11 @@ periodics:
       - --jq=/usr/bin/jq
 
 - name: ci-test-infra-triage
-  interval: 6h
+  interval: 4h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   decoration_config:
-    timeout: 5h
+    timeout: 3h
   max_concurrency: 1
   annotations:
     testgrid-num-failures-to-alert: '18'
@@ -136,16 +136,16 @@ periodics:
       command:
       - timeout
       args:
-      - "18000"
+      - "10800"
       - /update_summaries.sh
       # When changing CPUs, also change NUM_WORKERS above
       resources:
         requests:
-          cpu: 6
-          memory: 32Gi
+          cpu: 8
+          memory: 64Gi
         limits:
-          cpu: 6
-          memory: 32Gi
+          cpu: 8
+          memory: 64Gi
 
 - name: ci-test-infra-autobump-prowjobs
   cron: "06 14-23 * * 1-5"  # Run every hour at 7:06 - 16:06 PDT (in UTC) Mon-Fri


### PR DESCRIPTION
Revert the following:
- https://github.com/kubernetes/test-infra/pull/34892
- https://github.com/kubernetes/test-infra/pull/34890

And instead bump CPU/Memory to see if we can process things faster.