### PR TITLE
enable prometheus stack for 100 node dra workload test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
@@ -259,6 +259,7 @@ periodics:
               ./run-e2e.sh cluster-loader2
               --nodes=100 \
               --provider=aks \
+              --enable-prometheus-server=true \
               --testconfig=testing/dra/config.yaml \
               --report-dir=${ARTIFACTS}
               --nodes=100


### PR DESCRIPTION
This PR enables prometheus stack needed for using PrometheusSchedulingMetrics
measurement as implemented in this PR https://github.com/kubernetes/perf-tests/pull/3399/