### PR TITLE
kOps: Use stable marker for e2e-kops-pipeline-updown-kopsmaster

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1875,7 +1875,7 @@ def generate_pipeline():
         results.append(
             build_test(
                 cloud="aws",
-                k8s_version=version.replace('master', 'latest'),
+                k8s_version=version.replace('master', 'stable'),
                 kops_version=kops_version,
                 kops_channel='alpha',
                 name_override=f"kops-pipeline-updown-kops{version.replace('.', '')}",

--- a/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
@@ -2,7 +2,7 @@
 # 5 jobs, total of 840 runs per week
 periodics:
 
-# {"cloud": "aws", "distro": "u2404", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "latest", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+# {"cloud": "aws", "distro": "u2404", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-pipeline-updown-kopsmaster
   cron: '54 0-23/1 * * *'
   labels:
@@ -35,11 +35,11 @@ periodics:
           --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250821' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
           --publish-version-marker=gs://k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/latest.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
           -- \
           --test-args="-test.timeout=60m" \
-          --test-package-marker=latest.txt \
+          --test-package-marker=stable.txt \
           --focus-regex="\[k8s.io\]\sNetworking.*\[Conformance\]" \
           --skip-regex="\[Slow\]|\[Serial\]" \
           --parallel=25
@@ -61,11 +61,11 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404
     test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
-    test.kops.k8s.io/k8s_version: latest
+    test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-distro-u2404, kops-k8s-latest, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2404, kops-k8s-stable, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-pipeline-updown-kopsmaster
 


### PR DESCRIPTION
https://testgrid.k8s.io/kops-distro-u2404#kops-pipeline-updown-kopsmaster is failing due to `kube-apiserver` crashing :
https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-pipeline-updown-kopsmaster/1959917401613012992/artifacts/3.112.106.166/kube-apiserver.log
```
I0825 10:20:42.769139      12 store.go:1667] "Monitoring resource count at path" resource="replicationcontrollers" path="<storage-prefix>//controllers"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x846a5c]

goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*MetricVec).DeleteLabelValues(0x0, {0xc001308fe0?, 0x41595b?, 0xc0013090c0?})
	github.com/prometheus/client_golang@v1.22.0/prometheus/vec.go:75 +0x1c
k8s.io/apiserver/pkg/storage/etcd3/metrics.DeleteStoreStats({{0x0?, 0xc0013090d0?}, {0x332834f?, 0xc001485300?}})
	k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go:227 +0x94
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).startObservingCount.func2()
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1682 +0x30
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).CompleteWithOptions.func8.1()
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1643 +0x1f
sync.(*Once).doSlow(0x3?, 0x544aed8f0375ae09?)
	sync/once.go:78 +0xab
sync.(*Once).Do(...)
	sync/once.go:69
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).CompleteWithOptions.func8()
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1642 +0x45
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).Destroy(...)
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:325
k8s.io/kubernetes/pkg/registry/core/rest.(*legacyProvider).NewRESTStorage(0xc001610820, {0x398a6d8, 0xc0005310a0}, {0x39511e0, 0xc000a2dd40})
	k8s.io/kubernetes/pkg/registry/core/rest/storage_core.go:273 +0x133f
k8s.io/kubernetes/pkg/controlplane/apiserver.(*Server).InstallAPIs(0xc0013551e0, {0xc001612c60, 0x15, 0xe?})
	k8s.io/kubernetes/pkg/controlplane/apiserver/apis.go:105 +0x1eb
k8s.io/kubernetes/pkg/controlplane.CompletedConfig.New({0x2e14000?}, {0x399d000, 0xc0010fc388})
	k8s.io/kubernetes/pkg/controlplane/instance.go:340 +0x193
k8s.io/kubernetes/cmd/kube-apiserver/app.CreateServerChain({0xc000a20e70?})
	k8s.io/kubernetes/cmd/kube-apiserver/app/server.go:184 +0x26c
k8s.io/kubernetes/cmd/kube-apiserver/app.Run({0x398a898, 0xc0000b8be0}, {0xc0000b8be0?})
	k8s.io/kubernetes/cmd/kube-apiserver/app/server.go:162 +0x2fd
k8s.io/kubernetes/cmd/kube-apiserver/app.NewAPIServerCommand.func2(0xc00068a008, {0xc00076e488?, 0x0?, 0x21?})
	k8s.io/kubernetes/cmd/kube-apiserver/app/server.go:117 +0x193
github.com/spf13/cobra.(*Command).execute(0xc00068a008, {0xc000112258, 0x21, 0x22})
	github.com/spf13/cobra@v1.9.1/command.go:1015 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc00068a008)
	github.com/spf13/cobra@v1.9.1/command.go:1148 +0x46f
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.9.1/command.go:1071
k8s.io/component-base/cli.run(0xc00068a008)
	k8s.io/component-base/cli/run.go:143 +0x245
k8s.io/component-base/cli.Run(0xc000002380?)
	k8s.io/component-base/cli/run.go:44 +0x17
main.main()
	k8s.io/kubernetes/cmd/kube-apiserver/apiserver.go:34 +0x18
```

/cc @ameukam @rifelpet 