### PR TITLE
CAPZ: bump memory for periodic upgrade jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -39,10 +39,10 @@ periodics:
       resources:
         limits:
           cpu: 4
-          memory: 4Gi
+          memory: 9Gi
         requests:
           cpu: 4
-          memory: 4Gi
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capi-periodic-upgrade-main-1-29-1-30
@@ -88,10 +88,10 @@ periodics:
       resources:
         limits:
           cpu: 4
-          memory: 4Gi
+          memory: 9Gi
         requests:
           cpu: 4
-          memory: 4Gi
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capi-periodic-upgrade-main-1-30-1-31
@@ -137,10 +137,10 @@ periodics:
       resources:
         limits:
           cpu: 4
-          memory: 4Gi
+          memory: 9Gi
         requests:
           cpu: 4
-          memory: 4Gi
+          memory: 9Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: capi-periodic-upgrade-main-1-31-1-32


### PR DESCRIPTION
This run appears to have gotten OOM killed:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-31-1-32-main/1930741172167249920

https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes-sigs&var-repo=cluster-api-provider-azure&var-job=periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-31-1&var-build=All&from=1749158400000&to=1749169200000

Bumping the memory for these jobs to 9Gi to match the other e2e jobs.

/assign @willie-yao 