### PR TITLE
Bump Go 1.24.5 for gcb-docker-gcloud

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.24.3
+ARG GO_VERSION=1.24.5
 
 FROM multiarch/qemu-user-static:7.2.0-1 AS qemu-image
 

--- a/images/gcb-docker-gcloud/README.md
+++ b/images/gcb-docker-gcloud/README.md
@@ -6,7 +6,7 @@ combination of `docker`, `gcloud`, and `go` all in the same build step
 ## contents
 
 - base:
-  - golang:1.24.3-alpine
+  - golang:1.24.5-alpine
 - languages:
   - `go`
 - tools:


### PR DESCRIPTION
Bump Go 1.24.5 for `gcb-docker-gcloud`

Reason:  1.24.3 is reported Vuln. 

/sig testing /area images