### PR TITLE
chore: require blocking e2e for CAPA

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -238,9 +238,9 @@ presubmits:
       # The script this job runs is not in all branches.
       - ^main$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
-    #run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|exp|feature|hack|pkg|test|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|exp|feature|hack|pkg|test|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     always_run: false
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 5h


### PR DESCRIPTION
This requires that the E2E blocking tests pass before a PR can be merged. Currently, they take around 30 mins to run.

NOTE: this only covers the unmanaged clusters (i.e. non-eks) tests.

//cc @nrb @AndiDog @dlipovetsky 