### PR TITLE
Add kind repo presubmit for 1.34

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -292,6 +292,50 @@ presubmits:
             cpu: "7"
             memory: 9000Mi
   # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
+  - name: pull-kind-e2e-kubernetes-1-34
+    cluster: k8s-infra-prow-build
+    skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
+    optional: false
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: release-1.34
+      path_alias: k8s.io/kubernetes
+    path_alias: sigs.k8s.io/kind
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20250815-171060767f-1.34
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
+        env:
+        - name: FOCUS
+          value: "."
+        # TODO(bentheelder): reduce the skip list further
+        # NOTE: changes should filter down to pull-kubernetes-e2e-kind-canary
+        # and then pull-kubernetes-e2e-kind
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
   - name: pull-kind-e2e-kubernetes-1-33
     cluster: k8s-infra-prow-build
     skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
@@ -426,135 +470,3 @@ presubmits:
           requests:
             cpu: "7"
             memory: 9000Mi
-  # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
-  - name: pull-kind-e2e-kubernetes-1-30
-    cluster: k8s-infra-prow-build
-    skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
-    optional: false
-    labels:
-      preset-dind-enabled: "true"
-    decorate: true
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: release-1.30
-      path_alias: k8s.io/kubernetes
-    path_alias: sigs.k8s.io/kind
-    decoration_config:
-      timeout: 60m
-      grace_period: 15m
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20250714-70266d743a-1.30
-        command:
-        - wrapper.sh
-        - bash
-        - -c
-        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
-        env:
-        - name: FOCUS
-          value: "."
-        # TODO(bentheelder): reduce the skip list further
-        # NOTE: changes should filter down to pull-kubernetes-e2e-kind-canary
-        # and then pull-kubernetes-e2e-kind
-        - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|pull.from.private.registry.with.secret
-        - name: PARALLEL
-          value: "true"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: "7"
-            memory: 9000Mi
-          requests:
-            cpu: "7"
-            memory: 9000Mi
-  # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
-  - name: pull-kind-e2e-kubernetes-1-29
-    cluster: k8s-infra-prow-build
-    skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
-    optional: false
-    labels:
-      preset-dind-enabled: "true"
-    decorate: true
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: release-1.29
-      path_alias: k8s.io/kubernetes
-    path_alias: sigs.k8s.io/kind
-    decoration_config:
-      timeout: 60m
-      grace_period: 15m
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20250409-f52ea67ed6-1.29
-        command:
-        - wrapper.sh
-        - bash
-        - -c
-        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
-        env:
-        - name: FOCUS
-          value: "."
-        # TODO(bentheelder): reduce the skip list further
-        # NOTE: changes should filter down to pull-kubernetes-e2e-kind-canary
-        # and then pull-kubernetes-e2e-kind
-        - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|pull.from.private.registry.with.secret
-        - name: PARALLEL
-          value: "true"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: "7"
-            memory: 9000Mi
-          requests:
-            cpu: "7"
-            memory: 9000Mi
-  # mimic pull-kubernetes-e2e-kind, but using kind built in this PR
-  - name: pull-kind-e2e-kubernetes-1-28
-    cluster: k8s-infra-prow-build
-    skip_if_only_changed: '(^site/)|(^images/)|(^logo/)|(^.github/)|(.md$)|(OWNERS$)|(^SECURITY_CONTACTS$)|(^netlify.toml$)'
-    optional: false
-    decorate: true
-    decoration_config:
-      grace_period: 15m0s
-      timeout: 1h0m0s
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: release-1.28
-      path_alias: k8s.io/kubernetes
-    labels:
-      preset-dind-enabled: "true"
-    path_alias: sigs.k8s.io/kind
-    spec:
-      containers:
-      - command:
-        - wrapper.sh
-        - bash
-        - -c
-        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
-        env:
-        - name: FOCUS
-          value: .
-        - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist|pull.from.private.registry.with.secret
-        - name: PARALLEL
-          value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20241125-b4ea3e27a6-1.28
-        name: ""
-        resources:
-          limits:
-            cpu: "7"
-            memory: 9000Mi
-          requests:
-            cpu: "7"
-            memory: 9000Mi
-        securityContext:
-          privileged: true


### PR DESCRIPTION
Now that 1.34 is official, this adds a presubmit for the 1.34 release.

Also drops 1.30 and earlier. These are no longer supported, so no need to spend testing time on them.