### PR TITLE
revert scability master back to n1 machines

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -274,7 +274,7 @@ presets:
   env:
   # Override GCE defaults.
   - name: MASTER_SIZE
-    value: "e2-standard-4"
+    value: "n1-standard-4"
   - name: NODE_SIZE
     value: "e2-standard-8"
   - name: NODE_DISK_SIZE


### PR DESCRIPTION
Potentially fixes https://github.com/kubernetes/kubernetes/issues/132909.

Looking at the logs, I see the following:

```
WARNING: You have selected a disk size of under [200GB]. This may result in poor I/O performance. For more information, see: https://developers.google.com/compute/docs/disks#performance.
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - Setting minimum CPU platform is not supported for the selected machine type e2-standard-4.
Failed to create master instance due to non-retryable error
```

It looks like the switch to e2 everywhere broke some of the scalability lanes

