### PR TITLE
Tune resource requests for cluster-api-provider-aws-build-docker

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -90,14 +90,14 @@ presubmits:
         - ./scripts/ci-docker-build.sh
         resources:
           requests:
-            cpu: "6"
-            memory: "12Gi"
+            cpu: "4"
+            memory: "8Gi"
           limits:
-            cpu: "6"
-            memory: "12Gi"
+            cpu: "4"
+            memory: "8Gi"
         # docker-in-docker needs privileged mode
         securityContext:
-            privileged: true
+          privileged: true
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-build-docker


### PR DESCRIPTION
Reduce the memory limit back to 8Gi now we have reduced parallelism of the job. We observe it using approximately 6Gi, so 8Gi is safe headroom.

Also reduce CPU back to 4 as that's what it was until recently and the performance was acceptable.