### PR TITLE
Update sig-scalability-presubmit-dra-capz.yaml to revert branch and pre-upload workload image

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
@@ -128,9 +128,9 @@ presubmits:
       repo: kubernetes
       base_ref: master
       path_alias: k8s.io/kubernetes
-    - org: alaypatel07
+    - org: kubernetes
       repo: perf-tests
-      base_ref: dra-kubelet-latencies
+      base_ref: master
       path_alias: k8s.io/perf-tests
     spec:
       serviceAccountName: azure
@@ -206,6 +206,8 @@ presubmits:
           value: "6443"
         - name: PROMETHEUS_SCRAPE_KUBELETS
           value: "true"
+        - name: NODE_PRELOAD_IMAGES
+          value: "gcr.io/k8s-staging-perf-tests/sleep:v0.0.3"
         resources:
           requests:
             cpu: "6"


### PR DESCRIPTION
slow pod:
```
Jul 22 04:26:58.314294 capz-arvqwi-md-0-5twzn-2gp2t kubelet[1616]: I0722 04:26:58.314178    1616 pod_startup_latency_tracker.go:104] "Observed pod startup duration" pod="test-aed2mc-1/long-running-16-0-gwbcr" podStartSLOduration=5.158780407 podStartE2EDuration="10.314149728s" podCreationTimestamp="2025-07-22 04:26:48 +0000 UTC" firstStartedPulling="2025-07-22 04:26:49.978053322 +0000 UTC m=+1822.071393995" lastFinishedPulling="2025-07-22 04:26:55.133422543 +0000 UTC m=+1827.226763316" observedRunningTime="2025-07-22 04:26:56.180821782 +0000 UTC m=+1828.274162455" watchObservedRunningTime="2025-07-22 04:26:58.314149728 +0000 UTC m=+1830.407490501"
```

kubelet log:
```
Jul 22 04:26:55.132276 capz-arvqwi-md-0-5twzn-2gp2t containerd[1358]: time="2025-07-22T04:26:55.132230783Z" level=info msg="Pulled image \"gcr.io/k8s-staging-perf-tests/sleep:v0.0.3\" with image id \"sha256:99c52edc38d9087e4af9cc6f2093209835b82d2ab6b95edb4210e366d3f4d08f\", repo tag \"gcr.io/k8s-staging-perf-tests/sleep:v0.0.3\", repo digest \"gcr.io/k8s-staging-perf-tests/sleep@sha256:00ae8e01dd4439edfb7eb9f1960ac28eba16e952956320cce7f2ac08e3446e6b\", size \"1930946\" in 5.153759141s"
```

It was found that only fast-fill pods take the most time and that too the first pod landing on the node.

Experimented with pre-fetching the image https://github.com/kubernetes/perf-tests/pull/3438/commits/453ec34c3328150a7ae2101af930a90960bad80c and the test went green. 

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/5742/pull-cluster-api-provider-azure-load-test-dra-with-workload-custom-builds/1947553252815933440 and https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-azure-dra-with-workload-scalability/1947576531509317632

The plan is to first fix the presubmit, make the test job go green and then take the changes to periodic.