### PR TITLE
Fix failing ci-kubernetes-ppc64le-e2e-node-latest-kubetest2

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
@@ -163,8 +163,9 @@ periodics:
               cpu: 2
               memory: 10Gi
           command:
-            - /bin/bash
+            - runner.sh
           args:
+            - bash
             - -c
             - |
               set -o errexit


### PR DESCRIPTION
https://testgrid.k8s.io/ibm-k8s-e2e-node-ppc64le#ci-kubernetes-ppc64le-e2e-node-latest-kubetest2 started failing with below error after https://github.com/kubernetes/test-infra/pull/35040
`Error: could not find kubetest2 deployer "tf"`

This is because, only this job has been using `/bin/bash` instead of `runner.sh` in the job definition. Hence fixing this.