### PR TITLE
SIG testing: use only label filter for alpha/beta jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -299,6 +299,10 @@ presubmits:
           value: '{"AllBeta":true}'
         - name: RUNTIME_CONFIG
           value: '{"api/beta":"true", "api/ga":"true"}'
+        - name: SKIP
+          value: ""
+        - name: FOCUS
+          value: ""
         - name: LABEL_FILTER
           value: "Feature: isSubsetOf OffByDefault && !Alpha && !Deprecated && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
@@ -346,6 +350,10 @@ presubmits:
           value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
         - name: RUNTIME_CONFIG
           value: '{"api/all":"true"}'
+        - name: SKIP
+          value: ""
+        - name: FOCUS
+          value: ""
         - name: LABEL_FILTER
           value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
@@ -392,6 +400,10 @@ presubmits:
           value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
         - name: RUNTIME_CONFIG
           value: '{"api/all":"true"}'
+        - name: SKIP
+          value: ""
+        - name: FOCUS
+          value: ""
         - name: LABEL_FILTER
           value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL


### PR DESCRIPTION
The implicit default for SKIP is '\[Serial\]'. That's surprising ("what you see is *not* what you get") and unnecessary for these jobs. If we have serial tests, then we can and should run them to get full coverage.

There is a risk that too many serial tests slow down the overall job. If that is the case, then skipping serial tests should be added back inside the label filter.

FOCUS doesn't have a default in these jobs, but elsewhere it defaults to '[Conformance]'. It's safer to explicitly set it - perhaps someone does a copy-and-paste of these settings.

This was noticed after reviewing the result of the jobs without the previous legacy SKIP:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/134250/pull-kubernetes-e2e-kind-alpha-beta-features/1970893834220998656
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/134250/pull-kubernetes-e2e-kind-beta-features/1970893834086780928

Before https://github.com/kubernetes/test-infra/pull/35570/files, serial tests were enabled.

/assign @aojea 