### PR TITLE
kOps - Add back bare-metal e2e tests from required contexts

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -360,6 +360,7 @@ branch-protection:
         kops:
           required_status_checks:
             contexts:
+            - tests-e2e-scenarios-bare-metal
             - build-linux-amd64
             - build-linux-arm64
             - build-macos-amd64


### PR DESCRIPTION
Reverts kubernetes/test-infra#34627

/cc @ameukam @rifelpet 