### PR TITLE
Azure scale: Disable host-level API availability checks

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
@@ -90,6 +90,11 @@ periodics:
           value: "true"
         - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
           value: "99.5"
+        # CAPZ clusters don't expose each individual control plane node.
+        - name: CL2_API_AVAILABILITY_MEASUREMENT_IPS_CONFIGURED
+          value: "true"
+        - name: CL2_API_AVAILABILITY_MEASUREMENT_USE_INTERNAL_IPS
+          value: "false"
         # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy
         - name: DEPLOY_AZURE_CSI_DRIVER
           value: "false"


### PR DESCRIPTION
This PR follows up from #35109 to propagate the config to skip host-level API server availability tests for Azure clusters. The clusters built with CAPZ only expose the control plane via a public load balancer where each node only has an internal IP, so the host-level checks continuously fail and add noise to the logs. e.g. from https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-azure-scalability/1955357052398211072:

```
W0812 20:35:56.171581   37318 api_availability_measurement.go:83] execservice issue: problem with RunCommand(): output="+ curl --connect-timeout 5 -s -k -w '%{http_code}' -o /dev/null [https://10.0.0.6:443/readyz](https://10.0.0.6/readyz)\ncommand terminated with exit code 7\n", err=exit status 7
W0812 20:35:56.171611   37318 api_availability_measurement.go:86] host 10.0.0.6 not available; HTTP status code:
```

The changes from #35109 were tested by running the modified presubmit job and none of those logs appear anymore:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/5801/pull-cluster-api-provider-azure-load-test-custom-builds/1953910526153068544