### PR TITLE
Install `jq` in gcb-docker-gcloud image

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -32,6 +32,10 @@ WORKDIR /workspace
 RUN echo http://dl-cdn.alpinelinux.org/alpine/latest-stable/community >> /etc/apk/repositories && \
     apk --no-cache add curl python3 py-crcmod bash libc6-compat openssh-client git gnupg docker-cli make
 
+# Install jq
+RUN curl -o /usr/bin/jq -fsSLO https://github.com/jqlang/jq/releases/download/jq-1.8.0/jq-linux-amd64
+RUN chmod +x /usr/bin/jq
+
 RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz
 RUN tar xzf google-cloud-sdk.tar.gz -C /
 RUN rm google-cloud-sdk.tar.gz


### PR DESCRIPTION
This commit will install `jq` in `gcb-docker-gcloud` image so that the utility is available for all cloudbuild.yaml

Fixes: https://github.com/kubernetes/kubernetes/issues/131257
Ref Discussion: https://github.com/kubernetes/kubernetes/pull/131258#discussion_r2129567249

Built and locally tested:
```
arkas1@arkas1-ubuntu-vm:~/test-infra/images/gcb-docker-gcloud$ docker run -it --rm gcb-docker-gcloud:latest 
1ebeb22425f4:/workspace# jq
jq - commandline JSON processor [version 1.8.0]

Usage:	jq [options] <jq filter> [file...]
	jq [options] --args <jq filter> [strings...]
	jq [options] --jsonargs <jq filter> [JSON_TEXTS...]

jq is a tool for processing JSON inputs, applying the given filter to
its JSON text inputs and producing the filter's results as JSON on
standard output.

The simplest filter is ., which copies jq's input to its output
unmodified except for formatting. For more advanced filters see
the jq(1) manpage ("man jq") and/or https://jqlang.org/.

Example:

	$ echo '{"foo": 0}' | jq .
	{
	  "foo": 0
	}

For listing the command options, use jq --help.
```