### PR TITLE
Increase timeout for ci-kubetest2-push-binaries

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kubetest2.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kubetest2.yaml
@@ -41,6 +41,9 @@ periodics:
       testgrid-dashboards: sig-testing-kubetest2, sig-k8s-infra-gcb
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com
     decorate: true
+    decoration_config:
+      timeout: 180m
+      grace_period: 10m
     extra_refs:
       - org: kubernetes-sigs
         repo: kubetest2


### PR DESCRIPTION
Snippet from [log](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubetest2-push-binaries/1947293412596125696/build-log.txt):

```
Your build timed out. Use the [--timeout=DURATION] flag to change the timeout threshold.
ERROR: (gcloud.builds.submit) build 0d1453df-98ae-4609-9af0-6ab47d6be6dc completed with status "TIMEOUT"
```
/assign @upodroid @dims
