### PR TITLE
[kueue] Use BASE_BUILDER_IMAGE instead of BUILDER_IMAGE.

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodic-s390x-ppc64le-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodic-s390x-ppc64le-main.yaml
@@ -26,8 +26,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -180,8 +180,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.31"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -226,8 +226,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -272,8 +272,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.33"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -318,8 +318,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -364,8 +364,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -410,8 +410,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -456,8 +456,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -502,8 +502,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -548,8 +548,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-12.yaml
@@ -180,8 +180,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.31"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -226,8 +226,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -272,8 +272,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -318,8 +318,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -364,8 +364,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -410,8 +410,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -456,8 +456,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-13.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-13.yaml
@@ -180,8 +180,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.31"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -226,8 +226,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -272,8 +272,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.33"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -318,8 +318,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.33"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -364,8 +364,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.33"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -410,8 +410,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.33"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -456,8 +456,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.33"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -502,8 +502,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.33"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.12.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.12.yaml
@@ -26,8 +26,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.33"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.13.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.13.yaml
@@ -26,8 +26,8 @@ periodics:
           env:
             - name: E2E_K8S_VERSION
               value: "1.33"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -133,8 +133,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.31"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -171,8 +171,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -209,8 +209,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.33"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -247,8 +247,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -285,8 +285,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -323,8 +323,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -361,8 +361,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -399,8 +399,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -437,8 +437,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.34"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -517,8 +517,8 @@ presubmits:
         env:
         - name: GOMAXPROCS
           value: "2"
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.25
+        - name: BASE_BUILDER_IMAGE
+          value: public.ecr.aws/docker/library/golang
         resources:
           requests:
             cpu: "2"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-12.yaml
@@ -133,8 +133,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.31"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -171,8 +171,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -209,8 +209,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -247,8 +247,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -285,8 +285,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -323,8 +323,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -361,8 +361,8 @@ presubmits:
           env:
             - name: E2E_K8S_VERSION
               value: "1.32"
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -441,8 +441,8 @@ presubmits:
         env:
         - name: GOMAXPROCS
           value: "2"
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.25
+        - name: BASE_BUILDER_IMAGE
+          value: public.ecr.aws/docker/library/golang
         resources:
           requests:
             cpu: "2"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-13.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-13.yaml
@@ -133,8 +133,8 @@ presubmits:
             env:
               - name: E2E_K8S_VERSION
                 value: "1.31"
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.25
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -171,8 +171,8 @@ presubmits:
             env:
               - name: E2E_K8S_VERSION
                 value: "1.32"
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.25
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -209,8 +209,8 @@ presubmits:
             env:
               - name: E2E_K8S_VERSION
                 value: "1.33"
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.25
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -247,8 +247,8 @@ presubmits:
             env:
               - name: E2E_K8S_VERSION
                 value: "1.33"
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.25
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -285,8 +285,8 @@ presubmits:
             env:
               - name: E2E_K8S_VERSION
                 value: "1.33"
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.25
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -323,8 +323,8 @@ presubmits:
             env:
               - name: E2E_K8S_VERSION
                 value: "1.33"
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.25
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -361,8 +361,8 @@ presubmits:
             env:
               - name: E2E_K8S_VERSION
                 value: "1.33"
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.25
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -399,8 +399,8 @@ presubmits:
             env:
               - name: E2E_K8S_VERSION
                 value: "1.33"
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.25
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
             command:
               # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
@@ -479,8 +479,8 @@ presubmits:
             env:
               - name: GOMAXPROCS
                 value: "2"
-              - name: BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang:1.25
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
             resources:
               requests:
                 cpu: "2"


### PR DESCRIPTION
/hold for https://github.com/kubernetes-sigs/kueue/pull/6729 and https://github.com/kubernetes-sigs/kueue/pull/6730.

Fixes kubernetes-sigs/kueue#6724