### PR TITLE
swap-conformance: run memory eviction tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -534,7 +534,7 @@ periodics:
           - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
+          - --test_args=--nodes=1 --parallelism=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
           - --timeout=180m
         env:
           - name: GOPATH
@@ -588,7 +588,7 @@ periodics:
       - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=1 --timeout=4h --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
+      - --test_args=--nodes=1 --parallelism=1 --timeout=4h --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
       - --timeout=270m
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
       resources:

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -534,7 +534,7 @@ periodics:
           - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]" --skip="\[Flaky\]|\[Slow\]|\[Benchmark\]|\[Feature:Eviction\]"
+          - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
           - --timeout=180m
         env:
           - name: GOPATH
@@ -588,7 +588,7 @@ periodics:
       - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=1 --timeout=4h --focus="\[Feature:NodeSwap\]" --skip="\[Flaky\]|\[Slow\]|\[Benchmark\]|\[Feature:Eviction\]"
+      - --test_args=--nodes=1 --timeout=4h --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
       - --timeout=270m
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
       resources:

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -534,7 +534,7 @@ periodics:
           - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
+          - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
           - --timeout=180m
         env:
           - name: GOPATH
@@ -588,7 +588,7 @@ periodics:
       - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=1 --timeout=4h --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
+      - --test_args=--nodes=1 --timeout=4h --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
       - --timeout=270m
       - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
       resources:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2462,7 +2462,7 @@ presubmits:
             - '--node-test-args=--feature-gates=NodeSwap=true --service-feature-gates=NodeSwap=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
             - --provider=gce
-            - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
+            - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
             - --timeout=180m
           env:
             - name: GOPATH
@@ -2518,7 +2518,7 @@ presubmits:
         - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
+        - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
         - --timeout=180m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
         resources:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2462,7 +2462,7 @@ presubmits:
             - '--node-test-args=--feature-gates=NodeSwap=true --service-feature-gates=NodeSwap=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
             - --provider=gce
-            - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
+            - --test_args=--nodes=1 --parallelism=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
             - --timeout=180m
           env:
             - name: GOPATH
@@ -2518,7 +2518,7 @@ presubmits:
         - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
+        - --test_args=--nodes=1 --parallelism=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" --skip="\[Flaky\]|\[Benchmark\]"
         - --timeout=180m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
         resources:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2462,7 +2462,7 @@ presubmits:
             - '--node-test-args=--feature-gates=NodeSwap=true --service-feature-gates=NodeSwap=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --fail-swap-on=false --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
             - --node-tests=true
             - --provider=gce
-            - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]" --skip="\[Flaky\]|\[Slow\]|\[Benchmark\]|\[Feature:Eviction\]"
+            - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
             - --timeout=180m
           env:
             - name: GOPATH
@@ -2518,7 +2518,7 @@ presubmits:
         - '--node-test-args=--feature-gates="NodeSwap=true" --service-feature-gates="NodeSwap=true" --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]" --skip="\[Flaky\]|\[Slow\]|\[Benchmark\]|\[Feature:Eviction\]"
+        - --test_args=--nodes=1 --focus="\[Feature:NodeSwap\]|MemoryAllocatableEviction" --skip="\[Flaky\]|\[Benchmark\]"
         - --timeout=180m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml
         resources:


### PR DESCRIPTION
/sig node
/cc @kannon92

Start running memory eviction tests on the swap-conformance lane.

This was already tried in https://github.com/kubernetes/test-infra/pull/34507 and later reverted in https://github.com/kubernetes/test-infra/pull/34558.

However, after trying to run this locally with:
> make test-e2e-node PARALLELISM=1 CLEANUP=true DELETE_INSTANCES=true FOCUS="NodeSwap|MemoryAllocatableEviction|PriorityMemoryEvictionOrdering" SKIP="dummy" SSH_USER="core" KUBE_SSH_USER=core REMOTE=true RUNTIME=remote USE_DOCKERIZED_BUILD=false IMAGE_CONFIG_FILE="/workspace/test-infra/jobs/e2e_node/swap/image-config-swap-fedora.yaml" CONTAINER_RUNTIME_ENDPOINT="unix:///var/run/crio/crio.sock" TEST_ARGS='--kubelet-flags="--fail-swap-on=false --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/  --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}" --feature-gates=NodeSwap=true --service-feature-gates="NodeSwap=true"'

all of the tests passed (for multiple times):

```
Ran 14 of 793 Specs in 1576.462 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 779 Skipped
PASS
```

I suspect that the previous problem was due to the fact we lacked the `--parallelism=1` parameter that is now added as part of this PR.