### PR TITLE
Allocate more resources on ExternalDNS jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/external-dns/external-dns-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/external-dns/external-dns-presubmits.yaml
@@ -42,11 +42,11 @@ presubmits:
         - test
         resources:
           limits:
-            cpu: 1
-            memory: 4Gi
+            cpu: 4
+            memory: 8Gi
           requests:
-            cpu: 1
-            memory: 4Gi
+            cpu: 4
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-network-external-dns
       testgrid-tab-name: unit test


### PR DESCRIPTION
# Motivation

Current job can take more than 20 minutes, when it takes half on Github CI.