### PR TITLE
drop race-detector-nonblocking job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -63,41 +63,6 @@ presubmits:
             memory: "2Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
-  - name: pull-test-infra-unit-test-race-detector-nonblocking
-    cluster: eks-prow-build-cluster
-    branches:
-    - master
-    always_run: true
-    decorate: true
-    optional: true
-    skip_report: false
-    labels:
-      # Python unit tests run in docker.
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250815-171060767f-master
-        command:
-        - runner.sh
-        args:
-        - make
-        - unit
-        env:
-        - name: PROW_UNIT_TEST_EXTRA_FLAGS
-          value: "-race"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "8"
-            memory: "8Gi"
-          limits:
-            cpu: "8"
-            memory: "8Gi"
-    annotations:
-      testgrid-dashboards: presubmits-test-infra
-      testgrid-tab-name: unit-test-race-detector-nonblocking
   - name: pull-test-infra-unit-test
     cluster: eks-prow-build-cluster
     branches:

--- a/hack/make-rules/go-test/unit.sh
+++ b/hack/make-rules/go-test/unit.sh
@@ -64,7 +64,7 @@ fi
   umask 0022
   mkdir -p "${JUNIT_RESULT_DIR}"
   "${REPO_ROOT}/_bin/gotestsum" --junitfile="${JUNIT_RESULT_DIR}/junit-unit.xml" \
-    -- \
+    -- -race \
     ${PROW_UNIT_TEST_EXTRA_FLAGS[@]+${PROW_UNIT_TEST_EXTRA_FLAGS[@]}} \
     "./${folder_to_test}"
 )


### PR DESCRIPTION
/cc @BenTheElder @aojea 

The race-detector noblocking job was added back in #29797 and #30013 but prow has been moved to its own repo and the duplicate test is no longer required.

I reenabled -race flag.