### PR TITLE
Remove discovery-store from pull-kops-aws-distro-al2023

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -336,7 +336,7 @@ def presubmit_test(branch='master',
     if extra_flags is None:
         extra_flags = []
 
-    if irsa and cloud == "aws" and scenario is None:
+    if irsa and cloud == "aws" and scenario is None and name != "pull-kops-aws-distro-al2023":
         extra_flags.append("--discovery-store=s3://k8s-kops-prow/discovery")
 
     marker, k8s_deploy_url, test_package_url, test_package_dir = k8s_version_info(k8s_version)

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -673,7 +673,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-amazonlinux2
 
-# {"cloud": "aws", "distro": "al2023", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
+# {"cloud": "aws", "distro": "al2023", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-aws-distro-al2023
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -705,7 +705,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='137112412989/al2023-ami-2023.7.20250609.0-kernel-6.1-x86_64' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+            --create-args="--image='137112412989/al2023-ami-2023.7.20250609.0-kernel-6.1-x86_64' --channel=alpha --networking=calico" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -732,7 +732,6 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: al2023
-      test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico


### PR DESCRIPTION
Follows up on https://github.com/kubernetes/kops/pull/17520

This PR removes the `--discovery-store` flag from the `pull-kops-aws-distro-al2023` job in order to test if dynamic bucket creation works properly. This job is an optional job that's triggered manually. If it works for this job, we'll update all other jobs later on.

/assign @ameukam 