### PR TITLE
update pull-lws-test-e2e to k8s 1.33

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -69,7 +69,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.33.0
+              value: kindest/node:v1.33.1
           command:
             - runner.sh
           args:


### PR DESCRIPTION
this PR also removes k8s 1.30 tests since k8s 1.30 is deprecated, and later on, we should support k8s 1.34 tests