### PR TITLE
etcd: Add unit test for release-3.5 branch

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -1037,6 +1037,97 @@ periodics:
     nodeSelector:
       kubernetes.io/arch: arm64
 
+- name: ci-etcd-unit-test-release35-amd64
+  interval: 4h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.5
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-unit-test-release35-amd64
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250613-876fb90a97-master
+      command:
+      - runner.sh
+      args:
+      - make
+      - test-unit
+      resources:
+        requests:
+          cpu: "4"
+          memory: "4Gi"
+        limits:
+          cpu: "4"
+          memory: "4Gi"
+
+- name: ci-etcd-unit-test-release35-arm64
+  interval: 4h
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.5
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-unit-test-release35-arm64
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250613-876fb90a97-master
+      command:
+      - runner.sh
+      args:
+      - make
+      - test-unit
+      resources:
+        requests:
+          cpu: "4"
+          memory: "4Gi"
+        limits:
+          cpu: "4"
+          memory: "4Gi"
+    nodeSelector:
+      kubernetes.io/arch: arm64
+
+- name: ci-etcd-unit-test-release35-386
+  interval: 4h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: release-3.5
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+    testgrid-tab-name: ci-etcd-unit-test-release35-386
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250613-876fb90a97-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        GOOS=linux GOARCH=386 CPU=1 GO_TEST_FLAGS='-p=4' make test-unit
+      resources:
+        requests:
+          cpu: "4"
+          memory: "4Gi"
+        limits:
+          cpu: "4"
+          memory: "4Gi"
+
 - name: ci-etcd-e2e-release34-amd64
   interval: 4h
   cluster: eks-prow-build-cluster

--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -95,6 +95,7 @@ postsubmits:
     branches:
     - main
     - release-3.6
+    - release-3.5
     - release-3.4
     decorate: true
     annotations:
@@ -124,6 +125,7 @@ postsubmits:
     branches:
     - main
     - release-3.6
+    - release-3.5
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-postsubmits
@@ -154,6 +156,7 @@ postsubmits:
     branches:
     - main
     - release-3.6
+    - release-3.5
     - release-3.4
     decorate: true
     annotations:

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -64,6 +64,7 @@ presubmits:
     branches:
     - main
     - release-3.6
+    - release-3.5
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits


### PR DESCRIPTION
Adding unit test postsubmits and periodics. Continuing https://github.com/kubernetes/test-infra/pull/35000. 

Ref: https://github.com/kubernetes/test-infra/issues/32754

/cc @ivanvc @abdurrehman107