### PR TITLE
Add the HostnameOverride feature gate to the pull-kubernetes-e2e-gce-cos-alpha-features test job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -477,7 +477,7 @@ presubmits:
         - --gcp-region=us-central1
         - --provider=gce
         - --runtime-config=api/all=true
-        - --test_args=--ginkgo.focus=\[Feature:(WatchList|InPlacePodVerticalScaling|APIServerTracing|SidecarContainers|StorageVersionAPI|PodPreset|PodLifecycleSleepAction|PodLifecycleSleepActionAllowZero|RecoverVolumeExpansionFailure)\] --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0|\[KubeUp\] --minStartupPods=8
+        - --test_args=--ginkgo.focus=\[Feature:(WatchList|InPlacePodVerticalScaling|APIServerTracing|SidecarContainers|StorageVersionAPI|PodPreset|PodLifecycleSleepAction|PodLifecycleSleepActionAllowZero|RecoverVolumeExpansionFailure|HostnameOverride)\] --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0|\[KubeUp\] --minStartupPods=8
         - --timeout=180m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250702-e205934cd3-master
         resources:


### PR DESCRIPTION
Add the HostnameOverride feature gate to the pull-kubernetes-e2e-gce-cos-alpha-features test job, so we can test the EnvFiles feature gate in alpha-stage PRs.

relate PR: https://github.com/kubernetes/kubernetes/pull/132558