### PR TITLE
Replace canary jobs crio

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -74,61 +74,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250808-38ff9ff2bd-master
-      command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --deployment=node
-      - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-central1-b
-      - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=8 --focus="\[Feature:.+\]|\[Feature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:PodLifecycleSleepActionAllowZero]|\[Feature:UserNamespacesPodSecurityStandards]|\[Feature:KubeletCredentialProviders]|\[Alpha\]"
-      - --timeout=180m
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
-      env:
-      - name: GOPATH
-        value: /go
-      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-        value: "1"
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv1-node-e2e-features
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "OWNER: sig-node; runs Features e2e tests with crio master and cgroup v1"
-- name: ci-crio-cgroupv1-node-e2e-features-canary
-  cluster: k8s-infra-prow-build
-  interval: 1h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 180m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-features-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs Features e2e tests with crio master and cgroup v1"
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -129,61 +129,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250808-38ff9ff2bd-master
-      command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --deployment=node
-      - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-central1-b
-      - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=8 --focus="\[Feature:.+\]|\[Feature\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:NodeSwap\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:UserNamespacesPodSecurityStandards]|\[Feature:KubeletCredentialProviders]|\[Alpha\]"
-      - --timeout=180m
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2.yaml
-      env:
-      - name: GOPATH
-        value: /go
-      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-        value: "1"
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-features
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "OWNER: sig-node; runs Features e2e tests with crio master and cgroup v2"
-- name: ci-crio-cgroupv2-node-e2e-features-canary
-  cluster: k8s-infra-prow-build
-  interval: 1h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 180m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-features-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs Features e2e tests with crio master and cgroup v1"
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -890,58 +890,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 120m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250808-38ff9ff2bd-master
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        args:
-          - --deployment=node
-          - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-central1-b
-          - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-          - --node-tests=true
-          - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Feature:HugePages\]"
-          - --timeout=90m
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2-hugepages.yaml
-        env:
-          - name: GOPATH
-            value: /go
-          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-            value: "1"
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-hugepages
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "Executes hugepages e2e tests"
-- name: ci-crio-cgroupv2-node-e2e-hugepages-canary
-  cluster: k8s-infra-prow-build
-  interval: 4h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
     preset-pull-kubernetes-e2e: "true"
     preset-pull-kubernetes-e2e-gce: "true"
   decorate: true
@@ -959,7 +907,7 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-hugepages-canary
+    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-hugepages
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes hugepages e2e tests"
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -292,62 +292,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250808-38ff9ff2bd-master
-      command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --deployment=node
-      - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-central1-b
-      - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=1 --skip="\[Flaky\]|\[NodeConformance\]|\[Conformance\]|\[Serial\]|\[Feature:.+\]|\[Feature\]|\[Legacy:.+\]|\[Benchmark\]|\[Feature:SCTPConnectivity\]"
-      - --timeout=300m
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
-      env:
-      - name: GOPATH
-        value: /go
-      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-        value: "1"
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv1-node-e2e-unlabelled
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "Contains all uncategorized tests, these are tests which are not marked with a [Node] tag. All node tests should be marked with [Feature] or [NodeConformance] classification. Also skipped are [Flaky], [Benchmark], [Legacy]."
-
-- name: ci-crio-cgroupv1-node-e2e-unlabelled-canary
-  cluster: k8s-infra-prow-build
-  interval: 12h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 400m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-unlabelled-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Contains all uncategorized tests, these are tests which are not marked with a [Node] tag. All node tests should be marked with [Feature] or [NodeConformance] classification. Also skipped are [Flaky], [Benchmark], [Legacy]."
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -350,63 +350,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250808-38ff9ff2bd-master
-      command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --deployment=node
-      - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-central1-b
-      - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=1 --focus="\[Feature:Eviction\]" --timeout=300m
-      - --timeout=300m
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
-      env:
-      - name: GOPATH
-        value: /go
-      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-        value: "1"
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv1-node-e2e-eviction
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v1"
-- name: ci-crio-cgroupv1-node-e2e-eviction-canary
-  cluster: k8s-infra-prow-build
-  interval: 4h30m
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-pull-kubernetes-e2e: "true"
-    preset-pull-kubernetes-e2e-gce: "true"
-  decorate: true
-  decoration_config:
-    timeout: 320m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-eviction-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v1"
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -295,61 +295,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250808-38ff9ff2bd-master
-      command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --deployment=node
-      - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-central1-b
-      - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=1 --skip="\[Flaky\]|\[NodeConformance\]|\[Conformance\]|\[Serial\]|\[Feature:.+\]|\[Feature\]|\[Legacy:.+\]|\[Benchmark\]|\[Feature:SCTPConnectivity\]"
-      - --timeout=300m
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2.yaml
-      env:
-      - name: GOPATH
-        value: /go
-      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-        value: "1"
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-unlabelled
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "Contains all uncategorized tests, these are tests which are not marked with a [Node] tag. All node tests should be marked with [Feature] or [NodeConformance] classification. Also skipped are [Flaky], [Benchmark], [Legacy]."
-- name: ci-crio-cgroupv2-node-e2e-unlabelled-canary
-  cluster: k8s-infra-prow-build
-  interval: 12h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 400m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-unlabelled-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Contains all uncategorized tests, these are tests which are not marked with a [Node] tag. All node tests should be marked with [Feature] or [NodeConformance] classification. Also skipped are [Flaky], [Benchmark], [Legacy]."
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -406,63 +406,9 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250808-38ff9ff2bd-master
-      command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --deployment=node
-      - --env=KUBE_SSH_USER=core
-      - --gcp-zone=us-central1-b
-      - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=1 --focus="\[Feature:Eviction\]" --timeout=300m
-      - --timeout=300m
-      - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2.yaml
-      env:
-      - name: GOPATH
-        value: /go
-      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-        value: "1"
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-eviction
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
-- name: ci-crio-cgroupv2-node-e2e-eviction-canary
-  cluster: k8s-infra-prow-build
-  interval: 4h30m
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-pull-kubernetes-e2e: "true"
-    preset-pull-kubernetes-e2e-gce: "true"
-  decorate: true
-  decoration_config:
-    timeout: 320m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv2-node-e2e-eviction-canary
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
   spec:

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -938,58 +938,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 120m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  spec:
-    containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250808-38ff9ff2bd-master
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        args:
-          - --deployment=node
-          - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-central1-b
-          - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-          - --node-tests=true
-          - --provider=gce
-          - --test_args=--nodes=1 --focus="\[Feature:HugePages\]"
-          - --timeout=90m
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-hugepages.yaml
-        env:
-          - name: GOPATH
-            value: /go
-          - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
-            value: "1"
-        resources:
-          limits:
-            cpu: 4
-            memory: 6Gi
-          requests:
-            cpu: 4
-            memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-hugepages
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "Executes hugepages e2e tests"
-- name: ci-crio-cgroupv1-node-e2e-hugepages-canary
-  cluster: k8s-infra-prow-build
-  interval: 4h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
     preset-pull-kubernetes-e2e: "true"
     preset-pull-kubernetes-e2e-gce: "true"
   decorate: true
@@ -1007,7 +955,7 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-hugepages-canary
+    testgrid-tab-name: ci-crio-cgroupv1-node-e2e-hugepages
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
     description: "Executes hugepages e2e tests"
   spec:


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/issues/32567

All of the jobs have been working as expected for a cuple of weeks now(only exception are eviction tests), so make sense to replace the main jobs with the canaries.

The first batch of replacement was in [Replace crio canary periodics #35230](https://github.com/kubernetes/test-infra/pull/35230)

For this please note that for `eviction` tests are constantly failing on kubetest. the canary on kubetest2 test are on flaky so i propose we change those to. 

https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv1-node-e2e-eviction
https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv1-node-e2e-eviction-canary
https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv2-node-e2e-eviction
https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv2-node-e2e-eviction-canary

cc: @kannon92 