### PR TITLE
integration: mark pull-kubernetes-integration-race as optional

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -75,6 +75,7 @@ presubmits:
   - name: pull-kubernetes-integration-race
     cluster: eks-prow-build-cluster
     always_run: false # Has known failures.
+    optional: true
     decorate: true
     skip_branches:
     - release-\d+.\d+ # per-release job


### PR DESCRIPTION
It has known failures that can occur in a PR even if the PR itself is fine.

/assign @aojea 