### PR TITLE
Drop usages sigs.k8s.io/yaml/goyaml.v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tektoncd/pipeline v0.45.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.2
 	go4.org v0.0.0-20201209231011-d4a079459e60 // indirect
 	gocloud.dev v0.19.0 // indirect
 	golang.org/x/crypto v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -670,6 +670,8 @@ go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95a
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
+go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
+go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 go4.org v0.0.0-20201209231011-d4a079459e60 h1:iqAGo78tVOJXELHQFRjR6TMwItrvXH4hrGJ32I/NFF8=
 go4.org v0.0.0-20201209231011-d4a079459e60/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=
 gocloud.dev v0.19.0 h1:EDRyaRAnMGSq/QBto486gWFxMLczAfIYUmusV7XLNBM=

--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 	"text/template"
 
+	gyaml "go.yaml.in/yaml/v2"
 	"sigs.k8s.io/yaml"
-	gyaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	v1 "k8s.io/api/core/v1"
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"

--- a/releng/config-rotator/main.go
+++ b/releng/config-rotator/main.go
@@ -24,8 +24,8 @@ import (
 	"os"
 	"strings"
 
+	gyaml "go.yaml.in/yaml/v2"
 	"sigs.k8s.io/yaml"
-	gyaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	"sigs.k8s.io/prow/pkg/config"
 )


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/132056

Switch usages of `"sigs.k8s.io/yaml/goyaml.v2"` to `"go.yaml.in/yaml/v2"` to drop usages of forked code.
