### PR TITLE
CAPZ DRA scale: remove stray empty env var

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
@@ -101,7 +101,6 @@ presubmits:
           value: "2000"
         - name: CL2_SYSTEM_USED_MILLICORES
           value: "1200"  # this allows each workload pod to run with 100m
-        -
         - name: PROMETHEUS_SCRAPE_KUBELETS
           value: "true"
         resources:


### PR DESCRIPTION
This is causing an error when running the job:
```
— Pod can not be created: create pod test-pod ... .containers[0].env[21].name: Required value 
```