### PR TITLE
feat: Add test to prow for skip version testing

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -220,3 +220,61 @@ periodics:
           # this is mostly for building kubernetes
           memory: 9Gi
           cpu: 7
+- interval: 6h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-e2e-kind-skip-version-upgrade-n-minus-2
+  annotations:
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: skip-version-test-n-minus-2
+    description: Uses kind to upgrade a cluster from n-2 and upgrades the emulaion version from n-2 -> n-1 -> n, running conformance tests between.
+    # TODO(#34269) update owners in experiment/compatibility-versions
+    testgrid-alert-email: compatibility-version-test@google.com
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20250513-98d205aae3-master
+      imagePullPolicy: Always  # pull latest image for canary testing
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && ./../test-infra/experiment/compatibility-versions/experiment/compatibility-versions/e2e-skip-version-testing.sh
+      env:
+      - name: VERSION_DELTA
+        value: "2"
+      - name: SKIP
+        value: Alpha|Disruptive|Slow|Flaky|IPv6|LoadBalancer|PodSecurityPolicy|nfs
+      - name: PARALLEL
+        value: "true"
+      - name: FEATURE_GATES
+        value: '{"AllBeta":true}'
+      - name: RUNTIME_CONFIG
+        value: '{"api/beta":"true", "api/ga":"true"}'
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7


### PR DESCRIPTION
Add prow job for test added in #34870, tests bumping binary by two versions and then bumping the compat version iteratively while running conformance tests in between each bump.