### PR TITLE
move CI jobs to same GCP region as the CI cluster (us-west1 => us-central1)

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-windows-poc/csi-driver-windows-poc-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-windows-poc/csi-driver-windows-poc-config.yaml
@@ -25,7 +25,7 @@ presubmits:
         args:
         - --check-leaked-resources
         - --cluster=
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --extract=ci/latest
         - --provider=gce
         - --gcp-nodes=2

--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-manual-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-manual-config.yaml
@@ -26,7 +26,7 @@ presubmits:
         - --check-leaked-resources
         - --cluster=
         - --extract=ci/latest
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         - --gcp-nodes=1
         - --test=false
@@ -48,7 +48,7 @@ presubmits:
         - name: NUM_NODES
           value: "1"
         - name: GCP_ZONE
-          value: "us-west1-b"
+          value: "us-central1-b"
         securityContext:
             privileged: true
         resources:

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-gce.yaml
@@ -23,7 +23,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --extract=ci/latest
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --gcp-nodes=2
       - --test=false
@@ -80,7 +80,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=
       - --extract=ci/latest
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --gcp-nodes=2
       - --test=false

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -105,7 +105,7 @@ periodics:
         /workspace/scenarios/kubernetes_e2e.py
         --deployment=node
         --provider=gce
-        --gcp-zone=us-west1-b
+        --gcp-zone=us-central1-b
         --node-tests=true
         "--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml --extra-envs=${EXTRA_ENVS}"
         '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
@@ -152,7 +152,7 @@ periodics:
         --extract=ci/latest
         --provider=gce
         --gcp-node-image=gci
-        --gcp-zone=us-west1-b
+        --gcp-zone=us-central1-b
         --ginkgo-parallel=30
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
@@ -197,7 +197,7 @@ periodics:
         --extract=ci/latest
         --provider=gce
         --gcp-node-image=gci
-        --gcp-zone=us-west1-b
+        --gcp-zone=us-central1-b
         --ginkgo-parallel=30
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
@@ -242,7 +242,7 @@ periodics:
         --extract=ci/latest
         --provider=gce
         --gcp-node-image=ubuntu
-        --gcp-zone=us-west1-b
+        --gcp-zone=us-central1-b
         --ginkgo-parallel=30
         --image-family=pipeline-1-24
         --image-project=ubuntu-os-gke-cloud
@@ -289,7 +289,7 @@ periodics:
         --extract=ci/latest
         --provider=gce
         --gcp-node-image=ubuntu
-        --gcp-zone=us-west1-b
+        --gcp-zone=us-central1-b
         --ginkgo-parallel=30
         --image-family=pipeline-1-24
         --image-project=ubuntu-os-gke-cloud

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -130,7 +130,7 @@ presubmits:
           /workspace/scenarios/kubernetes_e2e.py
           --deployment=node
           --provider=gce
-          --gcp-zone=us-west1-b
+          --gcp-zone=us-central1-b
           --node-tests=true
           "--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml --extra-envs=${EXTRA_ENVS}"
           '--node-test-args=--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/"'
@@ -176,7 +176,7 @@ presubmits:
           --extract=ci/latest
           --provider=gce
           --gcp-node-image=gci
-          --gcp-zone=us-west1-b
+          --gcp-zone=us-central1-b
           --ginkgo-parallel=30
           --test_args=--ginkgo.focus=NodeProblemDetector
           --timeout=60m
@@ -220,7 +220,7 @@ presubmits:
           --extract=ci/latest
           --provider=gce
           --gcp-node-image=gci
-          --gcp-zone=us-west1-b
+          --gcp-zone=us-central1-b
           --ginkgo-parallel=30
           --test_args=--ginkgo.focus=NodeProblemDetector
           --timeout=60m
@@ -304,7 +304,7 @@ presubmits:
           --extract=ci/latest
           --provider=gce
           --gcp-node-image=ubuntu
-          --gcp-zone=us-west1-b
+          --gcp-zone=us-central1-b
           --ginkgo-parallel=30
           --image-family=pipeline-1-24
           --image-project=ubuntu-os-gke-cloud
@@ -350,7 +350,7 @@ presubmits:
           --extract=ci/latest
           --provider=gce
           --gcp-node-image=ubuntu
-          --gcp-zone=us-west1-b
+          --gcp-zone=us-central1-b
           --ginkgo-parallel=30
           --image-family=pipeline-1-24
           --image-project=ubuntu-os-gke-cloud

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -27,7 +27,7 @@ presubmits:
         - --down=false
         - --gcp-node-image=gci
         - --gcp-nodes=4
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         - --test_args=--ginkgo.focus=definitely-not-a-real-focus
         - --timeout=65m
@@ -74,7 +74,7 @@ presubmits:
         - --down=false
         - --gcp-node-image=gci
         - --gcp-nodes=4
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         - --test_args=--ginkgo.focus=definitely-not-a-real-focus
         - --timeout=65m

--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -21,7 +21,7 @@ periodics:
       - --env=KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE=http-connect
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=25
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
@@ -58,7 +58,7 @@ periodics:
       - --env=KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE=grpc
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=25
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
@@ -108,7 +108,7 @@ presubmits:
         - --env=EGRESS_VIA_KONNECTIVITY=true
         - --env=KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE=http-connect
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
@@ -158,7 +158,7 @@ presubmits:
         - --env=EGRESS_VIA_KONNECTIVITY=true
         - --env=KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE=grpc
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9

--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -16,7 +16,7 @@ periodics:
       args:
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -25,7 +25,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test=false
       - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh
@@ -71,7 +71,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test=false
       - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh
@@ -120,7 +120,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test=false
       - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh
@@ -169,7 +169,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test=false
       - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh
@@ -218,7 +218,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test=false
       - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh
@@ -268,7 +268,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=3
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
@@ -303,7 +303,7 @@ periodics:
       - --cluster=hpa
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       # Enable HPAScaleToZero. Required for scale to zero tests.
       - --env=KUBE_FEATURE_GATES=HPAScaleToZero=true
@@ -339,7 +339,7 @@ periodics:
       - --cluster=hpa
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       # Enable HPAScaleToZero. Required for scale to zero tests.
       - --env=KUBE_FEATURE_GATES=HPAScaleToZero=true
@@ -374,7 +374,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --provider=gce
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --gcp-node-image=gci
       - --extract=ci/latest
       - --timeout=240m
@@ -411,7 +411,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --provider=gce
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --gcp-node-image=gci
       - --extract=ci/latest
       - --timeout=240m

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -40,7 +40,7 @@ presubmits:
         - --env=ENABLE_POD_PRIORITY=true
         - --gcp-node-image=gci
         - --gcp-nodes=3
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         - --runtime-config=scheduling.k8s.io/v1alpha1=true
         - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
@@ -86,7 +86,7 @@ presubmits:
         - --build=quick
         - --check-leaked-resources
         - --provider=gce
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --gcp-node-image=gci
         - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Alpha\]|\[Beta\] --minStartupPods=8
         - --ginkgo-parallel=1
@@ -131,7 +131,7 @@ presubmits:
         - --build=quick
         - --check-leaked-resources
         - --provider=gce
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --gcp-node-image=gci
         - --env=KUBE_FEATURE_GATES=HPAConfigurableTolerance=true
         - --test_args=--ginkgo.focus=\[Feature:HPAConfigurableTolerance\] --minStartupPods=8
@@ -179,7 +179,7 @@ presubmits:
         - --cluster=hpa
         - --check-leaked-resources
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         # Enable HPAScaleToZero. Required for scale to zero tests.
         - --env=KUBE_FEATURE_GATES=HPAScaleToZero=true
@@ -221,7 +221,7 @@ presubmits:
         - --check-leaked-resources
         - --extract=ci/latest
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         - --test=false
         - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -17,7 +17,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
@@ -55,7 +55,7 @@ periodics:
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -133,7 +133,7 @@ periodics:
       - --extract=ci/k8s-stable1
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel
       - --provider=gce
       - --skew
@@ -171,7 +171,7 @@ periodics:
       - --extract=ci/k8s-stable1
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
@@ -208,7 +208,7 @@ periodics:
       - --extract=ci/k8s-stable1
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=25
       - --provider=gce
       - --skew
@@ -251,7 +251,7 @@ periodics:
       - --extract=ci/k8s-stable1
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
@@ -289,7 +289,7 @@ periodics:
       - --extract=ci/latest
       - --extract=ci/k8s-stable1
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=25
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
@@ -327,7 +327,7 @@ periodics:
       - --extract=ci/latest
       - --extract=ci/k8s-stable1
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
@@ -364,7 +364,7 @@ periodics:
       - --extract=ci/latest
       - --extract=ci/k8s-stable1
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
@@ -401,7 +401,7 @@ periodics:
       - --extract=ci/latest
       - --extract=ci/k8s-stable1
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
@@ -437,7 +437,7 @@ periodics:
       - --extract=ci/k8s-stable2
       - --extract=ci/k8s-stable1
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel
       - --provider=gce
       - --skew
@@ -475,7 +475,7 @@ periodics:
       - --extract=ci/k8s-stable2
       - --extract=ci/k8s-stable1
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
@@ -512,7 +512,7 @@ periodics:
       - --extract=ci/k8s-stable1
       - --extract=ci/k8s-stable2
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
@@ -549,7 +549,7 @@ periodics:
       - --extract=ci/k8s-stable1
       - --extract=ci/k8s-stable2
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -23,7 +23,7 @@ periodics:
       - --extract=ci/fast/latest-fast
       - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -50,7 +50,7 @@ presubmits:
         - --gcp-node-image=gci
         - --gcp-nodes=2
         - --gcp-project-type=gpu-project
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -49,7 +49,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-nodes=2
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m

--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -199,7 +199,7 @@ periodics:
       - --env=GCE_ALPHA_FEATURES=NetworkEndpointGroup
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
       - --extract=ci/latest
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=1
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]

--- a/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
@@ -52,7 +52,7 @@ presubmits:
         - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
         - --gcp-nodes=4
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         - --test_args=--ginkgo.focus=\[Feature:NEG\]|Loadbalancing|LoadBalancers|Ingress --ginkgo.skip=\[Feature:kubemci\]|\[Disruptive\]|\[Feature:IngressScale\]|\[Feature:NetworkPolicy\]
         - --timeout=320m
@@ -108,7 +108,7 @@ presubmits:
         - --env=NETWORK_POLICY_PROVIDER=kube-network-policies
         - --ginkgo-parallel=30
         - --gcp-nodes=4
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
         # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)
@@ -179,7 +179,7 @@ presubmits:
         - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
         - --gcp-nodes=4
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         - --ginkgo-parallel=30
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[sig-storage\]|\[Feature:.+\] --minStartupPods=8
@@ -240,7 +240,7 @@ presubmits:
         - --env=KUBE_PROXY_MODE=nftables
         - --env=KUBE_GCE_NODE_IMAGE=cos-113-18244-236-88
         - --gcp-nodes=4
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         - --gcp-master-image=gci
         - --gcp-node-image=gci
@@ -292,7 +292,7 @@ presubmits:
         - --env=KUBE_ENABLE_NODELOCAL_DNS=true
         - --env=KUBE_ENABLE_NODE_PROBLEM_DETECTOR=none
         - --extract=ci/latest
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\]|LoadBalancer --minStartupPods=8
@@ -363,7 +363,7 @@ periodics:
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GCEAlphaFeature\] --minStartupPods=8
@@ -476,7 +476,7 @@ periodics:
       - --env=CLUSTER_DNS_CORE_DNS=true
       - --env=KUBE_ENABLE_NODE_PROBLEM_DETECTOR=none
       - --extract=ci/latest
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[sig-storage\]|\[Feature:.+\] --minStartupPods=8
@@ -589,7 +589,7 @@ periodics:
       - --env=KUBE_ENABLE_NODELOCAL_DNS=true
       - --env=KUBE_ENABLE_NODE_PROBLEM_DETECTOR=none
       - --extract=ci/latest
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[sig-storage\]|\[Feature:.+\] --minStartupPods=8
@@ -623,7 +623,7 @@ periodics:
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
       - --extract=ci/fast/latest-fast
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:NEG\]|Loadbalancing|LoadBalancers|Ingress --ginkgo.skip=\[Feature:kubemci\]|\[Disruptive\]|\[Feature:IngressScale\]|\[Feature:NetworkPolicy\]
       - --timeout=320m
@@ -661,7 +661,7 @@ periodics:
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
       - --extract=ci/fast/latest-fast
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
@@ -697,7 +697,7 @@ periodics:
       - --env=CREATE_CUSTOM_NETWORK=true
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       - --timeout=180m
@@ -735,7 +735,7 @@ periodics:
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[sig-storage\]|\[Feature:.+\] --minStartupPods=8
@@ -772,7 +772,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --provider=gce
       # skip ESIPP should work from pods #97081
@@ -811,7 +811,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --provider=gce
       # skip ESIPP should work from pods #97081
@@ -852,7 +852,7 @@ periodics:
       - --cluster=
       - --env=CLUSTER_DNS_CORE_DNS=false
       - --extract=ci/latest
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\] --minStartupPods=8
@@ -887,7 +887,7 @@ periodics:
       - --env=KUBE_ENABLE_NODELOCAL_DNS=true
       - --env=KUBE_ENABLE_NODE_PROBLEM_DETECTOR=none
       - --extract=ci/latest
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\]|LoadBalancer --minStartupPods=8
@@ -923,7 +923,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[sig-storage\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\] --minStartupPods=8
       - --timeout=500m
@@ -960,7 +960,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[sig-storage\]|\[Feature:.+\]|LoadBalancer|\[sig-cloud-provider-gcp\]  --minStartupPods=8
       - --timeout=500m
@@ -993,7 +993,7 @@ periodics:
       - --env=NETWORK_POLICY_PROVIDER=kube-network-policies
       - --ginkgo-parallel=30
       - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       # Skipping snat tests probably GCE related? https://github.com/kubernetes/test-infra/issues/20321
       # Skipping Cloud Provider specific tests: LoadBalancer, ESIPP (Source IP Preservation)

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -70,7 +70,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --image-family=ubuntu-2204-lts
       - --image-project=ubuntu-os-cloud
@@ -120,7 +120,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/image-config-cgroupv1.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
@@ -223,7 +223,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/image-config-cgroupv1.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -487,7 +487,7 @@ periodics:
       - --env=KUBE_GCE_NODE_IMAGE=cos-109-17800-147-22
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
@@ -532,7 +532,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-eviction.yaml
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
       - --node-tests=true
@@ -587,7 +587,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/image-config.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-driver=systemd --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
@@ -638,7 +638,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/image-config.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-driver=systemd --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
@@ -678,7 +678,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --image-family=cos-109-lts
       - --image-project=cos-cloud
@@ -716,7 +716,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --image-family=pipeline-1-29
       - --image-project=ubuntu-os-gke-cloud
@@ -761,7 +761,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
@@ -808,7 +808,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
@@ -859,7 +859,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
@@ -911,7 +911,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
@@ -962,7 +962,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
@@ -1021,7 +1021,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --image-family=cos-stable
       - --image-project=cos-cloud
@@ -1077,7 +1077,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --image-family=cos-stable
       - --image-project=cos-cloud
@@ -1127,7 +1127,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2-serial.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=containerd --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -1167,7 +1167,7 @@ periodics:
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --provider=gce
       # [Driver: gcepd] tests are skipped because CSIMigrationGCE is on in 1.23 and can be un-skipped once the cluster-up process
@@ -1213,7 +1213,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -1262,7 +1262,7 @@ periodics:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-hugepages.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -1312,7 +1312,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap.yaml
           - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
           - --env=KUBE_NODE_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
@@ -1367,7 +1367,7 @@ periodics:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-driver=systemd --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}" --server-start-timeout=420s'
           - --node-tests=true
@@ -1416,7 +1416,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --lock-file=/var/run/kubelet.lock --exit-on-lock-contention=true" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -1463,7 +1463,7 @@ periodics:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -1508,7 +1508,7 @@ periodics:
         - --cluster=
         - --env=ENABLE_AUTH_PROVIDER_GCP=true
         - --extract=ci/latest
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --gcp-node-image=gci
         - --gcp-nodes=1
         - --provider=gce

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -27,7 +27,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -80,7 +80,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -132,7 +132,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -184,7 +184,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -236,7 +236,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -288,7 +288,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -340,7 +340,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -392,7 +392,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -444,7 +444,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -496,7 +496,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -548,7 +548,7 @@ periodics:
         args:
           - --deployment=node
           - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
           - --node-tests=true
           - --provider=gce
@@ -600,7 +600,7 @@ periodics:
         args:
           - --deployment=node
           - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
           - --node-tests=true
           - --provider=gce
@@ -652,7 +652,7 @@ periodics:
         args:
           - --deployment=node
           - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
           - --node-tests=true
           - --provider=gce
@@ -704,7 +704,7 @@ periodics:
         args:
           - --deployment=node
           - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
           - --node-tests=true
           - --provider=gce
@@ -756,7 +756,7 @@ periodics:
         args:
           - --deployment=node
           - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock
             --container-runtime-process-name=/usr/local/bin/crio
             --container-runtime-pid-file=
@@ -827,7 +827,7 @@ periodics:
           - --test=node
           - --
           - --repo-root=.
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --parallelism=1
           - --focus-regex=\[Feature:ProcMountType\]|\[Feature:UserNamespacesSupport\]
           - '--test-args=--service-feature-gates="UserNamespacesSupport=true,ProcMountType=true" --feature-gates="UserNamespacesSupport=true,ProcMountType=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'

--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -177,7 +177,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m
@@ -233,7 +233,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m
@@ -289,7 +289,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m
@@ -341,7 +341,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -194,7 +194,7 @@ periodics:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky'
         - --timeout=60m
@@ -253,7 +253,7 @@ periodics:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky'
         - --timeout=60m
@@ -312,7 +312,7 @@ periodics:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky'
         - --timeout=60m
@@ -367,7 +367,7 @@ periodics:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky'
         - --timeout=60m

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -183,7 +183,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m
@@ -240,7 +240,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m
@@ -297,7 +297,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m
@@ -350,7 +350,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -92,7 +92,7 @@
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky {%- if file != "ci" %} && !Slow {%- endif %}'
         - --timeout={{e2e_node_timeout}}

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -26,7 +26,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-v2.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -81,7 +81,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
       - --node-tests=true
@@ -138,7 +138,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
       - --node-tests=true
@@ -194,7 +194,7 @@ periodics:
       args:
           - --deployment=node
           - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-serial.yaml
           - --node-tests=true
@@ -249,7 +249,7 @@ periodics:
       args:
           - --deployment=node
           - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-serial.yaml
           - --node-tests=true
@@ -363,7 +363,7 @@ periodics:
         args:
           - --deployment=node
           - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
           - --node-tests=true
           - --provider=gce
@@ -419,7 +419,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap.yaml
           - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
           - --env=KUBE_NODE_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
@@ -476,7 +476,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -527,7 +527,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap.yaml
           - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
           - --env=KUBE_NODE_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
@@ -584,7 +584,7 @@ periodics:
       args:
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
@@ -635,7 +635,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config.yaml
           - '--node-test-args=--feature-gates=LocalStorageCapacityIsolationFSQuotaMonitoring=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -691,7 +691,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--standalone-mode=true --feature-gates=AllAlpha=true,EventedPLEG=false --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
@@ -749,7 +749,7 @@ periodics:
       args:
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - '--node-test-args=--standalone-mode=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
@@ -805,7 +805,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -858,7 +858,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -911,7 +911,7 @@ periodics:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -970,7 +970,7 @@ periodics:
         args:
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - '--node-test-args=--cri-proxy-enabled=true  --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
           - --node-tests=true
           - --provider=gce
@@ -1020,7 +1020,7 @@ periodics:
           - --build=quick
           - --cluster=
           - --env=KUBE_FEATURE_GATES=RelaxedEnvironmentVariableValidation=true
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --gcp-node-image=gci
           - --gcp-nodes=1
           - --provider=gce
@@ -1062,7 +1062,7 @@ periodics:
 #          - --
 #          - --deployment=node
 #          - --gcp-project-type=node-e2e-project
-#          - --gcp-zone=us-west1-b
+#          - --gcp-zone=us-central1-b
 #          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/perf-image-config.yaml
 #          - --node-test-args= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/" --server-start-timeout=420s
 #          - --node-tests=true

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -38,7 +38,7 @@ presubmits:
         - --cluster=
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Feature:RuntimeHandler\] --minStartupPods=8
@@ -90,7 +90,7 @@ presubmits:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
         - --node-tests=true
         - --provider=gce
@@ -372,7 +372,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
@@ -650,7 +650,7 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
           args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -702,7 +702,7 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
           args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -754,7 +754,7 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
           args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
           - '--node-test-args=--feature-gates=AllAlpha=true,EventedPLEG=false --service-feature-gates=AllAlpha=true --runtime-config=api/all=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -808,7 +808,7 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
           args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
           - '--node-test-args=--feature-gates=SidecarContainers=true --service-feature-gates=SidecarContainers=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -876,7 +876,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=Feature: containsAny Serial'
         - --skip-regex=\[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
@@ -928,7 +928,7 @@ presubmits:
             - /workspace/scenarios/kubernetes_e2e.py
           args:
             - --deployment=node
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-central1-b
             - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
             - --node-test-args=--service-feature-gates="PodLevelResources=true" --feature-gates="PodLevelResources=true" --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --cgroup-driver=systemd"
             - --node-tests=true
@@ -1051,7 +1051,7 @@ presubmits:
             - /workspace/scenarios/kubernetes_e2e.py
           args:
             - --deployment=node
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-central1-b
             - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
             - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --cgroup-driver=systemd"
             - --node-tests=true
@@ -1116,7 +1116,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=Feature: containsAny CPUManager && !Flaky'
         - --skip-regex=""
@@ -1168,7 +1168,7 @@ presubmits:
             - /workspace/scenarios/kubernetes_e2e.py
           args:
             - --deployment=node
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-central1-b
             - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
             - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
@@ -1233,7 +1233,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --skip-regex=""
         - '--label-filter=Feature: containsAny TopologyManager && !Flaky'
@@ -1285,7 +1285,7 @@ presubmits:
             - /workspace/scenarios/kubernetes_e2e.py
           args:
             - --deployment=node
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-central1-b
             - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-hugepages.yaml
             - '--node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
@@ -1335,7 +1335,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --timeout=3h
         - --focus-regex=\[NodeConformance\]|\[Feature:.+\]|\[Feature\]
@@ -1390,7 +1390,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --focus-regex=\[Feature:ProcMountType\]|\[Feature:UserNamespacesSupport\]
         - '--test-args=--service-feature-gates="UserNamespacesSupport=true,ProcMountType=true" --feature-gates="UserNamespacesSupport=true,ProcMountType=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
@@ -1443,7 +1443,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[Feature:ImageVolume\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
@@ -1496,7 +1496,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]|\[Feature:.+\]|\[Feature\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport\]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:PodLevelResources\]
@@ -1550,7 +1550,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]|\[Feature:.+\]|\[Feature\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport\]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:PodLevelResources\]
@@ -1618,7 +1618,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]|\[Feature:.+\]|\[Feature\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:PodLevelResources\]
@@ -1674,7 +1674,7 @@ presubmits:
             - --test=node
             - --
             - --repo-root=.
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-central1-b
             - --parallelism=8
             - --focus-regex=\[NodeConformance\]|\[Feature:.+\]|\[Feature\]
             - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:PodLevelResources\]
@@ -1715,7 +1715,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[Feature:.+\]|\[Feature\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport\]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:PodLevelResources\]
@@ -1772,7 +1772,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --focus-regex=\[Serial\]
         - --skip-regex=\[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
@@ -1829,7 +1829,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --focus-regex=\[Serial\]
         # *Manager jobs are skipped because they have corresponding test lanes with the right image
@@ -1901,7 +1901,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]|\[Feature:.+\]|\[Feature\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport\]|\[Feature:PodLifecycleSleepActionAllowZero\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:PodLevelResources\]
@@ -1946,7 +1946,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --focus-regex=\[Feature:HugePages\]
         - --skip-regex=""
@@ -2005,7 +2005,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --focus-regex=\[Feature:HugePages\]
         - --skip-regex=""
@@ -2065,7 +2065,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --skip-regex=""
         - '--label-filter=Feature: isSubsetOf { CPUManager, MemoryManager, TopologyManager }'
@@ -2125,7 +2125,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --skip-regex=""
         - '--label-filter=Feature: isSubsetOf { CPUManager, MemoryManager, TopologyManager }'
@@ -2187,7 +2187,7 @@ presubmits:
             - /workspace/scenarios/kubernetes_e2e.py
           args:
             - --deployment=node
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-central1-b
             - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
             - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
@@ -2239,7 +2239,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
@@ -2291,7 +2291,7 @@ presubmits:
         args:
         - --deployment=node
         - --env=KUBE_SSH_USER=core
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--service-feature-gates="NodeSwap=true" --feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
@@ -2342,7 +2342,7 @@ presubmits:
             - /workspace/scenarios/kubernetes_e2e.py
           args:
             - --deployment=node
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-central1-b
             - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap.yaml
             - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
             - --env=KUBE_NODE_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
@@ -2401,7 +2401,7 @@ presubmits:
         args:
         - --deployment=node
         - --env=KUBE_SSH_USER=core
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
@@ -2455,7 +2455,7 @@ presubmits:
             - /workspace/scenarios/kubernetes_e2e.py
           args:
             - --deployment=node
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-central1-b
             - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap.yaml
             - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/master.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
             - --env=KUBE_NODE_EXTRA_METADATA=user-data=/home/prow/go/src/github.com/containerd/containerd/test/e2e/node.yaml,containerd-configure-sh=/home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh=/home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/env-cgroupv2
@@ -2514,7 +2514,7 @@ presubmits:
         args:
         - --deployment=node
         - --env=KUBE_SSH_USER=core
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
@@ -2565,7 +2565,7 @@ presubmits:
           - /workspace/scenarios/kubernetes_e2e.py
         args:
           - --deployment=node
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
@@ -2624,7 +2624,7 @@ presubmits:
           - --build=quick
           - --cluster=
           - --env=ENABLE_AUTH_PROVIDER_GCP=true
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --gcp-node-image=gci
           - --gcp-nodes=1
           - --provider=gce
@@ -2683,7 +2683,7 @@ presubmits:
         args:
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2.yaml
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
         - --node-tests=true
         - --provider=gce
@@ -2739,7 +2739,7 @@ presubmits:
         args:
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2.yaml
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
         - --node-tests=true
         - --provider=gce
@@ -2795,7 +2795,7 @@ presubmits:
         args:
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2-serial.yaml
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=containerd --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
         - --node-tests=true
         - --provider=gce
@@ -2851,7 +2851,7 @@ presubmits:
         args:
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-eviction.yaml
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=containerd --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
         - --node-tests=true
         - --provider=gce
@@ -2908,7 +2908,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --focus-regex=\[Feature:Eviction\]
         - --skip-regex=""
@@ -2965,7 +2965,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --focus-regex=\[Feature:Eviction\]
         - --skip-regex=""
@@ -3022,7 +3022,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --focus-regex=SeparateDisk
         - --skip-regex=""
@@ -3078,7 +3078,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - --focus-regex=KubeletSeparateDiskGC
         - --skip-regex=""
@@ -3133,7 +3133,7 @@ presubmits:
         args:
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/image-config-cgroupv1.yaml
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
         - --node-tests=true
         - --provider=gce
@@ -3184,7 +3184,7 @@ presubmits:
         args:
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv1/image-config-cgroupv1.yaml
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
         - --node-tests=true
         - --provider=gce
@@ -3355,7 +3355,7 @@ presubmits:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--feature-gates="ResourceHealthStatus=true" --service-feature-gates="ResourceHealthStatus=true" --runtime-config=api/alpha=true,api/beta=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --node-tests=true
         - --provider=gce
@@ -3569,7 +3569,7 @@ presubmits:
           - --build=quick
           - --cluster=
           - --env=KUBE_FEATURE_GATES=RelaxedEnvironmentVariableValidation=true
-          - --gcp-zone=us-west1-b
+          - --gcp-zone=us-central1-b
           - --gcp-node-image=gci
           - --gcp-nodes=1
           - --provider=gce

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -17,7 +17,7 @@ periodics:
       - --extract=ci/fast/latest-fast
       - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
@@ -100,7 +100,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-nodes=1
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
@@ -609,7 +609,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -657,7 +657,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -718,7 +718,7 @@ presubmits:
         - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
         - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -784,7 +784,7 @@ presubmits:
         - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
         - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -897,7 +897,7 @@ presubmits:
         - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
         - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=1
         - --provider=gce
         - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1059,7 +1059,7 @@ presubmits:
         - --gcp-master-image=gci
         - --gcp-node-image=gci
         - --gcp-nodes=4
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1110,7 +1110,7 @@ presubmits:
         - --gcp-node-image=gci
         - --gcp-nodes=2
         - --gcp-project-type=gpu-project
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -1162,7 +1162,7 @@ presubmits:
         - --cluster=
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
@@ -1204,7 +1204,7 @@ presubmits:
       containers:
       - args:
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
         - --node-tests=true
         - --provider=gce
@@ -1447,7 +1447,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -17,7 +17,7 @@ periodics:
       - --extract=ci/fast/latest-fast
       - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
@@ -100,7 +100,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-nodes=1
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
@@ -604,7 +604,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -654,7 +654,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -717,7 +717,7 @@ presubmits:
         - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
         - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -832,7 +832,7 @@ presubmits:
         - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
         - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=1
         - --provider=gce
         - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -994,7 +994,7 @@ presubmits:
         - --gcp-master-image=gci
         - --gcp-node-image=gci
         - --gcp-nodes=4
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1045,7 +1045,7 @@ presubmits:
         - --gcp-node-image=gci
         - --gcp-nodes=2
         - --gcp-project-type=gpu-project
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -1097,7 +1097,7 @@ presubmits:
         - --cluster=
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
@@ -1139,7 +1139,7 @@ presubmits:
       containers:
       - args:
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
         - --node-tests=true
         - --provider=gce
@@ -1382,7 +1382,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -17,7 +17,7 @@ periodics:
       - --extract=ci/fast/latest-fast
       - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
@@ -100,7 +100,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-nodes=2
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
@@ -677,7 +677,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -727,7 +727,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -790,7 +790,7 @@ presubmits:
         - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
         - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -905,7 +905,7 @@ presubmits:
         - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
         - --gcp-master-image=ubuntu
         - --gcp-node-image=ubuntu
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=1
         - --provider=gce
         - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1067,7 +1067,7 @@ presubmits:
         - --gcp-master-image=gci
         - --gcp-node-image=gci
         - --gcp-nodes=4
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1118,7 +1118,7 @@ presubmits:
         - --gcp-node-image=gci
         - --gcp-nodes=2
         - --gcp-project-type=gpu-project
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -1170,7 +1170,7 @@ presubmits:
         - --cluster=
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
@@ -1212,7 +1212,7 @@ presubmits:
       containers:
       - args:
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
         - --node-tests=true
         - --provider=gce
@@ -1458,7 +1458,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -17,7 +17,7 @@ periodics:
       - --extract=ci/fast/latest-fast
       - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
@@ -100,7 +100,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-nodes=2
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
@@ -267,7 +267,7 @@ periodics:
       - --test=node
       - --
       - --repo-root=.
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --parallelism=1
       - '--label-filter=Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow'
       - --timeout=60m
@@ -322,7 +322,7 @@ periodics:
       - --test=node
       - --
       - --repo-root=.
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --parallelism=1
       - '--label-filter=Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow'
       - --timeout=60m
@@ -377,7 +377,7 @@ periodics:
       - --test=node
       - --
       - --repo-root=.
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --parallelism=1
       - '--label-filter=Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow'
       - --timeout=60m
@@ -428,7 +428,7 @@ periodics:
       - --test=node
       - --
       - --repo-root=.
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --parallelism=1
       - '--label-filter=Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow'
       - --timeout=60m
@@ -1359,7 +1359,7 @@ presubmits:
         - --gcp-node-image=gci
         - --gcp-nodes=2
         - --gcp-project-type=gpu-project
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -1540,7 +1540,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m
@@ -1592,7 +1592,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m
@@ -1644,7 +1644,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m
@@ -1692,7 +1692,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=Feature: containsAny DynamicResourceAllocation && Feature: isSubsetOf { Beta, DynamicResourceAllocation } && !Flaky && !Slow'
         - --timeout=60m
@@ -1743,7 +1743,7 @@ presubmits:
         - --cluster=
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Feature:RuntimeHandler\] --minStartupPods=8
@@ -1785,7 +1785,7 @@ presubmits:
       containers:
       - args:
         - --deployment=node
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
         - --node-tests=true
         - --provider=gce
@@ -2031,7 +2031,7 @@ presubmits:
         - --test=node
         - --
         - --repo-root=.
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --parallelism=8
         - --focus-regex=\[NodeConformance\]
         - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -42,7 +42,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --ginkgo-parallel=30
         - --provider=gce
         - --test_args=--ginkgo.focus=\[sig-storage\].*\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -101,7 +101,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
         - --timeout=150m
@@ -159,7 +159,7 @@ presubmits:
         - --build=quick
         - --cluster=
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         - --test_args=--ginkgo.focus=CSI.*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|\[Slow\] --minStartupPods=8
         - --timeout=150m
@@ -207,7 +207,7 @@ presubmits:
         - --build=quick
         - --gcp-master-image=gci
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-central1-b
         - --provider=gce
         - --test_args=--ginkgo.focus=\[sig-storage\].*\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=240m
@@ -313,7 +313,7 @@ periodics:
       - --extract=ci/fast/latest-fast
       - --gcp-master-image=ubuntu
       - --gcp-node-image=ubuntu
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=120m
@@ -345,7 +345,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -85,7 +85,7 @@ periodics:
         ../test-infra/scenarios/kubernetes_e2e.py \
           --build=quick \
           --dump-before-and-after \
-          --gcp-zone=us-west1-b \
+          --gcp-zone=us-central1-b \
           --provider=gce \
           --timeout=300m \
           --test_args="--ginkgo.focus=\[Conformance\]"
@@ -155,7 +155,7 @@ periodics:
           --gcp-master-image=gci \
           --gcp-node-image=gci \
           --gcp-nodes=4 \
-          --gcp-zone=us-west1-b \
+          --gcp-zone=us-central1-b \
           --ginkgo-parallel=30 \
           --provider=gce \
           --timeout=150m \

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -654,7 +654,7 @@ periodics:
         cp -f "${GCE_SSH_PUBLIC_KEY_FILE}" ~/.ssh/google_compute_engine.pub
         exec kubetest2 kindinv \
           --boskos-location=http://boskos.test-pods.svc.cluster.local \
-          --gcp-zone=us-west1-b \
+          --gcp-zone=us-central1-b \
           --instance-image=ubuntu-os-cloud/ubuntu-2204-lts \
           --instance-type=n2-standard-4 \
           --kind-rootless \

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -56,7 +56,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --deployment=node
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-central1-b
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config-canary.yaml
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -402,7 +402,7 @@ nodeCommon:
   - --deployment=node
   - --node-tests=true
   - --provider=gce
-  - --gcp-zone=us-west1-b
+  - --gcp-zone=us-central1-b
 
 nodeImages:
   cos1:


### PR DESCRIPTION
us-west1 appears to be having a stockout, jobs are continually failing

https://prow.k8s.io/?job=ci-kubernetes-node-kubelet-containerd-eviction