### PR TITLE
Organize ibm testgrid dashboards based on architecture

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -46,7 +46,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-etcd-ppc64le
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-ppc64le-etcd
     testgrid-tab-name: ci-etcd-e2e-ppc64le
   spec:
     containers:
@@ -78,7 +78,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-s390x, ibm-etcd-s390x
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-s390x, ibm-s390x-etcd
     testgrid-tab-name: ci-etcd-e2e-s390x
   spec:
     containers:
@@ -175,7 +175,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-etcd-ppc64le
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-ppc64le-etcd
     testgrid-tab-name: ci-etcd-unit-test-ppc64le
   spec:
     containers:
@@ -204,7 +204,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-s390x, ibm-etcd-s390x
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-s390x, ibm-s390x-etcd
     testgrid-tab-name: ci-etcd-unit-test-s390x
   spec:
     containers:
@@ -356,7 +356,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-ppc64le, ibm-etcd-ppc64le
+    testgrid-dashboards: sig-etcd-ppc64le, ibm-ppc64le-etcd
     testgrid-create-test-group: 'true'
   spec:
     containers:
@@ -400,7 +400,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-s390x, ibm-etcd-s390x
+    testgrid-dashboards: sig-etcd-s390x, ibm-s390x-etcd
     testgrid-create-test-group: 'true'
   spec:
     containers:
@@ -750,7 +750,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-etcd-ppc64le
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-ppc64le-etcd
     testgrid-tab-name: ci-etcd-integration-1-cpu-ppc64le
   spec:
     containers:
@@ -782,7 +782,7 @@ periodics:
       repo: etcd
       base_ref: main
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-s390x, ibm-etcd-s390x
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-s390x, ibm-s390x-etcd
     testgrid-tab-name: ci-etcd-integration-1-cpu-s390x
   spec:
     containers:
@@ -882,7 +882,7 @@ periodics:
       base_ref: main
   decorate: true
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-etcd-ppc64le
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-ppc64le-etcd
     testgrid-tab-name: ci-etcd-integration-2-cpu-ppc64le
   spec:
     containers:
@@ -914,7 +914,7 @@ periodics:
       base_ref: main
   decorate: true
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-s390x, ibm-etcd-s390x
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-s390x, ibm-s390x-etcd
     testgrid-tab-name: ci-etcd-integration-2-cpu-s390x
   spec:
     containers:
@@ -1014,7 +1014,7 @@ periodics:
       base_ref: main
   decorate: true
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-etcd-ppc64le
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-ppc64le-etcd
     testgrid-tab-name: ci-etcd-integration-4-cpu-ppc64le
   spec:
     containers:
@@ -1046,7 +1046,7 @@ periodics:
       base_ref: main
   decorate: true
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-s390x, ibm-etcd-s390x
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-s390x, ibm-s390x-etcd
     testgrid-tab-name: ci-etcd-integration-4-cpu-s390x
   spec:
     containers:
@@ -1148,7 +1148,7 @@ periodics:
       repo: etcd
       base_ref: release-3.6
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-etcd-ppc64le
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-ppc64le-etcd
     testgrid-tab-name: ci-etcd-e2e-release36-ppc64le
   spec:
     containers:
@@ -1245,7 +1245,7 @@ periodics:
       repo: etcd
       base_ref: release-3.6
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-etcd-ppc64le
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-ppc64le-etcd
     testgrid-tab-name: ci-etcd-unit-test-release36-ppc64le
   spec:
     containers:
@@ -1564,7 +1564,7 @@ periodics:
       repo: etcd
       base_ref: release-3.6
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-etcd-ppc64le
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-ppc64le-etcd
     testgrid-tab-name: ci-etcd-integration-1-cpu-release36-ppc64le
   spec:
     containers:
@@ -1764,7 +1764,7 @@ periodics:
       base_ref: release-3.6
   decorate: true
   annotations:
-    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-etcd-ppc64le
+    testgrid-dashboards: sig-etcd-periodics, sig-etcd-ppc64le, ibm-ppc64le-etcd
     testgrid-tab-name: ci-etcd-integration-4-cpu-release36-ppc64le
   spec:
     containers:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
@@ -4,7 +4,7 @@ periodics:
   interval: 12h
   decorate: true
   annotations:
-    testgrid-dashboards: ibm-periodics, ibm-cluster-api
+    testgrid-dashboards: ibm-ppc64le-periodics, ibm-cluster-api
     testgrid-tab-name: periodic-cluster-api-provider-ibmcloud-coverage
   extra_refs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -9,45 +9,8 @@ periodics:
         base_ref: master
         path_alias: k8s.io/kubernetes
     annotations:
-      testgrid-dashboards: ibm-k8s-ppc64le, ibm-periodics
+      testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics
       testgrid-tab-name: ci-kubernetes-unit-ppc64le
-    spec:
-      # unit tests have no business requiring root or doing privileged operations
-      securityContext:
-        # NOTE: these are arbitrary non-root values. They don't exist in the
-        # image and don't need to, the unit tests should only write to TMPDIR
-        runAsGroup: 2010
-        runAsUser: 2001
-      containers:
-        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250815-171060767f-master
-          command:
-            - make
-            - test
-          env:
-            - name: KUBE_TIMEOUT
-              value: "-timeout=300s"
-          securityContext:
-            allowPrivilegeEscalation: false
-          resources:
-            requests:
-              cpu: 6
-              memory: "28Gi"
-            limits:
-              cpu: 6
-              memory: "28Gi"
-
-  - name: ci-kubernetes-unit-s390x
-    interval: 1h
-    cluster: k8s-infra-s390x-prow-build
-    decorate: true
-    extra_refs:
-      - org: kubernetes
-        repo: kubernetes
-        base_ref: master
-        path_alias: k8s.io/kubernetes
-    annotations:
-      testgrid-dashboards: ibm-periodics, ibm-k8s-s390x
-      testgrid-tab-name: ci-kubernetes-unit-s390x
     spec:
       # unit tests have no business requiring root or doing privileged operations
       securityContext:
@@ -88,7 +51,7 @@ periodics:
         workdir: true
     annotations:
       description: Runs conformance tests using kubetest2 against kubernetes ci latest on IBM powervs
-      testgrid-dashboards: ibm-k8s-e2e, ibm-k8s-ppc64le, conformance-ppc64le
+      testgrid-dashboards: ibm-ppc64le-e2e, ibm-ppc64le-k8s, conformance-ppc64le, ibm-k8s-e2e
       testgrid-tab-name: ci-kubernetes-ppc64le-conformance-latest-kubetest2
     spec:
       containers:
@@ -170,7 +133,7 @@ periodics:
         workdir: true
     annotations:
       description: Runs e2e-node tests using kubetest2 on IBM powervs
-      testgrid-dashboards: ibm-node-e2e, ibm-k8s-ppc64le, sig-node-ppc64le
+      testgrid-dashboards: ibm-ppc64le-node-e2e, ibm-ppc64le-k8s, sig-node-ppc64le
       testgrid-tab-name: ci-kubernetes-ppc64le-e2e-node-latest-kubetest2
     spec:
       containers:
@@ -241,7 +204,7 @@ periodics:
         workdir: true
     annotations:
       description: Runs e2e tests with alpha enabled feature gates against kubernetes ci latest on IBM powervs
-      testgrid-dashboards: ibm-k8s-e2e, ibm-k8s-ppc64le
+      testgrid-dashboards: ibm-ppc64le-e2e, ibm-ppc64le-k8s, ibm-k8s-e2e
       testgrid-tab-name: ci-kubernetes-ppc64le-e2e-alpha-enabled-default
     spec:
       containers:
@@ -307,7 +270,7 @@ periodics:
         workdir: true
     annotations:
       description: Runs e2e tests with against kubernetes ci latest on IBM powervs
-      testgrid-dashboards: ibm-k8s-e2e, ibm-k8s-ppc64le
+      testgrid-dashboards: ibm-ppc64le-e2e, ibm-ppc64le-k8s, ibm-k8s-e2e
       testgrid-tab-name: ci-kubernetes-e2e-ppc64le-default
     spec:
       containers:
@@ -369,7 +332,7 @@ periodics:
         workdir: true
     annotations:
       description: Runs E2E slow tests using kubetest2 against kubernetes ci latest on IBM powervs
-      testgrid-dashboards: ibm-k8s-e2e, ibm-k8s-ppc64le
+      testgrid-dashboards: ibm-ppc64le-e2e, ibm-ppc64le-k8s, ibm-k8s-e2e
       testgrid-tab-name: ci-kubernetes-ppc64le-e2e-slow-kubetest2
     spec:
       containers:
@@ -432,7 +395,7 @@ periodics:
         workdir: true
     annotations:
       description: Runs E2E serial tests using kubetest2 against kubernetes ci latest on IBM powervs
-      testgrid-dashboards: ibm-k8s-e2e, ibm-k8s-ppc64le
+      testgrid-dashboards: ibm-ppc64le-e2e, ibm-ppc64le-k8s, ibm-k8s-e2e
       testgrid-tab-name: ci-kubernetes-e2e-ppc64le-serial-kubetest2
     spec:
       containers:

--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       timeout: 220m
     annotations:
       description: Optional presubmit job to test changes in kubernetes-sigs/provider-ibmcloud-test-infra repo
-      testgrid-dashboards: ibm-presubmits
+      testgrid-dashboards: ibm-ppc64le-presubmits
       testgrid-tab-name: pull-provider-ibmcloud-test-infra-kubernetes
     labels:
       preset-ibmcloud-cred: "true"

--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-s390x-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-s390x-periodics.yaml
@@ -1,0 +1,37 @@
+periodics:
+  - name: ci-kubernetes-unit-s390x
+    interval: 1h
+    cluster: k8s-infra-s390x-prow-build
+    decorate: true
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    annotations:
+      testgrid-dashboards: ibm-s390x-periodics, ibm-s390x-k8s
+      testgrid-tab-name: ci-kubernetes-unit-s390x
+    spec:
+      # unit tests have no business requiring root or doing privileged operations
+      securityContext:
+        # NOTE: these are arbitrary non-root values. They don't exist in the
+        # image and don't need to, the unit tests should only write to TMPDIR
+        runAsGroup: 2010
+        runAsUser: 2001
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250815-171060767f-master
+          command:
+            - make
+            - test
+          env:
+            - name: KUBE_TIMEOUT
+              value: "-timeout=300s"
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 6
+              memory: "28Gi"
+            limits:
+              cpu: 6
+              memory: "28Gi"

--- a/config/testgrids/ibm/config.yaml
+++ b/config/testgrids/ibm/config.yaml
@@ -1,23 +1,27 @@
 dashboard_groups:
 - name: ibm
   dashboard_names:
-    - ibm-k8s-e2e
-    - ibm-node-e2e
-    - ibm-k8s-ppc64le
-    - ibm-periodics
-    - ibm-k8s-s390x
+    - ibm-ppc64le-e2e
+    - ibm-ppc64le-node-e2e
+    - ibm-ppc64le-periodics
+    - ibm-ppc64le-presubmits
+    - ibm-ppc64le-k8s
+    - ibm-ppc64le-etcd
     - ibm-cluster-api
-    - ibm-etcd-ppc64le
-    - ibm-etcd-s390x
-    - ibm-presubmits
+    - ibm-s390x-periodics
+    - ibm-s390x-k8s
+    - ibm-s390x-etcd
+    - ibm-k8s-e2e
 
 dashboards:
-- name: ibm-k8s-e2e
-- name: ibm-node-e2e
-- name: ibm-k8s-ppc64le
-- name: ibm-k8s-s390x
-- name: ibm-etcd-ppc64le
-- name: ibm-etcd-s390x
+- name: ibm-ppc64le-e2e
+- name: ibm-ppc64le-node-e2e
+- name: ibm-ppc64le-periodics
+- name: ibm-ppc64le-presubmits
+- name: ibm-ppc64le-k8s
+- name: ibm-ppc64le-etcd
 - name: ibm-cluster-api
-- name: ibm-presubmits
-- name: ibm-periodics
+- name: ibm-s390x-periodics
+- name: ibm-s390x-k8s
+- name: ibm-s390x-etcd
+- name: ibm-k8s-e2e


### PR DESCRIPTION
Organizing dashboards at https://testgrid.k8s.io/ibm