### PR TITLE
sig-testing: remove alpha job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -102,55 +102,6 @@ periodics:
 
 - interval: 4h
   cluster: k8s-infra-prow-build
-  name: ci-kubernetes-e2e-kind-alpha-features
-  annotations:
-    testgrid-dashboards: sig-release-master-informing, sig-testing-kind
-    testgrid-tab-name: kind-master-alpha
-    description: Runs tests with no special requirements other than alpha feature gates in a KinD cluster where alpha feature gates and APIs are enabled.
-    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,release-team@kubernetes.io
-    testgrid-num-columns-recent: '6'
-  labels:
-    preset-dind-enabled: "true"
-  decorate: true
-  decoration_config:
-    timeout: 60m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20250904-c89b045f57-master
-      command:
-      - wrapper.sh
-      - bash
-      - -c
-      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
-      env:
-      - name: FEATURE_GATES
-        value: '{"AllAlpha":true,"EventedPLEG": false}'
-      - name: RUNTIME_CONFIG
-        value: '{"api/alpha":"true", "api/ga":"true"}'
-      - name: LABEL_FILTER
-        value: "Feature: isSubsetOf OffByDefault && !BetaOffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
-      - name: PARALLEL
-        value: "true"
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        limits:
-          memory: 9Gi
-          cpu: 7
-        requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: 9Gi
-          cpu: 7
-
-- interval: 4h
-  cluster: k8s-infra-prow-build
   name: ci-kubernetes-e2e-kind-beta-features
   annotations:
     testgrid-dashboards: sig-release-master-informing, sig-testing-kind

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -268,55 +268,6 @@ presubmits:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-testing-kind
 
-  - name: pull-kubernetes-e2e-kind-alpha-features
-    cluster: k8s-infra-prow-build
-    annotations:
-      description: Runs tests with no special requirements other than alpha feature gates in a KinD cluster where alpha feature gates and APIs are enabled.
-      testgrid-num-failures-to-alert: '10'
-      testgrid-alert-stale-results-hours: '24'
-      testgrid-create-test-group: 'true'
-    optional: true
-    always_run: false
-    decorate: true
-    skip_branches:
-    - release-\d+\.\d+ # per-release settings
-    labels:
-      preset-dind-enabled: "true"
-    decoration_config:
-      timeout: 60m
-      grace_period: 15m
-    path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20250904-c89b045f57-master
-        command:
-        - wrapper.sh
-        - bash
-        - -c
-        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
-        env:
-        # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
-        - name: FEATURE_GATES
-          value: '{"AllAlpha":true,"EventedPLEG":false}'
-        - name: RUNTIME_CONFIG
-          value: '{"api/alpha":"true", "api/ga":"true"}'
-        - name: LABEL_FILTER
-          value: "Feature: isSubsetOf OffByDefault && !BetaOffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
-        - name: SKIP
-          value: PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
-        - name: PARALLEL
-          value: "true"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 7
-            memory: 9000Mi
-          requests:
-            cpu: 7
-            memory: 9000Mi
-
   - name: pull-kubernetes-e2e-kind-beta-features
     cluster: k8s-infra-prow-build
     annotations:

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -101,9 +101,6 @@ dashboards:
   - name: pull-kubernetes-e2e-kind-dual-canary
     test_group_name: pull-kubernetes-e2e-kind-dual-canary
     base_options: width=10
-  - name: pull-kubernetes-e2e-kind-alpha-features
-    test_group_name: pull-kubernetes-e2e-kind-alpha-features
-    base_options: width=10
   - name: pull-kubernetes-e2e-kind-evented-pleg
     test_group_name: pull-kubernetes-e2e-kind-evented-pleg
     base_options: width=10


### PR DESCRIPTION
AllAlpha=true without a corresponding AllBeta=true is not guaranteed to work because an alpha feature might have a dependency on an off-by-default beta feature.

/assign @aojea 