### PR TITLE
Disable redundant pull-containerd-build job

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -1,7 +1,8 @@
 presubmits:
   containerd/containerd:
   - name: pull-containerd-build
-    always_run: true
+    always_run: false
+    optional: true
     cluster: k8s-infra-prow-build
     branches:
     - main


### PR DESCRIPTION
This job's function of building containerd artifacts on pull requests is already covered by the `binaries` job in containerd's GitHub Actions: https://github.com/containerd/containerd/blob/v2.1.3/.github/workflows/ci.yml#L183

Disabling this job is a step towards the larger goal of migrating containerd's CI off of the community-owned `prow.k8s.io` infrastructure.

Disabling this job by setting `always_run: false` and `optional: true` as a non-disruptive first step before its eventual removal.

/assign @BenTheElder 