### PR TITLE
Add presubmit build jobs for provider-ibmcloud-test-infra

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-presubmits.yaml
@@ -77,3 +77,53 @@ presubmits:
                   echo "ERROR: k8s setup and quick run exited with code: $rc"
                   exit $rc
               fi
+
+  - name: pull-provider-ibmcloud-test-infra-kubetest2-build
+    cluster: k8s-infra-ppc64le-prow-build
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 30m
+    annotations:
+      testgrid-dashboards: ibm-ppc64le-presubmits
+      testgrid-tab-name: kubetest2-tf-build
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250815-171060767f-master
+          command:
+            - runner.sh
+          args:
+            - make
+            - build-deployer-tf
+          resources:
+            requests:
+              cpu: 1
+              memory: "2Gi"
+            limits:
+              cpu: 1
+              memory: "2Gi"
+
+  - name: pull-provider-ibmcloud-test-infra-secretmanager-build
+    cluster: k8s-infra-ppc64le-prow-build
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 30m
+    annotations:
+      testgrid-dashboards: ibm-ppc64le-presubmits
+      testgrid-tab-name: secretmanager-build
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250815-171060767f-master
+          command:
+            - runner.sh
+          args:
+            - make
+            - build-secret-manager
+          resources:
+            requests:
+              cpu: 1
+              memory: "2Gi"
+            limits:
+              cpu: 1
+              memory: "2Gi"


### PR DESCRIPTION
This PR adds:
1. pull-provider-ibmcloud-test-infra-secretmanager-build
2. pull-provider-ibmcloud-test-infra-kubetest2-build

for the [kubernetes-sigs/provider-ibmcloud-test-infra](https://github.com/kubernetes-sigs/provider-ibmcloud-test-infra) repository. The jobs have been tested using `pj-on-kind.sh` utility from Prow.

Ref: https://github.com/kubernetes-sigs/provider-ibmcloud-test-infra/issues/42
