### PR TITLE
Enable cherrypicker, merge-method-comment, and mergecommitblocker on k-sigs/aws-ebs-csi-driver

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1520,6 +1520,8 @@ plugins:
     plugins:
     - release-note
     - override
+    - merge-method-comment
+    - mergecommitblocker
 
   kubernetes-sigs/cloud-provider-azure:
     plugins:
@@ -1845,6 +1847,12 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  kubernetes-sigs/aws-ebs-csi-driver:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   kubernetes-sigs/cloud-provider-azure:
   - name: cherrypicker
     events:


### PR DESCRIPTION
Hi, I am an admin/maintainer for the `kubernetes-sigs/aws-ebs-csi-driver` repo, and we'd like to enable some additional non-default prow plugins for our repos.

Admin team here with me as member: https://github.com/kubernetes/org/blob/d1e8c534c5f415c466a946ac18dff8c9edb2ecc5/config/kubernetes-sigs/sig-aws/teams.yaml#L2-L12 - I'll also get some other members to lgtm this PR.