### PR TITLE
add to ci  jobs with an equivalent presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -474,6 +474,64 @@ periodics:
     testgrid-tab-name: ci-crio-cgroupv1-node-e2e-eviction
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v1"
+- name: ci-crio-cgroupv1-node-e2e-eviction-canary
+  cluster: k8s-infra-prow-build
+  interval: 4h30m
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-pull-kubernetes-e2e: "true"
+    preset-pull-kubernetes-e2e-gce: "true"
+  decorate: true
+  decoration_config:
+    timeout: 320m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  annotations:
+    testgrid-dashboards: sig-node-cri-o
+    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-eviction-canary
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v1"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250702-e205934cd3-master
+      command:
+      - runner.sh
+      args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-central1-b
+      - --parallelism=1
+      - --focus-regex=\[Feature:Eviction\]
+      - --skip-regex=""
+      - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+      - --timeout=300m
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
+      resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 4
+          memory: 6Gi
+      env:
+        - name: GOPATH
+          value: /go
+        - name: KUBE_SSH_USER
+          value: core
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
 - name: ci-crio-cgroupv2-node-e2e-eviction
   cluster: k8s-infra-prow-build
   interval: 4h30m
@@ -526,6 +584,64 @@ periodics:
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-eviction
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
+- name: ci-crio-cgroupv2-node-e2e-eviction-canary
+  cluster: k8s-infra-prow-build
+  interval: 4h30m
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-pull-kubernetes-e2e: "true"
+    preset-pull-kubernetes-e2e-gce: "true"
+  decorate: true
+  decoration_config:
+    timeout: 320m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  annotations:
+    testgrid-dashboards: sig-node-cri-o
+    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-eviction-canary
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250702-e205934cd3-master
+      command:
+      - runner.sh
+      args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-central1-b
+      - --parallelism=1
+      - --focus-regex=\[Feature:Eviction\]
+      - --skip-regex=""
+      - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+      - --timeout=300m
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2.yaml
+      resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 4
+          memory: 6Gi
+      env:
+        - name: GOPATH
+          value: /go
+        - name: KUBE_SSH_USER
+          value: core
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
 - name: ci-node-kubelet-crio-cgroupv2-performance-test
   cluster: k8s-infra-prow-build
   interval: 12h
@@ -734,6 +850,63 @@ periodics:
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-resource-managers
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes CPU, Memory and Topology manager e2e tests with cgroup v2"
+- name: ci-crio-cgroupv2-node-e2e-resource-managers-canary
+  cluster: k8s-infra-prow-build
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-pull-kubernetes-e2e: "true"
+    preset-pull-kubernetes-e2e-gce: "true"
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  annotations:
+    testgrid-dashboards: sig-node-cri-o
+    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-resource-managers-canary
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: "Executes CPU, Memory and Topology manager e2e tests with cgroup v2"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250702-e205934cd3-master
+      command:
+      - runner.sh
+      args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-central1-b
+      - --parallelism=1
+      - --skip-regex=""
+      - '--label-filter=Feature: isSubsetOf { CPUManager, MemoryManager, TopologyManager }'
+      - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-resource-managers.yaml
+      resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 4
+          memory: 6Gi
+      env:
+        - name: GOPATH
+          value: /go
+        - name: KUBE_SSH_USER
+          value: core
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
 - name: ci-crio-cgroupv1-node-e2e-hugepages
   cluster: k8s-infra-prow-build
   interval: 4h
@@ -786,6 +959,63 @@ periodics:
     testgrid-tab-name: ci-crio-cgroupv1-node-e2e-hugepages
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes hugepages e2e tests"
+- name: ci-crio-cgroupv1-node-e2e-hugepages-canary
+  cluster: k8s-infra-prow-build
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-pull-kubernetes-e2e: "true"
+    preset-pull-kubernetes-e2e-gce: "true"
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  annotations:
+    testgrid-dashboards: sig-node-cri-o
+    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-hugepages-canary
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: "Executes hugepages e2e tests"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250702-e205934cd3-master
+      command:
+      - runner.sh
+      args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-central1-b
+      - --parallelism=1
+      - --focus-regex=\[Feature:HugePages\]
+      - --skip-regex=""
+      - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-hugepages.yaml
+      resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 4
+          memory: 6Gi
+      env:
+        - name: GOPATH
+          value: /go
+        - name: KUBE_SSH_USER
+          value: core
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
 - name: ci-crio-cgroupv2-node-e2e-hugepages
   cluster: k8s-infra-prow-build
   interval: 4h
@@ -838,6 +1068,63 @@ periodics:
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-hugepages
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes hugepages e2e tests"
+- name: ci-crio-cgroupv2-node-e2e-hugepages-canary
+  cluster: k8s-infra-prow-build
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-pull-kubernetes-e2e: "true"
+    preset-pull-kubernetes-e2e-gce: "true"
+  decorate: true
+  decoration_config:
+    timeout: 120m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  annotations:
+    testgrid-dashboards: sig-node-cri-o
+    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-hugepages-canary
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    description: "Executes hugepages e2e tests"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250702-e205934cd3-master
+      command:
+      - runner.sh
+      args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-central1-b
+      - --parallelism=1
+      - --focus-regex=\[Feature:HugePages\]
+      - --skip-regex=""
+      - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-hugepages.yaml
+      resources:
+        limits:
+          cpu: 4
+          memory: 6Gi
+        requests:
+          cpu: 4
+          memory: 6Gi
+      env:
+        - name: GOPATH
+          value: /go
+        - name: KUBE_SSH_USER
+          value: core
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
 - name: ci-crio-cgroupv1-evented-pleg
   cluster: k8s-infra-prow-build
   interval: 3h


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/issues/32567

Add canary jobs to eventually replace periodic jobs.
Included in this PR the jobs that has an equivalent presubmit job.

[First part ](https://github.com/kubernetes/test-infra/pull/34992)of adding canary resulted as expected so this is a second batch.

cc: @kannon92 