### PR TITLE
Remove unneeded AZURE_LOCATION from load test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -873,8 +873,6 @@ presubmits:
           value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-load.yaml"
-        - name: AZURE_LOCATION
-          value: "northeurope"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
           value: "Standard_D8s_v3"
         - name: CONTROL_PLANE_MACHINE_TYPE
@@ -976,8 +974,6 @@ presubmits:
           value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-load-dra.yaml"
-        - name: AZURE_LOCATION
-          value: "northeurope"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
           value: "Standard_D8s_v3"
         - name: CONTROL_PLANE_MACHINE_TYPE
@@ -1081,8 +1077,6 @@ presubmits:
           value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-load.yaml"
-        - name: AZURE_LOCATION
-          value: "northeurope"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
           value: "Standard_D8s_v3"
         - name: CONTROL_PLANE_MACHINE_TYPE

--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -62,8 +62,6 @@ periodics:
           value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-load-dra.yaml"
-        - name: AZURE_LOCATION
-          value: "northeurope"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
           value: "Standard_D8s_v3"
         - name: CONTROL_PLANE_MACHINE_TYPE
@@ -180,8 +178,6 @@ periodics:
               value: "false"
             - name: CLUSTER_TEMPLATE
               value: "templates/test/dev/cluster-template-custom-builds-load-dra.yaml"
-            - name: AZURE_LOCATION
-              value: "northeurope"
             - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
               value: "Standard_D8s_v3"
             - name: CONTROL_PLANE_MACHINE_TYPE

--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
@@ -62,8 +62,6 @@ presubmits:
           value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-load-dra.yaml"
-        - name: AZURE_LOCATION
-          value: "northeurope"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
           value: "Standard_D8s_v3"
         - name: CONTROL_PLANE_MACHINE_TYPE
@@ -163,8 +161,6 @@ presubmits:
           value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-load-dra.yaml"
-        - name: AZURE_LOCATION
-          value: "northeurope"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
           value: "Standard_D8s_v3"
         - name: CONTROL_PLANE_MACHINE_TYPE

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
@@ -65,8 +65,6 @@ periodics:
           value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-load.yaml"
-        - name: AZURE_LOCATION
-          value: "northeurope"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
           value: "Standard_D8s_v3"
         - name: CONTROL_PLANE_MACHINE_TYPE


### PR DESCRIPTION
This PR removes unneeded AZURE_LOCATION env variables from load test defs following https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5749

cc @nojnhuh 