### PR TITLE
replace loadbalancer blocking job

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
@@ -636,9 +636,9 @@ periodics:
           cpu: 1
           memory: "3Gi"
   annotations:
-    testgrid-dashboards: sig-release-master-blocking, google-gce, sig-network-gce
+    testgrid-dashboards: google-gce, sig-network-gce
     testgrid-tab-name: gci-gce-ingress
-    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com, release-team@kubernetes.io
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
     description: Uses kubetest to run e2e tests (+Feature:Ingress|NEG) against a cluster created with cluster/kube-up.sh
     testgrid-alert-stale-results-hours: '24'
 - interval: 6h

--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -895,8 +895,8 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: Alpha|Beta|LoadBalancer.Service.without.NodePort|NetworkPolicy|Disruptive|Flaky|IPv6|SCTPConnectivity
-      #  cloud-provider-kind implements loadbalancer in Proxy mode; it requires NodePort
+        value: Alpha|Beta|LoadBalancer.Service.without.NodePort|NetworkPolicy|Disruptive|Flaky|IPv6|SCTPConnectivity|IPerf2
+      # cloud-provider-kind implements loadbalancer in Proxy mode; it requires NodePort
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -908,10 +908,10 @@ periodics:
           cpu: 4
           memory: 9Gi
   annotations:
-    testgrid-dashboards: sig-network-kind
+    testgrid-dashboards: sig-release-master-blocking, sig-network-kind
     testgrid-tab-name: sig-network-kind, loadbalancer
-    description: Runs loadbalancer tests in kind with cloud-provider-kind
-    testgrid-alert-email: antonio.ojea.garcia@gmail.com, danwinship@redhat.com
+    description: "OWNER: sig-network; runs loadbalancer tests in kind with cloud-provider-kind"
+    testgrid-alert-email: antonio.ojea.garcia@gmail.com, danwinship@redhat.com, kubernetes-sig-network-test-failures@googlegroups.com, release-team@kubernetes.io
     testgrid-num-columns-recent: '3'
 - interval: 6h
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
cloud-provider-kind was created to improve the testing of the loadbalancer logic in the code base and to avoid the dependencies on specific implementations and remove the flakiness introduced by the infrastructure. It has a better stability than any other cloud provider because it operates in a containerize environment , see https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20loadbalancer&include-filter-by-regex=LoadBalancer

In addition, the ingress-gce job is unnmaintained, the cloud provider specific code was not updated since the last year https://github.com/kubernetes/kubernetes/blame/3aa448625c2d2f10275c608f54b88074ef6aeafa/cluster/gce/manifests/cloud-controller-manager.manifest#L26 and the infrastructure flakes are not debuggable by any kubernetes org member. see https://testgrid.k8s.io/sig-release-master-blocking#gci-gce-ingress.

/sig network
/sig release
/assign @danwinship 

Fixes: https://github.com/kubernetes/kubernetes/issues/132161