### PR TITLE
sig-k8s-infra: bump go version to 1.24 for Peribolos jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
@@ -21,7 +21,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - ./admin/update.sh
         args:
@@ -61,7 +61,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: public.ecr.aws/docker/library/golang:1.23
+    - image: public.ecr.aws/docker/library/golang:1.24
       command:
       - ./admin/update.sh
       args:


### PR DESCRIPTION
Bump golang version to fix failing job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-org-peribolos/1937057773938282496

```
 GOBIN=/home/prow/go/src/github.com/kubernetes/org/_output/bin go install sigs.k8s.io/prow/cmd/peribolos@main
go: downloading sigs.k8s.io/prow v0.0.0-20250623070453-a8bc6a7a8068
go: sigs.k8s.io/prow/cmd/peribolos@main: sigs.k8s.io/prow@v0.0.0-20250623070453-a8bc6a7a8068 requires go >= 1.24.0 (running go 1.23.10; GOTOOLCHAIN=local)
make: *** [Makefile
```

The above error is because of the go version bump in the Prow repo (https://github.com/kubernetes-sigs/prow/commit/a8bc6a7a8068e9ccf828956ae8819b9742b7a9f5)

/cc @kubernetes/sig-contributor-experience-leads 