### PR TITLE
Update kubekins-v2 to Go 1.24.4/1.23.10

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,31 +1,31 @@
 variants:
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.24.3
+    GO_VERSION: 1.24.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   master:
     CONFIG: master
-    GO_VERSION: 1.24.3
+    GO_VERSION: 1.24.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   '1.33':
     CONFIG: '1.33'
-    GO_VERSION: 1.24.3
+    GO_VERSION: 1.24.4
     K8S_RELEASE: latest-1.33
     BAZEL_VERSION: 3.4.1
   '1.32':
     CONFIG: '1.32'
-    GO_VERSION: 1.23.9
+    GO_VERSION: 1.23.10
     K8S_RELEASE: latest-1.32
     BAZEL_VERSION: 3.4.1
   '1.31':
     CONFIG: '1.31'
-    GO_VERSION: 1.23.9
+    GO_VERSION: 1.23.10
     K8S_RELEASE: latest-1.31
     BAZEL_VERSION: 3.4.1
   '1.30':
     CONFIG: '1.30'
-    GO_VERSION: 1.23.9
+    GO_VERSION: 1.23.10
     K8S_RELEASE: latest-1.30
     BAZEL_VERSION: 3.4.1


### PR DESCRIPTION
xref: https://github.com/kubernetes/release/issues/4024

/assign @ameukam @dims @xmudrii 
cc @kubernetes/release-managers 