### PR TITLE
kOps: add release pipeline for k8s 1.34

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1866,7 +1866,7 @@ def generate_versions():
 ######################
 def generate_pipeline():
     results = []
-    for version in ['master', '1.33', '1.32', '1.31', '1.30']:
+    for version in ['master', '1.34', '1.33', '1.32', '1.31']:
         branch = version if version == 'master' else f"release-{version}"
         publish_version_marker = f"gs://k8s-staging-kops/kops/releases/markers/{branch}/latest-ci-updown-green.txt"
         kops_version = f"https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/{branch}/latest-ci.txt"

--- a/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
@@ -69,6 +69,73 @@ periodics:
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-pipeline-updown-kopsmaster
 
+# {"cloud": "aws", "distro": "u2404", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.34", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+- name: e2e-kops-pipeline-updown-kops134
+  cron: '19 0-23/1 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  cluster: k8s-infra-kops-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        make test-e2e-install
+        kubetest2 kops \
+          -v 2 \
+          --up --down \
+          --cloud-provider=aws \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250821' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
+          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci.txt \
+          --publish-version-marker=gs://k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
+          --kubernetes-version=https://dl.k8s.io/release/stable-1.34.txt \
+          --test=kops \
+          -- \
+          --test-args="-test.timeout=60m" \
+          --test-package-marker=stable-1.34.txt \
+          --focus-regex="\[k8s.io\]\sNetworking.*\[Conformance\]" \
+          --skip-regex="\[Slow\]|\[Serial\]" \
+          --parallel=25
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250815-171060767f-master
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+  annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2404
+    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
+    test.kops.k8s.io/k8s_version: '1.34'
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/kops_version: latest
+    test.kops.k8s.io/networking: calico
+    testgrid-dashboards: kops-distro-u2404, kops-k8s-1.34, kops-latest, kops-versions, sig-cluster-lifecycle-kops
+    testgrid-days-of-results: '11'
+    testgrid-tab-name: kops-pipeline-updown-kops134
+
 # {"cloud": "aws", "distro": "u2404", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.33", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-pipeline-updown-kops133
   cron: '12 0-23/1 * * *'
@@ -269,70 +336,3 @@ periodics:
     testgrid-dashboards: kops-distro-u2404, kops-k8s-1.31, kops-latest, kops-versions, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '11'
     testgrid-tab-name: kops-pipeline-updown-kops131
-
-# {"cloud": "aws", "distro": "u2404", "extra_flags": "--discovery-store=s3://k8s-kops-prow/discovery", "k8s_version": "1.30", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
-- name: e2e-kops-pipeline-updown-kops130
-  cron: '46 0-23/1 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  cluster: k8s-infra-kops-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  extra_refs:
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    workdir: true
-    path_alias: k8s.io/kops
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      args:
-      - bash
-      - -c
-      - |
-        make test-e2e-install
-        kubetest2 kops \
-          -v 2 \
-          --up --down \
-          --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250821' --channel=alpha --networking=calico --discovery-store=s3://k8s-kops-prow/discovery" \
-          --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci.txt \
-          --publish-version-marker=gs://k8s-staging-kops/kops/releases/markers/release-1.30/latest-ci-updown-green.txt \
-          --kubernetes-version=https://dl.k8s.io/release/stable-1.30.txt \
-          --test=kops \
-          -- \
-          --test-args="-test.timeout=60m" \
-          --test-package-marker=stable-1.30.txt \
-          --focus-regex="\[k8s.io\]\sNetworking.*\[Conformance\]" \
-          --skip-regex="\[Slow\]|\[Serial\]" \
-          --parallel=25
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
-      - name: KUBE_SSH_USER
-        value: ubuntu
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250815-171060767f-master
-      imagePullPolicy: Always
-      resources:
-        limits:
-          cpu: "4"
-          memory: 6Gi
-        requests:
-          cpu: "4"
-          memory: 6Gi
-  annotations:
-    test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2404
-    test.kops.k8s.io/extra_flags: --discovery-store=s3://k8s-kops-prow/discovery
-    test.kops.k8s.io/k8s_version: '1.30'
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: latest
-    test.kops.k8s.io/networking: calico
-    testgrid-dashboards: kops-distro-u2404, kops-k8s-1.30, kops-latest, kops-versions, sig-cluster-lifecycle-kops
-    testgrid-days-of-results: '11'
-    testgrid-tab-name: kops-pipeline-updown-kops130


### PR DESCRIPTION
Follow-up of:
 - https://github.com/kubernetes/test-infra/pull/35399