### PR TITLE
Set CSI_PROW_E2E_VERSION=v1.33.0 for lib-volume-populator 1-31-on-kubernetes-1-31 and 1-32-on-kubernetes-1-32

### DIFF
--- a/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
+++ b/config/jobs/kubernetes-csi/lib-volume-populator/lib-volume-populator-config.yaml
@@ -33,6 +33,9 @@ presubmits:
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.31.0"
+        # Use K8s 1.33+ e2e test version: https://github.com/kubernetes-csi/lib-volume-populator/issues/221
+        - name: CSI_PROW_E2E_VERSION
+          value: "v1.33.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.31"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX
@@ -130,6 +133,9 @@ presubmits:
         # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.32.0"
+        # Use K8s 1.33+ e2e test version: https://github.com/kubernetes-csi/lib-volume-populator/issues/221
+        - name: CSI_PROW_E2E_VERSION
+          value: "v1.33.0"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.32"
         - name: CSI_PROW_DEPLOYMENT_SUFFIX


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-csi/lib-volume-populator/issues/221

This bumps prow jobs `pull-kubernetes-csi-lib-volume-populator-1-31-on-kubernetes-1-31` and `pull-kubernetes-csi-lib-volume-populator-1-32-on-kubernetes-1-32` to use the Kubernetes 1.33.0 tag as the e2e test base. This version has fixes from https://github.com/kubernetes/kubernetes/pull/129085, which fixes the volume expansion offline test logic.