### PR TITLE
CAPZ: fix periodic windows clone refs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -360,10 +360,10 @@ periodics:
     preset-kind-volume-mounts: "true"
     preset-azure-community: "true"
   extra_refs:
-  - org: kubernetes-sigs
-    repo: cloud-provider-azure
-    base_ref: master
-    path_alias: sigs.k8s.io/cloud-provider-azure
+  - base_ref: main
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    repo: cluster-api-provider-azure
   - org: kubernetes-sigs
     repo: cloud-provider-azure
     base_ref: master


### PR DESCRIPTION
[capz-periodic-upstream-k8s-ci-windows-containerd-main](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#capz-periodic-upstream-k8s-ci-windows-containerd-main) has been failing with this error since it was created AFAICT:

```
Invalid options: clone ref config 1 (for kubernetes-sigs/cloud-provider-azure) will be extracted to /home/prow/go/src/sigs.k8s.io/cloud-provider-azure, which clone ref 0 (for kubernetes-sigs/cloud-provider-azure) is also using
```
e.g. at https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-azure-windows-with-ci-artifacts-main/1949564903220056064

This PR replaces the duplicate ref to cloud-provider-azure with cluster-api-provider-azure.