### PR TITLE
CAPZ: fix disabling Windows for ci-entrypoint

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -692,7 +692,7 @@ presubmits:
           privileged: true
         env:
           - name: TEST_WINDOWS
-            value: "false"
+            value: "" # disabled
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
         resources:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -391,7 +391,7 @@ presubmits:
           privileged: true
         env:
           - name: TEST_WINDOWS
-            value: "false"
+            value: "" # disabled
           - name: WINDOWS_SERVER_VERSION
             value: "windows-2022"
         resources:


### PR DESCRIPTION
Follow-up fix for #35008. It turns out ci-entrypoint only checks if `TEST_WINDOWS` is set to _any_ value, and doesn't intelligently look for true/false:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/44da1de043eedf5f75d6484b2aa6403fc4db65f2/scripts/ci-entrypoint.sh#L110-L112

/assign @mboersma 