### PR TITLE
Fix image used by vsphere-csi markdown linter job

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -122,7 +122,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.17.0
+      - image: registry.k8s.io/cloud-pv-vsphere/extra/mdlint:0.17.0
         command:
         - /nodejs/bin/node
         args:


### PR DESCRIPTION
CSI Markdown test is using the wrong image, which is not accessible anymore. This is making the job timeout and fail.

This change fixes the image to be used on markdown job.