### PR TITLE
Re-enable compaction conformance tests in kind-alpha-beta test suites

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -947,10 +947,8 @@ periodics:
         value: '{"api/all":"true"}'
       - name: LABEL_FILTER
         value: "(Conformance || sig-network ) && !Feature: containsAny {Networking-IPv6, LoadBalancer, IPv6DualStack} && !Disruptive && !Flaky"
-      # ListFromCacheSnapshot does not implement the compaction behavior for watch cache defined in "Servers with support for API chunking should support continue listing from the last key if the original version has been compacted away" conformance test so it flakes
-      # Ref: https://issues.k8s.io/131011
       - name: SKIP
-        value: Servers.with.support.for.API.chunking.should.support.continue.listing.from.the.last.key.if.the.original.version.has.been.compacted.away|SCTPConnectivity
+        value: SCTPConnectivity
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -134,10 +134,6 @@ periodics:
         value: '{"api/alpha":"true", "api/ga":"true"}'
       - name: LABEL_FILTER
         value: "Feature: isSubsetOf OffByDefault && !BetaOffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
-      # ListFromCacheSnapshot does not implement the compaction behavior for watch cache defined in "Servers with support for API chunking should support continue listing from the last key if the original version has been compacted away" conformance test so it flakes
-      # Ref: https://issues.k8s.io/131011
-      - name: SKIP
-        value: Servers.with.support.for.API.chunking.should.support.continue.listing.from.the.last.key.if.the.original.version.has.been.compacted.away
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -236,10 +232,6 @@ periodics:
         value: '{"api/all":"true"}'
       - name: LABEL_FILTER
         value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
-      # ListFromCacheSnapshot does not implement the compaction behavior for watch cache defined in "Servers with support for API chunking should support continue listing from the last key if the original version has been compacted away" conformance test so it flakes
-      # Ref: https://issues.k8s.io/131011
-      - name: SKIP
-        value: Servers.with.support.for.API.chunking.should.support.continue.listing.from.the.last.key.if.the.original.version.has.been.compacted.away
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
The test should pass after https://github.com/kubernetes/kubernetes/pull/132876

This reverts https://github.com/kubernetes/test-infra/pull/34587

/assign @aojea @BenTheElder 

Fixes https://github.com/kubernetes/kubernetes/issues/131011

Tested on older version of PR, still need to retest on master branch.