### PR TITLE
Pin DRA scalability jobs to CAPZ 1.20

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -17,7 +17,7 @@ periodics:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: main
+      base_ref: release-1.20
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     - org: kubernetes-sigs
       repo: cloud-provider-azure
@@ -123,7 +123,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: main
+        base_ref: release-1.20
         path_alias: "sigs.k8s.io/cluster-api-provider-azure"
       - org: kubernetes-sigs
         repo: cloud-provider-azure


### PR DESCRIPTION
This PR pins the SIG-Scalability DRA periodic jobs to the most recent release branch of CAPZ, which contains all the necessary changes to support the jobs and should be more stable than the main branch. CI results for the most recent change to CAPZ's release-1.20 branch (https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5736) show the scalability jobs running with the same results as the periodic jobs.

/assign @jackfrancis 