### PR TITLE
Add tags for etcd-benchmark jobs to support reporting metrics on perfdash

### DIFF
--- a/config/jobs/etcd/etcd-benchmarks-periodic.yaml
+++ b/config/jobs/etcd/etcd-benchmarks-periodic.yaml
@@ -34,3 +34,6 @@ periodics:
             memory: "8Gi"
     nodeSelector:
       kubernetes.io/arch: amd64
+  tags:
+    - "perfDashPrefix: etcd"
+    - "perfDashJobType: etcdAPIBenchmark"


### PR DESCRIPTION
This PR adds tags to the job `ci-etcd-benchmark-put-amd64` to allow the perf-dash parser to correctly name the boards on [perf-dash.k8s.io](perf-dash.k8s.io)