### PR TITLE
kOps: Add the capability to get the latest GCE images from GCE projects

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -43,6 +43,7 @@ from build_vars import ( # pylint: disable=import-error, no-name-in-module
     skip_jobs,
     image,
     networking_options,
+    gce_distro_options,
     distro_options,
     k8s_versions,
     kops_versions,
@@ -485,7 +486,7 @@ def generate_grid():
     # TODO(justinsb): merge into above block when we can
     # pylint: disable=too-many-nested-blocks
     for networking in ['kubenet', 'calico', 'cilium', 'gce']: # TODO: all networking_options:
-        for distro in ['u2204']: # TODO: all distro_options:
+        for distro in gce_distro_options: # TODO: all distro_options:
             for k8s_version in k8s_versions:
                 for kops_version in [None]: # TODO: all kops_versions:
                     results.append(

--- a/config/jobs/kubernetes/kops/build_vars.py
+++ b/config/jobs/kubernetes/kops/build_vars.py
@@ -29,6 +29,11 @@ networking_options = [
     "kopeio",
 ]
 
+# GCE distributions
+gce_distro_options = [
+    "u2204",
+]
+
 # AWS distributions
 distro_options = [
     "al2023",

--- a/config/jobs/kubernetes/kops/pinned.list
+++ b/config/jobs/kubernetes/kops/pinned.list
@@ -1,3 +1,4 @@
+gce://images/ubuntu-os-cloud/ubuntu-2204-lts:X86_64=ubuntu-2204-jammy-v20250826
 aws://images/137112412989/al2023-ami-2*-kernel-6.1-x86_64:x86_64=137112412989/al2023-ami-2023.8.20250818.0-kernel-6.1-x86_64
 aws://images/137112412989/amzn2-ami-kernel-5.10-hvm-*-x86_64-gp2:x86_64=137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20250818.2-x86_64-gp2
 aws://images/136693071363/debian-11-amd64-*:x86_64=136693071363/debian-11-amd64-20250801-2191


### PR DESCRIPTION
Add a function to get the latest GCE image based on the project name, the family and the architecture.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>