### PR TITLE
kOps: Update periodic test for Azure

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -204,7 +204,7 @@ periodics:
         make test-e2e-install
         kubetest2 kops \
         -v 2 \
-        --up --build --down \
+        --up --down \
         --cloud-provider=azure \
         --env KOPS_FEATURE_FLAGS=Azure \
         --create-args "--networking=cilium" \


### PR DESCRIPTION
```
Error: init failed to check build flags: cannot use --kops-version-marker with --build
```

/cc @ameukam @rifelpet 