### PR TITLE
[sig-node] fix ci-crio-cgroupv2-node-e2e-features, ci-crio-cgroupv2-node-e2e-unlabelled jobs to use correct image-config-file

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -133,7 +133,7 @@ periodics:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-features
     testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
-    description: "OWNER: sig-node; runs Features e2e tests with crio master and cgroup v1"
+    description: "OWNER: sig-node; runs Features e2e tests with crio master and cgroup v2"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
@@ -150,7 +150,7 @@ periodics:
       - --focus-regex=\[Feature:.+\]|\[Feature\]
       - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:PodLifecycleSleepActionAllowZero]|\[Feature:UserNamespacesPodSecurityStandards]|\[Feature:KubeletCredentialProviders]|\[Alpha\]
       - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2.yaml
       resources:
         limits:
           cpu: 4
@@ -316,7 +316,7 @@ periodics:
       - --skip-regex=\[Flaky\]|\[NodeConformance\]|\[Conformance\]|\[Serial\]|\[Feature:.+\]|\[Feature\]|\[Legacy:.+\]|\[Benchmark\]|\[Feature:SCTPConnectivity\]
       - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=true --cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --timeout=300m
-      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1.yaml
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv2.yaml
       env:
       - name: GOPATH
         value: /go


### PR DESCRIPTION
Restores the correct image-config-file for cgroups v2.

Original commits with correct configuration:

- https://github.com/kubernetes/test-infra/commit/33940218fe1fe1335136b5a28bef1ced28a01906 (ci-crio-cgroupv2-node-e2e-features) 
- https://github.com/kubernetes/test-infra/commit/33940218fe1fe1335136b5a28bef1ced28a01906 (ci-crio-cgroupv2-node-e2e-unlabelled) 


Commits that mistakenly changed the configuration to cgroups v1:

- https://github.com/kubernetes/test-infra/commit/a630d7692c405fef719f9b0b25b8167e8e171100 (ci-crio-cgroupv2-node-e2e-features)
- https://github.com/kubernetes/test-infra/commit/303448a3b7e824d45f2425bc473c3b3ccedea59d (ci-crio-cgroupv2-node-e2e-unlabelled-canary)