### PR TITLE
[kjob] Remove E2E tests for k8s 1.30.

### DIFF
--- a/config/jobs/kubernetes-sigs/kjob/kjob-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-periodics-main.yaml
@@ -78,51 +78,6 @@ periodics:
               cpu: "2"
               memory: "4Gi"
   - interval: 12h
-    name: periodic-kjob-test-e2e-main-1-30
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-kjob-test-e2e-main-1-30
-      testgrid-alert-email: kjob-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kjob end to end tests for Kubernetes 1.30"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kjob
-        base_ref: main
-        path_alias: kubernetes-sigs/kjob
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250710-e96fecb3d6-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.30.10
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "4"
-              memory: "4Gi"
-            limits:
-              cpu: "4"
-              memory: "4Gi"
-  - interval: 12h
     name: periodic-kjob-test-e2e-main-1-31
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-periodics-release-0.1.yaml
@@ -78,51 +78,6 @@ periodics:
               cpu: "2"
               memory: "4Gi"
   - interval: 12h
-    name: periodic-kjob-test-e2e-release-0-1-1-30
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-kjob-test-e2e-release-0-1-1-30
-      testgrid-alert-email: kjob-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kjob end to end tests for Kubernetes 1.30"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kjob
-        base_ref: release-0.1
-        path_alias: kubernetes-sigs/kjob
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250710-e96fecb3d6-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.30.10
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "4"
-              memory: "4Gi"
-            limits:
-              cpu: "4"
-              memory: "4Gi"
-  - interval: 12h
     name: periodic-kjob-test-e2e-release-0-1-1-31
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-main.yaml
@@ -91,43 +91,6 @@ presubmits:
               limits:
                 cpu: "2"
                 memory: "4Gi"
-    - name: pull-kjob-test-e2e-main-1-30
-      cluster: eks-prow-build-cluster
-      branches:
-        - ^main
-      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-      decorate: true
-      path_alias: sigs.k8s.io/kjob
-      annotations:
-        testgrid-dashboards: sig-apps
-        testgrid-tab-name: pull-kjob-test-e2e-main-1-30
-        description: "Run kjob end to end tests for Kubernetes 1.30"
-      labels:
-        preset-dind-enabled: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250710-e96fecb3d6-master
-            env:
-              - name: E2E_KIND_VERSION
-                value: kindest/node:v1.30.10
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
-            command:
-              # generic runner script, handles DIND, bazelrc for caching, etc.
-              - runner.sh
-            args:
-              - make
-              - test-e2e
-            # docker-in-docker needs privileged mode
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                cpu: "4"
-                memory: "4Gi"
-              limits:
-                cpu: "4"
-                memory: "4Gi"
     - name: pull-kjob-test-e2e-main-1-31
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-release-0.1.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-release-0.1.yaml
@@ -91,43 +91,6 @@ presubmits:
               limits:
                 cpu: "2"
                 memory: "4Gi"
-    - name: pull-kjob-test-e2e-release-0-1-1-30
-      cluster: eks-prow-build-cluster
-      branches:
-        - ^release-0.1
-      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
-      decorate: true
-      path_alias: sigs.k8s.io/kjob
-      annotations:
-        testgrid-dashboards: sig-apps
-        testgrid-tab-name: pull-kjob-test-e2e-release-0-1-1-30
-        description: "Run kjob end to end tests for Kubernetes 1.30"
-      labels:
-        preset-dind-enabled: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250710-e96fecb3d6-master
-            env:
-              - name: E2E_KIND_VERSION
-                value: kindest/node:v1.30.10
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
-            command:
-              # generic runner script, handles DIND, bazelrc for caching, etc.
-              - runner.sh
-            args:
-              - make
-              - test-e2e
-            # docker-in-docker needs privileged mode
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                cpu: "4"
-                memory: "4Gi"
-              limits:
-                cpu: "4"
-                memory: "4Gi"
     - name: pull-kjob-test-e2e-release-0-1-1-31
       cluster: eks-prow-build-cluster
       branches:


### PR DESCRIPTION
Kubernetes 1.30 End of Life 2025-06-28.

https://kubernetes.io/releases/#release-v1-30