### PR TITLE
Change system type of node for couple of IBM jobs

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -89,6 +89,7 @@ periodics:
 
               set +o errexit
               set -o xtrace
+              export TF_VAR_powervs_system_type=e980
               kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} --powervs-ssh-key k8s-prow-sshkey \
@@ -304,6 +305,7 @@ periodics:
 
               set +o errexit
               set -o xtrace
+              export TF_VAR_powervs_system_type=e980
               kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} --powervs-ssh-key k8s-prow-sshkey \


### PR DESCRIPTION
This change is to modify system type of nodes where IBM kubernetes jobs are running. Doing it for below jobs
`ci-kubernetes-e2e-ppc64le-default` and `ci-kubernetes-ppc64le-conformance-latest-kubetest2`