### PR TITLE
CAPZ: bigger control plane nodes for DRA e2e tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -122,6 +122,8 @@ periodics:
           value: ${GOPATH}/src/sigs.k8s.io/cluster-api-provider-azure/test/e2e/data/kubetest/conformance-dra-ginkgo-v2.yaml
         - name: KUBERNETES_VERSION
           value: latest
+        - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
+          value: Standard_D8s_v3
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
This PR bumps the control plane VM SKU used for the DRA e2e tests from the default `Standard_B2s` to `Standard_D8s_v3` to accommodate the [`ResourceSlice Controller creates slices` test](https://github.com/kubernetes/kubernetes/blob/790393ae92e97262827d4f1fba24e8ae65bbada0/test/e2e/dra/dra.go#L2084). This test involves creating, deleting, and listing about 100 large (~684KB) ResourceSlices which was overwhelming the tiny VM the control plane was running on.

I didn't see any signs of Pods getting literally OOMKilled, but logging into a VM running the tests, I could see the VM had about 100-200MB of free memory out of ~3.5GB total. That seemed to be enough to get kube-apiserver to choke and cascade from there, locking up the control plane long enough for the test to time out.

There is probably a smaller VM SKU that would work, but I didn't look to see exactly how small we could make this with a SKU that's available in all the regions we test. The SKU I added here is the SKU we happen to use for scalability tests.

/assign @jackfrancis 