### PR TITLE
Bump go version from 1.24.5 to 1.24.6 for kubekins-e2e/kubekins-e2e-v2/krte

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,22 +1,22 @@
 variants:
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.24.5
+    GO_VERSION: 1.24.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   master:
     CONFIG: master
-    GO_VERSION: 1.24.5
+    GO_VERSION: 1.24.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   '1.34':
     CONFIG: '1.34'
-    GO_VERSION: 1.24.5
+    GO_VERSION: 1.24.6
     K8S_RELEASE: latest-1.34
     BAZEL_VERSION: 3.4.1
   '1.33':
     CONFIG: '1.33'
-    GO_VERSION: 1.24.5
+    GO_VERSION: 1.24.6
     K8S_RELEASE: latest-1.33
     BAZEL_VERSION: 3.4.1
   '1.32':


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/133516 has merged

so next step according to check list in https://github.com/kubernetes/release/issues/4077 is bumping kubekins-e2e/kubekins-e2e-v2/krte

/assign @cpanato @saschagrunert @puerco @ameukam 
cc @kubernetes/release-managers