### PR TITLE
sig-security: add new pull job for cve-feed tests

### DIFF
--- a/config/jobs/kubernetes/sig-security/cve-feed-tests.yaml
+++ b/config/jobs/kubernetes/sig-security/cve-feed-tests.yaml
@@ -1,0 +1,28 @@
+presubmits:
+  kubernetes/sig-security:
+  - name: pull-sig-security-cve-feed
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-security-cve-feed
+      testgrid-create-test-group: "true"
+      description: Running the CVE feed tests on PRs
+    run_if_changed: "^sig-security-tooling/cve-feed/hack/"
+    branches:
+    - main
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d
+        workingDir: sig-security-tooling/cve-feed/hack
+        command:
+        - python
+        args:
+        - test_cve_title_parser.py
+        - -v
+        resources:
+          limits:
+            cpu: 1
+            memory: "256m"
+          requests:
+            cpu: 1
+            memory: "256m"


### PR DESCRIPTION
This is for running the new CVE feed unit tests from https://github.com/kubernetes/sig-security/pull/155.

Context is we wanted to add something like this with GHA:
```yaml
name: CVE Feed Tests

on:
  pull_request:
    paths:
      - 'sig-security-tooling/cve-feed/hack/**'

jobs:
  run-cve-feed-tests:
    runs-on: ubuntu-latest

    steps:
    - name: Checkout code
      uses: actions/checkout@v4

    - name: Set up Python 3.11
      uses: actions/setup-python@v4
      with:
        python-version: '3.11'

    - name: Run CVE title parser tests
      working-directory: sig-security-tooling/cve-feed/hack
      run: python test_cve_title_parser.py -v
```

But of course we want to use Prow because it's k8s!!

/sig security
/hold on this one https://github.com/kubernetes/sig-security/pull/155 to be merged