### PR TITLE
drop stale inspur and huaweicloud conformance jobs

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -6,8 +6,6 @@ dashboard_groups:
     - conformance-ec2
     - conformance-gce
     - conformance-kind
-    - conformance-cloud-provider-huaweicloud
-    - conformance-cloud-provider-inspur
     - conformance-hack-local-up-cluster
     - conformance-ppc64le
     - conformance-gardener
@@ -112,19 +110,6 @@ dashboards:
 - name: conformance-apisnoop
 - name: conformance-ec2
 - name: conformance-gce
-
-- name: conformance-cloud-provider-huaweicloud
-  dashboard_tab:
-    - name: Huawei Cloud Provider, v1.17
-      description: Runs conformance tests using kubetest against kubernetes v1.17 with cloud-provider-huaweicloud
-      test_group_name: cloud-provider-huaweicloud-e2e-conformance-release-v1.17
-
-- name: conformance-cloud-provider-inspur
-  dashboard_tab:
-    - name: Inspur Cloud Provider, v1.18
-      description: Runs conformance tests using kubetest against kubernetes v1.18 with cloud-provider-inspur
-      test_group_name: cloud-provider-inspur-e2e-conformance-release-v1.18
-
 - name: conformance-hack-local-up-cluster
 - name: conformance-ppc64le
 
@@ -321,14 +306,6 @@ test_groups:
 # arm64 conformance Test Groups
 - name: arm64-conformance-containerd
   gcs_prefix: arm64-k8s-test/logs/conformance-arm64
-
-# cloud-provider-huaweicloud e2e conformance Test Groups
-- name: cloud-provider-huaweicloud-e2e-conformance-release-v1.17
-  gcs_prefix: k8s-conform-huaweicloud/cloud-provider-huaweicloud/e2e-conformance-release-v1.17
-
-# cloud-provider-inspur e2e conformance Test Groups
-- name: cloud-provider-inspur-e2e-conformance-release-v1.18
-  gcs_prefix: k8s-conform-inspur/cloud-provider-inspur/e2e-conformance-release-v1.18
 
 # CEL Conformance Tests
 - name: cel-go-conformance-tests


### PR DESCRIPTION
https://testgrid.k8s.io/conformance

These boards haven't been updated in a very long time. 

inspur bucket was last modified in Sep 2021 https://console.cloud.google.com/storage/browser/k8s-conform-inspur/cloud-provider-inspur/e2e-conformance-release-v1.18/e2e-conformance-release-v1.18;tab=configuration?inv=1&invt=Ab5uCw&prefix=&forceOnObjectsSortingFiltering=false
huawei bucket was last modified in Sep 2021 https://console.cloud.google.com/storage/browser/k8s-conform-huaweicloud;tab=configuration?inv=1&invt=Ab5uTg&prefix=&forceOnObjectsSortingFiltering=false

