### PR TITLE
etcd: enable pull-etcd-govulncheck for release-3.5 branch

### DIFF
--- a/config/jobs/etcd/etcd-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-postsubmits.yaml
@@ -67,6 +67,7 @@ postsubmits:
     branches:
     - main
     - release-3.6
+    - release-3.5
     - release-3.4
     decorate: true
     annotations:

--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -161,6 +161,7 @@ presubmits:
     branches:
     - main
     - release-3.6
+    - release-3.5
     - release-3.4
     decorate: true
     annotations:


### PR DESCRIPTION
This PR enables `pull-etcd-govulncheck` for release-3.5. 

ref: https://github.com/kubernetes/test-infra/issues/32754
- [x] https://github.com/etcd-io/etcd/pull/20172 

cc @ivanvc @joshjms  