### PR TITLE
Automated retesting: Only trigger required jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -255,7 +255,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     testgrid-tab-name: retester
-    description: Automatically /retest for approved PRs that are failing tests
+    description: Automatically /retest-required for approved PRs that are failing tests
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20250306-095fc63a16
@@ -302,7 +302,7 @@ periodics:
         - Prevent this bot from retesting with `/lgtm cancel` or `/hold`
         - Help make our tests less flaky by following our [Flaky Tests Guide][1]
 
-        /retest
+        /retest-required
 
         [1]: https://git.k8s.io/community/contributors/devel/sig-testing/flaky-tests.md
       - --template


### PR DESCRIPTION
The job is intended to trigger required tests that flake, however it currently triggers all tests, including optional ones that might not be stable.

Update it to use `/retest-required` so only mandatory jobs get triggered.

Ref https://github.com/kubernetes/test-infra/pull/22850

/assign @xmudrii 