### PR TITLE
ci-kubernetes-e2e-kind-rootless: set `--use-built-binaries`

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -299,6 +299,7 @@ periodics:
           --down \
           --test=ginkgo \
           -- \
+          --use-built-binaries \
           --focus-regex='\[NodeConformance\]' \
           --skip-regex='\[Environment:NotInUserNS\]|\[Slow\]' \
           --parallel=8


### PR DESCRIPTION
```console
$ kubetest2-tester-ginkgo --help
[...]
      --use-built-binaries            Look for binaries in _rundir/$KUBETEST2_RUN_DIR instead of extracting from tars downloaded from GCS.
```

This should ensure that the test uses the latest e2e binary.

Expected to fix:
- kubernetes/kubernetes#133330
- kubernetes/kubernetes#133369
