### PR TITLE
add minikube image build jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-minikube.yaml
+++ b/config/jobs/image-pushing/k8s-staging-minikube.yaml
@@ -1,0 +1,24 @@
+postsubmits:
+  kubernetes/minikube:
+    - name: post-minikube-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: minikube-postsubmits, sig-k8s-infra-gcb
+      decorate: true
+      branches:
+        - ^main$
+        - ^release-
+        # Build semver tags, too
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20241224-fe22c549c1
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-images
+              - --scratch-bucket=gs://k8s-staging-images-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
+              - .

--- a/config/jobs/kubernetes/minikube/minikube.yaml
+++ b/config/jobs/kubernetes/minikube/minikube.yaml
@@ -22,6 +22,8 @@ presubmits:
     always_run: true
     labels:
       preset-dind-enabled: "true"
+    annotations:
+      testgrid-dashboards: minikube-presubmits
     spec:
       containers:
       - image: gcr.io/k8s-minikube/prow-test:v0.0.7
@@ -45,8 +47,10 @@ presubmits:
   - name: pull-minikube-platform-tests
     cluster: eks-prow-build-cluster
     labels:
-        preset-minikube-e2e-creds: "true"
-        preset-k8s-ssh: "true"
+      preset-minikube-e2e-creds: "true"
+      preset-k8s-ssh: "true"
+    annotations:
+      testgrid-dashboards: minikube-presubmits
     always_run: false
     optional: true
     decorate: true

--- a/config/testgrids/kubernetes/minikube/config.yaml
+++ b/config/testgrids/kubernetes/minikube/config.yaml
@@ -1,0 +1,9 @@
+dashboard_groups:
+- name: minikube
+  dashboard_names:
+  - minikube-presubmits
+  - minikube-postsubmits
+  
+dashboards:
+- name: minikube-presubmits
+- name: minikube-postsubmits

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -47,14 +47,10 @@ type SQConfig struct {
 var (
 	companies = []string{
 		"amazon",
-		"canonical",
 		"cos",
 		"containerd",
-		"cri-o",
 		"istio",
-		"googleoss",
 		"google",
-		"kopeio",
 		"redhat",
 		"ibm",
 		"vmware",
@@ -64,6 +60,7 @@ var (
 	}
 	orgs = []string{
 		"conformance",
+		"minikube",
 		"cluster-api-core",
 		"kops",
 		"presubmits",


### PR DESCRIPTION
/cc @medyagh @ComradeProgrammer 

Please add cloudbuild.yaml file in the root of the minikube repo to push images to `us-central1-docker.pkg.dev/k8s-staging-images/minikube`

I also introduced a minikube dashboard group at testgrid.k8s.io