### PR TITLE
crio: update the version to pick latest changes

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupv1.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1.ign
@@ -55,7 +55,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgroupv1_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1_eventedpleg.ign
@@ -55,7 +55,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgroupv1_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1_hugepages.ign
@@ -55,7 +55,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_cgroupv2.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2.ign
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_cgroupv2_canary.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_canary.ign
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_cgroupv2_drop_infra_ctr.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_drop_infra_ctr.ign
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgroupv2_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_hugepages.ign
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_cgroupv2_imagefs.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_imagefs.ign
@@ -70,7 +70,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgroupv2_splitfs.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_splitfs.ign
@@ -70,7 +70,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_cgroupv2_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_swap1g.ign
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_cgroupv2_userns.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_userns.ign
@@ -62,7 +62,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Dc54e56dea6a3175198e3bd9b306f681a67c48a09%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dc5c41f21fa802d1c19a4114e88ecd91a270e3a15%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/templates/base/env-canary.yaml
+++ b/jobs/e2e_node/crio/templates/base/env-canary.yaml
@@ -6,5 +6,5 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"

--- a/jobs/e2e_node/crio/templates/base/env.yaml
+++ b/jobs/e2e_node/crio/templates/base/env.yaml
@@ -6,5 +6,5 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1.yaml
@@ -34,8 +34,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
     - path: /etc/crio/crio.conf.d/42-checkpoint-enabled.conf
       contents:
         local: 42-checkpoint-enabled.conf

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1_eventedpleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1_eventedpleg.yaml
@@ -34,8 +34,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
     - path: /etc/crio/crio.conf.d/40-evented-pleg.conf
       contents:
         local: 40-evented-pleg.conf

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1_hugepages.yaml
@@ -34,8 +34,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_canary.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_canary.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_drop_infra_ctr.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_drop_infra_ctr.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
     - path: /etc/crio/crio.conf.d/30-crio-drop-infra-ctr.conf
       contents:
         local: 30-crio-drop-infra-ctr.conf

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_hugepages.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_imagefs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_imagefs.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
     - path: /etc/containers/storage.conf
       contents:
         local: 50-storage.conf

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_splitfs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_splitfs.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
     - path: /etc/containers/storage.conf
       contents:
         local: 60-storage-split-disk.conf

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_swap1g.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_userns.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_userns.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=c54e56dea6a3175198e3bd9b306f681a67c48a09"
-          DefaultEnvironment="CRIO_COMMIT=c5c41f21fa802d1c19a4114e88ecd91a270e3a15"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
     # Note: this ignition file assumes FCOS has shadow-utils installed.
     # As of the time of writing this, it does.
     - path: /etc/subuid


### PR DESCRIPTION
This version has two fixes:
- Enable debug mode to understand the recent kubernetes CI failures
- Update golang to v1.24.3 to address the possible Segmentation Fault