### PR TITLE
dra: 1.34: remove redundant option

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -559,7 +559,7 @@ periodics:
       - --timeout=60m
       - --skip-regex=
       - '--test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true"
-        --runtime-config=api/ga=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock
+        --container-runtime-endpoint=unix:///var/run/crio/crio.sock
         --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file=
         --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
         --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service"
@@ -620,7 +620,7 @@ periodics:
       - --timeout=60m
       - --skip-regex=
       - '--test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true"
-        --runtime-config=api/ga=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock
+        --container-runtime-endpoint=unix:///var/run/crio/crio.sock
         --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file=
         --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
         --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service"
@@ -682,7 +682,7 @@ periodics:
       - --timeout=60m
       - --skip-regex=
       - '--test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true"
-        --runtime-config=api/ga=true --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+        --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
         --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file=
         --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
         --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service"
@@ -740,7 +740,7 @@ periodics:
       - --timeout=60m
       - --skip-regex=
       - '--test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true"
-        --runtime-config=api/ga=true --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+        --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
         --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file=
         --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
         --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service"
@@ -2448,7 +2448,7 @@ presubmits:
         - --timeout=60m
         - --skip-regex=
         - '--test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true"
-          --runtime-config=api/ga=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock
+          --container-runtime-endpoint=unix:///var/run/crio/crio.sock
           --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file=
           --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
           --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service"
@@ -2506,7 +2506,7 @@ presubmits:
         - --timeout=60m
         - --skip-regex=
         - '--test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true"
-          --runtime-config=api/ga=true --container-runtime-endpoint=unix:///var/run/crio/crio.sock
+          --container-runtime-endpoint=unix:///var/run/crio/crio.sock
           --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file=
           --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
           --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service"
@@ -2564,7 +2564,7 @@ presubmits:
         - --timeout=60m
         - --skip-regex=
         - '--test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true"
-          --runtime-config=api/ga=true --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+          --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
           --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file=
           --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
           --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service"
@@ -2618,7 +2618,7 @@ presubmits:
         - --timeout=60m
         - --skip-regex=
         - '--test-args=--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAllocation=true"
-          --runtime-config=api/ga=true --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+          --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
           --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file=
           --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
           --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service"


### PR DESCRIPTION
Removed redundant `--runtime-config=api/ga=true` option.