### PR TITLE
DRA: focus on kubelet tests in kubelet version skew tests, II

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -356,7 +356,7 @@ presubmits:
           # in a kubelet version skew job. We can filter them out by including
           # only tests which have the DynamicResourceAllocation feature because
           # only those cover kubelet behavior.
-          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
+          kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
@@ -469,7 +469,7 @@ presubmits:
           # in a kubelet version skew job. We can filter them out by including
           # only tests which have the DynamicResourceAllocation feature because
           # only those cover kubelet behavior.
-          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
+          kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -276,7 +276,7 @@ periodics:
           # in a kubelet version skew job. We can filter them out by including
           # only tests which have the DynamicResourceAllocation feature because
           # only those cover kubelet behavior.
-          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
+          kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
@@ -393,7 +393,7 @@ periodics:
           # in a kubelet version skew job. We can filter them out by including
           # only tests which have the DynamicResourceAllocation feature because
           # only those cover kubelet behavior.
-          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
+          kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -363,7 +363,7 @@ presubmits:
           # in a kubelet version skew job. We can filter them out by including
           # only tests which have the DynamicResourceAllocation feature because
           # only those cover kubelet behavior.
-          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
+          kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
@@ -478,7 +478,7 @@ presubmits:
           # in a kubelet version skew job. We can filter them out by including
           # only tests which have the DynamicResourceAllocation feature because
           # only those cover kubelet behavior.
-          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
+          kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation }$kubelet_label_filter && !Alpha && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -235,7 +235,7 @@ presubmits:
           # in a kubelet version skew job. We can filter them out by including
           # only tests which have the DynamicResourceAllocation feature because
           # only those cover kubelet behavior.
-          kubelet_label_filter+=" && Feature: contains DynamicResourceAllocation"
+          kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
           {%- endif %}
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } {%- if kubelet_skew|int > 0 %}$kubelet_label_filter{%- endif %} {%- if not all_features %} && !Alpha {%- endif %} && !Flaky {%- if not ci and not allow_slow %} && !Slow {%- endif %}" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &


### PR DESCRIPTION
This filters out control plane tests without having to label those with KubeletMinVersion:1.34, which was only indirect.

The previous commit did not actually use the expression which had worked (contains vs containsAny).

/assign @bart0sh 