### PR TITLE
Pin DRA scale periodic jobs to CAPZ main branch

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -17,7 +17,7 @@ periodics:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.20
+      base_ref: main
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     - org: kubernetes-sigs
       repo: cloud-provider-azure
@@ -133,7 +133,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.20
+        base_ref: main
         path_alias: "sigs.k8s.io/cluster-api-provider-azure"
       - org: kubernetes-sigs
         repo: cloud-provider-azure


### PR DESCRIPTION
We're planning on rapidly iterating on DRA scale tests and want to avoid the extra churn in CAPZ of cherry-picking changes to a release branch.