### PR TITLE
add k8s 1.34 for jobset e2e

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -188,3 +188,43 @@ periodics:
             requests:
               cpu: 3
               memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-main-1-34
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: main
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: periodic-jobset-test-e2e-main-1-34
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.34"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.34.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.24
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-8.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-8.yaml
@@ -188,3 +188,44 @@ periodics:
           requests:
             cpu: 3
             memory: 10Gi
+
+  - interval: 12h
+    name: periodic-jobset-test-e2e-release-0-8-1-34
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: release-0.8
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-8-1-34
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.34 on release 0.8"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+        env:
+        - name: E2E_KIND_VERSION
+          value: kindest/node:v1.34.0
+        - name: BUILDER_IMAGE
+          value: public.ecr.aws/docker/library/golang:1.24
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-9.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-9.yaml
@@ -188,3 +188,43 @@ periodics:
           requests:
             cpu: 3
             memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-release-0-9-1-34
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: release-0.9
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-9-1-34
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.34 on release 0.9"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+        env:
+        - name: E2E_KIND_VERSION
+          value: kindest/node:v1.34.0
+        - name: BUILDER_IMAGE
+          value: public.ecr.aws/docker/library/golang:1.24
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -160,6 +160,41 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-jobset-test-e2e-main-1-34
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: pull-jobset-test-e2e-main-1-34
+      description: "Run jobset end to end tests for Kubernetes 1.34"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.34.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.24
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-jobset-verify-main
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
Add k8s 1.34 for main presubmits and periodics for supported release branches.