### PR TITLE
[CAPI] Add duplicate job for cluster-api-e2e-main on GKE cluster for testing.

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -289,6 +289,54 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-main
+  # This job is added for testing purposes only.
+  - name: pull-cluster-api-e2e-main-gke
+    cluster: k8s-infra-prow-build
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    decorate: true
+    decoration_config:
+      timeout: 180m
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    path_alias: sigs.k8s.io/cluster-api
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250714-70266d743a-1.33
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
+          - name: GINKGO_LABEL_FILTER
+            value: "!Conformance"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 3000m
+            memory: 8Gi
+          limits:
+            cpu: 3000m
+            memory: 8Gi
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-e2e-main-gke
+
   - name: pull-cluster-api-e2e-upgrade-1-33-1-34-main
     cluster: eks-prow-build-cluster
     labels:


### PR DESCRIPTION
This PR is creating a duplicate of `cluster-api-e2e-main` for GKE cluster for testing. This is only a moving PR job, not periodic.

The following test is failing on the EKS cluster:
When following the Cluster API quick-start with dualstack and ipv4 primary [IPv6] Should create a workload cluster [IPv6] (https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-e2e-main/1945097169283321856)

Same test in kind is passing in the GKE cluster:
https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20dual,%20master 

Locally, this test also passes. We want to check if the issue is related to infra.
This started failing on 3rd July
Testgrid: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main 
Issue: https://github.com/kubernetes-sigs/cluster-api/issues/12449 
Slack discussion: https://kubernetes.slack.com/archives/C7J9RP96G/p1751991861631429 