### PR TITLE
Update ProwJob config to clone in k/k for scanning by snyk

### DIFF
--- a/config/jobs/kubernetes/sig-security/snyk-scan.yaml
+++ b/config/jobs/kubernetes/sig-security/snyk-scan.yaml
@@ -13,6 +13,11 @@ periodics:
   - org: kubernetes
     repo: sig-security
     base_ref: main
+    workdir: false
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: main
+    path_alias: k8s.io/kubernetes
     workdir: true
   spec:
     containers:
@@ -31,7 +36,7 @@ periodics:
       command:
       - sh
       - "-c"
-      - "cd sig-security-tooling/scanning/ && ./build-deps-and-release-images.sh"
+      - "/home/prow/go/src/github.com/kubernetes/sig-security/sig-security-tooling/scanning/build-deps-and-release-images.sh"
   annotations:
     testgrid-create-test-group: "true"
     testgrid-alert-email: security-tooling-private@kubernetes.io


### PR DESCRIPTION
Should fix #34939.

I'm still not sure why `snyk scan` ever had code to scan, unless `workdir` defaults to true for a solo `extra_refs`.

This clones in a copy of k/k and sets the job's current working directory to it, so that the plain `snyk scan` in [the script](https://github.com/kubernetes/sig-security/blob/main/sig-security-tooling/scanning/build-deps-and-release-images.sh) will know what to do.

The command is changed because we need to call the script directly from its git checkout directory, instead of doing relative path shenanigans, so that we can keep the CWD to be the k/k checkout.