### PR TITLE
Fix CVE Feed test job

### DIFF
--- a/config/jobs/kubernetes/sig-security/cve-feed-tests.yaml
+++ b/config/jobs/kubernetes/sig-security/cve-feed-tests.yaml
@@ -13,11 +13,10 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
-        workingDir: sig-security-tooling/cve-feed/hack
         command:
         - python
         args:
-        - test_cve_title_parser.py
+        - sig-security-tooling/cve-feed/hack/test_cve_title_parser.py
         - -v
         resources:
           limits:


### PR DESCRIPTION
The job [hangs forever](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/sig-security/162/pull-sig-security-cve-feed/1961555656708198400), probably because python isn't finding the script correctly.

I believe this will correct the problem.