### PR TITLE
Added milestone applier rules for 1.34, removed 1.30

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -474,10 +474,10 @@ milestone_applier:
     master: v1.34
   kubernetes/kubernetes:
     master: v1.34
+    release-1.34: v1.34
     release-1.33: v1.33
     release-1.32: v1.32
     release-1.31: v1.31
-    release-1.30: v1.30
   kubernetes/org:
     main: v1.34
   kubernetes/release:


### PR DESCRIPTION
Update to the `milestone_applier` configuration in `plugins.yaml` to align milestone versions with active versions of k8s.
Basically added 1.34 and removed 1.30 (EOL)