### PR TITLE
Bump go version from 1.23.11 to 1.23.12 for kubekins-e2e/kubekins-e2e-v2/krte

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -21,11 +21,11 @@ variants:
     BAZEL_VERSION: 3.4.1
   '1.32':
     CONFIG: '1.32'
-    GO_VERSION: 1.23.11
+    GO_VERSION: 1.23.12
     K8S_RELEASE: latest-1.32
     BAZEL_VERSION: 3.4.1
   '1.31':
     CONFIG: '1.31'
-    GO_VERSION: 1.23.11
+    GO_VERSION: 1.23.12
     K8S_RELEASE: latest-1.31
     BAZEL_VERSION: 3.4.1


### PR DESCRIPTION
xref: https://github.com/kubernetes/release/issues/4077

/assign @ameukam @dims @saschagrunert  
cc @kubernetes/release-managers 