### PR TITLE
vSphere CPI: add e2e tests on GCVE

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -354,3 +354,76 @@ presubmits:
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
       testgrid-tab-name: pr-verify-test-coverage
       description: Shows the test coverage of the Golang sources
+
+  # Executes the e2e tests.
+  - name: pull-cloud-provider-vsphere-e2e-test
+    cluster: k8s-infra-prow-build
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-gcve-e2e-config: "true"
+    branches:
+    - ^master$
+    path_alias: k8s.io/cloud-provider-vsphere
+    skip_submodules: true
+    always_run: false
+    run_if_changed: '\.go$|go.mod|hack/e2e\.sh|test/e2e/|charts/vsphere-cpi/'
+    skip_report: false
+    optional: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
+        command:
+        - runner.sh
+        args:
+        - ./hack/e2e.sh
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "4000m"
+            memory: "6Gi"
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
+      testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
+
+  # Executes the e2e tests with latest k8s version.
+  - name: pull-cloud-provider-vsphere-e2e-test-on-latest-k8s-version
+    cluster: k8s-infra-prow-build
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-gcve-e2e-config: "true"
+    branches:
+    - ^master$
+    path_alias: k8s.io/cloud-provider-vsphere
+    skip_submodules: true
+    always_run: false
+    run_if_changed: '\.go$|go.mod|hack/e2e\.sh|test/e2e/|charts/vsphere-cpi/'
+    skip_report: false
+    optional: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
+        command:
+        - runner.sh
+        args:
+        - ./hack/e2e.sh
+        - latest-k8s-version
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "4000m"
+            memory: "6Gi"
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
+      testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com


### PR DESCRIPTION
Enables cloud-provider-vsphere e2e tests based on community prow infrastructure.

/assign @zhanggbj

Requires:
- https://github.com/kubernetes/cloud-provider-vsphere/pull/1502

/hold