### PR TITLE
SIG testing: clean up alpha/beta presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -301,8 +301,6 @@ presubmits:
           value: '{"api/beta":"true", "api/ga":"true"}'
         - name: LABEL_FILTER
           value: "Feature: isSubsetOf OffByDefault && !Alpha && !Deprecated && !Slow && !Disruptive && !Flaky"
-        - name: SKIP
-          value: PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -350,8 +348,6 @@ presubmits:
           value: '{"api/all":"true"}'
         - name: LABEL_FILTER
           value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
-        - name: SKIP
-          value: PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -398,8 +394,6 @@ presubmits:
           value: '{"api/all":"true"}'
         - name: LABEL_FILTER
           value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
-        - name: SKIP
-          value: PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity
         - name: PARALLEL
           value: "true"
         # -race gets injected into the build of dynamically linked binaries during "kind build node-image".


### PR DESCRIPTION
It should no longer be necessary to skip specific tests. If they fail, then they are either broken and we want to know, or they are not labeled correctly and we want to fix that.

This intentionally only changes the presubmits for a trial run in a test PR. If that works, the periodics need to be updated accordingly.

/assign @aojea 
