### PR TITLE
skip: nfacct test in IPv6 cluster

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -688,7 +688,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: Alpha|Beta|NetworkPolicy|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv4|Internet.connection|SCTPConnectivity
+        value: Alpha|Beta|NetworkPolicy|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv4|Internet.connection|SCTPConnectivity|KubeProxyNFAcct
       command:
         - wrapper.sh
         - bash


### PR DESCRIPTION
https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20IPv6,%20master%20%5Bnon-serial%5D

With https://github.com/kubernetes/kubernetes/pull/131490, we removed the e2e skipper condition to skip the test in IPv6 clusters and added `KubeProxyNFAcct` as feature tag. We need to explicitly skip that test for IPv6 clusters.