### PR TITLE
Update image-builder pull-ova-all presubmit timeout

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-ova-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       optional: true
       decorate: true
       decoration_config:
-        timeout: 1h
+        timeout: 2h
       run_if_changed: 'images/capi/(Makefile|ansible\.cfg)|images/capi/ansible/.*|images/capi/scripts/ci-ova\.sh|images/capi/packer/(config|goss|ova)/.*|images/capi/hack/ensure-(ansible|packer|goss).*'
       path_alias: sigs.k8s.io/image-builder
       max_concurrency: 3


### PR DESCRIPTION
We're trying to update the OVA test to cover more OS's and it looks like we're seeing some cases where it will hit the 1h timeout now 
```
{"component":"entrypoint","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:169","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 1h0m0s timeout","severity":"error","time":"2025-06-26T09:12:25Z"}
```
Bumping this up to 2 hour to give some more breathing room to get these tests working.