### PR TITLE
Introduce periodic etcd benchmark jobs

### DIFF
--- a/config/jobs/etcd/etcd-benchmarks-periodic.yaml
+++ b/config/jobs/etcd/etcd-benchmarks-periodic.yaml
@@ -1,0 +1,36 @@
+---
+periodics:
+
+- name: ci-etcd-benchmark-put-amd64
+  interval: 24h
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 30m
+  extra_refs:
+    - org: etcd-io
+      repo: etcd
+      base_ref: main
+  annotations:
+    testgrid-dashboards: sig-etcd-periodics
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250613-876fb90a97-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          make install-benchmark
+          make bench-put
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
+    nodeSelector:
+      kubernetes.io/arch: amd64


### PR DESCRIPTION
This PR adds a periodic etcd benchmark job for put operations.
The job produces an artefact - `perfdash.json` file, which is intended to be parsed and displayed on [perfdash.k8s.io](https://perfdash.k8s.io/).

Currently, the job is configured to run periodically (once a day). In future, we may reconfigure the run to allow running it as an optional job on PRs. 