### PR TITLE
feat: Add tests with higher version skew for compatibility version

### DIFF
--- a/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/compatibility-versions-e2e.yaml
@@ -115,6 +115,63 @@ periodics:
           cpu: 7
 - interval: 1h
   cluster: k8s-infra-prow-build
+  name: ci-kubernetes-e2e-kind-compatibility-versions-n-minus-3
+  annotations:
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: compatibility-version-test-n-minus-3
+    description: Uses kind to run e2e tests from the n-3 kubernetes release against a latest kubernetes master components w/ --emulated-version=n-3 set.
+    # TODO(#34269) update owners in experiment/compatibility-versions
+    testgrid-alert-email: compatibility-version-test@google.com
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20250613-876fb90a97-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && ./../test-infra/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+      env:
+      - name: VERSION_DELTA
+        value: "3"
+      - name: SKIP
+        value: Alpha|Disruptive|Slow|Flaky|IPv6|LoadBalancer|PodSecurityPolicy|nfs
+      - name: PARALLEL
+        value: "true"
+      - name: FEATURE_GATES
+        value: '{"AllBeta":true}'
+      - name: RUNTIME_CONFIG
+        value: '{"api/beta":"true", "api/ga":"true"}'
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7
+- interval: 1h
+  cluster: k8s-infra-prow-build
   name: ci-kubernetes-e2e-kind-compatibility-versions-feature-gate-test
   annotations:
     testgrid-dashboards: sig-testing-kind
@@ -151,6 +208,58 @@ periodics:
       env:
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 14Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 14Gi
+          cpu: 7
+- interval: 1h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-e2e-kind-compatibility-versions-feature-gate-test-n-2
+  annotations:
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: compatibility-versions-feature-gate-test-n-minus-2
+    description: Uses kind to run bespoke feature gate tests from the n-2 kubernetes release yaml files against a latest kubernetes master components w/ --emulated-version=n-2 set.
+    # TODO(#34269) update owners in experiment/compatibility-versions
+    testgrid-alert-email: compatibility-version-test@google.com
+    testgrid-num-failures-to-alert: "2"
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250613-876fb90a97-master
+      command:
+      - runner.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && ./../test-infra/experiment/compatibility-versions/compatibility-versions-feature-gate-test.sh
+      env:
+      - name: RUNTIME_CONFIG
+        value: '{"api/beta":"true", "api/ga":"true"}'
+      - name: VERSION_DELTA
+        value: "2"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -226,7 +335,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-testing-kind
     testgrid-tab-name: skip-version-test-n-minus-2
-    description: Uses kind to upgrade a cluster from n-2 and upgrades the emulaion version from n-2 -> n-1 -> n, running conformance tests between.
+    description: Uses kind to upgrade a cluster from n-2 and upgrades the emulation version from n-2 -> n-1 -> n, running conformance tests between.
     # TODO(#34269) update owners in experiment/compatibility-versions
     testgrid-alert-email: compatibility-version-test@google.com
     testgrid-num-columns-recent: '6'
@@ -258,6 +367,64 @@ periodics:
       env:
       - name: VERSION_DELTA
         value: "2"
+      - name: SKIP
+        value: Alpha|Disruptive|Slow|Flaky|IPv6|LoadBalancer|PodSecurityPolicy|nfs
+      - name: PARALLEL
+        value: "true"
+      - name: FEATURE_GATES
+        value: '{"AllBeta":true}'
+      - name: RUNTIME_CONFIG
+        value: '{"api/beta":"true", "api/ga":"true"}'
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7
+- interval: 6h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-e2e-kind-skip-version-upgrade-n-minus-3
+  annotations:
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: skip-version-test-n-minus-3
+    description: Uses kind to upgrade a cluster from n-3 and upgrades the emulation version from n-3 -> n-2 -> ... -> n, running conformance tests between.
+    # TODO(#34269) update owners in experiment/compatibility-versions
+    testgrid-alert-email: compatibility-version-test@google.com
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250613-876fb90a97-master
+      imagePullPolicy: Always  # pull latest image for canary testing
+      command:
+      - runner.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && ./../test-infra/experiment/compatibility-versions/e2e-skip-version-testing.sh
+      env:
+      - name: VERSION_DELTA
+        value: "3"
       - name: SKIP
         value: Alpha|Disruptive|Slow|Flaky|IPv6|LoadBalancer|PodSecurityPolicy|nfs
       - name: PARALLEL


### PR DESCRIPTION
Now that the `alpha.1` tag has been cut for K8s, we have had emulated version added for 3 releases. Add tests for that use case as the KEP states that we should be able to support up to N-3 version skew for emulated versions.