### PR TITLE
[dependencies] Initialize GOCACHE env var

### DIFF
--- a/experiment/dependencies/update-dependencies-and-run-tests.sh
+++ b/experiment/dependencies/update-dependencies-and-run-tests.sh
@@ -48,11 +48,12 @@ fi
 # install kind
 curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/"
 
-# install depstat
+# install depstat and mdttohtml
 export WORKDIR=${ARTIFACTS:-$TMPDIR}
 export PATH=$PATH:$GOPATH/bin
 mkdir -p "${WORKDIR}"
 pushd "$WORKDIR"
+export GOCACHE="${GOCACHE:-"$(mktemp -d)/cache"}"
 go install github.com/kubernetes-sigs/depstat@latest
 go install github.com/sgaunet/mdtohtml@latest
 popd


### PR DESCRIPTION
trying to fix the following:

```
+ pushd /logs/artifacts
/logs/artifacts /home/prow/go/src/k8s.io/kubernetes
+ go install github.com/kubernetes-sigs/depstat@latest
go: downloading github.com/kubernetes-sigs/depstat v0.7.0
go: failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied
+ EXIT_VALUE=1
+ set +o xtrace
```

(log - https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-unit-dependencies/1931413107771445248/build-log.txt)