### PR TITLE
crio: bump to latest main on canary job

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupv2_canary.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv2_canary.ign
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D9cdf516777eb88e515173650bf28af18a87ec23f%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/templates/base/env-canary.yaml
+++ b/jobs/e2e_node/crio/templates/base/env-canary.yaml
@@ -7,4 +7,4 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
-          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
+          DefaultEnvironment="CRIO_COMMIT=9cdf516777eb88e515173650bf28af18a87ec23f"

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_canary.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_canary.yaml
@@ -33,7 +33,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
-          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
+          DefaultEnvironment="CRIO_COMMIT=9cdf516777eb88e515173650bf28af18a87ec23f"
 systemd:
   units:
     - name: configure-sysctl.service


### PR DESCRIPTION
primarily to fix prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-crio-cgroupv2-userns-e2e-serial/1942627412084789248 though we won't see that in this job (not userns)