### PR TITLE
Increase DRA load test repeats and api avail threshold

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -94,7 +94,9 @@ periodics:
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
           value: "true"
         - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-          value: "99.5"
+          value: "99.99"
+        - name: CL2_REPEATS
+          value: "10"
         resources:
           requests:
             cpu: "6"


### PR DESCRIPTION
This PR increases the CL2 test repeats and increases API server availability threshold to figure out issues with DRA being less available than normal load test