### PR TITLE
[dependencies] split arguments

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
@@ -74,7 +74,9 @@ presubmits:
           allowPrivilegeEscalation: false
         command:
         - runner.sh
-        - ./../test-infra/experiment/dependencies/update-dependencies-and-run-tests.sh --test-mode unit
+        - ./../test-infra/experiment/dependencies/update-dependencies-and-run-tests.sh
+        - --test-mode
+        - unit
         resources:
           limits:
             cpu: 7.2
@@ -169,7 +171,9 @@ periodics:
         allowPrivilegeEscalation: false
       command:
       - runner.sh
-      - ./../test-infra/experiment/dependencies/update-dependencies-and-run-tests.sh --test-mode unit
+      - ./../test-infra/experiment/dependencies/update-dependencies-and-run-tests.sh
+      - --test-mode
+      - unit
       resources:
         limits:
           cpu: 7.2


### PR DESCRIPTION
Not my day! this is the 3rd try! i should have stuck to the established pattern before :)

```
+ WRAPPED_COMMAND_PID=17
+ wait 17
+ './../test-infra/experiment/dependencies/update-dependencies-and-run-tests.sh --test-mode unit'
/usr/local/bin/runner.sh: line 103: ./../test-infra/experiment/dependencies/update-dependencies-and-run-tests.sh --test-mode unit: No such file or directory
+ EXIT_VALUE=127
+ set +o xtrace
```