### PR TITLE
stop requiring pull-kubernetes-e2e-kind-ipv6 ahead of disabling always_run

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -90,7 +90,8 @@ presubmits:
 
   - name: pull-kubernetes-e2e-kind-ipv6
     cluster: k8s-infra-prow-build
-    optional: false
+    # TODO: once this is no longer required in github, disable always_run
+    optional: true
     always_run: true
     skip_report: false
     decorate: true


### PR DESCRIPTION
We have release blocking coverage, and ipv6/dual-stack are pretty stable these days, we don't think we need to run this on every PR anymore (discussed in #sig-testing with leads)

https://testgrid.k8s.io/sig-release-master-blocking#kind-ipv6-master

/sig testing network
cc @aojea @pohly
/hold