### PR TITLE
drop duplicate gce conformance jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -4,45 +4,9 @@ periodics:
   name: ci-kubernetes-gce-conformance-latest
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "--extract=ci/latest-fast -> --extract=ci/latest-{{.Version}}"
-    testgrid-dashboards: conformance-all, conformance-gce
-    testgrid-tab-name: Conformance - GCE - master
-    description: Runs conformance tests using kubetest against kubernetes master on GCE
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 220m
-  spec:
-    containers:
-    - command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --extract=ci/fast/latest-fast
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\]
-      - --timeout=200m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250815-171060767f-master
-      resources:
-        limits:
-          cpu: 1
-          memory: 3Gi
-        requests:
-          cpu: 1
-          memory: 3Gi
-- interval: 3h
-  cluster: k8s-infra-prow-build
-  name: ci-kubernetes-gce-conformance-latest-kubetest2
-  annotations:
-    fork-per-release: "true"
     fork-per-release-replacements: "MARKER_VERSION=latest.txt -> MARKER_VERSION=latest-{{.Version}}.txt"
     testgrid-dashboards: sig-release-master-blocking, conformance-all, conformance-gce
-    testgrid-tab-name: Conformance - GCE - master - kubetest2
+    testgrid-tab-name: Conformance - GCE - master
     description: Runs conformance tests using kubetest2 against kubernetes master on GCE
     testgrid-num-failures-to-alert: '1'
     testgrid-alert-stale-results-hours: '24'
@@ -62,7 +26,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250815-171060767f-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250815-171060767f-master
       securityContext:
         privileged: true
       resources:
@@ -81,10 +45,6 @@ periodics:
         set -o nounset;
         set -o pipefail;
         set -o xtrace;
-        export GO111MODULE=on;
-        go install sigs.k8s.io/kubetest2@latest;
-        go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-        go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
         MARKER_VERSION=latest.txt;
         kubetest2 gce \;
           --v=9 \;

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -1,45 +1,11 @@
 periodics:
 - annotations:
-    testgrid-dashboards: conformance-all, conformance-gce, sig-release-job-config-errors
-    testgrid-tab-name: Conformance - GCE - 1.31
-  cluster: k8s-infra-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 3h40m0s
-  interval: 3h
-  labels:
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-  name: ci-kubernetes-gce-conformance-latest-1-31
-  spec:
-    containers:
-    - args:
-      - --extract=ci/fast/latest-fast
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\]
-      - --timeout=200m
-      command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250815-171060767f-1.31
-      name: ""
-      resources:
-        limits:
-          cpu: "1"
-          memory: 3Gi
-        requests:
-          cpu: "1"
-          memory: 3Gi
-- annotations:
     testgrid-alert-email: release-team@kubernetes.io
     testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-1.31-blocking, conformance-all, conformance-gce
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "1"
-    testgrid-tab-name: Conformance - GCE - 1.31 - kubetest2
+    testgrid-tab-name: Conformance - GCE - 1.31
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
@@ -54,7 +20,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-gce-conformance-latest-kubetest2-1-31
+  name: ci-kubernetes-gce-conformance-latest-1-31
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -1,45 +1,11 @@
 periodics:
 - annotations:
-    testgrid-dashboards: conformance-all, conformance-gce, sig-release-job-config-errors
-    testgrid-tab-name: Conformance - GCE - 1.32
-  cluster: k8s-infra-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 3h40m0s
-  interval: 3h
-  labels:
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-  name: ci-kubernetes-gce-conformance-latest-1-32
-  spec:
-    containers:
-    - args:
-      - --extract=ci/fast/latest-fast
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\]
-      - --timeout=200m
-      command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250815-171060767f-1.32
-      name: ""
-      resources:
-        limits:
-          cpu: "1"
-          memory: 3Gi
-        requests:
-          cpu: "1"
-          memory: 3Gi
-- annotations:
     testgrid-alert-email: release-team@kubernetes.io
     testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-1.32-blocking, conformance-all, conformance-gce
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "1"
-    testgrid-tab-name: Conformance - GCE - 1.32 - kubetest2
+    testgrid-tab-name: Conformance - GCE - 1.32
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
@@ -54,7 +20,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-gce-conformance-latest-kubetest2-1-32
+  name: ci-kubernetes-gce-conformance-latest-1-32
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -1,45 +1,11 @@
 periodics:
 - annotations:
-    testgrid-dashboards: conformance-all, conformance-gce, sig-release-job-config-errors
-    testgrid-tab-name: Conformance - GCE - 1.33
-  cluster: k8s-infra-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 3h40m0s
-  interval: 3h
-  labels:
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-  name: ci-kubernetes-gce-conformance-latest-1-33
-  spec:
-    containers:
-    - args:
-      - --extract=ci/fast/latest-fast
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\]
-      - --timeout=200m
-      command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250815-171060767f-1.33
-      name: ""
-      resources:
-        limits:
-          cpu: "1"
-          memory: 3Gi
-        requests:
-          cpu: "1"
-          memory: 3Gi
-- annotations:
     testgrid-alert-email: release-team@kubernetes.io
     testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-1.33-blocking, conformance-all, conformance-gce
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "1"
-    testgrid-tab-name: Conformance - GCE - 1.33 - kubetest2
+    testgrid-tab-name: Conformance - GCE - 1.33
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
@@ -54,7 +20,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-gce-conformance-latest-kubetest2-1-33
+  name: ci-kubernetes-gce-conformance-latest-1-33
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1,45 +1,11 @@
 periodics:
 - annotations:
-    testgrid-dashboards: conformance-all, conformance-gce, sig-release-job-config-errors
-    testgrid-tab-name: Conformance - GCE - 1.34
-  cluster: k8s-infra-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 3h40m0s
-  interval: 3h
-  labels:
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-  name: ci-kubernetes-gce-conformance-latest-1-34
-  spec:
-    containers:
-    - args:
-      - --extract=ci/fast/latest-fast
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Conformance\]
-      - --timeout=200m
-      command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250815-171060767f-1.34
-      name: ""
-      resources:
-        limits:
-          cpu: "1"
-          memory: 3Gi
-        requests:
-          cpu: "1"
-          memory: 3Gi
-- annotations:
     testgrid-alert-email: release-team@kubernetes.io
     testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-1.34-blocking, conformance-all, conformance-gce
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "1"
-    testgrid-tab-name: Conformance - GCE - 1.34 - kubetest2
+    testgrid-tab-name: Conformance - GCE - 1.34
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
@@ -54,7 +20,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-gce-conformance-latest-kubetest2-1-34
+  name: ci-kubernetes-gce-conformance-latest-1-34
   spec:
     containers:
     - args:


### PR DESCRIPTION
We have been running duplicate jobs for a very long time. https://testgrid.k8s.io/conformance-gce

Also, kubernetes_e2e.py is deprecated. For the master branch job, I switched the image to kubekins-e2e-v2 image as that image is leaner and has kubetest2 installed.

/hold will merge after 1.34 release