### PR TITLE
enable multiarch support in prowjobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -10,9 +10,10 @@ periodics:
     labels:
       # Enable dind for linters that required docker to run, for example typescript.
       preset-dind-enabled: "true"
+      preset-enable-multiarch-support: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251209-13d7d11b0f-master
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250904-c89b045f57-master
           command:
             - runner.sh
           args:

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251209-13d7d11b0f-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250904-c89b045f57-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -64,7 +64,7 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-test-infra
   - name: pull-test-infra-unit-test
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -72,9 +72,10 @@ presubmits:
     labels:
       # Python unit tests run in docker.
       preset-dind-enabled: "true"
+      preset-enable-multiarch-support: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251209-13d7d11b0f-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250904-c89b045f57-master
         command:
         - runner.sh
         args:
@@ -85,27 +86,26 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "8"
+            cpu: "7"
             memory: "8Gi"
           limits:
-            cpu: "8"
+            cpu: "7"
             memory: "8Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: unit-test
   # The following test builds the images specified in .test-infra-misc-images.yaml
   - name: pull-test-infra-misc-image-build-test
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - ^master$
     run_if_changed: '^(\.ko\.yaml|hack/(make-rules|prowimagebuilder)|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
     decorate: true
     labels:
-      # Building deck requires docker for typescript compilation.
-      preset-dind-enabled: "true"
+      preset-enable-multiarch-support: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251209-13d7d11b0f-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250904-c89b045f57-master
         command:
         - runner.sh
         args:
@@ -126,7 +126,7 @@ presubmits:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: misc-image-build-test
   - name: pull-test-infra-verify-lint
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     branches:
     - master
     always_run: true
@@ -134,9 +134,10 @@ presubmits:
     labels:
       # Enable dind for linters that required docker to run, for example typescript.
       preset-dind-enabled: "true"
+      preset-enable-multiarch-support: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251209-13d7d11b0f-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250904-c89b045f57-master
         command:
         - runner.sh
         args:
@@ -147,10 +148,10 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "8"
+            cpu: "7"
             memory: "8Gi"
           limits:
-            cpu: "8"
+            cpu: "7"
             memory: "8Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -1114,6 +1114,15 @@ presets:
       secret:
         defaultMode: 256
         secretName: prow-job-ssh-private-key
+
+# set this preset to enable jobs to run on both amd64 and arm64 nodes on GKE/AWS
+- labels:
+    preset-enable-multiarch-support: "true"
+  tolerations:
+    - effect: NoSchedule
+      key: kubernetes.io/arch
+      operator: Equal
+      value: arm64
 # enable GOPROXY by default
 - env:
   - name: GOPROXY

--- a/hack/make-rules/verify/yamllint.sh
+++ b/hack/make-rules/verify/yamllint.sh
@@ -35,7 +35,7 @@ LINT_COMMAND=("yamllint" "-c" "config/jobs/.yamllint.conf" "config/jobs" "config
     --rm -i \
     -v "${REPO_ROOT:?}:${REPO_ROOT:?}" -w "${REPO_ROOT}" \
     --security-opt="label=disable" \
-    "cytopia/yamllint:1.26@sha256:1bf8270a671a2e5f2fea8ac2e80164d627e0c5fa083759862bbde80628f942b2" \
+    "pipelinecomponents/yamllint:0.35.0@sha256:792a5c9f8c0f3b334996c8c5f9b58f000bd57ff8a87ba54fdd5e8d02679097f9" \
     "${LINT_COMMAND[@]:1}"
 
 if [[ -n "${NO_DOCKER:-}" ]]; then


### PR DESCRIPTION
I introduced a new label called `preset-enable-multiarch-support: "true"` that we can set on prowjobs that will allow them to tolerate the taint set on the arm64 nodes and run on them sometimes.

The intention is to attach the labels on jobs that don't care about the architecture, such as linting, verify, e2e runner jobs, etc

In the near future, the EKS cluster will also have Graviton(arm64) nodes enabled as well, so we can apply the same strategy there too.