### PR TITLE
[kueue] Bump go version to 1.25.

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodic-s390x-ppc64le-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodic-s390x-ppc64le-main.yaml
@@ -27,7 +27,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -22,7 +22,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           env:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
@@ -62,7 +62,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           command:
             - make
           args:
@@ -100,7 +100,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           command:
             - make
           args:
@@ -138,7 +138,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           command:
             - make
           args:
@@ -181,7 +181,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.31"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -227,7 +227,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -273,7 +273,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.33"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -319,7 +319,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -365,7 +365,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -411,7 +411,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -457,7 +457,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -503,7 +503,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -549,7 +549,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-12.yaml
@@ -22,7 +22,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           env:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
@@ -62,7 +62,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           command:
             - make
           args:
@@ -100,7 +100,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           command:
             - make
           args:
@@ -138,7 +138,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           command:
             - make
           args:
@@ -181,7 +181,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.31"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -227,7 +227,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -273,7 +273,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -319,7 +319,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -365,7 +365,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -411,7 +411,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -457,7 +457,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-13.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-13.yaml
@@ -22,7 +22,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           env:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
@@ -62,7 +62,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           command:
             - make
           args:
@@ -100,7 +100,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           command:
             - make
           args:
@@ -138,7 +138,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           command:
             - make
           args:
@@ -181,7 +181,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.31"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -227,7 +227,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -273,7 +273,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.33"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -319,7 +319,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.33"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -365,7 +365,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.33"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -411,7 +411,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.33"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -457,7 +457,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.33"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -503,7 +503,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.33"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.12.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.12.yaml
@@ -27,7 +27,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.33"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.13.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.13.yaml
@@ -27,7 +27,7 @@ periodics:
             - name: E2E_K8S_VERSION
               value: "1.33"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -13,7 +13,7 @@ presubmits:
       description: "Run kueue unit tests"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         env:
         - name: GO_TEST_FLAGS
           value: "-race -count 3"
@@ -43,7 +43,7 @@ presubmits:
       description: "Run kueue test-integration-baseline"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         command:
         - make
         args:
@@ -71,7 +71,7 @@ presubmits:
       description: "Run kueue test-integration-extended"
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           command:
             - make
           args:
@@ -99,7 +99,7 @@ presubmits:
       description: "Run kueue test-multikueue-integration"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         command:
         - make
         args:
@@ -134,7 +134,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.31"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -172,7 +172,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -210,7 +210,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.33"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -248,7 +248,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -286,7 +286,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -324,7 +324,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -362,7 +362,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -400,7 +400,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -438,7 +438,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.34"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -518,7 +518,7 @@ presubmits:
         - name: GOMAXPROCS
           value: "2"
         - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.24
+          value: public.ecr.aws/docker/library/golang:1.25
         resources:
           requests:
             cpu: "2"
@@ -539,7 +539,7 @@ presubmits:
       description: "Run kueue test-scheduling-perf"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-12.yaml
@@ -13,7 +13,7 @@ presubmits:
       description: "Run kueue unit tests"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         env:
         - name: GO_TEST_FLAGS
           value: "-race -count 3"
@@ -43,7 +43,7 @@ presubmits:
       description: "Run kueue test-integration-baseline"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         command:
         - make
         args:
@@ -71,7 +71,7 @@ presubmits:
       description: "Run kueue test-integration-extended"
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.24
+        - image: public.ecr.aws/docker/library/golang:1.25
           command:
             - make
           args:
@@ -99,7 +99,7 @@ presubmits:
       description: "Run kueue test-multikueue-integration"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         command:
         - make
         args:
@@ -134,7 +134,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.31"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -172,7 +172,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -210,7 +210,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -248,7 +248,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -286,7 +286,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -324,7 +324,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -362,7 +362,7 @@ presubmits:
             - name: E2E_K8S_VERSION
               value: "1.32"
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.24
+              value: public.ecr.aws/docker/library/golang:1.25
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -442,7 +442,7 @@ presubmits:
         - name: GOMAXPROCS
           value: "2"
         - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.24
+          value: public.ecr.aws/docker/library/golang:1.25
         resources:
           requests:
             cpu: "2"
@@ -463,7 +463,7 @@ presubmits:
       description: "Run kueue test-scheduling-perf"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-13.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-13.yaml
@@ -13,7 +13,7 @@ presubmits:
         description: "Run kueue unit tests"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.24
+          - image: public.ecr.aws/docker/library/golang:1.25
             env:
               - name: GO_TEST_FLAGS
                 value: "-race -count 3"
@@ -43,7 +43,7 @@ presubmits:
         description: "Run kueue test-integration-baseline"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.24
+          - image: public.ecr.aws/docker/library/golang:1.25
             command:
               - make
             args:
@@ -71,7 +71,7 @@ presubmits:
         description: "Run kueue test-integration-extended"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.24
+          - image: public.ecr.aws/docker/library/golang:1.25
             command:
               - make
             args:
@@ -99,7 +99,7 @@ presubmits:
         description: "Run kueue test-multikueue-integration"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.24
+          - image: public.ecr.aws/docker/library/golang:1.25
             command:
               - make
             args:
@@ -134,7 +134,7 @@ presubmits:
               - name: E2E_K8S_VERSION
                 value: "1.31"
               - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
+                value: public.ecr.aws/docker/library/golang:1.25
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -172,7 +172,7 @@ presubmits:
               - name: E2E_K8S_VERSION
                 value: "1.32"
               - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
+                value: public.ecr.aws/docker/library/golang:1.25
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -210,7 +210,7 @@ presubmits:
               - name: E2E_K8S_VERSION
                 value: "1.33"
               - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
+                value: public.ecr.aws/docker/library/golang:1.25
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -248,7 +248,7 @@ presubmits:
               - name: E2E_K8S_VERSION
                 value: "1.33"
               - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
+                value: public.ecr.aws/docker/library/golang:1.25
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -286,7 +286,7 @@ presubmits:
               - name: E2E_K8S_VERSION
                 value: "1.33"
               - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
+                value: public.ecr.aws/docker/library/golang:1.25
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -324,7 +324,7 @@ presubmits:
               - name: E2E_K8S_VERSION
                 value: "1.33"
               - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
+                value: public.ecr.aws/docker/library/golang:1.25
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -362,7 +362,7 @@ presubmits:
               - name: E2E_K8S_VERSION
                 value: "1.33"
               - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
+                value: public.ecr.aws/docker/library/golang:1.25
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -400,7 +400,7 @@ presubmits:
               - name: E2E_K8S_VERSION
                 value: "1.33"
               - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
+                value: public.ecr.aws/docker/library/golang:1.25
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -480,7 +480,7 @@ presubmits:
               - name: GOMAXPROCS
                 value: "2"
               - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.24
+                value: public.ecr.aws/docker/library/golang:1.25
             resources:
               requests:
                 cpu: "2"
@@ -501,7 +501,7 @@ presubmits:
         description: "Run kueue test-scheduling-perf"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.24
+          - image: public.ecr.aws/docker/library/golang:1.25
             command:
               - make
             args:


### PR DESCRIPTION
We already did revert for this changes on https://github.com/kubernetes/test-infra/pull/35437 because we had an error:

```
../../../go/pkg/mod/golang.org/x/tools@v0.24.0/internal/tokeninternal/tokeninternal.go:64:9: invalid array length -delta * delta (constant -256 of type int64)
```

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/6689/pull-kueue-test-unit-main/1962569907203739648
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/6689/pull-kueue-test-scheduling-perf-main/1962569912232710144

This error should be fixed after bump gotest.tools/gotestsum. I've created PR to fix this https://github.com/kubernetes-sigs/kueue/pull/6722. 
So we can give one more chance for this changes after merge https://github.com/kubernetes-sigs/kueue/pull/6722.

/hold for https://github.com/kubernetes-sigs/kueue/pull/6722