### PR TITLE
Fix Python call in k/sig-security CVE feed tests

### DIFF
--- a/config/jobs/kubernetes/sig-security/cve-feed-tests.yaml
+++ b/config/jobs/kubernetes/sig-security/cve-feed-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250905-c89b045f57-master
         command: ['runner.sh']
-        args: ['python', 'sig-security-tooling/cve-feed/hack/test_cve_title_parser.py', '-v']
+        args: ['python3', 'sig-security-tooling/cve-feed/hack/test_cve_title_parser.py', '-v']
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
Call python as python3, as required by kubekins-e2e runner image. Resolves errors such as [this](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/sig-security/162/pull-sig-security-cve-feed-unit-tests/1965578426827935744)