### PR TITLE
DRA canary: switch to testing with test/integration/dra/cluster

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -413,11 +413,13 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          # The latest kind is assumed to work also for older release branches, should this job get forked.
-          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          make WHAT="cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
           # "Normal" integration tests under test/integration/dra run in pull-kubernetes-integration.
-          # The "more complex" ones with a dependency on kind are under test/e2e/dra, in a separate Ginkgo suite.
-          make test WHAT="test/e2e/dra" KIND_COMMAND=kind KUBE_TIMEOUT=-timeout=30m KUBE_TEST_ARGS="-args -ginkgo.junit-report=${ARTIFACTS}/junit.xml"
+          # The "more complex" ones with a dependency on local-up-cluster.sh are under test/integration/dra/cluster, in a separate Ginkgo suite.
+          make test WHAT="test/integration/dra/cluster" KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir KUBE_TIMEOUT=-timeout=30m KUBE_TEST_ARGS="-args -ginkgo.junit-report=${ARTIFACTS}/junit.xml"
+        env:
+          - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+            value: "true"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-node/dra.generate.conf
+++ b/config/jobs/kubernetes/sig-node/dra.generate.conf
@@ -66,9 +66,7 @@ cluster = eks-prow-build-cluster
 run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*.go
 kubelet_skew = 2
 
-# This executes long-running unit tests in test/e2e/dra.
-# They don't run in pull-kubernetes-unit or pull-kubernetes-integration
-# because they are too slow and depend on kind.
+# This executes tests in test/integration/dra with special requirements (local-up-cluster.sh!).
 [dra-integration]
 description = Runs integration tests for DRA which need some additional setup in the job.
 use_dind = true

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -117,11 +117,13 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          # The latest kind is assumed to work also for older release branches, should this job get forked.
-          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          make WHAT="cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
           # "Normal" integration tests under test/integration/dra run in pull-kubernetes-integration.
-          # The "more complex" ones with a dependency on kind are under test/e2e/dra, in a separate Ginkgo suite.
-          make test WHAT="test/e2e/dra" KIND_COMMAND=kind KUBE_TIMEOUT=-timeout=30m KUBE_TEST_ARGS="-args -ginkgo.junit-report=${ARTIFACTS}/junit.xml"
+          # The "more complex" ones with a dependency on local-up-cluster.sh are under test/integration/dra/cluster, in a separate Ginkgo suite.
+          make test WHAT="test/integration/dra/cluster" KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir KUBE_TIMEOUT=-timeout=30m KUBE_TEST_ARGS="-args -ginkgo.junit-report=${ARTIFACTS}/junit.xml"
+        env:
+          - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+            value: "true"
 
         {%- elif job_type == "e2e" %}
         args:


### PR DESCRIPTION
Needs local-up-cluster.sh now instead of kind.

/assign @dims 