### PR TITLE
feature: add memory limit to env variable for pull-kubernetes-verify

### DIFF
--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -19,6 +19,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250710-e96fecb3d6-master
         imagePullPolicy: Always
+        name: verify
         command:
         - runner.sh
         args:
@@ -32,6 +33,11 @@ presubmits:
           value: master
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
+        - name: VERIFY_MEM_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: verify
+              resource: limits.memory
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
#### What type of PR is this?

/sig testing
/kind cleanup

#### What this PR does / why we need it:

precondition of PR [ci: delaying golang gc for 'make verify' to speed up prow jobs #132917](https://github.com/kubernetes/kubernetes/pull/132917)

#### Which issue(s) this PR is related to:

[Tracking Issue: Presubmit Performance #130762](https://github.com/kubernetes/kubernetes/issues/130762)
[prow check speeding up: pull-kubernetes-verify #132758](https://github.com/kubernetes/kubernetes/issues/132758)

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
