### PR TITLE
Node e2e with golang tip

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
@@ -419,3 +419,58 @@ periodics:
           requests:
             cpu: 4
             memory: "8Gi"
+
+- name: ci-cgroup-systemd-containerd-node-e2e-golang-tip
+  cluster: k8s-infra-prow-build
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+    - org: containerd
+      repo: containerd
+      base_ref: main
+      path_alias: github.com/containerd/containerd
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250808-38ff9ff2bd-master
+        command:
+          - runner.sh
+          - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
+          - --deployment=node
+          - --gcp-zone=us-central1-b
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
+          - --timeout=65m
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+        env:
+          - name: GOPATH
+            value: /go
+          - name: GO_VERSION
+            value: "devel"
+  annotations:
+    testgrid-dashboards: sig-arch-code-organization
+    testgrid-tab-name: cgroup-systemd-containerd-node-e2e-golang-tip
+    testgrid-alert-email: davanum@gmail.com


### PR DESCRIPTION
clone of `ci-cgroup-systemd-containerd-node-e2e` CI job but with golang tip.

/sig architecture
/area code-organization
/assign @BenTheElder @ameukam @upodroid 