### PR TITLE
Revert "Add system-spec-name flag to crio-cgroupv1 job" and move flag to test-args

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1832,8 +1832,7 @@ presubmits:
         - --parallelism=1
         - --focus-regex=\[Serial\]
         - --skip-regex=\[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
-        - --system-spec-name=crio-cgroupv1
-        - '--test-args=--ginkgo.timeout=3h --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+        - '--test-args=--system-spec-name=crio-cgroupv1 --ginkgo.timeout=3h --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-cgroupv1-serial.yaml
         resources:
           limits:


### PR DESCRIPTION
This PR reverts the change from #35531 and moves the `--system-spec-name` flag to be passed via `--test-args` for the `pull-kubernetes-node-kubelet-serial-crio-cgroupv1` Prow job.

The previous PR added `--system-spec-name` as a direct argument to the job. However, this prevented the test binary from correctly parsing the flag and identifying the testing environment.

This change corrects the issue and will be followed by a change in `test/e2e_node/summary_test.go` to implement the check.

This addresses the problem initially identified in [kubernetes/kubernetes#133473](https://github.com/kubernetes/kubernetes/pull/133473#issuecomment-3190284990) and [kubernetes/kubernetes#133456](https://github.com/kubernetes/kubernetes/issues/133456#issuecomment-3287284474).

Fixes #35531