### PR TITLE
fix command line issues in audit log parsing

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
@@ -32,9 +32,10 @@ presubmits:
                   curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/"
                   && curl -sO https://raw.githubusercontent.com/ii/kind/ci-audit-logging/hack/ci/e2e-k8s.sh
                   && bash e2e-k8s.sh
-                  && python3 ./../test-infra/experiment/audit/audit_log_parser.py ${ARTIFACTS}/audit/audit*.log \
+                  && python3 ./../test-infra/experiment/audit/audit_log_parser.py \
                       --output "${ARTIFACTS}/audit/audit-endpoints.txt" \
-                      --swagger-url "file://$PWD/api/openapi-spec/swagger.json"
+                      --swagger-url "file://$PWD/api/openapi-spec/swagger.json" \
+                      --audit-logs ${ARTIFACTS}/audit/audit*.log
             env:
               - name: BUILD_TYPE
                 value: docker

--- a/experiment/audit/audit_log_parser.py
+++ b/experiment/audit/audit_log_parser.py
@@ -23,7 +23,7 @@ This script parses a Kubernetes audit log file and generates a list of
 Kubernetes API endpoints using the official Swagger/OpenAPI specification
 for accurate endpoint naming.
 
-Usage: python3 audit_log_parser.py <audit_log_file> [--output <output_file>] [--swagger-url <url>]
+Usage: python3 audit_log_parser.py --audit-logs <audit_log_file>... [--output <output_file>] [--swagger-url <url>]
 """
 
 import json
@@ -602,15 +602,15 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  python3 audit_log_parser_swagger.py audit.log
-  python3 audit_log_parser_swagger.py audit1.log audit2.log
-  python3 audit_log_parser_swagger.py audit.log --output results.txt
-  python3 audit_log_parser_swagger.py audit*.log --sort count --output results.txt
-  python3 audit_log_parser_swagger.py audit.log --swagger-url https://custom-swagger.json
+  python3 audit_log_parser_swagger.py --audit-logs audit.log
+  python3 audit_log_parser_swagger.py --audit-logs audit1.log audit2.log
+  python3 audit_log_parser_swagger.py --audit-logs audit.log --output results.txt
+  python3 audit_log_parser_swagger.py --audit-logs audit*.log --sort count --output results.txt
+  python3 audit_log_parser_swagger.py --audit-logs audit.log --swagger-url https://custom-swagger.json
         """
     )
 
-    parser.add_argument('audit_logs', nargs='+', help='Path(s) to Kubernetes audit log file(s)')
+    parser.add_argument('--audit-logs', nargs='+', required=True, help='Path(s) to Kubernetes audit log file(s)')
     parser.add_argument('-o', '--output', help='Output file (default: print to stdout)')
     parser.add_argument('--swagger-url', help='Custom Swagger/OpenAPI specification URL')
     parser.add_argument('--sort', choices=['count', 'name'], default='name',


### PR DESCRIPTION
CLI params were treated as files!

snippet from [here](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/133132/pull-audit-kind-conformance/1958170914424098816/build-log.txt):
```
Parsing 6 audit log file(s):
  [1/6] /logs/artifacts/audit/audit-2025-08-20T15-11-38.989.log
  [2/6] /logs/artifacts/audit/audit.log
  [3/6]  --output
  [4/6] /logs/artifacts/audit/audit-endpoints.txt
  [5/6]  --swagger-url
  [6/6] file:///home/prow/go/src/k8s.io/kubernetes/api/openapi-spec/swagger.json
```