### PR TITLE
Enable target group cleanup on AWS CI account

### DIFF
--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -15,6 +15,7 @@ periodics:
       - --ttl=6h
       - --path=s3://cloud-provider-aws-shared-e2e/objs.json
       - --exclude-tags=Shared=Ignore
+      - --enable-target-group-clean=true
       image: gcr.io/k8s-staging-boskos/aws-janitor:v20240801-1221bfe
       resources:
         requests:


### PR DESCRIPTION
Leaked target groups slowly fill up in this account (whenever a job is aborted or similarly is unable to cleanup its cluster), and then spill over breaking the CI of all CSI drivers using it (e.g. https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/2585/pull-aws-ebs-csi-driver-external-test/1948449565313077248).

The `aws-janitor` actually has the ability to cleanup target groups, but its disabled by default (https://github.com/kubernetes-sigs/boskos/blob/e9e53220ffb605e8982f66ebde3e893b76857910/cmd/aws-janitor/main.go#L52), this PR turns it on.