### PR TITLE
fixing kind job in CAPI for testing

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -533,7 +533,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: capi-pr-e2e-latestk8s-main
   # network test against kubernetes master branch with `kind` ipv6
-  - name: capi-kubernetes-kind-network-ipv6
+  - name: capi-kubernetes-kind-network-dual
     cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
@@ -563,11 +563,11 @@ presubmits:
           value: "true"
         # tell kind CI script to use ipv6
         - name: "IP_FAMILY"
-          value: "ipv6"
+          value: "dual"
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv4|IPv6DualStack|Internet.connection|PerformanceDNS|upstream.nameserver|SCTPConnectivity
+          value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|SCTPConnectivity
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
This PR is followup of this PR: https://github.com/kubernetes/test-infra/pull/35219 
This PR is changing 
`IP_FAMILY` to `dual`
and GINKGO_SKIP to Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|SCTPConnectivity 
This will run this https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20dual,%20master but as a presubmit on CAPI repo.

NOTE: This is just for debugging purposes, this will be removed once issue is resolved. 