### PR TITLE
run triage more often

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -94,7 +94,7 @@ periodics:
       - --jq=/usr/bin/jq
 
 - name: ci-test-infra-triage
-  interval: 4h
+  interval: 3h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   decoration_config:


### PR DESCRIPTION
runs are typically closer to 2h or less now, sometimes as much as 2.5h (though not recently)

running this more often gives us lower latency to determining if flake fixes worked.

we reduced the frequency previously in budget crunch desperation, this job used to run continuously (scheduled on 30m interval)

https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-test-infra-triage