### PR TITLE
Warn folks to update pending_eligible_endpoints.yaml

### DIFF
--- a/experiment/audit/audit_log_parser.py
+++ b/experiment/audit/audit_log_parser.py
@@ -834,53 +834,6 @@ def write_results(endpoint_counts, operation_samples, stats, swagger_mapper=None
     for endpoint, count in sorted_endpoints:
         output.append(f"{endpoint} | {count}")
 
-    # Find and display missing endpoints from Swagger spec
-    if swagger_mapper and swagger_mapper.path_to_operation:
-        all_swagger_operations = set(swagger_mapper.path_to_operation.values())
-        found_operations = set(endpoint_counts.keys())
-
-        # Only count operations that are actually from Swagger (not fallback)
-        swagger_found = found_operations & all_swagger_operations
-        missing_operations = all_swagger_operations - swagger_found
-
-        # Filter out alpha and beta versions from missing operations
-        stable_missing_operations = {
-            op for op in missing_operations
-            if not any(version in op for version in
-                       ['V1alpha', 'V1beta', 'V2alpha', 'V2beta', 'V3alpha', 'V3beta', 'alpha', 'beta'])
-        }
-
-        # Filter out ineligible endpoints from missing operations
-        if ineligible_endpoints:
-            stable_missing_operations = stable_missing_operations - ineligible_endpoints
-
-        # Filter out pending eligible endpoints from missing operations
-        if pending_eligible_endpoints:
-            stable_missing_operations = stable_missing_operations - pending_eligible_endpoints
-
-        # Filter out deprecated operations from missing operations
-        if deprecated_operations:
-            stable_missing_operations = stable_missing_operations - deprecated_operations
-
-        if stable_missing_operations:
-            filtered_count = len(missing_operations) - len(stable_missing_operations)
-
-            output.append("")
-            output.append("=" * 70)
-            output.append("STABLE ENDPOINTS NOT FOUND IN AUDIT LOG")
-            output.append("=" * 70)
-            output.append(f"Total missing stable endpoints: {len(stable_missing_operations)}")
-            if filtered_count > 0:
-                output.append(
-                    f"(Filtered out {filtered_count} alpha/beta/deprecated/ineligible/pending eligible endpoints)")
-            output.append(
-                f"These are stable, non-deprecated API endpoints defined in the Swagger spec but not exercised in this audit log:")
-            output.append("")
-
-            # Sort missing operations alphabetically
-            for operation in sorted(stable_missing_operations):
-                output.append(f"{operation} | NOT FOUND")
-
     result_text = "\n".join(output)
 
     if output_file:
@@ -899,6 +852,61 @@ def write_results(endpoint_counts, operation_samples, stats, swagger_mapper=None
     # Generate audit-operations.json JSON file with sample audit entries
     _write_audit_operations_json(filtered_endpoint_counts, operation_samples, ineligible_endpoints,
                                  pending_eligible_endpoints, deprecated_operations, audit_operations_json)
+
+    # Find and display missing endpoints from Swagger spec
+    if swagger_mapper and swagger_mapper.path_to_operation:
+        warn_on_missing_stable_endpoints(deprecated_operations, endpoint_counts, ineligible_endpoints,
+                                         pending_eligible_endpoints, swagger_mapper)
+
+
+def warn_on_missing_stable_endpoints(deprecated_operations, endpoint_counts, ineligible_endpoints,
+                                     pending_eligible_endpoints, swagger_mapper):
+    all_swagger_operations = set(swagger_mapper.path_to_operation.values())
+    found_operations = set(endpoint_counts.keys())
+    # Only count operations that are actually from Swagger (not fallback)
+    swagger_found = found_operations & all_swagger_operations
+    missing_operations = all_swagger_operations - swagger_found
+    # Filter out alpha and beta versions from missing operations
+    stable_missing_operations = {
+        op for op in missing_operations
+        if not any(version in op for version in
+                   ['V1alpha', 'V1beta', 'V2alpha', 'V2beta', 'V3alpha', 'V3beta', 'alpha', 'beta'])
+    }
+    # Filter out ineligible endpoints from missing operations
+    if ineligible_endpoints:
+        stable_missing_operations = stable_missing_operations - ineligible_endpoints
+    # Filter out pending eligible endpoints from missing operations
+    if pending_eligible_endpoints:
+        stable_missing_operations = stable_missing_operations - pending_eligible_endpoints
+    # Filter out deprecated operations from missing operations
+    if deprecated_operations:
+        stable_missing_operations = stable_missing_operations - deprecated_operations
+    if stable_missing_operations:
+        filtered_count = len(missing_operations) - len(stable_missing_operations)
+
+        # Log stable missing operations directly to stdout (not to output file)
+        print("")
+        print("=" * 70)
+        print("STABLE ENDPOINTS NOT FOUND IN AUDIT LOG")
+        print("=" * 70)
+        print(f"Total missing stable endpoints: {len(stable_missing_operations)}")
+        if filtered_count > 0:
+            print(f"(Filtered out {filtered_count} alpha/beta/deprecated/ineligible/pending eligible endpoints)")
+        print(
+            "These are stable, non-deprecated API endpoints defined in the Swagger spec but not exercised in this audit log:")
+        print()
+
+        # Sort missing operations alphabetically
+        for operation in sorted(stable_missing_operations):
+            print(f"{operation} | NOT FOUND")
+
+        print()
+        print("ACTION REQUIRED:")
+        print("For each missing stable endpoint, please either:")
+        print("1. Add conformance tests to exercise these API operations, OR")
+        print("2. Add them to pending_eligible_endpoints.yaml if they should be excluded from conformance testing")
+        print()
+        sys.exit(1)
 
 
 def _write_audit_operations_json(filtered_endpoint_counts, operation_samples, ineligible_endpoints,


### PR DESCRIPTION
When folks add new conformance tests, if pending_eligible_endpoints.yaml still lists things that are being tested, we should inform that the yaml needs to be updated!

When folks add new operations in swagger, poke them to add a conformance test or update pending_eligible_endpoints.yaml to ensure we do not drop coverage