### PR TITLE
image-builder: enable override plugin

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1621,6 +1621,7 @@ plugins:
   kubernetes-sigs/image-builder:
     plugins:
     - mergecommitblocker
+    - override
 
   kubernetes-sigs/contributor-playground:
     plugins:


### PR DESCRIPTION
e2e tests in image-builder run on multiple cloud providers, and we sometimes run into cases where skipping a particular job is appropriate. The `/override` command would be perfect, but wasn't yet enabled for the project.