### PR TITLE
prow job for release-0.10 branch

### DIFF
--- a/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver-release-0.10.yaml
+++ b/config/jobs/kubernetes-sigs/ibm-powervs-block-csi-driver/ibm-powervs-block-csi-driver-release-0.10.yaml
@@ -1,0 +1,116 @@
+presubmits:
+  kubernetes-sigs/ibm-powervs-block-csi-driver:
+    - name: pull-ibm-powervs-block-csi-driver-build-test-release-0-10
+      cluster: eks-prow-build-cluster
+      always_run: true
+      decorate: true
+      labels:
+        preset-dind-enabled: 'true'
+      path_alias: sigs.k8s.io/ibm-powervs-block-csi-driver
+      annotations:
+        testgrid-dashboards: sig-cloud-provider-ibm-powervs-block-csi-driver
+        testgrid-tab-name: build-test-release-0-10
+        description: Build test in ibm-powervs-block-csi-driver repo.
+      branches:
+        # The script this job runs is not in all branches.
+        - ^release-0.10
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250808-38ff9ff2bd-1.33
+            command:
+              - runner.sh
+            args:
+              - make
+              - driver
+            resources:
+              limits:
+                cpu: 2
+                memory: 4Gi
+              requests:
+                cpu: 2
+                memory: 4Gi
+            securityContext:
+              privileged: true
+    - name: pull-ibm-powervs-block-csi-driver-image-build-test-release-0-10
+      cluster: eks-prow-build-cluster
+      always_run: true
+      decorate: true
+      labels:
+        preset-dind-enabled: 'true'
+      path_alias: sigs.k8s.io/ibm-powervs-block-csi-driver
+      annotations:
+        testgrid-dashboards: sig-cloud-provider-ibm-powervs-block-csi-driver
+        testgrid-tab-name: image-build-test-release-0-10
+        description: Build image test in ibm-powervs-block-csi-driver repo.
+      branches:
+        # The script this job runs is not in all branches.
+        - ^release-0.10
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250808-38ff9ff2bd-1.33
+            command:
+              - runner.sh
+            args:
+              - make
+              - image
+            resources:
+              limits:
+                cpu: 2
+                memory: 4Gi
+              requests:
+                cpu: 2
+                memory: 4Gi
+            securityContext:
+              privileged: true
+    - name: pull-ibm-powervs-block-csi-driver-unit-test-release-0-10
+      cluster: eks-prow-build-cluster
+      always_run: true
+      decorate: true
+      path_alias: sigs.k8s.io/ibm-powervs-block-csi-driver
+      annotations:
+        testgrid-dashboards: sig-cloud-provider-ibm-powervs-block-csi-driver
+        testgrid-tab-name: unit-test-release-0-10
+        description: Unit tests in ibm-powervs-block-csi-driver repo.
+      branches:
+        # The script this job runs is not in all branches.
+        - ^release-0.10
+      spec:
+        containers:
+          - image: 'public.ecr.aws/docker/library/golang:1.24'
+            command:
+              - make
+            args:
+              - test
+            resources:
+              limits:
+                cpu: 2
+                memory: 4Gi
+              requests:
+                cpu: 2
+                memory: 4Gi
+    - name: pull-ibm-powervs-block-csi-driver-verify-test-release-0-10
+      cluster: eks-prow-build-cluster
+      always_run: true
+      decorate: true
+      path_alias: sigs.k8s.io/ibm-powervs-block-csi-driver
+      annotations:
+        testgrid-dashboards: sig-cloud-provider-ibm-powervs-block-csi-driver
+        testgrid-tab-name: verify-test-release-0-10
+        description: ibm-powervs-block-csi-driver basic code verification.
+      branches:
+        # The script this job runs is not in all branches.
+        - ^release-0.10
+      spec:
+        containers:
+          - image: 'public.ecr.aws/docker/library/golang:1.24'
+            command:
+              - make
+            args:
+              - verify
+            resources:
+              limits:
+                cpu: 2
+                memory: 8Gi
+              requests:
+                cpu: 2
+                memory: 8Gi


### PR DESCRIPTION
New job for new release branch [release-0.10](https://github.com/kubernetes-sigs/ibm-powervs-block-csi-driver/tree/release-0.10) for ibm-powervs-block-csi-driver.

This branch includes go v1.24 and k8s v1.33.