### PR TITLE
CAPZ: remove expected coredns and etcd versions from upgrade tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -31,10 +31,6 @@ periodics:
           value: "stable-1.29"
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.30"
-        - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.9-0"
-        - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.11.1"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -84,10 +80,6 @@ periodics:
           value: "stable-1.30"
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.31"
-        - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.10-0"
-        - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.11.3"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker
@@ -137,10 +129,6 @@ periodics:
           value: "stable-1.31"
         - name: KUBERNETES_VERSION_UPGRADE_TO
           value: "stable-1.32"
-        - name: ETCD_VERSION_UPGRADE_TO
-          value: "3.5.12-0"
-        - name: COREDNS_VERSION_UPGRADE_TO
-          value: "v1.11.3"
         - name: GINKGO_FOCUS
           value: "\\[K8s-Upgrade\\]"
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
The jobs testing Kubernetes upgrades of CAPZ-managed clusters don't really care about upgrading to particular versions of etcd or coredns, and if these hardcoded versions get too far out of date then the tests break. In https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5528 we've seen passing runs of the presubmit version of these jobs where these variables aren't defined.

/assign @willie-yao 