### PR TITLE
etcd: use the latest kubekins image for govulncheck presubmit

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -160,15 +160,18 @@ presubmits:
             cpu: "4"
             memory: "4Gi"
 
-  - name: pull-etcd-govulncheck-main
+  - name: pull-etcd-govulncheck
     cluster: eks-prow-build-cluster
     always_run: true
     branches:
     - main
+    - release-3.6
+    - release-3.5
+    - release-3.4
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
-      testgrid-tab-name: pull-etcd-govulncheck-main
+      testgrid-tab-name: pull-etcd-govulncheck
     spec:
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250815-171060767f-master
@@ -176,39 +179,6 @@ presubmits:
         - runner.sh
         args:
         - bash
-        - -c
-        - |
-          export PATH=$GOPATH/bin:$PATH && make run-govulncheck
-        resources:
-          requests:
-            cpu: "4"
-            memory: "4Gi"
-          limits:
-            cpu: "4"
-            memory: "4Gi"
-
-  - name: pull-etcd-govulncheck-release-branches
-    cluster: eks-prow-build-cluster
-    always_run: true
-    branches:
-    - release-3.6
-    - release-3.5
-    - release-3.4
-    decorate: true
-    annotations:
-      testgrid-dashboards: sig-etcd-presubmits
-      testgrid-tab-name: pull-etcd-govulncheck-release-branches
-    spec:
-      containers:
-      # Keep it in sync with the Go version used by the stable releases.
-      # Once the stable branches use Go 1.24, we can use the tool directive
-      # and the installed tools should use the same toolchain version from the
-      # go.mod. Therefore, we can go back to use the kubekins image, and
-      # consolidate the jobs.
-      - image: public.ecr.aws/docker/library/golang:1.23
-        command:
-        - /bin/bash
-        args:
         - -c
         - |
           export PATH=$GOPATH/bin:$PATH && make run-govulncheck


### PR DESCRIPTION
Required for the release-3.6 Go 1.24 update.

Reference: https://github.com/etcd-io/etcd/pull/20527 / #20518.