### PR TITLE
Switch to latest snoopdb image

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -12,7 +12,7 @@ periodics:
   spec:
     containers:
     - name: apisnoop-gate
-      image: gcr.io/k8s-staging-apisnoop/snoopdb:v20240310-auditlogger-1.2.11-30-g3c40359
+      image: gcr.io/k8s-staging-apisnoop/snoopdb:v20250901-auditlogger-1.2.13-116-g8c55744
       env:
         - name: LOAD_K8S_DATA
           value: "true"


### PR DESCRIPTION
New image from:
https://storage.googleapis.com/kubernetes-ci-logs/logs/apisnoop-push-snoopdb-images/1962421977222221824/build-log.txt

Verified that the image exists:
https://explore.ggcr.dev/?image=gcr.io%2Fk8s-staging-apisnoop%2Fsnoopdb:v20250901-auditlogger-1.2.13-116-g8c55744

/assign @upodroid @ameukam @koksay 