### PR TITLE
Remove unnecessary export of PATH and GO111MODULE vars

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
@@ -78,8 +78,6 @@ periodics:
               set -o pipefail
               set -o xtrace
 
-              export PATH=$GOPATH/bin:$PATH
-              export GO111MODULE=on
               RESOURCE_TYPE="powervs"
               #Call to boskos to checkout resource
               source "./hack/boskos.sh"
@@ -174,8 +172,6 @@ periodics:
               set -o pipefail
               set -o xtrace
 
-              export PATH=$GOPATH/bin:$PATH
-              export GO111MODULE=on
               RESOURCE_TYPE="powervs"
               source "./hack/boskos.sh"
 
@@ -254,8 +250,6 @@ periodics:
               set -o pipefail
               set -o xtrace
 
-              export PATH=$GOPATH/bin:$PATH
-              export GO111MODULE=on
               RESOURCE_TYPE="powervs"
               #Call to boskos to checkout resource
               source "./hack/boskos.sh"
@@ -335,8 +329,6 @@ periodics:
               set -o pipefail
               set -o xtrace
 
-              export PATH=$GOPATH/bin:$PATH
-              export GO111MODULE=on
               RESOURCE_TYPE="powervs"
               #Call to boskos to checkout resource
               source "./hack/boskos.sh"
@@ -416,8 +408,6 @@ periodics:
               set -o pipefail
               set -o xtrace
 
-              export PATH=$GOPATH/bin:$PATH
-              export GO111MODULE=on
               RESOURCE_TYPE="powervs"
               #Call to boskos to checkout resource
               source "./hack/boskos.sh"
@@ -494,8 +484,6 @@ periodics:
               set -o pipefail
               set -o xtrace
 
-              export PATH=$GOPATH/bin:$PATH
-              export GO111MODULE=on
               RESOURCE_TYPE="powervs"
 
               #Call to boskos to checkout resource

--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-presubmits.yaml
@@ -40,8 +40,6 @@ presubmits:
               set -o pipefail
               set -o xtrace
 
-              export PATH=$GOPATH/bin:$PATH
-              export GO111MODULE=on
               RESOURCE_TYPE="powervs"
               #Call to boskos to checkout resource
               source "./hack/boskos.sh"


### PR DESCRIPTION
- `export PATH=$GOPATH/bin:$PATH` is not needed as `kubekins-e2e` image already has this. Ref: https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e-v2/Dockerfile#L28:L29
- Go 1.16 and onwards modules are on by default Ref: https://go.dev/blog/go116-module-changes