### PR TITLE
use 1.33.1 for jobset 1.33 e2e tests

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -170,7 +170,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.33.0
+              value: kindest/node:v1.33.1
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-7.yaml
@@ -170,7 +170,7 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
         env:
         - name: E2E_KIND_VERSION
-          value: kindest/node:v1.33.0
+          value: kindest/node:v1.33.1
         - name: BUILDER_IMAGE
           value: public.ecr.aws/docker/library/golang:1.23
         command:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-8.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-8.yaml
@@ -170,9 +170,9 @@ periodics:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
         env:
         - name: E2E_KIND_VERSION
-          value: kindest/node:v1.33.0
+          value: kindest/node:v1.33.1
         - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.23
+          value: public.ecr.aws/docker/library/golang:1.24
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -141,7 +141,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.33.0
+              value: kindest/node:v1.33.1
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:


### PR DESCRIPTION
We are getting some odd failures for 1.33.0. I notice Kueue/KJob are using 1.33.1 so going to try that first.
