### PR TITLE
Update sig-scheduling OWNERS file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -113,9 +113,9 @@ aliases:
     - shyamjvs
     - wojtek-t
   sig-scheduling-leads:
-    - Huang-Wei
-    - ahg-g
-    - alculquicondor
+    - dom4ha
+    - macsko
+    - sanposhiho
   sig-security-leads:
     - IanColdwater
     - cailyn-codes
@@ -258,6 +258,22 @@ aliases:
     - SergeyKanzhelev
     - endocrimes
     - kannon92
+  sig-scheduling-reviewers:
+    - AxeZhan
+    - damemi
+    - denkensk
+    - dom4ha
+    - macsko
+    - sanposhiho
+    - utam0k
+    - kerthcet
+  sig-scheduling-approvers:
+    - ahg-g
+    - dom4ha
+    - Huang-Wei
+    - kerthcet
+    - macsko
+    - sanposhiho
   # - emeritus
   # - yguo0905
   # - dashpole

--- a/config/jobs/kubernetes/sig-scheduling/OWNERS
+++ b/config/jobs/kubernetes/sig-scheduling/OWNERS
@@ -1,20 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-    - ahg-g
-    - alculquicondor
-    - AxeZhan
-    - damemi
-    - denkensk
-    - Huang-Wei
-    - kerthcet
-    - macsko
-    - sanposhiho
+- sig-scheduling-reviewers
 approvers:
-    - ahg-g
-    - alculquicondor
-    - Huang-Wei
-    - kerthcet
-    - sanposhiho
+- sig-scheduling-approvers
 labels:
 - sig/scheduling


### PR DESCRIPTION
This PR updates the OWNERS file for SIG Scheduling reflecting the (recent?) changes.