### PR TITLE
Update sig-scalability-periodic-dra.yaml to fix cl2 report directory

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -300,7 +300,7 @@ periodics:
             - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
             - --test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true
             - --test-cmd-args=--testconfig=testing/dra/config.yaml
-            - --test-cmd-args=--report-dir=/workspace/_artifacts
+            - --test-cmd-args=--report-dir=${ARTIFACTS}
             - --test-cmd-name=ClusterLoaderV2
             - --use-logexporter
           resources:


### PR DESCRIPTION
Noticed that the artifacts directory doesnt have intended output from CL2 run: https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-azure-dra-scalability/1950246208756781056/

This PR attempts to fix the output directory of clusterloader2