### PR TITLE
update cri-o version

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupv1.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1.ign
@@ -55,7 +55,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0083f3f8aa9e4368292c6fc4879e56f615e46585%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dbdcf72ff47866e1377cf1ba5372c7fc53ed9de99%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgroupv1_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1_eventedpleg.ign
@@ -55,7 +55,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0083f3f8aa9e4368292c6fc4879e56f615e46585%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dbdcf72ff47866e1377cf1ba5372c7fc53ed9de99%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgroupv1_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1_hugepages.ign
@@ -55,7 +55,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0083f3f8aa9e4368292c6fc4879e56f615e46585%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dbdcf72ff47866e1377cf1ba5372c7fc53ed9de99%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_cgroupv2.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2.ign
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0083f3f8aa9e4368292c6fc4879e56f615e46585%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dbdcf72ff47866e1377cf1ba5372c7fc53ed9de99%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_cgroupv2_drop_infra_ctr.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_drop_infra_ctr.ign
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0083f3f8aa9e4368292c6fc4879e56f615e46585%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dbdcf72ff47866e1377cf1ba5372c7fc53ed9de99%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgroupv2_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_hugepages.ign
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0083f3f8aa9e4368292c6fc4879e56f615e46585%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dbdcf72ff47866e1377cf1ba5372c7fc53ed9de99%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_cgroupv2_imagefs.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_imagefs.ign
@@ -70,7 +70,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0083f3f8aa9e4368292c6fc4879e56f615e46585%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dbdcf72ff47866e1377cf1ba5372c7fc53ed9de99%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgroupv2_splitfs.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_splitfs.ign
@@ -70,7 +70,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0083f3f8aa9e4368292c6fc4879e56f615e46585%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dbdcf72ff47866e1377cf1ba5372c7fc53ed9de99%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgroupv2_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_swap1g.ign
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0083f3f8aa9e4368292c6fc4879e56f615e46585%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dbdcf72ff47866e1377cf1ba5372c7fc53ed9de99%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_cgroupv2_userns.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_userns.ign
@@ -62,7 +62,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0083f3f8aa9e4368292c6fc4879e56f615e46585%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dbdcf72ff47866e1377cf1ba5372c7fc53ed9de99%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/templates/base/env.yaml
+++ b/jobs/e2e_node/crio/templates/base/env.yaml
@@ -6,5 +6,5 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0083f3f8aa9e4368292c6fc4879e56f615e46585"
-          DefaultEnvironment="CRIO_COMMIT=bdcf72ff47866e1377cf1ba5372c7fc53ed9de99"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
+          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1.yaml
@@ -34,8 +34,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0083f3f8aa9e4368292c6fc4879e56f615e46585"
-          DefaultEnvironment="CRIO_COMMIT=bdcf72ff47866e1377cf1ba5372c7fc53ed9de99"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
+          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
     - path: /etc/crio/crio.conf.d/42-checkpoint-enabled.conf
       contents:
         local: 42-checkpoint-enabled.conf

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1_eventedpleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1_eventedpleg.yaml
@@ -34,8 +34,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0083f3f8aa9e4368292c6fc4879e56f615e46585"
-          DefaultEnvironment="CRIO_COMMIT=bdcf72ff47866e1377cf1ba5372c7fc53ed9de99"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
+          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
     - path: /etc/crio/crio.conf.d/40-evented-pleg.conf
       contents:
         local: 40-evented-pleg.conf

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1_hugepages.yaml
@@ -34,8 +34,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0083f3f8aa9e4368292c6fc4879e56f615e46585"
-          DefaultEnvironment="CRIO_COMMIT=bdcf72ff47866e1377cf1ba5372c7fc53ed9de99"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
+          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0083f3f8aa9e4368292c6fc4879e56f615e46585"
-          DefaultEnvironment="CRIO_COMMIT=bdcf72ff47866e1377cf1ba5372c7fc53ed9de99"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
+          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_drop_infra_ctr.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_drop_infra_ctr.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0083f3f8aa9e4368292c6fc4879e56f615e46585"
-          DefaultEnvironment="CRIO_COMMIT=bdcf72ff47866e1377cf1ba5372c7fc53ed9de99"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
+          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
     - path: /etc/crio/crio.conf.d/30-crio-drop-infra-ctr.conf
       contents:
         local: 30-crio-drop-infra-ctr.conf

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_hugepages.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0083f3f8aa9e4368292c6fc4879e56f615e46585"
-          DefaultEnvironment="CRIO_COMMIT=bdcf72ff47866e1377cf1ba5372c7fc53ed9de99"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
+          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_imagefs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_imagefs.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0083f3f8aa9e4368292c6fc4879e56f615e46585"
-          DefaultEnvironment="CRIO_COMMIT=bdcf72ff47866e1377cf1ba5372c7fc53ed9de99"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
+          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
     - path: /etc/containers/storage.conf
       contents:
         local: 50-storage.conf

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_splitfs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_splitfs.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0083f3f8aa9e4368292c6fc4879e56f615e46585"
-          DefaultEnvironment="CRIO_COMMIT=bdcf72ff47866e1377cf1ba5372c7fc53ed9de99"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
+          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
     - path: /etc/containers/storage.conf
       contents:
         local: 60-storage-split-disk.conf

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_swap1g.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0083f3f8aa9e4368292c6fc4879e56f615e46585"
-          DefaultEnvironment="CRIO_COMMIT=bdcf72ff47866e1377cf1ba5372c7fc53ed9de99"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
+          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_userns.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_userns.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0083f3f8aa9e4368292c6fc4879e56f615e46585"
-          DefaultEnvironment="CRIO_COMMIT=bdcf72ff47866e1377cf1ba5372c7fc53ed9de99"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
+          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
     # Note: this ignition file assumes FCOS has shadow-utils installed.
     # As of the time of writing this, it does.
     - path: /etc/subuid

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -80,3 +80,17 @@ for i in "${!CONFIGURATIONS[@]}"; do
         -ps -d $BASE_PATH <"$i.yaml" >../"$i.ign"
     { set +x; } 2>/dev/null
 done
+
+CRIO_SCRIPT_COMMIT=$(grep "CRIO_SCRIPT_COMMIT" "$BASE_PATH/env.yaml" | sed -rn 's/^.*CRIO_SCRIPT_COMMIT=([0-9a-f]+).*$/\1/p')
+CRIO_SCRIPT_URL="https://raw.githubusercontent.com/cri-o/packaging/$CRIO_SCRIPT_COMMIT/get"
+curl -fs "$CRIO_SCRIPT_URL" -o /dev/null || {
+  echo "Error: CRIO_SCRIPT_COMMIT in $BASE_PATH/env.yaml is wrong. The get script was not found at: $CRIO_SCRIPT_URL" 1>&2
+  exit 1
+}
+
+CRIO_COMMIT=$(grep "CRIO_COMMIT" "$BASE_PATH/env.yaml" | sed -rn 's/^.*CRIO_COMMIT=([0-9a-f]+).*$/\1/p')
+CRIO_BIN_URL="https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.$CRIO_COMMIT.tar.gz"
+curl -fs "$CRIO_BIN_URL" -o /dev/null || {
+    echo "Error: CRIO_COMMIT in $BASE_PATH/env.yaml is wrong. The cri-o binary was not found at: $CRIO_BIN_URL" 1>&2
+    exit 1
+}


### PR DESCRIPTION
This version change was verified with canary job.
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/131317/pull-kubernetes-node-crio-cgrpv2-e2e-canary/1932275940260319232

- https://github.com/kubernetes/test-infra/pull/34909


