### PR TITLE
run on demand  nftables and cloud provider jobs on release branches

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -58,6 +58,7 @@ presubmits:
     decorate: true
     branches:
     - master
+    - ^release-
     path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes-sigs
@@ -111,6 +112,7 @@ presubmits:
     cluster: k8s-infra-prow-build
     branches:
     - master
+    - ^release-
     optional: true
     always_run: false
     skip_report: false


### PR DESCRIPTION
we need to be able to get some signal before merging backports on loadbalancer and nftables code, that is optional and not well covered across release branches