### PR TITLE
integration testing: update timeout

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -21,9 +21,6 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250815-171060767f-master
         command:
         - runner.sh
-        env:
-        - name: KUBE_TIMEOUT
-          value: "-timeout=1h30m"
         args:
         - ./hack/jenkins/test-integration-dockerized.sh
         # docker-in-docker needs privileged mode
@@ -96,7 +93,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBE_TIMEOUT
-          value: "-timeout=1h30m"
+          value: "-timeout=15m"
         - name: KUBE_RACE
           value: "-race"
         args:
@@ -248,6 +245,8 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
+      - name: KUBE_TIMEOUT
+        value: "-timeout=15m"
       - name: KUBE_RACE
         value: "-race"
       # docker-in-docker needs privileged mode


### PR DESCRIPTION
KUBE_TIMEOUT is the timeout per package, not per job. Setting it to -timeout=1h30m for pull-kubernetes-integration was a mistake. That mistake then got perpetuated for pull-kubernetes-integration-race.

Now pull-kubernetes-integration uses the default (10 minutes), without setting it explicitly. When race detection is enabled, the additional overhead causes some packages to time out, so 15 minutes are used for presubmit and ci race jobs.