### PR TITLE
update help wanted to reflect recent changes and link to rendered docs

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -143,6 +143,7 @@ approve:
   ignore_review_state: true
 
 help:
+  help_guidelines_url: https://www.kubernetes.dev/docs/guide/help-wanted/
   help_guidelines_summary: |
                         Please ensure that the issue body includes answers to the following questions:
                         - Why are we solving this issue?

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -147,7 +147,6 @@ help:
                         Please ensure that the issue body includes answers to the following questions:
                         - Why are we solving this issue?
                         - To address this issue, are there any code changes? If there are code changes, what needs to be done in the code and what places can the assignee treat as reference points?
-                        - Does this issue have zero to low barrier of entry?
                         - How can the assignee reach out to you for help?
 
 # Lower bounds in number of lines changed; XS is assumed to be zero.


### PR DESCRIPTION
/sig contributor-experience

https://www.kubernetes.dev/docs/guide/help-wanted/

Previously:
https://github.com/kubernetes/test-infra/pull/34746
https://github.com/kubernetes/community/pull/8447

- remove barrier to entry line (from help wanted, NOT good first issue)
- use rendered link instead of https://git.k8s.io/community/contributors/guide/help-wanted.md (the defualt)