### PR TITLE
ci-kubernetes-e2e-gce-scale-correctness reduce nodes from 5000 to 2000

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -20,7 +20,7 @@ periodics:
     testgrid-tab-name: gce-master-scale-correctness
     # exclude-filter-by-regex=^(kubetest\.Test|ci-kubernetes-e2e-gce-scale-correctness\.Overall)$
     testgrid-base-options: 'exclude-filter-by-regex=%5E(kubetest%5C.Test%7Cci-kubernetes-e2e-gce-scale-correctness%5C.Overall)%24'
-    description: "Uses kubetest to run correctness tests against a 5000-node cluster created with cluster/kube-up.sh"
+    description: "Uses kubetest to run correctness tests against a 2000-node cluster created with cluster/kube-up.sh"
   spec:
     volumes:
     - name: cache-secret


### PR DESCRIPTION
Reduce number of nodes from 5000 to 2000 to check if this fixes flakiness of the tests in this job: ci-kubernetes-e2e-gce-scale-correctness