### PR TITLE
Update filter for ResourceHealthStatus job to run new e2e tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3365,7 +3365,7 @@ presubmits:
         - '--node-test-args=--feature-gates="ResourceHealthStatus=true" --service-feature-gates="ResourceHealthStatus=true" --runtime-config=api/alpha=true,api/beta=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --node-tests=true
         - --provider=gce
-        - '--test_args=--timeout=1h --label-filter="Feature: containsAny ResourceHealthStatus && Feature: isSubsetOf ResourceHealthStatus && !Flaky && !Slow"'
+        - '--test_args=--timeout=1h --label-filter="[FeatureGate:ResourceHealthStatus] && ![FeatureGate:ResourceHealthStatus:Disabled] && Serial && !Flaky && !Slow"'
         - --timeout=65m
         - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/cgroupv2/image-config-cgroupv2.yaml
         resources:


### PR DESCRIPTION
This change modifies the `pull-kubernetes-node-e2e-resource-health-status` presubmit job to correctly select and run the new e2e tests for the `ResourceHealthStatus` feature, introduced in kubernetes/kubernetes#130606.

The previous `--label-filter` was not effective at selecting these new tests. This update adjusts the filter to use precise Ginkgo labels, ensuring the job runs the correct tests:

- It now targets tests with the `[FeatureGate:ResourceHealthStatus]` label.
- It excludes tests labeled `[FeatureGate:ResourceHealthStatus:Disabled]`, which are intended for jobs where the feature gate is off.
- It includes the `[Serial]` label, which is required for these node-level tests.

This change allows the job to be used to get a clear CI signal for the new feature-gated functionality.