### PR TITLE
kOps: Use K8s v1.33.5 for the upgrade test

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -2342,7 +2342,7 @@ def generate_presubmits_e2e():
             scenario='upgrade-ab',
             env={
                 'KOPS_VERSION_A': "1.33",
-                'K8S_VERSION_A': "v1.33.0",
+                'K8S_VERSION_A': "v1.33.5",
                 'KOPS_VERSION_B': "latest",
                 'K8S_VERSION_B': "latest",
                 'KOPS_SKIP_E2E': '1',

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -2428,7 +2428,7 @@ presubmits:
         - name: KOPS_VERSION_A
           value: "1.33"
         - name: K8S_VERSION_A
-          value: "v1.33.0"
+          value: "v1.33.5"
         - name: KOPS_VERSION_B
           value: "latest"
         - name: K8S_VERSION_B


### PR DESCRIPTION
Upgrade from K8s v1.33.0 to v1.35.0-alpha.0 fails (seems related to https://github.com/kubernetes/kubernetes/issues/133405):
```
I0911 21:43:20.706445      11 store.go:1667] "Monitoring resource count at path" resource="replicationcontrollers" path="<storage-prefix>//controllers"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x846a5c]

goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*MetricVec).DeleteLabelValues(0x0, {0xc0012aefe0?, 0x415985?, 0xc0012af0c0?})
	github.com/prometheus/client_golang@v1.22.0/prometheus/vec.go:75 +0x1c
k8s.io/apiserver/pkg/storage/etcd3/metrics.DeleteStoreStats({{0x0?, 0xc0012af0d0?}, {0x332834f?, 0x1a1d86bd3b725cdd?}})
	k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go:227 +0x94
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).startObservingCount.func2()
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1682 +0x30
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).CompleteWithOptions.func8.1()
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1643 +0x1f
sync.(*Once).doSlow(0x3?, 0x302789ab407c3848?)
	sync/once.go:78 +0xab
sync.(*Once).Do(...)
	sync/once.go:69
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).CompleteWithOptions.func8()
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1642 +0x45
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).Destroy(...)
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:325
k8s.io/kubernetes/pkg/registry/core/rest.(*legacyProvider).NewRESTStorage(0xc000f45380, {0x398a6d8, 0xc000607e80}, {0x39511e0, 0xc000ad3d40})
	k8s.io/kubernetes/pkg/registry/core/rest/storage_core.go:273 +0x133f
k8s.io/kubernetes/pkg/controlplane/apiserver.(*Server).InstallAPIs(0xc0014f2a50, {0xc00054cb00, 0x15, 0xe?})
	k8s.io/kubernetes/pkg/controlplane/apiserver/apis.go:105 +0x1eb
k8s.io/kubernetes/pkg/controlplane.CompletedConfig.New({0x2e14000?}, {0x399d000, 0xc000f2c708})
	k8s.io/kubernetes/pkg/controlplane/instance.go:340 +0x193
k8s.io/kubernetes/cmd/kube-apiserver/app.CreateServerChain({0xc00067f350?})
	k8s.io/kubernetes/cmd/kube-apiserver/app/server.go:184 +0x26c
k8s.io/kubernetes/cmd/kube-apiserver/app.Run({0x398a898, 0xc00040e0f0}, {0xc00040e0f0?})
	k8s.io/kubernetes/cmd/kube-apiserver/app/server.go:162 +0x2fd
k8s.io/kubernetes/cmd/kube-apiserver/app.NewAPIServerCommand.func2(0xc000672008, {0xc000479688?, 0x0?, 0x22?})
	k8s.io/kubernetes/cmd/kube-apiserver/app/server.go:117 +0x193
github.com/spf13/cobra.(*Command).execute(0xc000672008, {0xc000110258, 0x22, 0x22})
	github.com/spf13/cobra@v1.9.1/command.go:1015 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc000672008)
	github.com/spf13/cobra@v1.9.1/command.go:1148 +0x46f
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.9.1/command.go:1071
k8s.io/component-base/cli.run(0xc000672008)
	k8s.io/component-base/cli/run.go:143 +0x245
k8s.io/component-base/cli.Run(0xc000002380?)
	k8s.io/component-base/cli/run.go:44 +0x17
main.main()
	k8s.io/kubernetes/cmd/kube-apiserver/apiserver.go:34 +0x18
```

/cc @ameukam 