### PR TITLE
image-builder: add OVA presubmit based on vSphere

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
@@ -1,0 +1,35 @@
+presubmits:
+  kubernetes-sigs/image-builder:
+    - name: pull-ova-all
+      cluster: k8s-infra-prow-build
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-gcve-e2e-config: "true"
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 1h
+      run_if_changed: 'images/capi/(Makefile|ansible\.cfg)|images/capi/ansible/.*|images/capi/scripts/ci-ova\.sh|images/capi/packer/(config|goss|ova)/.*|images/capi/hack/ensure-(ansible|packer|goss).*'
+      path_alias: sigs.k8s.io/image-builder
+      max_concurrency: 3
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
+            args:
+              - runner.sh
+              - "./images/capi/scripts/ci-ova.sh"
+            resources:
+              requests:
+                cpu: "1000m"
+                memory: "4Gi"
+              limits:
+                cpu: "1000m"
+                memory: "4Gi"
+            securityContext:
+              privileged: true
+              capabilities:
+                add: ["NET_ADMIN"]
+      annotations:
+        testgrid-dashboards: sig-cluster-lifecycle-image-builder
+        testgrid-tab-name: pr-ova-all


### PR DESCRIPTION
Recovers the OVA presubmit job (as optional) for image-builder.

Further required adjustments and testing can happen at:

- https://github.com/kubernetes-sigs/image-builder/pull/1767

(after this merged)