### PR TITLE
added e2e test to gateway-inference-extension under k8s-sigs

### DIFF
--- a/config/jobs/kubernetes-sigs/gateway-api-inference-extension/inference-extension-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/gateway-api-inference-extension/inference-extension-periodics-main.yaml
@@ -33,3 +33,37 @@ periodics:
           requests:
             cpu: 3
             memory: 10Gi
+  - interval: 12h
+    name: periodic-gateway-api-inference-extension-test-e2e-main
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: gateway-api-inference-extension
+        base_ref: main
+        path_alias: sigs.k8s.io/gateway-api-inference-extension
+    annotations:
+      testgrid-dashboards: sig-network-gateway-api
+      testgrid-tab-name: periodic-gateway-api-inference-extension-test-e2e-main
+      description: "Run periodic gateway-api-inference-extension e2e tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi

--- a/config/jobs/kubernetes-sigs/gateway-api-inference-extension/inference-extension-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/gateway-api-inference-extension/inference-extension-presubmit-main.yaml
@@ -29,6 +29,35 @@ presubmits:
           requests:
             cpu: 3
             memory: 10Gi
+  - name: pull-gateway-api-inference-extension-test-e2e-main
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/gateway-api-inference-extension
+    annotations:
+      testgrid-dashboards: sig-network-gateway-api
+      testgrid-tab-name: pull-gateway-api-inference-extension-test-e2e-main
+      description: "Run inference extension e2e tests"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi
   - name: pull-gateway-api-inference-extension-verify-main
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
This PR adds pre submit and periodic ci job to trigger e2e tests in gateway-inference-extension repo