### PR TITLE
CentOS Stream 10: Update powervs instance image to CentOS-Stream-10

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -89,7 +89,7 @@ periodics:
 
               set +o errexit
               set -o xtrace
-              kubetest2 tf --powervs-image-name CentOS-Stream-9 --powervs-memory 32 \
+              kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
@@ -165,7 +165,7 @@ periodics:
               CLUSTER_NAME="config2-$(date +%s)"
 
               set +o errexit
-              kubetest2 tf --powervs-image-name CentOS-Stream-9 --powervs-memory 32 \
+              kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
@@ -240,7 +240,7 @@ periodics:
 
               set +o errexit
               set -o xtrace
-              kubetest2 tf --powervs-image-name CentOS-Stream-9 --powervs-memory 32 \
+              kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
@@ -304,7 +304,7 @@ periodics:
 
               set +o errexit
               set -o xtrace
-              kubetest2 tf --powervs-image-name CentOS-Stream-9 --powervs-memory 32 \
+              kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
@@ -368,7 +368,7 @@ periodics:
 
               set +o errexit
               set -o xtrace
-              kubetest2 tf --powervs-image-name CentOS-Stream-9 --powervs-memory 32 \
+              kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
@@ -429,7 +429,7 @@ periodics:
 
               set +o errexit
               set -o xtrace
-              kubetest2 tf --powervs-image-name CentOS-Stream-9 --powervs-memory 32 \
+              kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \


### PR DESCRIPTION
As CentOS-Stream-10 is now available, updating the PowerVS instance image to CentOS-Stream-10 in the Prow CI jobs to use the latest image.