### PR TITLE
Revert the test images back to latest

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.32-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.32-windows-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
     labels:
       preset-azure-community: "true"
       preset-capz-containerd-1-7-latest: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
       preset-capz-windows-common-pull: "true"
       preset-dind-enabled: "true"
     optional: true

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.32-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.32-windows.yaml
@@ -26,7 +26,7 @@ periodics:
   labels:
     preset-azure-community: "true"
     preset-capz-containerd-1-7-latest: "true"
-    preset-capz-windows-2022-202503b: "true"
+    preset-capz-windows-2022: "true"
     preset-capz-windows-common: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -61,7 +61,7 @@ periodics:
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
-    preset-capz-windows-2022-202503b: "true"
+    preset-capz-windows-2022: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
     labels:
       preset-azure-community: "true"
       preset-capz-containerd-1-7-latest: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
       preset-capz-windows-common-pull: "true"
       preset-dind-enabled: "true"
     optional: true

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows.yaml
@@ -26,7 +26,7 @@ periodics:
   labels:
     preset-azure-community: "true"
     preset-capz-containerd-1-7-latest: "true"
-    preset-capz-windows-2022-202503b: "true"
+    preset-capz-windows-2022: "true"
     preset-capz-windows-common: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -61,7 +61,7 @@ periodics:
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
-    preset-capz-windows-2022-202503b: "true"
+    preset-capz-windows-2022: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"
       preset-azure-community: "true"
@@ -81,7 +81,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"
       preset-azure-community: "true"
@@ -140,7 +140,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common-pull: "true"
       preset-azure-community: "true"
@@ -199,7 +199,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-azure-community: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
       preset-capz-windows-common-pull: "true"
     extra_refs:
       - org: kubernetes-sigs
@@ -256,7 +256,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-azure-community: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
       preset-capz-windows-common-pull: "true"
       preset-capz-containerd-1-7-latest: "true"
     extra_refs:
@@ -320,7 +320,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
       preset-capz-windows-common: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
       preset-capz-containerd-1-7-latest: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -383,7 +383,7 @@ presubmits:
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-azure-community: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -485,7 +485,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
       preset-azure-community: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -536,7 +536,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
       preset-azure-community: "true"
     extra_refs:
     - org: kubernetes-sigs
@@ -590,7 +590,7 @@ presubmits:
       preset-azure-community: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -647,7 +647,7 @@ presubmits:
       preset-azure-community: "true"
       preset-capz-windows-common: "true"
       preset-capz-containerd-1-7-latest: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
@@ -706,7 +706,7 @@ presubmits:
       preset-azure-community: "true"
       preset-capz-containerd-1-7-latest: "true"
       preset-capz-windows-common: "true"
-      preset-capz-windows-2022-202503b: "true"
+      preset-capz-windows-2022: "true"
     extra_refs:
     - org: kubernetes
       repo: kubernetes

--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -27,13 +27,6 @@ presets:
   - name: WINDOWS_SERVER_VERSION
     value: "windows-2022"
 - labels:
-    preset-capz-windows-2022-202503b: "true"
-  env:
-  - name: WINDOWS_SERVER_VERSION
-    value: "windows-2022"
-  - name: IMAGE_VERSION
-    value: "1.32.3"
-- labels:
     preset-capz-windows-2025: "true"
   env:
   - name: GALLERY_IMAGE_NAME
@@ -91,7 +84,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-capz-windows-common: "true"
-    preset-capz-windows-2022-202503b: "true"
+    preset-capz-windows-2022: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-azure-community: "true"
   extra_refs:
@@ -145,7 +138,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-capz-windows-common: "true"
-    preset-capz-windows-2022-202503b: "true"
+    preset-capz-windows-2022: "true"
     preset-capz-containerd-2-0-latest: "true"
     preset-azure-community: "true"
   extra_refs:
@@ -198,7 +191,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-community: "true"
     preset-capz-windows-common: "true"
-    preset-capz-windows-2022-202503b: "true"
+    preset-capz-windows-2022: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
     preset-capz-gmsa-setup: "true"
@@ -255,7 +248,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-community: "true"
     preset-capz-windows-common: "true"
-    preset-capz-windows-2022-202503b: "true"
+    preset-capz-windows-2022: "true"
     preset-capz-containerd-1-7-latest: "true"
     preset-capz-serial-slow: "true"
   extra_refs:
@@ -309,7 +302,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-community: "true"
     preset-capz-windows-common: "true"
-    preset-capz-windows-2022-202503b: "true"
+    preset-capz-windows-2022: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -361,7 +354,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-community: "true"
     preset-capz-windows-common: "true"
-    preset-capz-windows-2022-202503b: "true"
+    preset-capz-windows-2022: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -421,7 +414,7 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-community: "true"
     preset-capz-windows-common: "true"
-    preset-capz-windows-2022-202503b: "true"
+    preset-capz-windows-2022: "true"
     preset-capz-containerd-1-7-latest: "true"
   extra_refs:
   - org: kubernetes-sigs


### PR DESCRIPTION
The commit here: https://github.com/kubernetes-sigs/image-builder/commit/78d1b28e21d0bf193f7ab03f5a6c5f9e04f47680 is supposed to work around an issue in windows 2022 image, which make the windows test grid flaky. with that, we can revert the image back to use the latest ones