### PR TITLE
Kops - Dont use discovery store on terraform jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -143,7 +143,7 @@ def build_test(cloud='aws',
     tab = name_override or (f"kops-grid{suffix}")
     job_name = f"e2e-{tab}"
 
-    if irsa and cloud == "aws" and scenario is None:
+    if irsa and cloud == "aws" and scenario is None and terraform_version is None:
         if extra_flags is None:
             extra_flags = []
         if build_cluster == "k8s-infra-kops-prow-build":
@@ -336,7 +336,8 @@ def presubmit_test(branch='master',
     if extra_flags is None:
         extra_flags = []
 
-    if irsa and cloud == "aws" and scenario is None and name != "pull-kops-aws-distro-al2023":
+    if (irsa and cloud == "aws" and scenario is None and
+            terraform_version is None and name != "pull-kops-aws-distro-al2023"):
         extra_flags.append("--discovery-store=s3://k8s-kops-prow/discovery")
 
     marker, k8s_deploy_url, test_package_url, test_package_dir = k8s_version_info(k8s_version)


### PR DESCRIPTION
The prow aws accounts' s3 buckets used for kops state store and discovery store are in different regions.

The terraform that kops generates can't handle the state store s3 bucket and discovery store s3 bucket being in different regions.

Since it is reasonable for cluster administrators to have both buckets in the same region and only prow's shared buckets are in different regions, we can just skip the discovery store in our terraform tests.

Ideally kops would recognize the region for each and create separate terraform provider aliases for state store s3_objects and discovery store s3_objects.

/cc @hakman