### PR TITLE
e2-standard-2 does not support nvidia-tesla-t4

### DIFF
--- a/jobs/e2e_node/containerd/image-config-serial.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial.yaml
@@ -10,7 +10,7 @@ images:
   cos-stable2:
     image_family: cos-stable
     project: cos-cloud
-    machine: e2-standard-2 # These tests need a lot of memory
+    machine: n1-standard-4 # These tests need a lot of memory
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
     resources:
       accelerators:


### PR DESCRIPTION
`pull-kubernetes-node-kubelet-serial-containerd-kubetest2` has failures:
```
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - [e2-standard-2, nvidia-tesla-t4] features are not compatible for creating instance.
```
example above from https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/132940/pull-kubernetes-node-kubelet-serial-containerd-kubetest2/1948155537296199680/build-log.txt

we had switched over to e2 machines in https://github.com/kubernetes/test-infra/pull/35099 for a good reason. but that machine type does not support `nvidia-tesla-t4`

So go back to n1 machines, but instead of n1-standard-2, we switch to n1-standard-4 for better performance.