### PR TITLE
use with git dir

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-jobset.yaml
+++ b/config/jobs/image-pushing/k8s-staging-jobset.yaml
@@ -20,4 +20,5 @@ postsubmits:
               - --project=k8s-staging-images
               - --scratch-bucket=gs://k8s-staging-images-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
               - .


### PR DESCRIPTION
Following up from @BenTheElder suggestion [here](https://github.com/kubernetes-sigs/jobset/pull/1005#issuecomment-3255675494).

Adding with-git-dir for the jobset image push to use git commands.