### PR TITLE
DRA: focus on kubelet tests in kubelet version skew tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -352,6 +352,12 @@ presubmits:
           # including all unsupportd kubelet versions in a deny list.
           kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
 
+          # Running tests which only cover control plane behavior are not useful
+          # in a kubelet version skew job. We can filter them out by including
+          # only tests which have the DynamicResourceAllocation feature because
+          # only those cover kubelet behavior.
+          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
+
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -458,6 +464,12 @@ presubmits:
           # generating `! KubeletMinVersion: containsAny { 1.33, 1.34 }`, i.e.
           # including all unsupportd kubelet versions in a deny list.
           kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
+
+          # Running tests which only cover control plane behavior are not useful
+          # in a kubelet version skew job. We can filter them out by including
+          # only tests which have the DynamicResourceAllocation feature because
+          # only those cover kubelet behavior.
+          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -272,6 +272,12 @@ periodics:
           # including all unsupportd kubelet versions in a deny list.
           kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
 
+          # Running tests which only cover control plane behavior are not useful
+          # in a kubelet version skew job. We can filter them out by including
+          # only tests which have the DynamicResourceAllocation feature because
+          # only those cover kubelet behavior.
+          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
+
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -382,6 +388,12 @@ periodics:
           # generating `! KubeletMinVersion: containsAny { 1.33, 1.34 }`, i.e.
           # including all unsupportd kubelet versions in a deny list.
           kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
+
+          # Running tests which only cover control plane behavior are not useful
+          # in a kubelet version skew job. We can filter them out by including
+          # only tests which have the DynamicResourceAllocation feature because
+          # only those cover kubelet behavior.
+          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -359,6 +359,12 @@ presubmits:
           # including all unsupportd kubelet versions in a deny list.
           kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
 
+          # Running tests which only cover control plane behavior are not useful
+          # in a kubelet version skew job. We can filter them out by including
+          # only tests which have the DynamicResourceAllocation feature because
+          # only those cover kubelet behavior.
+          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
+
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -467,6 +473,12 @@ presubmits:
           # generating `! KubeletMinVersion: containsAny { 1.33, 1.34 }`, i.e.
           # including all unsupportd kubelet versions in a deny list.
           kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
+
+          # Running tests which only cover control plane behavior are not useful
+          # in a kubelet version skew job. We can filter them out by including
+          # only tests which have the DynamicResourceAllocation feature because
+          # only those cover kubelet behavior.
+          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -230,6 +230,12 @@ presubmits:
           # generating `! KubeletMinVersion: containsAny { 1.33, 1.34 }`, i.e.
           # including all unsupportd kubelet versions in a deny list.
           kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
+
+          # Running tests which only cover control plane behavior are not useful
+          # in a kubelet version skew job. We can filter them out by including
+          # only tests which have the DynamicResourceAllocation feature because
+          # only those cover kubelet behavior.
+          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
           {%- endif %}
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } {%- if kubelet_skew|int > 0 %}$kubelet_label_filter{%- endif %} {%- if not all_features %} && !Alpha {%- endif %} && !Flaky {%- if not ci and not allow_slow %} && !Slow {%- endif %}" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &


### PR DESCRIPTION
This filters out control plane tests without having to label those with KubeletMinVersion:1.34, which was only indirect.

Removing that KubeletMinVersion currently breaks https://github.com/kubernetes/kubernetes/pull/133107/files. Removing KubeletMinVersion is good because it otherwise it shows up in conformance tests, which already confused reviewers.

In https://github.com/kubernetes/kubernetes/pull/133107, before:
```console
$ _output/bin/ginkgo run -v --dry-run --timeout=24h --silence-skips --force-newlines --no-color '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && ! KubeletMinVersion: containsAny { 1.33, 1.34 } && !Alpha && !Flaky && !Slow' ./test/e2e | grep -e "control plane" -e "^Ran"
Random Seed: 1753167179 - will randomize all specs
[sig-node] [DRA] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] control plane supports count/resourceclaims.resource.k8s.io ResourceQuota [ConformanceCandidate] [sig-node, DRA, FeatureGate:DynamicResourceAllocation, Beta, Feature:OffByDefault, BetaOffByDefault, ConformanceCandidate]
[sig-node] [DRA] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] control plane must apply per-node permission checks [ConformanceCandidate] [sig-node, DRA, FeatureGate:DynamicResourceAllocation, Beta, Feature:OffByDefault, BetaOffByDefault, ConformanceCandidate]
Ran 35 of 7095 Specs in 0.204 seconds
```

With the extra term:
```console
$ _output/bin/ginkgo run -v --dry-run --timeout=24h --silence-skips --force-newlines --no-color '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && ! KubeletMinVersion: containsAny { 1.33, 1.34 } && Feature: containsAny { DynamicResourceAllocation } && !Alpha && !Flaky && !Slow' ./test/e2e | grep -e "control plane" -e "^Ran"
Random Seed: 1753167158 - will randomize all specs
Ran 31 of 7095 Specs in 0.208 seconds
```

The four removed tests:
```console
$ _output/bin/ginkgo run -v --dry-run --timeout=24h --silence-skips --force-newlines --no-color '--label-filter=DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && ! KubeletMinVersion: containsAny { 1.33, 1.34 } && ! Feature: containsAny { DynamicResourceAllocation } && !Alpha && !Flaky && !Slow' ./test/e2e 
  W0722 08:53:52.884899   12806 test_context.go:542] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I0722 08:53:52.884966 12806 test_context.go:565] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
  I0722 08:53:52.885030   12806 e2e.go:109] Starting e2e run "7ef066ad-48a8-4adb-b379-f906bea2f3d9" on Ginkgo node 1
Running Suite: Kubernetes e2e suite - /nvme/gopath/src/k8s.io/kubernetes/test/e2e
=================================================================================
Random Seed: 1753167222 - will randomize all specs

Will run 4 of 7095 specs
------------------------------
[ReportBeforeSuite] 
/nvme/gopath/src/k8s.io/kubernetes/test/e2e/e2e_test.go:153
[ReportBeforeSuite] PASSED [0.000 seconds]
------------------------------
[SynchronizedBeforeSuite] 
/nvme/gopath/src/k8s.io/kubernetes/test/e2e/e2e.go:69
[SynchronizedBeforeSuite] PASSED [0.000 seconds]
------------------------------
[sig-api-machinery] ResourceQuota should create a ResourceQuota and capture the life of a ResourceClaim [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] [DRA] [sig-api-machinery, FeatureGate:DynamicResourceAllocation, Beta, Feature:OffByDefault, BetaOffByDefault, DRA]
/nvme/gopath/src/k8s.io/kubernetes/test/e2e/apimachinery/resource_quota.go:507
• [0.000 seconds]
------------------------------
[sig-node] [DRA] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] control plane must apply per-node permission checks [ConformanceCandidate] [sig-node, DRA, FeatureGate:DynamicResourceAllocation, Beta, Feature:OffByDefault, BetaOffByDefault, ConformanceCandidate]
/nvme/gopath/src/k8s.io/kubernetes/test/e2e/dra/dra.go:2141
• [0.000 seconds]
------------------------------
[sig-node] [DRA] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] ResourceSlice Controller creates slices [ConformanceCandidate] [sig-node, DRA, FeatureGate:DynamicResourceAllocation, Beta, Feature:OffByDefault, BetaOffByDefault, ConformanceCandidate]
/nvme/gopath/src/k8s.io/kubernetes/test/e2e/dra/dra.go:1935
• [0.000 seconds]
------------------------------
[sig-node] [DRA] [FeatureGate:DynamicResourceAllocation] [Beta] [Feature:OffByDefault] control plane supports count/resourceclaims.resource.k8s.io ResourceQuota [ConformanceCandidate] [sig-node, DRA, FeatureGate:DynamicResourceAllocation, Beta, Feature:OffByDefault, BetaOffByDefault, ConformanceCandidate]
/nvme/gopath/src/k8s.io/kubernetes/test/e2e/dra/dra.go:2081
• [0.000 seconds]
------------------------------
[SynchronizedAfterSuite] 
/nvme/gopath/src/k8s.io/kubernetes/test/e2e/e2e.go:80
[SynchronizedAfterSuite] PASSED [0.000 seconds]
------------------------------
[ReportAfterSuite] Kubernetes e2e suite report
/nvme/gopath/src/k8s.io/kubernetes/test/e2e/e2e_test.go:157
[ReportAfterSuite] PASSED [0.000 seconds]
------------------------------

Ran 4 of 7095 Specs in 0.208 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 7091 Skipped
PASS
```

Once this is merged,  https://github.com/kubernetes/kubernetes/pull/133107 will get updated to remove KubeletMinVersion from all control plane tests.

/assign @bart0sh 