### PR TITLE
cve-feed-tests: fix job by changing image and command

### DIFF
--- a/config/jobs/kubernetes/sig-security/cve-feed-tests.yaml
+++ b/config/jobs/kubernetes/sig-security/cve-feed-tests.yaml
@@ -12,12 +12,9 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
-        command:
-        - python
-        args:
-        - sig-security-tooling/cve-feed/hack/test_cve_title_parser.py
-        - -v
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250902-2613a23300-master
+        command: ['runner.sh']
+        args: ['python', 'sig-security-tooling/cve-feed/hack/test_cve_title_parser.py', '-v']
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
User @upodroid suggest me:

	Hi, can you amend the job like this:
	use the image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250902-2613a23300-master
	command: runner.sh
	args: ['python', 'sig-security-tooling/cve-feed/hack/test_cve_title_parser.py', '-v']

For reference https://kubernetes.slack.com/archives/CCK68P2Q2/p1756890918525729?thread_ts=1756888713.055379&cid=CCK68P2Q2