### PR TITLE
DRA: Use 1k node presubmit test configuration

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
@@ -150,8 +150,7 @@ presubmits:
             --provider=aks \
             --enable-prometheus-server=true \
             --testconfig=testing/dra/config.yaml \
-            --report-dir=${ARTIFACTS}
-            --nodes=100
+            --report-dir=${ARTIFACTS} \
             --v=2
         securityContext:
           privileged: true
@@ -218,5 +217,120 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: capz-pr-scalability-100-node-dra-with-workload-k8s-main
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Conducts load testing with custom builds to assess DRA scalability on the main branch.
+  - name: pull-cluster-api-provider-azure-load-test-1k-dra-with-workload-custom-builds
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 8h
+    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    always_run: false
+    optional: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    branches:
+      - ^main$
+      - ^release-1.*
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: master
+      path_alias: sigs.k8s.io/cloud-provider-azure
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    - org: kubernetes
+      repo: perf-tests
+      base_ref: master
+      path_alias: k8s.io/perf-tests
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-master
+        command:
+        - runner.sh
+        - ./scripts/ci-entrypoint.sh
+        args:
+          - bash
+          - -c
+          - >-
+            sleep 300 &&
+            cd ${GOPATH}/src/k8s.io/perf-tests/ &&
+            ./run-e2e.sh cluster-loader2
+            --nodes=1000 \
+            --provider=aks \
+            --enable-prometheus-server=true \
+            --testconfig=testing/dra/config.yaml \
+            --report-dir=${ARTIFACTS} \
+            --v=2
+        securityContext:
+          privileged: true
+        env:
+        # CAPZ variables
+        - name: TEST_K8S
+          value: "true"
+        - name: WINDOWS
+          value: "false"
+        - name: CLUSTER_TEMPLATE
+          value: "templates/test/dev/cluster-template-custom-builds-load-dra.yaml"
+        - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
+          value: "Standard_D8s_v3"
+        - name: CONTROL_PLANE_MACHINE_TYPE
+          value: "Standard_D8s_v3"
+        - name: AZURE_NODE_MACHINE_TYPE
+          value: "Standard_D2s_v3"
+        - name: NODE_MACHINE_TYPE
+          value: "Standard_D2s_v3"
+        - name: TEST_WINDOWS
+          value: "false"
+        # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy
+        - name: DEPLOY_AZURE_CSI_DRIVER
+          value: "false"
+        - name: "CONTROL_PLANE_MACHINE_COUNT"
+          value: "5"
+        - name: WINDOWS_WORKER_MACHINE_COUNT
+          value: "0" # Don't create windows workers
+        - name: WORKER_MACHINE_COUNT
+          value: "1000"
+        # Based on pull-kubernetes-e2e-gce-100-performance CL2 config
+        - name: CL2_ENABLE_DNS_PROGRAMMING
+          value: "true"
+        - name: CL2_SCHEDULER_THROUGHPUT_THRESHOLD
+          value: "0"
+        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+          value: "true"
+        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+          value: "99.5"
+        # For DRA cl2 tests
+        - name: CL2_MODE
+          value: "Indexed"
+        - name: CL2_NODES_PER_NAMESPACE
+          value: "100"
+        - name: CL2_JOB_RUNNING_TIME
+          value: "3s"
+        - name: CL2_LONG_JOB_RUNNING_TIME
+          value: "150m"
+        - name: PROMETHEUS_PVC_STORAGE_CLASS
+          value: "default"
+        - name: PROMETHEUS_APISERVER_SCRAPE_PORT
+          value: "6443"
+        - name: PROMETHEUS_SCRAPE_KUBELETS
+          value: "true"
+        - name: NODE_PRELOAD_IMAGES
+          value: "gcr.io/k8s-staging-perf-tests/sleep:v0.0.3"
+        resources:
+          requests:
+            cpu: "6"
+            memory: "9Gi"
+          limits:
+            cpu: "6"
+            memory: "9Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      testgrid-tab-name: capz-pr-scalability-1000-node-dra-with-workload-k8s-main
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
       description: Conducts load testing with custom builds to assess DRA scalability on the main branch.


### PR DESCRIPTION
This PR updates the presubmit DRA load test configuration to accommodate 1k nodes.

Upon observation, we are only using < 1 CPU core during test runs, so we will use 2 core instead of 8 core VMs to enable more quota usage.