### PR TITLE
Adding 1.34 serial slow and pre-submit jobs for Windows

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows-presubmits.yaml
@@ -1,0 +1,55 @@
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-e2e-capz-windows-1-34
+    cluster: eks-prow-build-cluster
+    always_run: false
+    branches:
+    - release-1.34
+    decorate: true
+    extra_refs:
+    - base_ref: release-1.19
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      repo: cluster-api-provider-azure
+      workdir: false
+    - base_ref: master
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      repo: cloud-provider-azure
+    - org: kubernetes-sigs
+      repo: windows-testing
+      base_ref: master
+      path_alias: k8s.io/windows-testing
+      workdir: true
+    labels:
+      preset-azure-community: "true"
+      preset-capz-containerd-1-7-latest: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-windows-common-pull: "true"
+      preset-dind-enabled: "true"
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: azure.*\.go$|.*windows\.go$|test/e2e/windows/.*
+    spec:
+      serviceAccountName: azure
+      containers:
+      - command:
+        - "runner.sh"
+        - "env"
+        - KUBERNETES_VERSION=latest-1.34
+        - "./capz/run-capz-e2e.sh"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-1.34
+        name: ""
+        resources:
+          requests:
+            cpu: "2"
+            memory: "9Gi"
+          limits:
+            cpu: "2"
+            memory: "9Gi"
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-windows-presubmit
+      testgrid-tab-name: pull-kubernetes-e2e-capz-windows-1-34
+      testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows.yaml
@@ -1,0 +1,107 @@
+periodics:
+- name: ci-kubernetes-e2e-capz-master-windows-1-34
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-release-1.34-informing, sig-windows-1.34-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-1.34
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: release-1.19
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    repo: cluster-api-provider-azure
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+    workdir: true
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    repo: cloud-provider-azure
+  interval: 24h
+  labels:
+    preset-azure-community: "true"
+    preset-capz-containerd-1-7-latest: "true"
+    preset-capz-windows-2022: "true"
+    preset-capz-windows-common: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    serviceAccountName: azure
+    containers:
+    - command:
+      - runner.sh
+      - env
+      - KUBERNETES_VERSION=latest-1.34
+      - ./capz/run-capz-e2e.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-1.34
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 9Gi
+        requests:
+          cpu: "2"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+- name: ci-kubernetes-e2e-capz-1-34-windows-serial-slow
+  cluster: eks-prow-build-cluster
+  interval: 48h
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-azure-community: "true"
+    preset-capz-containerd-1-7-latest: "true"
+    preset-capz-serial-slow: "true"
+    preset-capz-gmsa-setup: "true"
+    preset-capz-windows-2022: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: release-1.19
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-1.34
+        command:
+          - "runner.sh"
+          - "env"
+          - KUBERNETES_VERSION=latest-1.34
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: GINKGO_FOCUS
+            value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
+          - name: GINKGO_SKIP
+            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|should.be.able.to.gracefully.shutdown.pods.with.various.grace.periods|\[Alpha\]|\[Feature:SchedulerAsyncPreemption\]
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-1.34-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-1-34-serial-slow

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1170,57 +1170,6 @@ periodics:
           memory: 24Gi
       securityContext:
         privileged: true
-- annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io,
-      release-team@kubernetes.io
-    testgrid-dashboards: sig-release-1.34-informing, sig-windows-master-release, sig-windows-signal
-    testgrid-tab-name: capz-windows-1.34
-  cluster: eks-prow-build-cluster
-  decorate: true
-  decoration_config:
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubernetes-sigs
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    repo: cluster-api-provider-azure
-  - base_ref: master
-    org: kubernetes-sigs
-    path_alias: sigs.k8s.io/windows-testing
-    repo: windows-testing
-    workdir: true
-  - base_ref: master
-    org: kubernetes-sigs
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    repo: cloud-provider-azure
-  interval: 3h
-  labels:
-    preset-azure-community: "true"
-    preset-capz-containerd-1-7-latest: "true"
-    preset-capz-windows-2022: "true"
-    preset-capz-windows-common: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  name: ci-kubernetes-e2e-capz-master-windows-1-34
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - env
-      - KUBERNETES_VERSION=latest-1.34
-      - ./capz/run-capz-e2e.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-1.34
-      name: ""
-      resources:
-        limits:
-          cpu: "2"
-          memory: 9Gi
-        requests:
-          cpu: "2"
-          memory: 9Gi
-      securityContext:
-        privileged: true
-    serviceAccountName: azure
 postsubmits: {}
 presubmits:
   kubernetes/kubernetes:

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -5,6 +5,7 @@ dashboard_groups:
     - sig-windows-1.31-release
     - sig-windows-1.32-release
     - sig-windows-1.33-release
+    - sig-windows-1.34-release
     - sig-windows-master-release
     - sig-windows-presubmit
     - sig-windows-gce
@@ -17,6 +18,7 @@ dashboards:
 - name: sig-windows-1.31-release
 - name: sig-windows-1.32-release
 - name: sig-windows-1.33-release
+- name: sig-windows-1.34-release
 - name: sig-windows-master-release
 - name: sig-windows-presubmit
 - name: sig-windows-gce


### PR DESCRIPTION
This PR

- Adds a release-1.34 dashboard tab under sig-windows
- Moves the existing 1.34 Windows CI job to the sig-windows folder (to ensure we update it with the others)
- Adds a serial-slow Windows CI job
- Adds a pre-submit job targeting release-1.34 branch

/sig windows
/assign @aravindhp @claudiubelu @zylxjtu @jeremyrickard 