### PR TITLE
etcd: use bash in govulncheck for golang based image

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -203,9 +203,8 @@ presubmits:
       # consolidate the jobs.
       - image: public.ecr.aws/docker/library/golang:1.23
         command:
-        - runner.sh
+        - /bin/bash
         args:
-        - bash
         - -c
         - |
           export PATH=$GOPATH/bin:$PATH && make run-govulncheck


### PR DESCRIPTION
Follow up from https://github.com/kubernetes/test-infra/pull/34990. Fix the command for the golang image.

Part of #32754 

/cc @abdurrehman107 @joshjms @ahrtr @jmhbnz 