### PR TITLE
DRA: enable CDI for Docker-in-Docker

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -418,7 +418,7 @@ presubmits:
           # The "more complex" ones with a dependency on local-up-cluster.sh are under test/integration/dra/cluster, in a separate Ginkgo suite.
           make test WHAT="test/integration/dra/cluster" KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir KUBE_TIMEOUT=-timeout=30m KUBE_TEST_ARGS="-args -ginkgo.junit-report=${ARTIFACTS}/junit.xml"
         env:
-          - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          - name: CDI_IN_DOCKER_ENABLED
             value: "true"
         # docker-in-docker needs privileged mode
         securityContext:

--- a/config/jobs/kubernetes/sig-node/dra.generate.conf
+++ b/config/jobs/kubernetes/sig-node/dra.generate.conf
@@ -70,6 +70,7 @@ kubelet_skew = 2
 [dra-integration]
 description = Runs integration tests for DRA which need some additional setup in the job.
 use_dind = true
+use_dind_cdi = true
 job_type = integration
 cluster = eks-prow-build-cluster
 run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*.go

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -122,7 +122,7 @@ presubmits:
           # The "more complex" ones with a dependency on local-up-cluster.sh are under test/integration/dra/cluster, in a separate Ginkgo suite.
           make test WHAT="test/integration/dra/cluster" KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir KUBE_TIMEOUT=-timeout=30m KUBE_TEST_ARGS="-args -ginkgo.junit-report=${ARTIFACTS}/junit.xml"
         env:
-          - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          - name: CDI_IN_DOCKER_ENABLED
             value: "true"
 
         {%- elif job_type == "e2e" %}

--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -42,6 +42,19 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     echo "Docker in Docker enabled, initializing..."
     printf '=%.0s' {1..80}; echo
 
+    # optionally enable CDI in Docker/containerd (see https://github.com/cncf-tags/container-device-interface?tab=readme-ov-file#docker-configuration)
+    export CDI_IN_DOCKER_ENABLED=${CDI_IN_DOCKER_ENABLED:-false}
+    if [[ "${CDI_IN_DOCKER_ENABLED}" == "true" ]]; then
+        echo "Enabling CDI for Docker."
+        cat /etc/docker/daemon.json <<EOF
+{
+  "features": {
+    "cdi": true
+  }
+}
+EOF
+    fi
+
     # docker v27+ has ipv6 by default, but not all e2e hosts have everything
     # we need enabled by default
     # enable ipv6


### PR DESCRIPTION
When using containerd in a local-up-cluster for testing DRA, CDI must be enabled.

DOCKER_IN_DOCKER_IPV6_ENABLED was set unnecessarily because of cut-and-paste, it no longer has an effect.

/assign @dims 