### PR TITLE
csi: add CSI_PROW_E2E_VERSION for csi-release-tools jobs

### DIFF
--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -118,6 +118,8 @@ presubmits:
           value: /home/prow/go/src/github.com/kubernetes-csi/external-provisioner
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.32.0"
+        - name: CSI_PROW_E2E_VERSION
+          value: "release-1.32"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.32"
         - name: CSI_PROW_DRIVER_VERSION
@@ -169,6 +171,8 @@ presubmits:
           value: /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter
         - name: CSI_PROW_KUBERNETES_VERSION
           value: "1.32.0"
+        - name: CSI_PROW_E2E_VERSION
+          value: "release-1.32"
         - name: CSI_PROW_KUBERNETES_DEPLOYMENT
           value: "1.32"
         - name: CSI_PROW_DRIVER_VERSION


### PR DESCRIPTION
/cc @gnufied  @sunnylovestiramisu @xing-yang

To unlock https://github.com/kubernetes-csi/csi-release-tools/pull/278

releated:
- https://github.com/kubernetes/test-infra/pull/35137


