### PR TITLE
chore: increase concurrency and reduce timeout for CAPA blocking

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -238,13 +238,13 @@ presubmits:
       # The script this job runs is not in all branches.
       - ^main$
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
-    run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|exp|feature|hack|pkg|test|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
-    always_run: false
+    #run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|exp|feature|hack|pkg|test|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    always_run: true
     optional: false
     decorate: true
     decoration_config:
-      timeout: 5h
-    max_concurrency: 1
+      timeout: 2h
+    max_concurrency: 3
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
Increase the job concurrency for the CAPA e2e blocking job. This is so we don't get too much of a backlog on PRs waiting for this job. 

As the job currently takes less than 1 hour we can set a timeout lower. 

Also, removing the run_if_changed for now to make the job unconditional.

//cc @nrb @AndiDog @dlipovetsky 