### PR TITLE
Bump memory for pull-kubernetes-verify CI job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -40,10 +40,10 @@ presubmits:
           # addressed in https://github.com/kubernetes/kubernetes/issues/93822
           limits:
             cpu: 7
-            memory: 12Gi
+            memory: 24Gi
           requests:
             cpu: 7
-            memory: 12Gi
+            memory: 24Gi
   - name: pull-kubernetes-linter-hints
     cluster: eks-prow-build-cluster
     decorate: true


### PR DESCRIPTION
All the periodic equivalents are `24Gi` but the primary presubmit is half of it. Let's please bump!

- https://github.com/kubernetes/test-infra/blob/40369af1c1983b2a167bd6d836072ac03e4e4341/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml#L487
- https://github.com/kubernetes/test-infra/blob/40369af1c1983b2a167bd6d836072ac03e4e4341/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml#L482
- https://github.com/kubernetes/test-infra/blob/40369af1c1983b2a167bd6d836072ac03e4e4341/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml#L482
- https://github.com/kubernetes/test-infra/blob/40369af1c1983b2a167bd6d836072ac03e4e4341/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml#L799

follow up from comments in:
https://github.com/kubernetes/kubernetes/pull/132290#issuecomment-2980283982