### PR TITLE
fix: switch skip version testing to use kubekins

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -191,7 +191,7 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20250527-1b2b10e804-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
       command:
       - wrapper.sh
       - bash


### PR DESCRIPTION
We can either do this or use kubekins image as krte doesn't have jq installed. Not sure besides that it is a lighter image what the differences are between the two. Installing jq as a dependency makes sense regardless since we make good use out of it and if any other tests want to start using the new helper functions they would need to have it installed.