### PR TITLE
Do not enforce branch protection in Headlamp

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -574,6 +574,11 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        headlamp:
+          exclude:
+          - "*" # We don't want to protect any branches (except the main one) in this repo
+          include:
+          - main
         hydrophone:
           exclude:
             - "^dependencies/" # don't protect branches created by github action that updates dependencies


### PR DESCRIPTION
In Headlamp we only have one branch where preventing force push makes sense. That's the main one.
All the rest we would like to force push and even to delete them since lots of branches were carried over from when we moved the repo and they are WIP or already merged ones.

I am not sure if this config is the correct way. I did read the source code for the prow and seems like it should work, but let me know otherwise.