### PR TITLE
Added periodic job for building kueue image for s390x and power

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodic-s390x-ppc64le-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodic-s390x-ppc64le-main.yaml
@@ -1,0 +1,48 @@
+periodics:
+  - interval: 12h
+    name: periodic-kueue-test-unit-s390x-ppc64le-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-unit-s390x-ppc64le-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run s390x periodic kueue unit tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+       containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.30"
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.24
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - image-build
+            - PLATFORMS=linux/s390x,linux/ppc64le
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "4"
+              memory: "6Gi"
+            limits:
+              cpu: "4"
+              memory: "6Gi"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.11.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.11.yaml
@@ -1,0 +1,48 @@
+periodics:
+  - interval: 12h
+    name: periodic-kueue-test-unit-s390x-ppc64le-release-0-11
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-unit-s390x-ppc64le-release-0-11
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run s390x periodic kueue unit tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+       containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.30"
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.24
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - image-build
+            - PLATFORMS=linux/s390x,linux/ppc64le
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "4"
+              memory: "6Gi"
+            limits:
+              cpu: "4"
+              memory: "6Gi"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.12.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.12.yaml
@@ -1,0 +1,48 @@
+periodics:
+  - interval: 12h
+    name: periodic-kueue-test-unit-s390x-ppc64le-release-0-12
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-unit-s390x-ppc64le-release-0-12
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run s390x periodic kueue unit tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+       containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250527-1b2b10e804-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.30"
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.24
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - image-build
+            - PLATFORMS=linux/s390x,linux/ppc64le
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "4"
+              memory: "6Gi"
+            limits:
+              cpu: "4"
+              memory: "6Gi"


### PR DESCRIPTION
## PR Description
Added periodic jobs to build and test Kueue on s390x and ppc64le architectures. This helps ensure Kueue works properly on these platforms.

### Added files
- `kueue-periodic-s390x-ppc64le-main.yaml`: Periodic job for main branch
- `kueue-periodics-s390x-ppc64le-release-0.11.yaml`: Periodic job for release-0.11
- `kueue-periodics-s390x-ppc64le-release-0.12.yaml`: Periodic job for release-0.12

### Changes include
- Added 12h interval periodic jobs for unit tests
- Configured for both s390x and ppc64le platforms
- Using kubekins-e2e image with Docker-in-Docker support

### Testing Done
- Tested locally.
- Image build is working.