### PR TITLE
Sync Azure DRA presubmit with periodic

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -7,8 +7,8 @@ periodics:
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
-      timeout: 6h
-    interval: 6h
+      timeout: 3h
+    interval: 3h
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
@@ -4,7 +4,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
-      timeout: 8h
+      timeout: 3h
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     always_run: false
     optional: true
@@ -24,9 +24,9 @@ presubmits:
       repo: kubernetes
       base_ref: master
       path_alias: k8s.io/kubernetes
-    - org: kubernetes
+    - org: nojnhuh
       repo: perf-tests
-      base_ref: master
+      base_ref: api-avail-err-log
       path_alias: k8s.io/perf-tests
     spec:
       serviceAccountName: azure
@@ -91,7 +91,7 @@ presubmits:
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
           value: "true"
         - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-          value: "99.5"
+          value: "99.99"
         resources:
           requests:
             cpu: "6"


### PR DESCRIPTION
Follow-up from #35104 and #35105 to sync the presubmit CAPZ DRA job with its corresponding periodic job.