### PR TITLE
Disable periodic enhancements sync for v1.34

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -1,8 +1,8 @@
 periodics:
 - name: periodic-sync-enhancements-github-project-1-34
   # temporarily disable job by with an impossible cron date instead of deleting it
-  # cron: '0 0 31 2 *'
-  interval: 6h
+  cron: '0 0 31 2 *'
+  # interval: 6h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   annotations:


### PR DESCRIPTION
Disable the syncing of `lead-opted-in` KEPs to the [1.34 enhancements tracking board](https://github.com/orgs/kubernetes/projects/213).

Opening this PR early to get approvals. We can remove the hold once Enhancements Freeze is in effect (*21:00 UTC Friday 20th June 2025*)

cc @Vyom-Yadav @katcosgrove 

/hold
