### PR TITLE
[testgrid] Dashboard to monitor jobs that require/use a GPU

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -26,7 +26,7 @@ periodics:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/fast/latest-fast -> --extract=ci/latest-{{.Version}}"
     fork-per-release-cron: 0 0-23/2 * * *, 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *, 0 14-23/24 * * *
-    testgrid-dashboards: sig-release-master-blocking, google-gce
+    testgrid-dashboards: sig-release-master-blocking, google-gce, sig-node-gpu
     testgrid-tab-name: gce-device-plugin-gpu-master
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com, release-team@kubernetes.io
     description: "Uses kubetest to run e2e tests (+Feature:GPUDevicePlugin) against a cluster created with cluster/kube-up.sh"

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -3,7 +3,7 @@ periodics:
   cluster: eks-prow-build-cluster
   name: ci-kubernetes-e2e-ec2-device-plugin-gpu
   annotations:
-    testgrid-dashboards: amazon-ec2
+    testgrid-dashboards: amazon-ec2, sig-node-gpu
     testgrid-tab-name: ci-kubernetes-e2e-ec2-device-plugin-gpu
   labels:
     preset-e2e-containerd-ec2: "true"

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -500,7 +500,7 @@ periodics:
           cpu: 4
           memory: 6Gi
   annotations:
-    testgrid-dashboards: sig-node-containerd
+    testgrid-dashboards: sig-node-containerd, sig-node-gpu
     testgrid-tab-name: e2e-cos-device-plugin-gpu
     testgrid-num-failures-to-alert: '8'
     testgrid-alert-stale-results-hours: '24'

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.30.yaml
@@ -78,7 +78,7 @@ periodics:
     fork-per-release-cron: 0 14-23/24 * * *
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
-    testgrid-dashboards: sig-release-1.30-blocking, google-gce
+    testgrid-dashboards: sig-release-1.30-blocking, google-gce, sig-node-gpu
     testgrid-num-failures-to-alert: "6"
     testgrid-tab-name: gce-device-plugin-gpu-1.30
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -78,7 +78,7 @@ periodics:
     fork-per-release-cron: 0 8-23/24 * * *, 0 14-23/24 * * *
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
-    testgrid-dashboards: sig-release-1.31-blocking, google-gce
+    testgrid-dashboards: sig-release-1.31-blocking, google-gce, sig-node-gpu
     testgrid-num-failures-to-alert: "6"
     testgrid-tab-name: gce-device-plugin-gpu-1.31
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -78,7 +78,7 @@ periodics:
     fork-per-release-cron: 0 8-23/12 * * *, 0 8-23/24 * * *, 0 14-23/24 * * *
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
-    testgrid-dashboards: sig-release-1.32-blocking, google-gce
+    testgrid-dashboards: sig-release-1.32-blocking, google-gce, sig-node-gpu
     testgrid-num-failures-to-alert: "6"
     testgrid-tab-name: gce-device-plugin-gpu-1.32
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -78,7 +78,7 @@ periodics:
     fork-per-release-cron: 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *, 0 14-23/24 * * *
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
-    testgrid-dashboards: sig-release-1.33-blocking, google-gce
+    testgrid-dashboards: sig-release-1.33-blocking, google-gce, sig-node-gpu
     testgrid-num-failures-to-alert: "6"
     testgrid-tab-name: gce-device-plugin-gpu-1.33
   cluster: k8s-infra-prow-build

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -8,6 +8,7 @@ dashboard_groups:
     - sig-node-dynamic-resource-allocation
     - sig-node-presubmits
     - sig-node-ec2
+    - sig-node-gpu
     - sig-node-ppc64le
     # These dashboards are for out-of-tree SIG Node projects
     - sig-node-cadvisor
@@ -129,4 +130,5 @@ dashboards:
 
 - name: sig-node-dynamic-resource-allocation
 - name: sig-node-presubmits
+- name: sig-node-gpu
 - name: sig-node-image-pushes


### PR DESCRIPTION
We have 3 tests in k/k that are currently being run:
- `should run nvidia-smi and cuda-demo-suite` ( https://github.com/kubernetes/kubernetes/blob/2a03dd1d5ecc66ca6a21fc9f526d4eedc9fef179/test/e2e/node/gpu.go#L64 )
- `should run gpu based matrix multiplication` ( https://github.com/kubernetes/kubernetes/blob/2a03dd1d5ecc66ca6a21fc9f526d4eedc9fef179/test/e2e/node/gpu.go#L93 )
- `should run gpu based jobs` ( https://github.com/kubernetes/kubernetes/blob/2a03dd1d5ecc66ca6a21fc9f526d4eedc9fef179/test/e2e/node/gpu.go#L122 )

We seem to be running these in the following jobs:
- ci-cri-containerd-e2e-gce-device-plugin-gpu
- ci-kubernetes-e2e-ec2-device-plugin-gpu
- ci-kubernetes-e2e-gce-device-plugin-gpu
- ci-kubernetes-e2e-gce-device-plugin-gpu-1-30
- ci-kubernetes-e2e-gce-device-plugin-gpu-1-31
- ci-kubernetes-e2e-gce-device-plugin-gpu-1-32
- ci-kubernetes-e2e-gce-device-plugin-gpu-1-33

Let's make them all appear on a single dashboard to see what exactly we are testing and what is failing if any etc.