### PR TITLE
sig-security: fix naming of cve feed units tests job

### DIFF
--- a/config/jobs/kubernetes/sig-security/cve-feed-tests.yaml
+++ b/config/jobs/kubernetes/sig-security/cve-feed-tests.yaml
@@ -1,11 +1,11 @@
 presubmits:
   kubernetes/sig-security:
-  - name: pull-sig-security-cve-feed
+  - name: pull-sig-security-cve-feed-unit-tests
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-security-cve-feed
       testgrid-create-test-group: "true"
-      description: Running the CVE feed tests on PRs
+      description: Running the CVE feed unit tests on each PRs touching the scripts
     run_if_changed: "^sig-security-tooling/cve-feed/hack/"
     branches:
     - main


### PR DESCRIPTION
I initially wanted to push this along the initial patch to follow conventions I've seen in other jobs but forgot to git add / git push...

I hope it won't affect the dashboard too much 🤔. Pretty innocent patch.

/sig security
/cc @tabbysable 