### PR TITLE
DRA: use VMSS infra for azure presubmit tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
@@ -61,7 +61,7 @@ presubmits:
         - name: WINDOWS
           value: "false"
         - name: CLUSTER_TEMPLATE
-          value: "templates/test/dev/cluster-template-custom-builds-load-dra.yaml"
+          value: "templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
           value: "Standard_D8s_v3"
         - name: CONTROL_PLANE_MACHINE_TYPE
@@ -163,7 +163,7 @@ presubmits:
         - name: WINDOWS
           value: "false"
         - name: CLUSTER_TEMPLATE
-          value: "templates/test/dev/cluster-template-custom-builds-load-dra.yaml"
+          value: "templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
           value: "Standard_D8s_v3"
         - name: CONTROL_PLANE_MACHINE_TYPE
@@ -280,7 +280,7 @@ presubmits:
         - name: WINDOWS
           value: "false"
         - name: CLUSTER_TEMPLATE
-          value: "templates/test/dev/cluster-template-custom-builds-load-dra.yaml"
+          value: "templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
           value: "Standard_D8s_v3"
         - name: CONTROL_PLANE_MACHINE_TYPE


### PR DESCRIPTION
We have better results building VMSS infra w/ CAPZ when running large cluster tests.