### PR TITLE
prow: add release-note and require-matching-label to k/autoscaler

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -695,6 +695,7 @@ tide:
     - kubernetes/sample-controller
     - kubernetes-sigs/cloud-provider-azure
     - kubernetes-sigs/cluster-api
+    - kubernetes/autoscaler
     labels:
     - lgtm
     - approved
@@ -792,6 +793,22 @@ tide:
       - do-not-merge/needs-area
       - do-not-merge/release-note-label-needed
       - do-not-merge/work-in-progress
+  - repos:
+    - kubernetes/autoscaler
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - do-not-merge/needs-area
   merge_method:
     kubernetes-client/csharp: squash
     kubernetes-client/gen: squash

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -931,6 +931,16 @@ require_matching_label:
     Area labels can be added by org members by writing `/area ${COMPONENT}` in a comment
 
     Please see the [labels list](https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md#labels-that-apply-to-kubernetes-sigscluster-api-for-both-issues-and-prs) for possible areas.
+- missing_label: do-not-merge/needs-area
+  org: kubernetes
+  repo: autoscaler
+  issues: false
+  prs: true
+  regexp: ^area/
+  missing_comment: |
+    This PR is currently missing an area label, which is used to identify the modified component when generating release notes.
+
+    Area labels can be added by org members by writing `/area ${COMPONENT}` in a comment
 - missing_label: needs-priority
   org: kubernetes-sigs
   repo: cluster-api
@@ -1250,6 +1260,8 @@ plugins:
   kubernetes/autoscaler:
     plugins:
     - milestone
+    - release-note
+    - require-matching-label
 
   kubernetes/cloud-provider-aws:
     plugins:


### PR DESCRIPTION
This PR updates the prow configuration for the `kubernetes/autoscaler` repository to add the `release-note` and `require-matching-label` plugins.

More specifically, we want block PR merges that don't declare an `area/` label prefix.