### PR TITLE
Update kubekins-v2 to Go 1.24.5 for master and canary

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,12 +1,12 @@
 variants:
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.24.4
+    GO_VERSION: 1.24.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   master:
     CONFIG: master
-    GO_VERSION: 1.24.4
+    GO_VERSION: 1.24.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   '1.33':


### PR DESCRIPTION
xref: https://github.com/kubernetes/release/issues/4055

/assign @ameukam @dims @saschagrunert  
cc @kubernetes/release-managers 