### PR TITLE
kOps: Use K8s stable marker as a target for the upgrade test

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -2331,7 +2331,7 @@ def generate_presubmits_e2e():
             skip_regex=r'\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|HostPort|two.untainted.nodes',
         ),
         presubmit_test(
-            name="pull-kops-e2e-aws-upgrade-k133-ko133-to-klatest-kolatest-many-addons",
+            name="pull-kops-e2e-aws-upgrade-k133-ko133-to-kstable-kolatest-many-addons",
             optional=True,
             distro='u2204',
             networking='cilium',
@@ -2344,7 +2344,7 @@ def generate_presubmits_e2e():
                 'KOPS_VERSION_A': "1.33",
                 'K8S_VERSION_A': "v1.33.5",
                 'KOPS_VERSION_B': "latest",
-                'K8S_VERSION_B': "latest",
+                'K8S_VERSION_B': "stable",
                 'KOPS_SKIP_E2E': '1',
                 'KOPS_TEMPLATE': 'tests/e2e/templates/many-addons.yaml.tmpl',
                 'KOPS_CONTROL_PLANE_SIZE': '3',

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -2390,7 +2390,7 @@ presubmits:
       testgrid-tab-name: pull-kops-e2e-aws-ipv6-karpenter
 
 # {"cloud": "aws", "distro": "u2204", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
-  - name: pull-kops-e2e-aws-upgrade-k133-ko133-to-klatest-kolatest-many-addons
+  - name: pull-kops-e2e-aws-upgrade-k133-ko133-to-kstable-kolatest-many-addons
     cluster: k8s-infra-kops-prow-build
     branches:
     - master
@@ -2432,7 +2432,7 @@ presubmits:
         - name: KOPS_VERSION_B
           value: "latest"
         - name: K8S_VERSION_B
-          value: "latest"
+          value: "stable"
         - name: KOPS_SKIP_E2E
           value: "1"
         - name: KOPS_TEMPLATE
@@ -2442,7 +2442,7 @@ presubmits:
         - name: CLOUD_PROVIDER
           value: "aws"
         - name: CLUSTER_NAME
-          value: "e2e-3f9ef5afb0-ddea2.test-cncf-aws.k8s.io"
+          value: "e2e-1727ac1946-2023e.test-cncf-aws.k8s.io"
         - name: KOPS_STATE_STORE
           value: "s3://k8s-kops-prow"
         - name: KOPS_IRSA
@@ -2459,7 +2459,7 @@ presubmits:
       test.kops.k8s.io/networking: cilium
       testgrid-dashboards: kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
-      testgrid-tab-name: pull-kops-e2e-aws-upgrade-k133-ko133-to-klatest-kolatest-many-addons
+      testgrid-tab-name: pull-kops-e2e-aws-upgrade-k133-ko133-to-kstable-kolatest-many-addons
 
 # {"cloud": "aws", "distro": "u2404", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: presubmit-kops-aws-boskos


### PR DESCRIPTION
/cc @ameukam @rifelpet 