### PR TITLE
CRI-O jobs: remove crun TODO

### DIFF
--- a/jobs/e2e_node/crio/templates/base/crun-enabled.yaml
+++ b/jobs/e2e_node/crio/templates/base/crun-enabled.yaml
@@ -2,10 +2,6 @@
 storage:
   files:
     - path: /etc/crio/crio.conf.d/99-crun.conf
-      # Note: This also assumes the crun handler is enabled in the base crio.conf,
-      # crun is installed, and the version of crun supports the `crun features` command.
-      # All of this is true at the time of writing.
-      # TODO(haircommander): This can be removed when runc 1.2.0 is released
       contents:
         local: 99-crun.conf
       mode: 0644

--- a/jobs/e2e_node/crio/templates/crio_cgroupv2_userns.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv2_userns.yaml
@@ -47,10 +47,6 @@ storage:
       mode: 0644
       overwrite: true
     - path: /etc/crio/crio.conf.d/99-crun.conf
-      # Note: This also assumes the crun handler is enabled in the base crio.conf,
-      # crun is installed, and the version of crun supports the `crun features` command.
-      # All of this is true at the time of writing.
-      # TODO(haircommander): This can be removed when runc 1.2.0 is released
       contents:
         local: 99-crun.conf
       mode: 0644

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -84,8 +84,8 @@ done
 CRIO_SCRIPT_COMMIT=$(grep "CRIO_SCRIPT_COMMIT" "$BASE_PATH/env.yaml" | sed -rn 's/^.*CRIO_SCRIPT_COMMIT=([0-9a-f]+).*$/\1/p')
 CRIO_SCRIPT_URL="https://raw.githubusercontent.com/cri-o/packaging/$CRIO_SCRIPT_COMMIT/get"
 curl -fs "$CRIO_SCRIPT_URL" -o /dev/null || {
-  echo "Error: CRIO_SCRIPT_COMMIT in $BASE_PATH/env.yaml is wrong. The get script was not found at: $CRIO_SCRIPT_URL" 1>&2
-  exit 1
+    echo "Error: CRIO_SCRIPT_COMMIT in $BASE_PATH/env.yaml is wrong. The get script was not found at: $CRIO_SCRIPT_URL" 1>&2
+    exit 1
 }
 
 CRIO_COMMIT=$(grep "CRIO_COMMIT" "$BASE_PATH/env.yaml" | sed -rn 's/^.*CRIO_COMMIT=([0-9a-f]+).*$/\1/p')


### PR DESCRIPTION
The `TODO` can be removed since we already ship runc v1.3.0.

@kubernetes/sig-node-cri-o-test-maintainers PTAL