### PR TITLE
Download all binaries instead of building them locally for compat version tests

### DIFF
--- a/experiment/compatibility-versions/common.sh
+++ b/experiment/compatibility-versions/common.sh
@@ -235,6 +235,30 @@ build_prev_version_bins() {
   echo "Finished building e2e.test binary from ${PREV_RELEASE_BRANCH}."
 }
 
+download_prev_version_bins() {
+  local version=$1
+  wget https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable-${version}.txt)/kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz
+  if [ $? -ne 0 ]; then
+    echo "failed to download previous version binaries"
+    return 1
+  fi
+  tar -xvf kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz 
+  mkdir -p _output/bin
+  mv kubernetes/test/bin/* _output/bin
+  return 0
+}
+
+download_current_version_bins() {
+  wget https://dl.k8s.io/ci/$(curl -Ls https://dl.k8s.io/ci/latest.txt)/kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz
+  if [ $? -ne 0 ]; then
+    echo "failed to download previous version binaries"
+    return 1
+  fi
+  tar -xvf kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz
+  mv kubernetes/test/bin/* _output/bin
+  return 0
+}
+
 # run e2es with ginkgo-e2e.sh
 run_prev_version_tests() {
   # IPv6 clusters need some CoreDNS changes in order to work in k8s CI:

--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -119,7 +119,7 @@ main() {
 
   # enter the cloned prev repo branch (in temp) and run tests
   pushd "${PREV_RELEASE_REPO_PATH}"
-  build_prev_version_bins || res=$?
+  download_prev_version_bins ${EMULATED_VERSION} || res=$?
   run_prev_version_tests || res=$?
   popd
 

--- a/experiment/compatibility-versions/e2e-skip-version-testing.sh
+++ b/experiment/compatibility-versions/e2e-skip-version-testing.sh
@@ -49,7 +49,8 @@ run_skip_version_tests() {
       return 1
     fi
     pushd "${PREV_RELEASE_REPO_PATH}"
-    build_prev_version_bins || ret=$?
+
+    download_prev_version_bins ${EMULATED_VERSION} || ret=$?
     run_prev_version_tests || ret=$?
     if [[ "$ret" -ne 0 ]]; then
       echo "Failed running skip version tests for emulated version $EMULATED_VERSION"
@@ -66,7 +67,7 @@ run_skip_version_tests() {
   # Test removal of emulated version entirely.
   export PREV_RELEASE_BRANCH="release-${EMULATED_VERSION}"
   delete_emulation_version || ret=$?
-  build_prev_version_bins || ret=$?
+  download_current_version_bins || ret=$?
   run_prev_version_tests || ret=$?
   return $ret
 }

--- a/experiment/compatibility-versions/e2e-two-steps-upgrade.sh
+++ b/experiment/compatibility-versions/e2e-two-steps-upgrade.sh
@@ -123,7 +123,7 @@ main() {
 
   # enter the cloned prev repo branch (in temp) and run tests
   pushd "${PREV_RELEASE_REPO_PATH}"
-  build_prev_version_bins || res=$?
+  download_prev_version_bins ${EMULATED_VERSION} || res=$?
   run_prev_version_tests || res=$?
   popd
 

--- a/experiment/compatibility-versions/kind-upgrade.sh
+++ b/experiment/compatibility-versions/kind-upgrade.sh
@@ -32,8 +32,9 @@ CONTROL_PLANE_COMPONENTS="kube-apiserver kube-controller-manager kube-scheduler"
 KUBE_ROOT="."
 # KUBE_ROOT="$(go env GOPATH)/src/k8s.io/kubernetes"
 source "${KUBE_ROOT}/hack/lib/version.sh"
-kube::version::get_version_vars
-DOCKER_TAG=${KUBE_GIT_VERSION/+/_}
+LATEST_IMAGE=$(curl -Ls https://dl.k8s.io/ci/latest.txt)
+echo "{\"revision\":\"$LATEST_IMAGE\"}" >"${ARTIFACTS}/metadata.json"
+DOCKER_TAG=${LATEST_IMAGE/+/_}
 DOCKER_REGISTRY=${KUBE_DOCKER_REGISTRY:-registry.k8s.io}
 export GOFLAGS="-tags=providerless"
 export KUBE_BUILD_CONFORMANCE=n
@@ -66,9 +67,9 @@ parse_args()
 
 parse_args $*
 
-build_docker(){
-  build/run.sh make all WHAT="cmd/kubectl cmd/kubelet" 1> /dev/null
-  make quick-release-images 1> /dev/null
+download_docker(){
+  curl -L 'https://dl.k8s.io/ci/'${LATEST_IMAGE}'/kubernetes-server-linux-amd64.tar.gz' > kubernetes-server-linux-amd64.tar.gz
+  tar -xvf kubernetes-server-linux-amd64.tar.gz
 }
 
 update_kubelet() {
@@ -110,9 +111,9 @@ usage()
 }
 
 # Main
-build_docker
-IMAGES_PATH="${KUBE_ROOT}/_output/release-images/amd64"
-KUBELET_BINARY=$(find ${KUBE_ROOT}/_output/ -type f -name kubelet)
+download_docker
+IMAGES_PATH="${KUBE_ROOT}/kubernetes/server/bin"
+KUBELET_BINARY=$(find ${KUBE_ROOT}/kubernetes/server/bin/ -type f -name kubelet)
 
 if [[ "$UPDATE_CONTROL_PLANE" == "true" ]]; then
   update_control_plane "true"


### PR DESCRIPTION
This pr downloads all required docker and test binaries and uses those to run the tests rather than building them locally. Running these tests locally showed a major performance improvement from this. 

The two major changes are downloading all the control plane docker images rather than building them from source and also downloading the test binaries instead of building them to run conformance tests.