### PR TITLE
Make node E2E presubmit optional for containerd

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -37,7 +37,8 @@ presubmits:
             memory: 6Gi
 
   - name: pull-containerd-node-e2e
-    always_run: true
+    always_run: false
+    optional: true
     cluster: k8s-infra-prow-build
     max_concurrency: 8
     decorate: true
@@ -97,7 +98,8 @@ presubmits:
             memory: 6Gi
 
   - name: pull-containerd-node-e2e-1-7
-    always_run: true
+    always_run: false
+    optional: true
     cluster: k8s-infra-prow-build
     max_concurrency: 8
     decorate: true


### PR DESCRIPTION
K8s node E2E tests now run via Github Actions on containerd pull requests, as part of the containerd migration off of Prow: https://github.com/containerd/containerd/issues/11486

Given that these tests are stable, we can proceed with marking these Prow tests as optional on containerd pull requests.

The job for the 1.6 branch was left untouched because the node E2E tests that run as Github Actions do not work on that branch, however 1.6 is past EOL and so we can remove this job once we remove the other containerd jobs.