### PR TITLE
fix limits for triage job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -141,11 +141,11 @@ periodics:
       # When changing CPUs, also change NUM_WORKERS above
       resources:
         requests:
-          cpu: 8
-          memory: 64Gi
+          cpu: 7
+          memory: 48Gi
         limits:
-          cpu: 8
-          memory: 64Gi
+          cpu: 7
+          memory: 48Gi
 
 - name: ci-test-infra-autobump-prowjobs
   cron: "06 14-23 * * 1-5"  # Run every hour at 7:06 - 16:06 PDT (in UTC) Mon-Fri


### PR DESCRIPTION
The change in #34902 failed.

https://prow.k8s.io/?job=ci-test-infra-triage

node spec: https://gcloud-compute.com/n1-highmem-8.html

/cc @dims @ameukam 