### PR TITLE
deprecate jobset 0.7 and support release-0.9

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-9.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-9.yaml
@@ -1,17 +1,17 @@
 periodics:
   - interval: 12h
-    name: periodic-jobset-test-unit-release-0-7
+    name: periodic-jobset-test-unit-release-0-9
     cluster: eks-prow-build-cluster
     extra_refs:
       - org: kubernetes-sigs
         repo: jobset
-        base_ref: release-7.1
+        base_ref: release-0.9
         path_alias: sigs.k8s.io/jobset
     annotations:
       testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-jobset-test-unit-release-0-7
+      testgrid-tab-name: periodic-jobset-test-unit-release-0-9
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset unit tests on release 0.7"
+      description: "Run periodic jobset unit tests on release 0.9"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -38,25 +38,25 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-integration-release-0-7
+    name: periodic-jobset-test-integration-release-0-9
     cluster: eks-prow-build-cluster
     extra_refs:
       - org: kubernetes-sigs
         repo: jobset
-        base_ref: release-7.1
+        base_ref: release-0.9
         path_alias: sigs.k8s.io/jobset
     annotations:
       testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-jobset-test-integration-release-0-7
+      testgrid-tab-name: periodic-jobset-test-integration-release-0-9
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset integration tests on release 0.7"
+      description: "Run periodic jobset integration tests on release 0.9"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
     decorate: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23
+      - image: public.ecr.aws/docker/library/golang:1.24
         command:
         - make
         args:
@@ -69,18 +69,18 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-e2e-release-0-7-1-31
+    name: periodic-jobset-test-e2e-release-0-9-1-31
     cluster: eks-prow-build-cluster
     extra_refs:
       - org: kubernetes-sigs
         repo: jobset
-        base_ref: release-7.1
+        base_ref: release-0.9
         path_alias: sigs.k8s.io/jobset
     annotations:
       testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-jobset-test-e2e-release-0-7-1-31
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-9-1-31
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset end to end tests for Kubernetes 1.31 on release 0.7"
+      description: "Run periodic jobset end to end tests for Kubernetes 1.31 on release 0.9"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -92,7 +92,7 @@ periodics:
         - name: E2E_KIND_VERSION
           value: kindest/node:v1.31.0
         - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.23
+          value: public.ecr.aws/docker/library/golang:1.24
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -109,18 +109,18 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-e2e-release-0-7-1-32
+    name: periodic-jobset-test-e2e-release-0-9-1-32
     cluster: eks-prow-build-cluster
     extra_refs:
       - org: kubernetes-sigs
         repo: jobset
-        base_ref: release-7.1
+        base_ref: release-0.9
         path_alias: sigs.k8s.io/jobset
     annotations:
       testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-jobset-test-e2e-release-0-7-1-32
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-9-1-32
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset end to end tests for Kubernetes 1.32 on release 0.7"
+      description: "Run periodic jobset end to end tests for Kubernetes 1.32 on release 0.9"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -132,7 +132,7 @@ periodics:
         - name: E2E_KIND_VERSION
           value: kindest/node:v1.32.0
         - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.23
+          value: public.ecr.aws/docker/library/golang:1.24
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -149,18 +149,18 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-e2e-release-0-7-1-33
+    name: periodic-jobset-test-e2e-release-0-9-1-33
     cluster: eks-prow-build-cluster
     extra_refs:
       - org: kubernetes-sigs
         repo: jobset
-        base_ref: release-7.1
+        base_ref: release-0.9
         path_alias: sigs.k8s.io/jobset
     annotations:
       testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-jobset-test-e2e-release-0-7-1-33
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-9-1-33
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset end to end tests for Kubernetes 1.33 on release 0.7"
+      description: "Run periodic jobset end to end tests for Kubernetes 1.33 on release 0.9"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -172,7 +172,7 @@ periodics:
         - name: E2E_KIND_VERSION
           value: kindest/node:v1.33.1
         - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.23
+          value: public.ecr.aws/docker/library/golang:1.24
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh


### PR DESCRIPTION
As part of our release process, we support two releases at a time.

Deprecate 0.7 and add e2e testing for release-0.9.