### PR TITLE
Sync CAPO maintainers

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/OWNERS
@@ -4,12 +4,8 @@
 approvers:
   - sig-cluster-lifecycle-leads
   - EmilienM
-  - jichenjc
   - lentzi90
-  - mdbooth
 
 reviewers:
   - EmilienM
-  - jichenjc
   - lentzi90
-  - mdbooth


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2727

Also sync previous emeritus maintainers
