### PR TITLE
Trigger build of kubekins image with fresh kubetest2

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.24.6
+    GO_VERSION: 1.25.1
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   master:


### PR DESCRIPTION
bump go-canary version to latest available... as a way to retrigger a fresh build of kubekins image with latest kubetest2