### PR TITLE
Update DRA scalability job with CL2 with more logs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -7,8 +7,8 @@ periodics:
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
-      timeout: 8h
-    interval: 12h
+      timeout: 6h
+    interval: 6h
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     labels:
       preset-dind-enabled: "true"
@@ -27,9 +27,9 @@ periodics:
       repo: kubernetes
       base_ref: master
       path_alias: k8s.io/kubernetes
-    - org: kubernetes
+    - org: nojnhuh
       repo: perf-tests
-      base_ref: master
+      base_ref: api-avail-err-log
       path_alias: k8s.io/perf-tests
     spec:
       serviceAccountName: azure


### PR DESCRIPTION
This PR updates the CL2 used for the Azure DRA scale test with these changes: https://github.com/kubernetes/perf-tests/compare/master...nojnhuh:perf-tests:api-avail-err-log

/assign @jackfrancis 