### PR TITLE
job/presubmit/ccm-aws: bump mem and cpu limit to prevent OOMKill

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
@@ -3,6 +3,8 @@ presubmits:
   - name: pull-cloud-provider-aws-e2e
     cluster: eks-prow-build-cluster
     decorate: true
+    decoration_config:
+      timeout: 4h
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(LICENSE|OWNERS)$"
     skip_branches:
     - gh-pages
@@ -17,10 +19,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 6Gi
         command:
         - runner.sh
         args:


### PR DESCRIPTION
The idea of this PR is to bump resource utilization of e2e targeting
stability of existing presubmits which is curently having high falure[1]
ratio with many hours to get the feedback to the user[2].

[1]
The root cause of mostly failures cuased by CI infra is pointing to be
OOMKill. Here is one example of a e2e job using above mem and CPU limits:
- failed job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/cloud-provider-aws/1158/pull-cloud-provider-aws-e2e/1953110200760143872
- dashboard for referenced job: https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes&var-repo=cloud-provider-aws&var-job=pull-cloud-provider-aws-e2e&var-build=All&from=1754491871179&to=1754494399603
- snapshot image (just in case the data points isn't available when this PR is reviewed):https://issues.redhat.com/secure/attachment/13469904/13469904_Screenshot+From+2025-08-06+21-06-13.png
- Slack discussion about the issue: https://kubernetes.slack.com/archives/C7J9RP96G/p1754505741634999

You can see instability on e2e presubmits recently (almost two weeks):
https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-cloud-provider-aws-e2e

[2]  https://github.com/kubernetes-sigs/prow/issues/210