### PR TITLE
pull-test-infra-gubernator is not optional

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -6,6 +6,7 @@ presubmits:
     - master
     run_if_changed: 'gubernator|config/prow/config.yaml|config/jobs/.+\.yaml'
     decorate: true
+    optional: false
     labels:
       preset-service-account: "true"
     spec:


### PR DESCRIPTION
this has some useful tests and used to be required, it's working reliably and should be required again

cc @dims @aojea 