### PR TITLE
Update sig-scalability-periodic-dra.yaml to create resource quota for dra plugin pods for gke

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -268,9 +268,9 @@ periodics:
         repo: kubernetes
         base_ref: master
         path_alias: k8s.io/kubernetes
-      - org: kubernetes
+      - org: alaypatel07
         repo: perf-tests
-        base_ref: master
+        base_ref: dra-gke-plugin-in-kube-system
         path_alias: k8s.io/perf-tests
     spec:
       containers:


### PR DESCRIPTION
The GKE jobs are failing because dra-example-driver daemonset starts the pod with `system-node-critical` priority class and there isnt quota configured in the namespace for it.

```
I0728 08:53:49.846899      12 daemon_controller.go:1032] "Failed creation, decrementing expectations for daemon set" logger="daemonset-controller" daemonset="dra-example-driver/dra-example-driver-kubeletplugin"
E0728 08:53:49.846921      12 daemon_controller.go:1035] "Unhandled Error" err="insufficient quota to match these scopes: [{PriorityClass In [system-node-critical system-cluster-critical]}]" logger="UnhandledError"
```

https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-100-node-dra-with-workload/1949752139634970624/artifacts/e2e-5e99df7d83-72e90-master/kube-controller-manager.log

The idea is that quota is configured in kube-system namespace, the test will move further.