### PR TITLE
CAPZ: Bump coredns version for upgrade tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -34,7 +34,7 @@ periodics:
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.5.9-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.10.1"
+          value: "v1.11.1"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -87,7 +87,7 @@ periodics:
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.5.10-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.11.1"
+          value: "v1.11.3"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -140,7 +140,7 @@ periodics:
         - name: ETCD_VERSION_UPGRADE_TO
           value: "3.5.12-0"
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.11.1"
+          value: "v1.11.3"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
Bumps `COREDNS_VERSION_UPGRADE_TO` to correct expected versions for workload upgrade tests.