### PR TITLE
update pull-publishing-bot-validate to use go1.25

### DIFF
--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -158,7 +158,7 @@ presubmits:
       path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         env:
         - name: "GOWORK"
           value: "off"


### PR DESCRIPTION
follow up of #35581 

needed for https://github.com/kubernetes/kubernetes/pull/134260

/assign @saschagrunert @dims 
cc @kubernetes/release-managers 