### PR TITLE
set HOME and GOROOT_BOOTSTRAP for ci-kubernetes-build-golang-tip

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
@@ -403,7 +403,8 @@ periodics:
           - bash
           - -c
           - |
-            export GOROOT_BOOTSTRAP=$(readlink -f $(dirname $(readlink -f $(which go)))/../..)
+            export HOME="$(mktemp -d)"
+            export GOROOT_BOOTSTRAP="$(go env GOROOT)"
             GIMME_DEBUG=true third_party/gimme/gimme master
         resources:
           limits:


### PR DESCRIPTION
use a temp HOME directory to prevent failures:
```
++ dirname //.gimme/versions/go
+ mkdir -p //.gimme/versions
mkdir: cannot create directory '//.gimme': Permission denied
```

Also avoid `which` for finding the go root directory and use `go env` per @ameukam 's suggestion in previous PR