### PR TITLE
Add system-spec-name flag to crio-cgroupv1 job; v0

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1832,6 +1832,7 @@ presubmits:
         - --parallelism=1
         - --focus-regex=\[Serial\]
         - --skip-regex=\[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+        - --system-spec-name=crio-cgroupv1
         - '--test-args=--ginkgo.timeout=3h --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-serial.yaml
         resources:


### PR DESCRIPTION
This change adds the `--system-spec-name=crio-cgroupv1` flag to the `pull-kubernetes-node-kubelet-serial-crio-cgroupv1` Prow job.

Currently, this job does not pass its context to the test binary, which prevents the test from correctly identifying an environment mismatch when a cgroupv1 test is run on a cgroupv2 node. This leads to confusing test failures. See original comment from [PR #133473](https://github.com/kubernetes/kubernetes/pull/133473#issuecomment-3190284990) identifying the problem, and comment in [Issue 133456](https://github.com/kubernetes/kubernetes/issues/133456#issuecomment-3287284474) confirming the environment mismatch.

This change is the first step in fixing the test failure and provides the necessary context for a corresponding change in the test code to implement a "fast-fail" check. A separate PR will be made to add the check in the test/e2e_node/summary_test.go file and checked once this one is merged. Thank you team!

/cc @kubernetes/sig-testing-leads
