### PR TITLE
auto bump prow in test-infra

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
@@ -103,7 +103,7 @@ periodics:
           cpu: 100m
           memory: 512Mi
 
-- name: ci-k8sio-autobump-prow-build-clusters
+- name: ci-k8sio-autobump-prow
   cron: "15 14-20/5 * * 1-5"  # Run at :15 every hour between 9:15 and 6:15 PM PST Mon-Fri
   cluster: k8s-infra-prow-build-trusted
   decorate: true
@@ -116,7 +116,7 @@ periodics:
     testgrid-dashboards: sig-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     testgrid-num-failures-to-alert: '3'
-    description: runs autobumper to create/update a PR that updates prow build cluster component images
+    description: runs autobumper to create/update a PR that updates prow.k8s.io
   rerun_auth_config:
     github_team_slugs:
     # proxy for sig-k8s-infra-oncall
@@ -127,7 +127,7 @@ periodics:
       slug: test-infra-admins
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250606-e2a3dbcc9
       command:
       - generic-autobumper
       args:
@@ -141,21 +141,20 @@ periodics:
       secret:
         secretName: k8s-infra-ci-robot-github-token
 
-- name: ci-k8sio-autobump-prow-build-clusters-for-autodeploy
-  # This is arbitrarily 3h earlier than test-infra-oncall's prow autobump job
-  cron: "30 14-19/5 * * 1-5"  # Run at 7:30 and 12:30 PST Mon-Fri
+- name: ci-test-infra-autobump-prow
+  cron: "15 14-20/5 * * 1-5"  # Run at :15 every hour between 9:15 and 6:15 PM PST Mon-Fri
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   max_concurrency: 1
   extra_refs:
   - org: kubernetes
-    repo: k8s.io
-    base_ref: main
+    repo: test-infra
+    base_ref: master
   annotations:
     testgrid-dashboards: sig-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io
-    testgrid-num-failures-to-alert: '1'
-    description: runs autobumper to create/update a PR that updates prow build cluster component images
+    testgrid-num-failures-to-alert: '3'
+    description: runs autobumper to create/update a PR that updates prow components in k/test-infra
   rerun_auth_config:
     github_team_slugs:
     # proxy for sig-k8s-infra-oncall
@@ -166,13 +165,12 @@ periodics:
       slug: test-infra-admins
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240802-66b115076
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250606-e2a3dbcc9
       command:
       - generic-autobumper
       args:
-      - --config=hack/autobump-config.yaml
+      - --config=config/prow/autobump-config/prow-component-autobump-config.yaml
       - --labels-override=skip-review
-      - --skip-if-no-oncall
       volumeMounts:
       - name: github
         mountPath: /etc/github-token

--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -1,8 +1,8 @@
 ---
-gitHubLogin: "k8s-ci-robot"
-gitHubToken: "/etc/github-token/oauth"
+gitHubLogin: "k8s-infra-ci-robot"
+gitHubToken: "/etc/github-token/token"
 gitName: "Kubernetes Prow Robot"
-gitEmail: "20407524+k8s-ci-robot@users.noreply.github.com"
+gitEmail: "75457971+k8s-infra-ci-robot@users.noreply.github.com"
 onCallAddress: "" # No oncall assigned to this at the moment.
 selfAssign: true # Commenting `/cc`, so that autobump PR is not assigned to anyone
 additionalPRBody: "/cc @dims"
@@ -12,18 +12,14 @@ gitHubRepo: "test-infra"
 remoteName: "test-infra"
 upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
 includedConfigPaths:
-  - "."
-excludedConfigPaths:
-  - ".ko.yaml" # Contains gcr.io/k8s-staging-test-infra/git, which is not pushed by prow
+  - "config/jobs"
+extraFiles:
+  - config/mkpj.sh
+  - config/prow/config.yaml
 targetVersion: "latest"
 prefixes:
   - name: "Prow"
     prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
     repo: "https://github.com/kubernetes-sigs/prow"
     summarise: true
-    consistentImages: true
-  - name: "Boskos"
-    prefix: "gcr.io/k8s-staging-boskos/"
-    repo: "https://github.com/kubernetes-sigs/boskos"
-    summarise: false
     consistentImages: true


### PR DESCRIPTION
We haven't been bumping prow images in this repository since the migration in August, which meant the images [here](https://github.com/search?q=repo%3Akubernetes%2Ftest-infra+us-docker.pkg.dev%2Fk8s-infra-prow%2Fimages+path%3A%2F%5Econfig%5C%2Fjobs%2F&type=code) and in https://github.com/kubernetes/test-infra/blob/master/config/prow/config.yaml#L18 are out of date.

Also, `ci-k8sio-autobump-prow-build-clusters-for-autodeploy` never worked because we don't have oncall and all the PRs in k/k8s.io are being merged manually by me.