### PR TITLE
fix cloud-provider-gcp-tests prow job OOMKilled

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -38,11 +38,11 @@ presubmits:
           fi
         resources:
           limits:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 10Gi
           requests:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 10Gi
   - name: cloud-provider-gcp-verify-all
     cluster: k8s-infra-prow-build
     always_run: true


### PR DESCRIPTION
Attempt to fix presubmit prow job failure
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/cloud-provider-gcp/856/cloud-provider-gcp-tests/1932867324889534464


```
Terminated (OOMKilled - : Found 121 targets and 27 test targets... [0 / 57] [Prepa] Writing file external/go_sdk/packages.txt ... (4 actions, 0 running) [36 / 1,495] GoToolchainBinaryBuild external/go_sdk/builder; 14s processwrapper-sandbox ... (8 actions running) [37 / 1,496] GoToolchainBinaryBuild external/go_sdk/builder; 23s processwrapper-sandbox ... (8 actions, 7 running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 34s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 56s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 74s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 109s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 133s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 160s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 195s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 235s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 279s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 328s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 384s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 450s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 525s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 611s processwrapper-sandbox ... (8 actions running) [39 / 1,503] GoToolchainBinaryBuild external/go_sdk/builder; 711s processwrapper-sandbox ... (8 actions running) ) at 2025-06-11 18:40:45 +0000 UTC with exit code 137
```

---------
https://github.com/kubernetes/cloud-provider-gcp/pull/856 