### PR TITLE
bump tools in kubekins-e2e v2 image

### DIFF
--- a/images/kubekins-e2e-v2/cloudbuild.yaml
+++ b/images/kubekins-e2e-v2/cloudbuild.yaml
@@ -24,14 +24,14 @@ steps:
     - us-central1-docker.pkg.dev/$PROJECT_ID/images/kubekins-e2e:$_GIT_TAG-$_CONFIG
     - us-central1-docker.pkg.dev/$PROJECT_ID/images/kubekins-e2e:latest-$_CONFIG
 substitutions:
-  _CFSSL_VERSION: 1.6.4
+  _CFSSL_VERSION: 1.6.5
   _CONFIG: master
   _GIT_TAG: '12345'
   _GO_VERSION: 1.13.5
   _K8S_RELEASE: stable
-  _KIND_VERSION: '0.22.0'
+  _KIND_VERSION: '0.30.0'
   _KUBETEST2_VERSION: 'master'
-  _YQ_VERSION: v4.40.7
+  _YQ_VERSION: v4.47.1
 timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE


### PR DESCRIPTION
I need to rebuild this image to pickup https://github.com/kubernetes-sigs/kubetest2/commit/9560e3922fc039b76e6f3bab9b9711c38ac6d486

Fixes #35438

/cc @dims