### PR TITLE
CAPZ: Update periodic jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -1,54 +1,5 @@
 periodics:
 
-- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-29-1-30-main
-  cluster: eks-prow-build-cluster
-  minimum_interval: 24h
-  decorate: true
-  decoration_config:
-    timeout: 4h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-community: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    serviceAccountName: azure
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-1.32
-      args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-      env:
-        - name: KUBERNETES_VERSION_UPGRADE_FROM
-          value: "stable-1.29"
-        - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "stable-1.30"
-        - name: GINKGO_FOCUS
-          value: "\\[K8s-Upgrade\\]"
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        limits:
-          cpu: 4
-          memory: 9Gi
-        requests:
-          cpu: 4
-          memory: 9Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capi-periodic-upgrade-main-1-29-1-30
-    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: "Runs Kubernetes upgrade tests from v1.29 to v1.30 on CAPZ main branch"
-
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-30-1-31-main
   cluster: eks-prow-build-cluster
   minimum_interval: 24h
@@ -146,3 +97,52 @@ periodics:
     testgrid-tab-name: capi-periodic-upgrade-main-1-31-1-32
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
     description: "Runs Kubernetes upgrade tests from v1.31 to v1.32 on CAPZ main branch"
+
+- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-32-1-33-main
+  cluster: eks-prow-build-cluster
+  minimum_interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250717-57d1ca3de9-1.32
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.32"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.33"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capi-periodic-upgrade-main-1-32-1-33
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: "Runs Kubernetes upgrade tests from v1.32 to v1.33 on CAPZ main branch"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.20.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.20.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-provider-azure-conformance-v1beta1-release-1-18
+- name: periodic-cluster-api-provider-azure-conformance-v1beta1-release-1-20
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -12,7 +12,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.18
+      base_ref: release-1.20
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     serviceAccountName: azure
@@ -34,10 +34,10 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-conformance-v1beta1-release-1-18
+    testgrid-tab-name: capz-periodic-conformance-v1beta1-release-1-20
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-1.18 (v1beta1)
-- name: periodic-cluster-api-provider-azure-conformance-v1beta1-with-ci-artifacts-release-1-18
+    description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-1.20 (v1beta1)
+- name: periodic-cluster-api-provider-azure-conformance-v1beta1-with-ci-artifacts-release-1-20
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -50,7 +50,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.18
+      base_ref: release-1.20
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs
@@ -81,10 +81,10 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-conformance-k8s-ci-v1beta1-release-1-18
+    testgrid-tab-name: capz-periodic-conformance-k8s-ci-v1beta1-release-1-20
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-1.18 (v1beta1)
-- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-18
+    description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-1.20 (v1beta1)
+- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-20
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -97,7 +97,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.18
+      base_ref: release-1.20
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     serviceAccountName: azure
@@ -124,10 +124,10 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-18
+    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-20
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: Runs Cluster API E2E tests on cluster-api-provider-azure release-1.18 (v1beta1)
-- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-18
+    description: Runs Cluster API E2E tests on cluster-api-provider-azure release-1.20 (v1beta1)
+- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-20
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -140,7 +140,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.18
+      base_ref: release-1.20
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     serviceAccountName: azure
@@ -167,10 +167,10 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-18
+    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-20
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: Runs workload cluster creation E2E tests on cluster-api-provider-azure release-1.18 (v1beta1)
-- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-18
+    description: Runs Cluster API Provider Azure E2E tests on cluster-api-provider-azure release-1.20 (v1beta1)
+- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-20
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -183,7 +183,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.18
+      base_ref: release-1.20
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     serviceAccountName: azure
@@ -210,6 +210,6 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-18
+    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-20
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: Runs managed Kubernetes E2E tests on cluster-api-provider-azure release-1.18 (v1beta1)
+    description: Runs managed Kubernetes E2E tests on cluster-api-provider-azure release-1.20 (v1beta1)


### PR DESCRIPTION
- Replace periodic jobs for the release-1.18 branch with jobs for the release-1.20 branch.
- Roll the k8s versions we use to test upgrades.

/assign @mboersma 