### PR TITLE
Increase KUBE_TIMEOUT value for ci-kubernetes-unit-ppc64le job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-periodics.yaml
@@ -23,6 +23,9 @@ periodics:
           command:
             - make
             - test
+          env:
+            - name: KUBE_TIMEOUT
+              value: "-timeout=300s"
           securityContext:
             allowPrivilegeEscalation: false
           resources:


### PR DESCRIPTION
This is to stop https://testgrid.k8s.io/ibm-k8s-unit-tests-ppc64le from failing