### PR TITLE
to reduce hanging of cluster-api-provider-aws-build-docker test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -90,11 +90,11 @@ presubmits:
         - ./scripts/ci-docker-build.sh
         resources:
           requests:
-            cpu: "4"
-            memory: "8Gi"
+            cpu: "6"
+            memory: "12Gi"
           limits:
-            cpu: "4"
-            memory: "8Gi"
+            cpu: "6"
+            memory: "12Gi"
         # docker-in-docker needs privileged mode
         securityContext:
             privileged: true


### PR DESCRIPTION
Everytime the job [hangs](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-cluster-api-provider-aws-build-docker) seems to be due to OOM issue , hence increasing Memorylimit/requests a bit .
Increased cpu too.

