### PR TITLE
Update perf-tests fork for DRA workload presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
@@ -126,9 +126,9 @@ presubmits:
       repo: kubernetes
       base_ref: master
       path_alias: k8s.io/kubernetes
-    - org: kubernetes
+    - org: alaypatel07
       repo: perf-tests
-      base_ref: master
+      base_ref: dra-kubelet-latencies
       path_alias: k8s.io/perf-tests
     spec:
       serviceAccountName: azure


### PR DESCRIPTION
Update the perf-tests version to @alaypatel07's fork for DRA scale presubmit jobs in CAPZ.