### PR TITLE
Replace crio canary periodics

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -288,61 +288,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-master
-      command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --deployment=node
-      - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-central1-b
-      - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=1 --focus="\[Flaky\]"
-      - --timeout=60m
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
-      env:
-      - name: GOPATH
-        value: /go
-      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-        value: "1"
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv1-node-e2e-flaky
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "OWNER: sig-node; runs Features e2e tests with crio master and cgroup v1"
-- name: ci-crio-cgroupv1-node-e2e-flaky-canary
-  cluster: k8s-infra-prow-build
-  interval: 2h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-flaky-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs Features e2e tests with crio master and cgroup v1"
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -779,61 +779,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-master
-      command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --deployment=node
-      - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-central1-b
-      - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=1 --focus="Node Performance Testing"
-      - --timeout=60m
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-performance.yaml
-      env:
-      - name: GOPATH
-        value: /go
-      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-        value: "1"
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: node-kubelet-crio-cgroupv2-performance-test
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
-- name: ci-node-kubelet-crio-cgroupv2-performance-test-canary
-  cluster: k8s-infra-prow-build
-  interval: 12h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: node-kubelet-crio-cgroupv2-performance-test-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -999,63 +999,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-master
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        args:
-          - --deployment=node
-          - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-central1-b
-          - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-          - --node-tests=true
-          - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]"
-          - --timeout=90m
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-resource-managers.yaml
-        env:
-          - name: GOPATH
-            value: /go
-          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-            value: "1"
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-resource-managers
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "Executes CPU, Memory and Topology manager e2e tests with cgroup v2"
-- name: ci-crio-cgroupv2-node-e2e-resource-managers-canary
-  cluster: k8s-infra-prow-build
-  interval: 4h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-pull-kubernetes-e2e: "true"
-    preset-pull-kubernetes-e2e-gce: "true"
-  decorate: true
-  decoration_config:
-    timeout: 120m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-resource-managers-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes CPU, Memory and Topology manager e2e tests with cgroup v2"
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -1536,70 +1536,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-master
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        args:
-          - --deployment=node
-          - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-central1-b
-          - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock
-            --container-runtime-process-name=/usr/local/bin/crio
-            --container-runtime-pid-file=
-            --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true
-            --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service
-            --kubelet-cgroups=/system.slice/kubelet.service"
-            --feature-gates=EventedPLEG=true --extra-log="{\"name\":
-            \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-          - --node-tests=true
-          - --provider=gce
-          - --test_args=--nodes=8 --focus="\[NodeConformance\]"
-            --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-          - --timeout=180m
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-evented-pleg.yaml
-        env:
-          - name: GOPATH
-            value: /go
-          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-            value: "1"
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv1-evented-pleg
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master,
-      cgroup v1 and the evented pleg feature enabled"
-- name: ci-crio-cgroupv1-evented-pleg-canary
-  cluster: k8s-infra-prow-build
-  interval: 3h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 240m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv1-evented-pleg-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master,
       cgroup v1 and the evented pleg feature enabled"

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -887,61 +887,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-master
-      command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --deployment=node
-      - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-central1-b
-      - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-      - --timeout=180m
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2.yaml
-      env:
-      - name: GOPATH
-        value: /go
-      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-        value: "1"
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-node-cri-o, sig-node-release-blocking
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-conformance
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com, release-team@kubernetes.io
-    description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v2"
-- name: ci-crio-cgroupv2-node-e2e-conformance-canary
-  cluster: k8s-infra-prow-build
-  interval: 1h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 240m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-release-master-blocking, sig-node-cri-o, sig-node-release-blocking
-    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-conformance-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com, release-team@kubernetes.io
     description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v2"
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -995,61 +995,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-master
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        args:
-          - --deployment=node
-          - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-central1-b
-          - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-          - --node-tests=true
-          - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]"
-          - --timeout=90m
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-resource-managers.yaml
-        env:
-          - name: GOPATH
-            value: /go
-          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-            value: "1"
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv1-node-e2e-resource-managers
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "Executes CPU, Memory and Topology manager e2e tests"
-- name: ci-crio-cgroupv1-node-e2e-resource-managers-canary
-  cluster: k8s-infra-prow-build
-  interval: 4h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 120m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-resource-managers-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes CPU, Memory and Topology manager e2e tests"
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -18,62 +18,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-master
-      command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --deployment=node
-      - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-central1-b
-      - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
-      - --timeout=180m
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
-      env:
-      - name: GOPATH
-        value: /go
-      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-        value: "1"
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-node-cri-o,  sig-node-release-blocking
     testgrid-tab-name: ci-crio-cgroupv1-node-e2e-conformance
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com, release-team@kubernetes.io
-
-    description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v1"
-- name: ci-crio-cgroupv1-node-e2e-conformance-canary
-  interval: 1h
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 240m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-release-master-blocking, sig-node-cri-o,  sig-node-release-blocking
-    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-conformance-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com, release-team@kubernetes.io
     description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v1"
   spec:


### PR DESCRIPTION
Replace some of the periodic Jobs to use kubetest2 from their canary variants. This jobs has been consistenly behaving as the original jobs for more than a week.

cc: @kannon92 

Part of https://github.com/kubernetes/test-infra/issues/32567