### PR TITLE
Azure scale: Disable host-level API availability checks

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -898,6 +898,11 @@ presubmits:
           value: "true"
         - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
           value: "99.5"
+        # CAPZ clusters don't expose each individual control plane node.
+        - name: CL2_API_AVAILABILITY_MEASUREMENT_IPS_CONFIGURED
+          value: "true"
+        - name: CL2_API_AVAILABILITY_MEASUREMENT_USE_INTERNAL_IPS
+          value: "false"
         # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy
         - name: DEPLOY_AZURE_CSI_DRIVER
           value: "false"

--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
@@ -92,6 +92,11 @@ presubmits:
           value: "true"
         - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
           value: "99.99"
+        # CAPZ clusters don't expose each individual control plane node.
+        - name: CL2_API_AVAILABILITY_MEASUREMENT_IPS_CONFIGURED
+          value: "true"
+        - name: CL2_API_AVAILABILITY_MEASUREMENT_USE_INTERNAL_IPS
+          value: "false"
         - name: CL2_NODE_AVAILABLE_MILLICORES
           value: "2000"
         - name: CL2_SYSTEM_USED_MILLICORES


### PR DESCRIPTION
The Azure clusters built for SIG-Scalability tests don't expose each control plane node behind a different address, only a shared public load balancer with a single IP and port. The host-level checks that are enabled by default for the APIAvailabilty CL2 test are thus failing and adding lots of noise to logs. This change disables those checks in favor of the cluster-wide one.

These changes are based on this snippet of the CL2 config:
https://github.com/kubernetes/perf-tests/blob/690e2e8bcf598bba7d773c85dc3f871719198f90/clusterloader2/testing/load/modules/measurements.yaml#L135-L147

And here where those values are used:
https://github.com/kubernetes/perf-tests/blob/690e2e8bcf598bba7d773c85dc3f871719198f90/clusterloader2/pkg/measurement/common/api_availability_measurement.go#L204

Initially these changes are only made to the presubmit jobs. Once we determine they do what we expect, we'll promote them to the periodic jobs.

/assign @jackfrancis 