### PR TITLE
etcd-operator: run verify instead of lint target

### DIFF
--- a/config/jobs/etcd/etcd-operator-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-postsubmits.yaml
@@ -58,14 +58,14 @@ postsubmits:
           limits:
             cpu: "4"
             memory: "4Gi"
-  - name: post-etcd-operator-lint
+  - name: post-etcd-operator-verify
     cluster: eks-prow-build-cluster
     branches:
     - main
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-operator-postsubmits
-      testgrid-tab-name: post-etcd-operator-lint
+      testgrid-tab-name: post-etcd-operator-verify
     spec:
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250905-c89b045f57-master
@@ -74,7 +74,7 @@ postsubmits:
         args:
         - bash
         - -c
-        - make lint
+        - make verify
         resources:
           requests:
             cpu: "4"

--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -59,7 +59,7 @@ presubmits:
           limits:
             cpu: "4"
             memory: "4Gi"
-  - name: pull-etcd-operator-lint
+  - name: pull-etcd-operator-verify
     cluster: eks-prow-build-cluster
     always_run: true
     branches:
@@ -67,7 +67,7 @@ presubmits:
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-operator-presubmits
-      testgrid-tab-name: pull-etcd-operator-lint
+      testgrid-tab-name: pull-etcd-operator-verify
     spec:
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250905-c89b045f57-master
@@ -76,7 +76,7 @@ presubmits:
         args:
         - bash
         - -c
-        - make lint
+        - make verify
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
Use `verify` instead of `lint`.

Link to:
* https://github.com/etcd-io/etcd-operator/issues/206
* https://github.com/etcd-io/etcd-operator/pull/212
* https://github.com/etcd-io/etcd-operator/pull/214
* https://github.com/etcd-io/etcd-operator/pull/204

/cc @ahrtr @hwdef 