### PR TITLE
Increase memory request/limit for `pull-aws-ebs-csi-driver-unit`

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -147,10 +147,10 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
           limits:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-ebs-unit-test


### PR DESCRIPTION
This PR increases the memory request/limit for `pull-aws-ebs-csi-driver-unit` from 4Gi -> 8Gi, similar to `pull-aws-ebs-csi-driver-verify`. Should unblock https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2601.