### PR TITLE
Update tests config 1.34

### DIFF
--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -150,6 +150,9 @@ jobs:
     releaseBlocking: true
     testgridNumFailuresToAlert: 6
   ci-kubernetes-e2e-gce-cos-k8sstable3-serial:
+    args:
+    - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\]
+      --minStartupPods=8
     interval: 24h
     sigOwners: [sig-cloud-provider-gcp]
     releaseInforming: true
@@ -166,34 +169,34 @@ jobs:
     testSuite: alphafeatures-eventedpleg
 
   # stable4
-  ci-kubernetes-e2e-gce-cos-k8sstable4-reboot:
-    interval: 24h
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseBlocking: true
-  ci-kubernetes-e2e-gce-cos-k8sstable4-ingress:
-    interval: 24h
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseBlocking: true
-  ci-kubernetes-e2e-gce-cos-k8sstable4-default:
-    interval: 24h
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseBlocking: true
-    testgridNumFailuresToAlert: 6
-  ci-kubernetes-e2e-gce-cos-k8sstable4-serial:
-    interval: 24h
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseInforming: true
-    testgridNumFailuresToAlert: 6
-  ci-kubernetes-e2e-gce-cos-k8sstable4-slow:
-    interval: 24h
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseInforming: true
-    testgridNumFailuresToAlert: 6
-  ci-kubernetes-e2e-gce-cos-k8sstable4-alphafeatures:
-    interval: 24h
-    sigOwners: [sig-cloud-provider-gcp]
-    releaseBlocking: true
-    testSuite: alphafeatures-eventedpleg
+#  ci-kubernetes-e2e-gce-cos-k8sstable4-reboot:
+#    interval: 24h
+#    sigOwners: [sig-cloud-provider-gcp]
+#    releaseBlocking: true
+#  ci-kubernetes-e2e-gce-cos-k8sstable4-ingress:
+#    interval: 24h
+#    sigOwners: [sig-cloud-provider-gcp]
+#    releaseBlocking: true
+#  ci-kubernetes-e2e-gce-cos-k8sstable4-default:
+#    interval: 24h
+#    sigOwners: [sig-cloud-provider-gcp]
+#    releaseBlocking: true
+#    testgridNumFailuresToAlert: 6
+#  ci-kubernetes-e2e-gce-cos-k8sstable4-serial:
+#    interval: 24h
+#    sigOwners: [sig-cloud-provider-gcp]
+#    releaseInforming: true
+#    testgridNumFailuresToAlert: 6
+#  ci-kubernetes-e2e-gce-cos-k8sstable4-slow:
+#    interval: 24h
+#    sigOwners: [sig-cloud-provider-gcp]
+#    releaseInforming: true
+#    testgridNumFailuresToAlert: 6
+#  ci-kubernetes-e2e-gce-cos-k8sstable4-alphafeatures:
+#    interval: 24h
+#    sigOwners: [sig-cloud-provider-gcp]
+#    releaseBlocking: true
+#    testSuite: alphafeatures-eventedpleg
 
 # The following settings are used by cluster e2e tests.
 
@@ -245,24 +248,24 @@ k8sVersions:
     version: master
   beta:
     args:
+    - --extract=ci/latest-1.34
+    version: '1.34'
+  stable1:
+    args:
     - --extract=ci/latest-1.33
     version: '1.33'
-  stable1:
+  stable2:
     args:
     - --extract=ci/latest-1.32
     version: '1.32'
-  stable2:
+  stable3:
     args:
     - --extract=ci/latest-1.31
     version: '1.31'
-  stable3:
-    args:
-    - --extract=ci/latest-1.30
-    version: '1.30'
-  stable4:
-    args:
-    - --extract=ci/latest-1.29
-    version: '1.29'
+# stable4:
+#   args:
+#   - --extract=ci/latest-1.30
+#   version: '1.30'
 
 testSuites:
   alphafeatures:
@@ -445,24 +448,24 @@ nodeK8sVersions:
 
   beta:
     args:
+    - --repo=k8s.io/kubernetes=release-1.34
+    prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250807-xxxxxxxx-1.34 # TODO this is a placeholder, update with the actual image tag
+  stable1:
+    args:
     - --repo=k8s.io/kubernetes=release-1.33
     prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-1.33
-  stable1:
+  stable2:
     args:
     - --repo=k8s.io/kubernetes=release-1.32
     prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-1.32
-  stable2:
+  stable3:
     args:
     - --repo=k8s.io/kubernetes=release-1.31
     prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-1.31
-  stable3:
-    args:
-    - --repo=k8s.io/kubernetes=release-1.30
-    prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250714-70266d743a-1.30
-  stable4:
-    args:
-    - --repo=k8s.io/kubernetes=release-1.29
-    prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250409-f52ea67ed6-1.29
+# stable4:
+#    args:
+#    - --repo=k8s.io/kubernetes=release-1.30
+#    prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250714-70266d743a-1.30
 
 nodeTestSuites:
   default:


### PR DESCRIPTION
Updating test configuration to add support for the upcoming 1.34 release, promote existing versions, and deprecate (comment out) the oldest supported version (stable4) which is currently 1.30 (EOL). 