### PR TITLE
DRA canary: experiment with kubelet version skew

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -32,7 +32,8 @@ presubmits:
         - |
           set -o pipefail
           # A presubmit job uses the checked out and merged source code.
-          kind_yaml=$(cat test/e2e/dra/kind.yaml)
+          revision=$(git describe --tags)
+          kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
           features=( )
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
@@ -40,19 +41,35 @@ presubmits:
           e2e_test=_output/bin/e2e.test
           # The latest kind is assumed to work also for older release branches, should this job get forked.
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
-          kind build node-image --image=dra/node:latest "${kind_node_source}"
+          control_plane_image=dra/node:latest
+          kind build node-image --image="$control_plane_image" "${kind_node_source}"
+          worker_image="$control_plane_image"
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
-          # Inject ClusterConfiguration which causes etcd to use /tmp
-          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
-          if ! echo "$kind_yaml" | grep -q '^kubeadmConfigPatches:'; then
-              # Add kubeadmConfigPatches list before node list, there is none at the moment.
-              kind_yaml=$(echo "$kind_yaml" | sed -e '/nodes:/ i\kubeadmConfigPatches:')
-          fi
-          kind_yaml=$(echo "$kind_yaml" | sed -e '/^kubeadmConfigPatches:/ a\- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd')
-          # Additional features are not in kind.yaml, but they can be added at the end.
-          kind create cluster --retain --config <(echo "${kind_yaml}"; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
+          # The final config gets dumped to stderr of the job.
+          # It's the result of getting the original kind.yaml, manipulating it with sed,
+          # and adding something at the end.
+          kind create cluster --retain --config <( (
+              ${kind_yaml_cmd[@]} |
+              # Configure potentially different images for control plane and workers.
+              sed -e "/^- role: control-plane/ a \  image: $control_plane_image" -e "/^- role: worker/ a \  image: $worker_image"
+
+              # Additional features are not in kind.yaml, but they can be added at the end.
+              for feature in ${features[@]}; do echo "  ${feature}: true"; done
+
+              # Append ClusterConfiguration which causes etcd to use /tmp
+              # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+              # There's no kubeadmConfigPatches in any kind.yaml, so we can append at the end.
+              cat <<EOF
+          kubeadmConfigPatches:
+          - |
+            kind: ClusterConfiguration
+            etcd:
+              local:
+                dataDir: /tmp/etcd
+          EOF
+          ) | tee /dev/stderr )
           atexit () {
               kind export logs "${ARTIFACTS}/kind"
               kind delete cluster
@@ -101,7 +118,8 @@ presubmits:
         - |
           set -o pipefail
           # A presubmit job uses the checked out and merged source code.
-          kind_yaml=$(cat test/e2e/dra/kind.yaml)
+          revision=$(git describe --tags)
+          kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
           # Which DRA features exist can change over time.
           features=( $( grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/' ) )
@@ -111,25 +129,132 @@ presubmits:
           e2e_test=_output/bin/e2e.test
           # The latest kind is assumed to work also for older release branches, should this job get forked.
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
-          kind build node-image --image=dra/node:latest "${kind_node_source}"
+          control_plane_image=dra/node:latest
+          kind build node-image --image="$control_plane_image" "${kind_node_source}"
+          worker_image="$control_plane_image"
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
-          # Inject ClusterConfiguration which causes etcd to use /tmp
-          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
-          if ! echo "$kind_yaml" | grep -q '^kubeadmConfigPatches:'; then
-              # Add kubeadmConfigPatches list before node list, there is none at the moment.
-              kind_yaml=$(echo "$kind_yaml" | sed -e '/nodes:/ i\kubeadmConfigPatches:')
-          fi
-          kind_yaml=$(echo "$kind_yaml" | sed -e '/^kubeadmConfigPatches:/ a\- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd')
-          # Additional features are not in kind.yaml, but they can be added at the end.
-          kind create cluster --retain --config <(echo "${kind_yaml}"; for feature in ${features[@]}; do echo "  ${feature}: true"; done) --image dra/node:latest
+          # The final config gets dumped to stderr of the job.
+          # It's the result of getting the original kind.yaml, manipulating it with sed,
+          # and adding something at the end.
+          kind create cluster --retain --config <( (
+              ${kind_yaml_cmd[@]} |
+              # Configure potentially different images for control plane and workers.
+              sed -e "/^- role: control-plane/ a \  image: $control_plane_image" -e "/^- role: worker/ a \  image: $worker_image"
+
+              # Additional features are not in kind.yaml, but they can be added at the end.
+              for feature in ${features[@]}; do echo "  ${feature}: true"; done
+
+              # Append ClusterConfiguration which causes etcd to use /tmp
+              # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+              # There's no kubeadmConfigPatches in any kind.yaml, so we can append at the end.
+              cat <<EOF
+          kubeadmConfigPatches:
+          - |
+            kind: ClusterConfiguration
+            etcd:
+              local:
+                dataDir: /tmp/etcd
+          EOF
+          ) | tee /dev/stderr )
           atexit () {
               kind export logs "${ARTIFACTS}/kind"
               kind delete cluster
           }
           trap atexit EXIT
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
+
+  - name: pull-kubernetes-kind-dra-n-1-canary
+    cluster: eks-prow-build-cluster
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    always_run: false
+    optional: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind with kubelet from the previous release.
+      testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+    decorate: true
+    decoration_config:
+      timeout: 90m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
+        command:
+        - runner.sh
+        args:
+        - /bin/bash
+        - -xce
+        - |
+          set -o pipefail
+          # A presubmit job uses the checked out and merged source code.
+          revision=$(git describe --tags)
+          kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
+          kind_node_source=.
+          features=( )
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
+          ginkgo=_output/bin/ginkgo
+          e2e_test=_output/bin/e2e.test
+          # The latest kind is assumed to work also for older release branches, should this job get forked.
+          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          control_plane_image=dra/node:latest
+          kind build node-image --image="$control_plane_image" "${kind_node_source}"
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\([0-9]*\).*/\1/')
+          # TODO: find latest patch release
+          worker_image=dra/node:skewed1
+          kind build node-image --image="$worker_image" "https://dl.k8s.io/v$major.$((minor - 1)).0/kubernetes-server-linux-amd64.tar.gz"
+          # We might need support for disabling tests which need a recent kubelet. We'll see...
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # The final config gets dumped to stderr of the job.
+          # It's the result of getting the original kind.yaml, manipulating it with sed,
+          # and adding something at the end.
+          kind create cluster --retain --config <( (
+              ${kind_yaml_cmd[@]} |
+              # Configure potentially different images for control plane and workers.
+              sed -e "/^- role: control-plane/ a \  image: $control_plane_image" -e "/^- role: worker/ a \  image: $worker_image"
+
+              # Additional features are not in kind.yaml, but they can be added at the end.
+              for feature in ${features[@]}; do echo "  ${feature}: true"; done
+
+              # Append ClusterConfiguration which causes etcd to use /tmp
+              # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+              # There's no kubeadmConfigPatches in any kind.yaml, so we can append at the end.
+              cat <<EOF
+          kubeadmConfigPatches:
+          - |
+            kind: ClusterConfiguration
+            etcd:
+              local:
+                dataDir: /tmp/etcd
+          EOF
+          ) | tee /dev/stderr )
+          atexit () {
+              kind export logs "${ARTIFACTS}/kind"
+              kind delete cluster
+          }
+          trap atexit EXIT
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Alpha && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes/sig-node/dra.generate.conf
+++ b/config/jobs/kubernetes/sig-node/dra.generate.conf
@@ -19,6 +19,8 @@ timeout = 90m
 # Must be sufficiently smaller than the overall job timeout to leave time
 # for test setup (compilation, deploying VM) and collecting results.
 e2e_node_timeout = 60m
+# Values > 0 enable version skew testing with an older kubelet version.
+kubelet_skew = 0
 
 # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently beta)
 # on a kind cluster with containerd updated to a version with CDI support.
@@ -38,6 +40,17 @@ cluster = eks-prow-build-cluster
 all_features = true
 use_dind = true
 run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*.go
+
+# This job runs the current e2e.test against a cluster where the kubelet is from the previous release (n - 1).
+#
+# It enables and tests the same features as kind-dra.
+[kind-dra-n-1]
+description = Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind with kubelet from the previous release.
+use_dind = true
+cluster = eks-prow-build-cluster
+run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*.go
+kubelet_skew = 1
+generate = canary # not ready for periodic yet
 
 # This job runs e2e_node.test with a focus on tests for the Dynamic Resource Allocation feature (currently beta)
 [node-e2e-crio-cgrpv1-dra]

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -117,6 +117,87 @@ presubmits:
         - -xce
         - |
           set -o pipefail
+          {%- if canary %}
+          {%- if ci %}
+          # A CI job uses pre-built release artifacts and pulls necessary source files from GitHub.
+          revision=$(curl --fail --silent --show-error --location ${CI_URL}/${LATEST_TXT})
+          # Report what was tested.
+          echo "{\"revision\":\"$revision\"}" >"${ARTIFACTS}/metadata.json"
+          # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
+          hash=${revision/*+/}
+          kind_yaml_cmd=(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
+          kind_node_source="${CI_URL}/$revision/kubernetes-server-linux-amd64.tar.gz"
+          {%- else %}
+          # A presubmit job uses the checked out and merged source code.
+          revision=$(git describe --tags)
+          kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
+          kind_node_source=.
+          {%- endif %}
+          {%- if all_features %}
+          # Which DRA features exist can change over time.
+          features=( $( {%- if ci %} curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/pkg/features/kube_features.go" | grep '"DRA' {% else %} grep '"DRA' pkg/features/kube_features.go {%- endif %} | sed 's/.*"\(.*\)"/\1/' ) )
+          : "Enabling DRA feature(s): ${features[*]}."
+          {%- else %}
+          features=( )
+          {%- endif %}
+          {%- if ci %}
+          curl --fail --silent --show-error --location "${CI_URL}/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
+          ginkgo=kubernetes/test/bin/ginkgo
+          e2e_test=kubernetes/test/bin/e2e.test
+          {%- else %}
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
+          ginkgo=_output/bin/ginkgo
+          e2e_test=_output/bin/e2e.test
+          {%- endif %}
+          # The latest kind is assumed to work also for older release branches, should this job get forked.
+          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          control_plane_image=dra/node:latest
+          kind build node-image --image="$control_plane_image" "${kind_node_source}"
+          {%- if kubelet_skew|int > 0 %}
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\([0-9]*\).*/\1/')
+          # TODO: find latest patch release
+          worker_image=dra/node:skewed{{kubelet_skew}}
+          kind build node-image --image="$worker_image" "https://dl.k8s.io/v$major.$((minor - {{kubelet_skew|int}})).0/kubernetes-server-linux-amd64.tar.gz"
+          # We might need support for disabling tests which need a recent kubelet. We'll see...
+          {%- else %}
+          worker_image="$control_plane_image"
+          {%- endif %}
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # The final config gets dumped to stderr of the job.
+          # It's the result of getting the original kind.yaml, manipulating it with sed,
+          # and adding something at the end.
+          kind create cluster --retain --config <( (
+              ${kind_yaml_cmd[@]} |
+              # Configure potentially different images for control plane and workers.
+              sed -e "/^- role: control-plane/ a \  image: $control_plane_image" -e "/^- role: worker/ a \  image: $worker_image"
+
+              # Additional features are not in kind.yaml, but they can be added at the end.
+              for feature in ${features[@]}; do echo "  ${feature}: true"; done
+
+              # Append ClusterConfiguration which causes etcd to use /tmp
+              # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+              # There's no kubeadmConfigPatches in any kind.yaml, so we can append at the end.
+              cat <<EOF
+          kubeadmConfigPatches:
+          - |
+            kind: ClusterConfiguration
+            etcd:
+              local:
+                dataDir: /tmp/etcd
+          EOF
+          ) | tee /dev/stderr )
+          atexit () {
+              kind export logs "${ARTIFACTS}/kind"
+              kind delete cluster
+          }
+          trap atexit EXIT
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } {%- if not all_features %} && !Alpha {%- endif %} && !Flaky {%- if not ci %} && !Slow {%- endif %}" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
+          {%- else -%}
           {%- if ci %}
           # A CI job uses pre-built release artifacts and pulls necessary source files from GitHub.
           revision=$(curl --fail --silent --show-error --location ${CI_URL}/${LATEST_TXT})
@@ -170,6 +251,7 @@ presubmits:
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } {%- if not all_features %} && !Alpha {%- endif %} && !Flaky {%- if not ci %} && !Slow {%- endif %}" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
+          {%- endif -%}
         {%- if ci %}
         env:
         - name: LATEST_TXT


### PR DESCRIPTION
The intent is to run the current set of tests against a cluster where the kubelet is from a previous release. Which tests will pass remains to be seen...

While at it, avoid repeatedly dumping intermediate kind_yaml variable assignment into the job's log output. Instead, manipulate the content once and dump the final result.