### PR TITLE
Fix the duplicate kind-network job in CAPI

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -556,7 +556,6 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20250717-57d1ca3de9-master
         command:
-          - cd ./../kind &&
           - wrapper.sh
           - bash
           - -c


### PR DESCRIPTION
Fix the duplicate kind-network job in CAPI