### PR TITLE
Revert "Add extra kernel argument to force cgropuv1 spin up in [crio_cgroupv1.ign]"

### DIFF
--- a/jobs/e2e_node/crio/crio_cgroupv1.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1.ign
@@ -4,8 +4,7 @@
   },
   "kernelArguments": {
     "shouldExist": [
-      "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1",
-      "systemd.unified_cgroup_hierarchy=0"
+      "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1"
     ],
     "shouldNotExist": [
       "mitigations=auto,nosmt"

--- a/jobs/e2e_node/crio/crio_cgroupv1_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1_eventedpleg.ign
@@ -4,8 +4,7 @@
   },
   "kernelArguments": {
     "shouldExist": [
-      "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1",
-      "systemd.unified_cgroup_hierarchy=0"
+      "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1"
     ],
     "shouldNotExist": [
       "mitigations=auto,nosmt"

--- a/jobs/e2e_node/crio/crio_cgroupv1_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_cgroupv1_hugepages.ign
@@ -4,8 +4,7 @@
   },
   "kernelArguments": {
     "shouldExist": [
-      "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1",
-      "systemd.unified_cgroup_hierarchy=0"
+      "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1"
     ],
     "shouldNotExist": [
       "mitigations=auto,nosmt"

--- a/jobs/e2e_node/crio/templates/base/cgroupv1.yaml
+++ b/jobs/e2e_node/crio/templates/base/cgroupv1.yaml
@@ -2,4 +2,3 @@
 kernel_arguments:
   should_exist:
     - SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1
-    - systemd.unified_cgroup_hierarchy=0

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1.yaml
@@ -6,7 +6,6 @@ kernel_arguments:
     - mitigations=auto,nosmt
   should_exist:
     - SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1
-    - systemd.unified_cgroup_hierarchy=0
 storage:
   files:
     - path: /etc/zincati/config.d/90-disable-auto-updates.toml

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1_eventedpleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1_eventedpleg.yaml
@@ -6,7 +6,6 @@ kernel_arguments:
     - mitigations=auto,nosmt
   should_exist:
     - SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1
-    - systemd.unified_cgroup_hierarchy=0
 storage:
   files:
     - path: /etc/zincati/config.d/90-disable-auto-updates.toml

--- a/jobs/e2e_node/crio/templates/crio_cgroupv1_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_cgroupv1_hugepages.yaml
@@ -6,7 +6,6 @@ kernel_arguments:
     - mitigations=auto,nosmt
   should_exist:
     - SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1
-    - systemd.unified_cgroup_hierarchy=0
 storage:
   files:
     - path: /etc/zincati/config.d/90-disable-auto-updates.toml


### PR DESCRIPTION
Reverts kubernetes/test-infra#35551

This broke our cgroup v1 jobs. It technically broke them by actually starting on cgroup v1.

We need to evaluate if/how we are going to roll this change out.

Going to revert to fix the CI.