### PR TITLE
bump pull-release-image-go-runner timeout

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -235,6 +235,8 @@ presubmits:
   - name: pull-release-image-go-runner
     cluster: k8s-infra-prow-build
     decorate: true
+    decoration_config:
+      timeout: 2h
     run_if_changed: '^images\/build\/go-runner\/'
     path_alias: k8s.io/release
     spec:


### PR DESCRIPTION
Trying to update k/release to build golang ourselves in https://github.com/kubernetes/release/pull/4111 - job is timing out