### PR TITLE
DRA scalability: separate node for prometheus, canadacentral azure region

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -72,6 +72,10 @@ periodics:
           value: "Standard_D8s_v3"
         - name: TEST_WINDOWS
           value: "false"
+        - name: MONITORING_MACHINE_COUNT
+          value: "1" # One monitoring machine for prometheus server
+        - name: AZURE_LOCATION
+          value: "canadacentral" # Use canadacentral for proximity to prow container
         # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy
         - name: DEPLOY_AZURE_CSI_DRIVER
           value: "false"
@@ -190,6 +194,10 @@ periodics:
               value: "Standard_D8s_v3"
             - name: TEST_WINDOWS
               value: "false"
+            - name: MONITORING_MACHINE_COUNT
+              value: "1" # One monitoring machine for prometheus server
+            - name: AZURE_LOCATION
+              value: "canadacentral" # Use canadacentral for proximity to prow container
             # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy
             - name: DEPLOY_AZURE_CSI_DRIVER
               value: "false"

--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
@@ -72,6 +72,8 @@ presubmits:
           value: "Standard_D8s_v3"
         - name: TEST_WINDOWS
           value: "false"
+        - name: MONITORING_MACHINE_COUNT
+          value: "1" # One monitoring machine for prometheus server
         # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy
         - name: DEPLOY_AZURE_CSI_DRIVER
           value: "false"
@@ -172,6 +174,8 @@ presubmits:
           value: "Standard_D8s_v3"
         - name: TEST_WINDOWS
           value: "false"
+        - name: MONITORING_MACHINE_COUNT
+          value: "1" # One monitoring machine for prometheus server
         # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy
         - name: DEPLOY_AZURE_CSI_DRIVER
           value: "false"
@@ -287,6 +291,8 @@ presubmits:
           value: "Standard_D2s_v3"
         - name: TEST_WINDOWS
           value: "false"
+        - name: MONITORING_MACHINE_COUNT
+          value: "1" # One monitoring machine for prometheus server
         # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy
         - name: DEPLOY_AZURE_CSI_DRIVER
           value: "false"


### PR DESCRIPTION
This PR updates the Azure DRA scalability test configs to instruct CAPZ to build a dedicated node to run prometheus. For periodic tests, we statically set the region to canadacentral which we have observed is more proximate to the prow containers, and remove CL2 client connection latency from test result data.