### PR TITLE
ci: migrate logexporter image to community-hosted one

### DIFF
--- a/logexporter/cluster/logexporter-daemonset.yaml
+++ b/logexporter/cluster/logexporter-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: gcr.io/k8s-testimages/logexporter:v20220831-a9d3b0ad39
+        image: registry.k8s.io/logexporter:v0.1.1
         env:
         - name: NODE_NAME
           valueFrom:

--- a/logexporter/cluster/logexporter-pod.yaml
+++ b/logexporter/cluster/logexporter-pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
   - name: logexporter-test
-    image: gcr.io/k8s-testimages/logexporter:v0.1.6
+    image: registry.k8s.io/logexporter:v0.1.1
     env:
     - name: NODE_NAME
       valueFrom:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig architecture
/sig testing
/priority important-longterm

#### What this PR does / why we need it:

Remove image reference to Google-owned legacy registry. Use the community-hosted registry.

#### Which issue(s) this PR is related to:

[Migrate away from gcr.io/k8s-testimages repo #34922 ](https://github.com/kubernetes/test-infra/issues/34922))

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE