### PR TITLE
node: add podresources API presubmit and disambiguare pod level resources presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -887,7 +887,7 @@ presubmits:
           operator: "Equal"
           value: "sig-node"
           effect: "NoSchedule"
-  - name: pull-kubernetes-node-kubelet-serial-podresources
+  - name: pull-kubernetes-node-kubelet-serial-podlevelresources
     cluster: k8s-infra-prow-build
     always_run: false
     optional: true
@@ -896,7 +896,7 @@ presubmits:
     - release-\d+\.\d+  # per-release image
     annotations:
       testgrid-dashboards: sig-node-presubmits
-      testgrid-tab-name: pr-kubelet-serial-e2e-podresources
+      testgrid-tab-name: pr-kubelet-serial-e2e-podlevelresources
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -944,6 +944,63 @@ presubmits:
           operator: "Equal"
           value: "sig-node"
           effect: "NoSchedule"
+  - name: pull-kubernetes-node-kubelet-serial-podresourcesapi
+    cluster: k8s-infra-prow-build
+    always_run: false
+    optional: true
+    skip_report: false
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-dashboards: sig-node-presubmits
+      testgrid-tab-name: pr-kubelet-serial-e2e-podresourcesapi
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    decorate: true
+    decoration_config:
+      timeout: 240m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: release
+      base_ref: master
+      path_alias: k8s.io/release
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250714-70266d743a-master
+          resources:
+            limits:
+              cpu: 4
+              memory: 6Gi
+            requests:
+              cpu: 4
+              memory: 6Gi
+          command:
+            - runner.sh
+            - /workspace/scenarios/kubernetes_e2e.py
+          args:
+            - --deployment=node
+            - --gcp-zone=us-central1-b
+            - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+            - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --cgroup-driver=systemd"
+            - --node-tests=true
+            - --provider=gce
+            - --runtime-config=api/all=true
+            - '--test_args=--nodes=1 --skip= --label-filter="Feature: containsAny PodResourcesAPI"'
+            - --timeout=180m
+          env:
+            - name: GOPATH
+              value: /go
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "sig-node"
+          effect: "NoSchedule"
   - name: pull-kubernetes-node-e2e-alpha-ec2
     # duplicate job of ci-kubernetes-e2e-ec2-alpha-features to test changes in provider-aws-test-infra
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
Up until now, we used "podresources" ambiguosly: it historically referred to podresources API, but we started to use for pod-level resources tests. This PR disambiguate the term, but most notably adds a presubmit job which targets explicitly the podresources API tests, which previously where running incidentally in other lanes.

xref: https://github.com/kubernetes/enhancements/pull/5346#discussion_r2150961273
xref: https://github.com/kubernetes/kubernetes/pull/132345