### PR TITLE
Bump Go1.24 for kube-scheduler-simulator

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - /bin/bash
         - -c

--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
Bump Go v1.24 in order to upgrade Kubernetes v1.32.
ref: https://github.com/kubernetes-sigs/kube-scheduler-simulator/pull/440

/cc sanposhiho
/sig scheduling
/kind cleanup