### PR TITLE
DRA: Improve kubelet version selection logic

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -334,8 +334,20 @@ presubmits:
           major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
           minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 1))
-          # Test with the lastest stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
-          previous=$(curl --silent -L "https://dl.k8s.io/release/stable-$major.$previous_minor.txt" )
+          # Test with the stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
+          response=$(curl --silent -w '%{http_code}' -L "https://dl.k8s.io/release/stable-$major.$previous_minor.txt" )
+          status="${response: -3}"
+          previous="${response::-3}"
+          if [ status == 404 ] ; then
+              # if stable doesn't exist - use latest
+              response=$(curl --silent -w '%{http_code}' -L "https://dl.k8s.io/release/latest-$major.$previous_minor.txt" )
+              status="${response: -3}"
+              previous="${response::-3}"
+          fi
+          if [ status -ne 200 ] ; then
+              echo "error: unable to get release $major.$previous_minor info"
+              exit 1
+          fi
           curl --silent -L "https://dl.k8s.io/release/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
           chmod a+rx /tmp/kubelet
           /tmp/kubelet --version
@@ -447,8 +459,20 @@ presubmits:
           major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
           minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 2))
-          # Test with the lastest stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
-          previous=$(curl --silent -L "https://dl.k8s.io/release/stable-$major.$previous_minor.txt" )
+          # Test with the stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
+          response=$(curl --silent -w '%{http_code}' -L "https://dl.k8s.io/release/stable-$major.$previous_minor.txt" )
+          status="${response: -3}"
+          previous="${response::-3}"
+          if [ status == 404 ] ; then
+              # if stable doesn't exist - use latest
+              response=$(curl --silent -w '%{http_code}' -L "https://dl.k8s.io/release/latest-$major.$previous_minor.txt" )
+              status="${response: -3}"
+              previous="${response::-3}"
+          fi
+          if [ status -ne 200 ] ; then
+              echo "error: unable to get release $major.$previous_minor info"
+              exit 1
+          fi
           curl --silent -L "https://dl.k8s.io/release/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
           chmod a+rx /tmp/kubelet
           /tmp/kubelet --version

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -341,7 +341,7 @@ presubmits:
           major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
           minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 1))
-          # Test with the lastest stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
+          # Test with the stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
           previous=$(curl --silent -L "https://dl.k8s.io/release/stable-$major.$previous_minor.txt" )
           curl --silent -L "https://dl.k8s.io/release/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
           chmod a+rx /tmp/kubelet
@@ -456,7 +456,7 @@ presubmits:
           major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
           minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 2))
-          # Test with the lastest stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
+          # Test with the stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
           previous=$(curl --silent -L "https://dl.k8s.io/release/stable-$major.$previous_minor.txt" )
           curl --silent -L "https://dl.k8s.io/release/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
           chmod a+rx /tmp/kubelet

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -212,8 +212,24 @@ presubmits:
           previous=$(curl --silent -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
           curl --silent -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
           {%- else %}
-          # Test with the lastest stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
+          # Test with the stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
+          {%- if canary %}
+          response=$(curl --silent -w '%{http_code}' -L "https://dl.k8s.io/release/stable-$major.$previous_minor.txt" )
+          status="${response: -3}"
+          previous="${response::-3}"
+          if [ status == 404 ] ; then
+              # if stable doesn't exist - use latest
+              response=$(curl --silent -w '%{http_code}' -L "https://dl.k8s.io/release/latest-$major.$previous_minor.txt" )
+              status="${response: -3}"
+              previous="${response::-3}"
+          fi
+          if [ status -ne 200 ] ; then
+              echo "error: unable to get release $major.$previous_minor info"
+              exit 1
+          fi
+          {%- else %}
           previous=$(curl --silent -L "https://dl.k8s.io/release/stable-$major.$previous_minor.txt" )
+          {%- endif %}
           curl --silent -L "https://dl.k8s.io/release/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
           {%- endif %}
           chmod a+rx /tmp/kubelet


### PR DESCRIPTION
Instead of assuming the previous stable release always exists, check for its presence and fall back to the latest release if necessary.

Fixes: https://github.com/kubernetes/kubernetes/issues/133507

NOTE: It's done only for -canary job to avoid breakages in other job types (ci, presubmit). If it works, I'll propagate these changes to the ci and presubmit jobs.