### PR TITLE
CAPZ: disable Windows for ci-entrypoint presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -692,7 +692,7 @@ presubmits:
           privileged: true
         env:
           - name: TEST_WINDOWS
-            value: "true"
+            value: "false"
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
         resources:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -391,7 +391,7 @@ presubmits:
           privileged: true
         env:
           - name: TEST_WINDOWS
-            value: "true"
+            value: "false"
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
         resources:


### PR DESCRIPTION
Since bootstrapping Windows nodes has been flaky lately, this change disables creating Windows machines for the ci-entrypoint jobs. We primarily run ci-entrypoint on PRs to make sure we won't break real users of that script, but whether or not Windows nodes are used shouldn't have much bearing on that that wouldn't be caught in the rest of CAPZ's e2e tests.

Related to https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/5686