### PR TITLE
Add rerun block for boskos job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-boskos.yaml
+++ b/config/jobs/image-pushing/k8s-staging-boskos.yaml
@@ -1,6 +1,13 @@
 postsubmits:
   kubernetes-sigs/boskos:
     - name: post-boskos-push-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: sig-testing-leads
+        github_users:
+          - mkumatag
+          - Amulyam24
       skip_branches:
         # do not run on dependabot branches, these exist prior to merge
         # only merged code should trigger these jobs


### PR DESCRIPTION
There are lot of [flakes](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/post-boskos-push-images) during the image build, we need to add the rerun block for retriggering the job as a stop-gap solution.