### PR TITLE
cloud-provider-gcp-e2e-full: ignore a broken test case from node-sig

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -223,7 +223,7 @@ presubmits:
             export TEST_PACKAGE_VERSION="v1.25.0";
             echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0";
           fi;
-          kubetest2 gce -v 2 --repo-root "${REPO_ROOT}" --build --up --down --test=ginkgo --node-size e2-standard-4 --master-size e2-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+          kubetest2 gce -v 2 --repo-root "${REPO_ROOT}" --build --up --down --test=ginkgo --node-size e2-standard-4 --master-size e2-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-node\] Container Runtime blackbox test when running a container with a new image \[It\] should be able to pull from private registry with secret \[NodeConformance\]'
         resources:
           limits:
             cpu: 4


### PR DESCRIPTION
The broken test case prevents PR merging in the project and it doesn't seem like it will be fixed quick. Issue about the test https://github.com/kubernetes/kubernetes/issues/133369