### PR TITLE
update to golang 1.24

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:
@@ -31,7 +31,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:
@@ -52,7 +52,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:
@@ -73,7 +73,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/scheduler-plugins/issues/916

CI is failing because 1.33 requires golang 1.24.