### PR TITLE
match timeout in pull-release-image-go-runner to be same as post job

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -236,7 +236,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
-      timeout: 2h
+      timeout: 240m
+      grace_period: 10m
     run_if_changed: '^images\/build\/go-runner\/'
     path_alias: k8s.io/release
     spec:


### PR DESCRIPTION
use the same configuration we have in:
```
post-release-push-image-go-runner
```

https://github.com/kubernetes/test-infra/blob/5497b2ffcac7e40d1acbae36995b24eabe7ed97a/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml#L73-L75