### PR TITLE
Add 1.33 sig node tests and remove 1.29/1.30

### DIFF
--- a/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
+++ b/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
@@ -1,102 +1,4 @@
 periodics:
-- name: ci-kubernetes-node-release-branch-1-29
-  cluster: k8s-infra-prow-build
-  interval: 24h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 240m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: release-1.29
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250702-e205934cd3-master
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        args:
-          - --deployment=node
-          - --gcp-zone=us-central1-a
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.29.yaml
-          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
-          - --node-tests=true
-          - --provider=gce
-          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-          - --timeout=180m
-        env:
-          - name: GOPATH
-            value: /go
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-node-release-blocking
-    testgrid-tab-name: node-conformance-release-1.29
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: Node conformance tests in release branch 1.29
-- name: ci-kubernetes-node-release-branch-1-30
-  cluster: k8s-infra-prow-build
-  interval: 24h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 240m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: release-1.30
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250702-e205934cd3-master
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        args:
-          - --deployment=node
-          - --gcp-zone=us-central1-a
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.30.yaml
-          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
-          - --node-tests=true
-          - --provider=gce
-          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-          - --timeout=180m
-        env:
-          - name: GOPATH
-            value: /go
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-node-release-blocking
-    testgrid-tab-name: node-conformance-release-1.30
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: Node conformance tests in release branch 1.30
 - name: ci-kubernetes-node-release-branch-1-31
   cluster: k8s-infra-prow-build
   interval: 24h
@@ -195,3 +97,55 @@ periodics:
     testgrid-tab-name: node-conformance-release-1.32
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: Node conformance tests in release branch 1.32
+- name: ci-kubernetes-node-release-branch-1-33
+  cluster: k8s-infra-prow-build
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 240m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.33
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250702-e205934cd3-master
+        command:
+        - runner.sh
+        args:
+          - kubetest2
+          - noop
+          - --test=node
+          - --
+          - --repo-root=.
+          - --gcp-zone=us-central1-a
+          - --parallelism=8
+          - --focus-regex=\[NodeConformance\]
+          - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.33.yaml
+          - --timeout=180m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+  annotations:
+    testgrid-dashboards: sig-node-release-blocking
+    testgrid-tab-name: node-conformance-release-1.33
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: Node conformance tests in release branch 1.33

--- a/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
+++ b/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
@@ -149,3 +149,4 @@ periodics:
     testgrid-tab-name: node-conformance-release-1.33
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: Node conformance tests in release branch 1.33
+    

--- a/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
+++ b/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
@@ -149,4 +149,3 @@ periodics:
     testgrid-tab-name: node-conformance-release-1.33
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: Node conformance tests in release branch 1.33
-    

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.30.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.30.yaml
@@ -1,5 +1,0 @@
-images:
-  cos-dev:
-    image_family: cos-109-lts
-    project: cos-cloud
-    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.33.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.33.yaml
@@ -1,5 +1,5 @@
 images:
   cos-dev:
-    image_family: cos-109-lts
+    image_family: cos-113-lts
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.33.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.33.yaml
@@ -1,5 +1,5 @@
 images:
   cos-dev:
-    image_family: cos-113-lts
+    image_family: cos-121-lts
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"


### PR DESCRIPTION
Fixes #34927 

removed 1.29 and 1.30. Please note that for 1.33 used kuebtest2 to add the test. 
cc: @kannon92 