### PR TITLE
grab log files generated in ci-kubernetes-build-golang-tip

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
@@ -405,6 +405,12 @@ periodics:
           - |
             export HOME="$(mktemp -d)"
             export GOROOT_BOOTSTRAP="$(go env GOROOT)"
+
+            atexit () {
+              find "$HOME/.gimme" -name "*.log" -exec cp {} "${ARTIFACTS}" \;
+            }
+            trap 'atexit' EXIT
+
             GIMME_DEBUG=true third_party/gimme/gimme master
         resources:
           limits:


### PR DESCRIPTION
log files are generated by `gimme` relative to `$HOME/.gimme` like so. let's grab it from there and stick it into our log/artifacts directory
```
+ export GOOS=linux GOARCH=amd64
+ GOOS=linux
+ GOARCH=amd64
+ export CGO_ENABLED=
+ CGO_ENABLED=
+ export CC_FOR_TARGET=
+ CC_FOR_TARGET=
+ local make_log=/tmp/tmp.sEagHPGi3d/.gimme/versions/go/make.linux.amd64.log
+ [[ true -ge 2 ]]
+ ./make.bash
+ return 1
```