### PR TITLE
update pull-publishing-bot-validate jobs to use go1.25

### DIFF
--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
     path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         command:
         - make
         - test
@@ -53,7 +53,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         env:
         - name: "GOWORK"
           value: "off"


### PR DESCRIPTION
```
go: go.mod requires go >= 1.25.0 (running go 1.24.7; GOTOOLCHAIN=local)
```

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/134260/pull-publishing-bot-validate/1971121571120549888

need for https://github.com/kubernetes/kubernetes/pull/134260

/assign @saschagrunert @dims 
cc @kubernetes/release-managers 