### PR TITLE
windows-alpha-features: use CAPZ main branch

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -204,7 +204,7 @@ presubmits:
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.17
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
         workdir: false
       - org: kubernetes-sigs


### PR DESCRIPTION
This PR updates the `pull-kubernetes-e2e-capz-windows-alpha-features` presubmit job to follow the latest CAPZ changes at main branch.