### PR TITLE
run pull-kubernetes-audit-kind-conformance when any conformance related files are touched

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
@@ -5,6 +5,7 @@ presubmits:
       cluster: k8s-infra-prow-build
       optional: true
       always_run: false
+      run_if_changed: '^(test/conformance/testdata/|api/openapi-spec/)'
       decorate: true
       skip_branches:
         - release-\d+\.\d+ # per-release settings
@@ -33,7 +34,6 @@ presubmits:
                   && curl -sO https://raw.githubusercontent.com/ii/kind/ci-audit-logging/hack/ci/e2e-k8s.sh
                   && bash e2e-k8s.sh
                   && python3 ./../test-infra/experiment/audit/audit_log_parser.py --audit-logs ${ARTIFACTS}/audit/audit*.log --output "${ARTIFACTS}/audit/audit-endpoints.txt" --audit-operations-json "${ARTIFACTS}/audit/audit-operations.json" --swagger-url "file://$PWD/api/openapi-spec/swagger.json"
-                  && set -x
                   && python3 ./../test-infra/experiment/audit/kubernetes_api_analysis.py --pull-audit-endpoints "${ARTIFACTS}/audit/audit-endpoints.txt" --swagger-url "file://$PWD/api/openapi-spec/swagger.json"
             env:
               - name: BUILD_TYPE


### PR DESCRIPTION
Run this presubmit job when any of the files in specified regex are modified. 

NOTE: this job does not yet fail hard with untested API. This PR is to test-drive the scripts on various PRs to check if the outputs are valid.

```
❯ find . -type f | cut -b 3- | grep -E '^(test/conformance/testdata/|api/openapi-spec/)'
test/conformance/testdata/embed.go
test/conformance/testdata/ineligible_endpoints.yaml
test/conformance/testdata/pending_eligible_endpoints.yaml
test/conformance/testdata/OWNERS
test/conformance/testdata/conformance.yaml
api/openapi-spec/swagger.json
api/openapi-spec/README.md
api/openapi-spec/v3/apis__internal.apiserver.k8s.io_openapi.json
api/openapi-spec/v3/apis__events.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__storage.k8s.io_openapi.json
api/openapi-spec/v3/apis__resource.k8s.io__v1alpha3_openapi.json
api/openapi-spec/v3/.well-known__openid-configuration_openapi.json
api/openapi-spec/v3/logs_openapi.json
api/openapi-spec/v3/apis__storagemigration.k8s.io__v1alpha1_openapi.json
api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis_openapi.json
api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
api/openapi-spec/v3/apis__admissionregistration.k8s.io_openapi.json
api/openapi-spec/v3/apis__discovery.k8s.io_openapi.json
api/openapi-spec/v3/apis__apiextensions.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__coordination.k8s.io_openapi.json
api/openapi-spec/v3/apis__certificates.k8s.io__v1alpha1_openapi.json
api/openapi-spec/v3/apis__coordination.k8s.io__v1alpha2_openapi.json
api/openapi-spec/v3/apis__rbac.authorization.k8s.io_openapi.json
api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io_openapi.json
api/openapi-spec/v3/apis__node.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__rbac.authorization.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__coordination.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__storagemigration.k8s.io_openapi.json
api/openapi-spec/v3/apis__authorization.k8s.io_openapi.json
api/openapi-spec/v3/apis__autoscaling_openapi.json
api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1beta1_openapi.json
api/openapi-spec/v3/version_openapi.json
api/openapi-spec/v3/apis__apps__v1_openapi.json
api/openapi-spec/v3/apis__storage.k8s.io__v1alpha1_openapi.json
api/openapi-spec/v3/apis__autoscaling__v1_openapi.json
api/openapi-spec/v3/apis__certificates.k8s.io_openapi.json
api/openapi-spec/v3/api__v1_openapi.json
api/openapi-spec/v3/apis__policy__v1_openapi.json
api/openapi-spec/v3/apis__scheduling.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__authentication.k8s.io_openapi.json
api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1alpha1_openapi.json
api/openapi-spec/v3/apis__batch_openapi.json
api/openapi-spec/v3/apis__authorization.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__apiextensions.k8s.io_openapi.json
api/openapi-spec/v3/apis__node.k8s.io_openapi.json
api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__apiregistration.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__networking.k8s.io__v1beta1_openapi.json
api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__coordination.k8s.io__v1beta1_openapi.json
api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
api/openapi-spec/v3/apis__networking.k8s.io_openapi.json
api/openapi-spec/v3/apis__authentication.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__policy_openapi.json
api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
api/openapi-spec/v3/apis__apps_openapi.json
api/openapi-spec/v3/api_openapi.json
api/openapi-spec/v3/apis__storage.k8s.io__v1beta1_openapi.json
api/openapi-spec/v3/apis__certificates.k8s.io__v1beta1_openapi.json
api/openapi-spec/v3/apis__events.k8s.io_openapi.json
api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__scheduling.k8s.io_openapi.json
api/openapi-spec/v3/apis__discovery.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
api/openapi-spec/v3/apis__resource.k8s.io_openapi.json
api/openapi-spec/v3/apis__apiregistration.k8s.io_openapi.json
api/openapi-spec/v3/apis__batch__v1_openapi.json
api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
api/openapi-spec/v3/openid__v1__jwks_openapi.json
```