### PR TITLE
Set ARM tests optional for now.

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -37,6 +37,8 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
+    # TODO(https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/2146): turn this test to required once the test is fixed.
+    optional: true
     decorate: true
     decoration_config:
       timeout: 60m


### PR DESCRIPTION
It will be required once https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/2146 is fixed.