### PR TITLE
DRA canary: debug containerd setup, II

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -501,7 +501,10 @@ presubmits:
         - |
           cat /etc/docker/daemon.json
           ps -efww
-          lsof -p `pidof containerd`
+          cat /var/run/docker/containerd/containerd.toml || true
+          ls -l /etc/containerd/runtime_*.toml || true
+          cat /etc/containerd/runtime_*.toml || true
+          exit 1
           make WHAT="cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
           # "Normal" integration tests under test/integration/dra run in pull-kubernetes-integration.
           # The "more complex" ones with a dependency on local-up-cluster.sh are under test/integration/dra/cluster, in a separate Ginkgo suite.

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -119,7 +119,10 @@ presubmits:
         - |
           cat /etc/docker/daemon.json
           ps -efww
-          lsof -p `pidof containerd`
+          cat /var/run/docker/containerd/containerd.toml || true
+          ls -l /etc/containerd/runtime_*.toml || true
+          cat /etc/containerd/runtime_*.toml || true
+          exit 1
           make WHAT="cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
           # "Normal" integration tests under test/integration/dra run in pull-kubernetes-integration.
           # The "more complex" ones with a dependency on local-up-cluster.sh are under test/integration/dra/cluster, in a separate Ginkgo suite.


### PR DESCRIPTION
Despite "Enabling CDI for Docker", CDI still seems to be disabled when using local-up-cluster.sh. Perhaps these debug statements will show something.

/assign @bart0sh 