### PR TITLE
Allow CAPA maintainers to rerun jobs and remove old job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -4,6 +4,10 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes-sigs
+        slug: cluster-api-provider-aws-maintainers
   interval: 12h
   labels:
     preset-dind-enabled: "true"
@@ -49,6 +53,10 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes-sigs
+        slug: cluster-api-provider-aws-maintainers
   interval: 12h
   labels:
     preset-dind-enabled: "true"
@@ -93,6 +101,10 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes-sigs
+        slug: cluster-api-provider-aws-maintainers
   interval: 12h
   labels:
     preset-dind-enabled: "true"
@@ -135,6 +147,10 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes-sigs
+        slug: cluster-api-provider-aws-maintainers
   interval: 12h
   labels:
     preset-dind-enabled: "true"
@@ -187,6 +203,10 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 5h
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes-sigs
+        slug: cluster-api-provider-aws-maintainers
   interval: 12h
   extra_refs:
     - org: kubernetes-sigs
@@ -238,6 +258,10 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes-sigs
+        slug: cluster-api-provider-aws-maintainers
   path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   extra_refs:
     - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -9,6 +9,10 @@ postsubmits:
       decorate: true
       decoration_config:
         timeout: 5h
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: cluster-api-provider-aws-maintainers
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
@@ -53,6 +57,10 @@ postsubmits:
       decorate: true
       decoration_config:
         timeout: 5h
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: cluster-api-provider-aws-maintainers
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
@@ -95,6 +103,10 @@ postsubmits:
       decorate: true
       decoration_config:
         timeout: 5h
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: cluster-api-provider-aws-maintainers
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.7.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.7.yaml
@@ -193,51 +193,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-conformance-release-2-7
       testgrid-num-columns-recent: '20'
-  # conformance test against kubernetes main branch with `kind` + cluster-api-provider-aws
-  - name: pull-cluster-api-provider-aws-e2e-conformance-with-ci-artifacts-release-2-7
-    cluster: eks-prow-build-cluster
-    branches:
-    # The script this job runs is not in all branches.
-    - ^release-2.7$
-    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
-    always_run: false
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 5h
-    max_concurrency: 1
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-service-account: "true"
-      preset-aws-ssh: "true"
-      preset-aws-credential: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250714-70266d743a-1.30
-          command:
-            - "runner.sh"
-            - "./scripts/ci-conformance.sh"
-          env:
-            - name: BOSKOS_HOST
-              value: "boskos.test-pods.svc.cluster.local"
-            - name: AWS_REGION
-              value: "us-west-2"
-            - name: E2E_ARGS
-              value: "-kubetest.use-ci-artifacts"
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 2
-              memory: "9Gi"
-            limits:
-              cpu: 2
-              memory: "9Gi"
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: pr-conformance-release-2-7-k8s-main
-      testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-blocking-release-2-7
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -8,6 +8,10 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes-sigs
+          slug: cluster-api-provider-aws-maintainers
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
@@ -27,6 +31,10 @@ presubmits:
   - name: pull-cluster-api-provider-aws-apidiff-main
     cluster: eks-prow-build-cluster
     decorate: true
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes-sigs
+          slug: cluster-api-provider-aws-maintainers
     path_alias: sigs.k8s.io/cluster-api-provider-aws
     always_run: true
     optional: true
@@ -80,6 +88,10 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes-sigs
+          slug: cluster-api-provider-aws-maintainers
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
@@ -150,6 +162,10 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 5h
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes-sigs
+          slug: cluster-api-provider-aws-maintainers
     max_concurrency: 1
     extra_refs:
     - org: kubernetes-sigs
@@ -199,6 +215,10 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 5h
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes-sigs
+          slug: cluster-api-provider-aws-maintainers
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
@@ -244,6 +264,10 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 2h
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes-sigs
+          slug: cluster-api-provider-aws-maintainers
     max_concurrency: 3
     labels:
       preset-dind-enabled: "true"
@@ -291,6 +315,10 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 5h
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes-sigs
+          slug: cluster-api-provider-aws-maintainers
     max_concurrency: 2
     labels:
       preset-dind-enabled: "true"
@@ -333,6 +361,10 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 5h
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes-sigs
+          slug: cluster-api-provider-aws-maintainers
     max_concurrency: 2
     labels:
       preset-dind-enabled: "true"
@@ -375,6 +407,10 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 5h
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes-sigs
+          slug: cluster-api-provider-aws-maintainers
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
@@ -417,6 +453,10 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 5h
+    rerun_auth_config:
+      github_team_slugs:
+        - org: kubernetes-sigs
+          slug: cluster-api-provider-aws-maintainers
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
- Allow CAPA maintainers to re-run prow jobs
- Remove job testing 2.7 release against k8s main
