### PR TITLE
Add periodic job for signed kubelet serving certs

### DIFF
--- a/config/jobs/kubernetes/sig-auth/signed-kubelet-server-certs.yaml
+++ b/config/jobs/kubernetes/sig-auth/signed-kubelet-server-certs.yaml
@@ -1,0 +1,47 @@
+periodics:
+- interval: 6h
+  name: ci-kubernetes-e2e-kind-signed-kubelet-certs
+  cluster: k8s-infra-prow-build
+  annotations:
+    testgrid-dashboards: sig-release-master-informing
+    testgrid-alert-email: release-team@kubernetes.io
+    description: Runs conformance tests on a cluster with kubelet serving certificates signed by the CP against a latest kubernetes master cluster created with sigs.k8s.io/kind
+  labels:
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: "k8s.io/test-infra"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20250717-57d1ca3de9-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && $GOPATH/src/k8s.io/test-infra/experiment/kubelet-serving-certificates/e2e-k8s.sh
+      env:
+      - name: LABEL_FILTER
+        value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+      - name: PARALLEL
+        value: "true"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7


### PR DESCRIPTION
This runs all the e2e tests for on-by-default features against a cluster with kubelet server certificates signed by the CP (as opposed to the default self-signed). This way we make sure we exercise certificate validation on any test making exec/logs/port-forward requests.

I tested this locally (with pj on kind) and I got all tests passing except a few ones using volumes. I suspect this is because I'm running "prow" inside a kind cluster and not because of the job's code. I got the same failures when running `ci-kubernetes-e2e-kind` locally.