### PR TITLE
[kjob] Use kindest/node:v1.34.0.

### DIFF
--- a/config/jobs/kubernetes-sigs/kjob/kjob-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-periodics-main.yaml
@@ -238,7 +238,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.34.1
+              value: kindest/node:v1.34.0
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.24
           command:

--- a/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kjob/kjob-presubmits-main.yaml
@@ -220,7 +220,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250904-c89b045f57-master
             env:
               - name: E2E_KIND_VERSION
-                value: kindest/node:v1.34.1
+                value: kindest/node:v1.34.0
               - name: BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang:1.24
             command:


### PR DESCRIPTION
The kindest/node:v1.34.1 image still not deployed.