### PR TITLE
Added kubekins-e2e-v2 variants for 1.34

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -9,6 +9,11 @@ variants:
     GO_VERSION: 1.24.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
+  '1.34':
+    CONFIG: '1.34'
+    GO_VERSION: 1.24.5
+    K8S_RELEASE: latest-1.34
+    BAZEL_VERSION: 3.4.1
   '1.33':
     CONFIG: '1.33'
     GO_VERSION: 1.24.5


### PR DESCRIPTION
Update kubekins-e2e-v2 variant with 1.34 config.

/sig release
/area release-eng
/hold