### PR TITLE
Update peribolos jobs to use golang:1.24

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
@@ -21,7 +21,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - ./admin/update.sh
         args:
@@ -61,7 +61,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: public.ecr.aws/docker/library/golang:1.23
+    - image: public.ecr.aws/docker/library/golang:1.24
       command:
       - ./admin/update.sh
       args:


### PR DESCRIPTION
fixes error:
```
go: sigs.k8s.io/prow/cmd/peribolos@main: sigs.k8s.io/prow@v0.0.0-20250623070453-a8bc6a7a8068 requires go >= 1.24.0 (running go 1.23.10; GOTOOLCHAIN=local)
```

this error was caused by https://github.com/kubernetes-sigs/prow/pull/481