### PR TITLE
Move external-health-monitor to hostpath_example_repos

### DIFF
--- a/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
+++ b/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
@@ -2,7 +2,357 @@
 
 presubmits:
   kubernetes-csi/external-health-monitor:
-  - name: pull-kubernetes-csi-external-health-monitor
+  - name: pull-kubernetes-csi-external-health-monitor-1-31-on-kubernetes-1-31
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: false
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-health-monitor
+      testgrid-tab-name: 1-31-on-kubernetes-1-31
+      description: Kubernetes-CSI pull job in repo external-health-monitor for non-alpha tests, using deployment 1.31 on Kubernetes 1.31
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.31.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.31"
+        - name: CSI_PROW_E2E_VERSION
+          value: "release-1.31"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.17.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-health-monitor-1-31-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-health-monitor
+      testgrid-tab-name: 1-31-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-health-monitor for non-alpha tests, using deployment 1.31 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.17.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-health-monitor-1-32-on-kubernetes-1-32
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: false
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-health-monitor
+      testgrid-tab-name: 1-32-on-kubernetes-1-32
+      description: Kubernetes-CSI pull job in repo external-health-monitor for non-alpha tests, using deployment 1.32 on Kubernetes 1.32
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.32.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.32"
+        - name: CSI_PROW_E2E_VERSION
+          value: "release-1.32"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.17.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-health-monitor-1-32-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-health-monitor
+      testgrid-tab-name: 1-32-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-health-monitor for non-alpha tests, using deployment 1.32 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.17.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-health-monitor-1-33-on-kubernetes-1-33
+    cluster: eks-prow-build-cluster
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-health-monitor
+      testgrid-tab-name: 1-33-on-kubernetes-1-33
+      description: Kubernetes-CSI pull job in repo external-health-monitor for non-alpha tests, using deployment 1.33 on Kubernetes 1.33
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.33.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.33"
+        - name: CSI_PROW_E2E_VERSION
+          value: "release-1.33"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.17.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-health-monitor-1-33-on-kubernetes-master
+    # Explicitly needs to be started with /test.
+    # This cannot be enabled by default because there's always the risk
+    # that something changes in master which breaks the pre-merge check.
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-health-monitor
+      testgrid-tab-name: 1-33-on-kubernetes-master
+      description: Kubernetes-CSI pull job in repo external-health-monitor for non-alpha tests, using deployment 1.33 on Kubernetes master
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.17.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_TESTS
+          value: "sanity serial parallel"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-health-monitor-alpha-1-32-on-kubernetes-1-32
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-health-monitor
+      testgrid-tab-name: alpha-1-32-on-kubernetes-1-32
+      description: Kubernetes-CSI pull job in repo external-health-monitor for alpha tests, using deployment 1.32 on Kubernetes 1.32
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        # We pick some version for which there are pre-built images for kind.
+        # Update only when the newer version is known to not cause issues,
+        # otherwise presubmit jobs may start to fail for reasons that are
+        # unrelated to the PR. Testing against the latest Kubernetes is covered
+        # by periodic jobs (see https://testgrid.k8s.io/sig-storage-csi-ci#Summary).
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "1.32.0"
+        - name: CSI_PROW_KUBERNETES_DEPLOYMENT
+          value: "1.32"
+        - name: CSI_PROW_E2E_VERSION
+          value: "release-1.32"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.17.0"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v6.1.0"
+        - name: CSI_PROW_TESTS
+          value: "serial-alpha parallel-alpha"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+  - name: pull-kubernetes-csi-external-health-monitor-unit
     cluster: eks-prow-build-cluster
     always_run: true
     decorate: true
@@ -13,9 +363,9 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     annotations:
-      testgrid-dashboards: sig-storage-csi-other
-      testgrid-tab-name: pull-kubernetes-csi-external-health-monitor
-      description: Kubernetes-CSI pull job in repo external-health-monitor
+      testgrid-dashboards: sig-storage-csi-external-health-monitor
+      testgrid-tab-name: unit
+      description: Kubernetes-CSI pull job in repo external-health-monitor for unit tests
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -24,6 +374,61 @@ presubmits:
         - runner.sh
         args:
         - ./.prow.sh
+        env:
+        - name: CSI_PROW_TESTS
+          value: "unit"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "9Gi"
+            cpu: 4
+          limits:
+            memory: "9Gi"
+            cpu: 4
+
+  - name: pull-kubernetes-csi-external-health-monitor-canary
+    cluster: eks-prow-build-cluster
+    optional: true
+    decorate: true
+    skip_report: false
+    skip_branches: []
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      testgrid-dashboards: sig-storage-csi-external-health-monitor
+      testgrid-tab-name: canary
+      description: Kubernetes-CSI pull job in repo external-health-monitor for canary tests
+    spec:
+      containers:
+      # We need this image because it has Docker in Docker and go.
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
+        command:
+        - runner.sh
+        args:
+        - ./.prow.sh
+        env:
+        - name: CSI_PROW_KUBERNETES_VERSION
+          value: "latest"
+        - name: CSI_PROW_TESTS
+          value: "serial-alpha parallel-alpha"
+        - name: CSI_PROW_BUILD_JOB
+          value: "true"
+        - name: CSI_PROW_HOSTPATH_CANARY
+          value: "canary"
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "master"
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "master"
+        # ... but the RBAC rules only when testing on master.
+        # The other jobs test against the unmodified deployment for
+        # that Kubernetes version, i.e. with the original RBAC rules.
+        - name: UPDATE_RBAC_RULES
+          value: "true"
+
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -63,6 +63,7 @@ livenessprobe
 node-driver-registrar
 lib-volume-populator
 volume-data-source-validator
+external-health-monitor
 "
 
 # All kubernetes-csi repos for which want to define pull tests for
@@ -88,7 +89,6 @@ single_kubernetes_repos="
 
 # kubernetes-csi repos which only need unit testing.
 unit_testing_repos="
-external-health-monitor
 csi-test
 csi-release-tools
 csi-lib-utils

--- a/config/testgrids/kubernetes/sig-storage/config.yaml
+++ b/config/testgrids/kubernetes/sig-storage/config.yaml
@@ -11,6 +11,7 @@ dashboard_groups:
     - sig-storage-csi-external-resizer
     - sig-storage-csi-external-snapshotter
     - sig-storage-csi-external-snapshot-metadata
+    - sig-storage-csi-external-health-monitor
     - sig-storage-csi-livenessprobe
     - sig-storage-csi-node-driver-registrar
     - sig-storage-csi-other
@@ -94,6 +95,7 @@ dashboards:
 - name: sig-storage-csi-external-resizer
 - name: sig-storage-csi-external-snapshotter
 - name: sig-storage-csi-external-snapshot-metadata
+- name: sig-storage-csi-external-health-monitor
 - name: sig-storage-csi-livenessprobe
 - name: sig-storage-csi-node-driver-registrar
 - name: sig-storage-csi-other


### PR DESCRIPTION
Move external-health-monitor to hostpath_example_repos & re-generate config.

External health monitor was failing on [bumping dependencies](https://github.com/kubernetes-csi/external-health-monitor/pull/336#issuecomment-3258672885) with timeout on `volume-expand Verify if offline PVC expansion works`.