### PR TITLE
scheduler_perf: KUBE_CACHE_MUTATION_DETECTOR=false

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -746,6 +746,8 @@ periodics:
       args:
       - ./test/integration/scheduler_perf/...
       env:
+      - name: KUBE_CACHE_MUTATION_DETECTOR
+        value: "false"
       - name: KUBE_TIMEOUT
         value: --timeout=3h55m
       # Keep the unprocessed `go test` JSON output for debugging.

--- a/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
+++ b/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
@@ -80,7 +80,7 @@ presubmits:
         args:
         - /bin/sh
         - -c
-        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} make test-integration WHAT=./test/integration/scheduler_perf/... KUBE_TIMEOUT=--timeout=3h55m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1ns -bench=BenchmarkPerfScheduling -data-items-dir=${ARTIFACTS}" SHORT='--short=false' KUBE_PRUNE_JUNIT_TESTS=false
+        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} make test-integration WHAT=./test/integration/scheduler_perf/... KUBE_CACHE_MUTATION_DETECTOR=false KUBE_TIMEOUT=--timeout=3h55m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1ns -bench=BenchmarkPerfScheduling -data-items-dir=${ARTIFACTS}" SHORT='--short=false' KUBE_PRUNE_JUNIT_TESTS=false
         # We need to constraint compute resources so all the tests
         # finish approximately at the same time. More compute power
         # can increase scheduling throughput and make consequent results


### PR DESCRIPTION
As explained in https://github.com/kubernetes/kubernetes/pull/134010, we want to measure performance of real production scheduling, which has the client-go cache mutation disabled. To avoid getting this enabled for us by "make test-integration", we have to explicitly disable it.

/assign @macsko 