### PR TITLE
Run aws-ebs-csi-driver bottle rocket test only on release branch

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -320,10 +320,9 @@ presubmits:
   - name: pull-aws-ebs-csi-driver-external-test-eks-bottlerocket
     cluster: eks-prow-build-cluster
     decorate: true
-    optional: true
-    skip_report: true
-    skip_branches:
-      - gh-pages
+    optional: false
+    branches:
+      - ^release-.*$
     skip_if_only_changed: "^docs/|^examples/|.md$|OWNERS$|^.github/"
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
This CR sets`pull-aws-ebs-csi-driver-external-test-eks-bottlerocket` as required and only runs it on the release branch.