### PR TITLE
kOps: Update periodic test for Azure

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -208,7 +208,7 @@ periodics:
         --cloud-provider=azure \
         --env KOPS_FEATURE_FLAGS=Azure \
         --create-args "--networking=cilium" \
-        --cluster-name=e2e-kops-k8s-azure-cilium \
+        --cluster-name=e2e-k8s-azure-cilium.kops \
         --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
         --kubernetes-version=https://dl.k8s.io/release/stable.txt \
         --test=kops \


### PR DESCRIPTION
```
Error: objectMeta.name: Invalid value: "e2e-kops-k8s-azure-cilium": Cluster Name must be a fully-qualified DNS name (e.g. --name=mycluster.myzone.com)
```
/cc @ameukam @rifelpet 