### PR TITLE
fix reference to k/k master branch

### DIFF
--- a/config/jobs/kubernetes/sig-security/snyk-scan.yaml
+++ b/config/jobs/kubernetes/sig-security/snyk-scan.yaml
@@ -16,7 +16,7 @@ periodics:
     workdir: false
   - org: kubernetes
     repo: kubernetes
-    base_ref: main
+    base_ref: master
     path_alias: k8s.io/kubernetes
     workdir: true
   spec:


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/34941, I accidentally specified `main` branch of k/k, but we never finished that migration.

Correct the branch reference to `master`.

See also [job failure logs](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-snyk-master/1931105791348051968#1:build-log.txt%3A1236)