### PR TITLE
integration testing: update timeout, II

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -93,7 +93,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBE_TIMEOUT
-          value: "-timeout=15m"
+          value: "-timeout=20m"
         - name: KUBE_RACE
           value: "-race"
         args:
@@ -246,7 +246,7 @@ periodics:
       - name: SHORT
         value: --short=false
       - name: KUBE_TIMEOUT
-        value: "-timeout=15m"
+        value: "-timeout=20m"
       - name: KUBE_RACE
         value: "-race"
       # docker-in-docker needs privileged mode


### PR DESCRIPTION
When race detection is enabled, the additional overhead causes some packages to time out (in particular test/integration/scheduler_perf). 15 minutes still wasn't long enough, let's try with 20 minutes.

/assign @aojea 

https://testgrid.k8s.io/sig-testing-canaries#integration-race-master