### PR TITLE
kind jobs: stop relying on implicit SKIP=[Serial]

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -191,7 +191,7 @@ presubmits:
         - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Conformance && Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         - name: IP_FAMILY
@@ -236,7 +236,7 @@ presubmits:
         - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -278,7 +278,7 @@ presubmits:
         - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/kube-network-policies/kube-network-policies-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-network-policies/kube-network-policies-presubmits.yaml
@@ -26,7 +26,7 @@ presubmits:
         - name: "PARALLEL"
           value: "true"
         - name: LABEL_FILTER
-          value: "!Slow && !Disruptive && !Flaky && Feature: containsAny NetworkPolicy"
+          value: "!Serial && !Slow && !Disruptive && !Flaky && Feature: containsAny NetworkPolicy"
         - name: SKIP
           value: \[Feature:SCTPConnectivity\]
         command:
@@ -79,7 +79,7 @@ presubmits:
         - name: "PARALLEL"
           value: "true"
         - name: LABEL_FILTER
-          value: "!Slow && !Disruptive && !Flaky && Feature: containsAny NetworkPolicy"
+          value: "!Serial && !Slow && !Disruptive && !Flaky && Feature: containsAny NetworkPolicy"
         - name: SKIP
           value: \[Feature:SCTPConnectivity\]
         command:

--- a/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
@@ -28,6 +28,7 @@ presubmits:
         - ./../test-infra/experiment/dependencies/update-dependencies-and-run-tests.sh --test-mode kind
         env:
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
@@ -119,6 +120,7 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"

--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -948,7 +948,7 @@ periodics:
       - name: RUNTIME_CONFIG
         value: '{"api/all":"true"}'
       - name: LABEL_FILTER
-        value: "(Conformance || sig-network ) && !Feature: containsAny {Networking-IPv6, LoadBalancer, IPv6DualStack} && !Disruptive && !Flaky"
+        value: "(Conformance || sig-network ) && !Serial && !Feature: containsAny {Networking-IPv6, LoadBalancer, IPv6DualStack} && !Disruptive && !Flaky"
       - name: SKIP
         value: SCTPConnectivity
       - name: PARALLEL

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1029,7 +1029,7 @@ periodics:
         -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       - name: LABEL_FILTER
-        value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
+        value: '!Serial && Feature: isEmpty && !Slow && !Disruptive && !Flaky'
       - name: PARALLEL
         value: "true"
       image: gcr.io/k8s-staging-test-infra/krte:v20250925-95b5a2c7a5-1.34
@@ -1076,7 +1076,7 @@ periodics:
       - name: IP_FAMILY
         value: ipv6
       - name: LABEL_FILTER
-        value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
+        value: '!Serial && Feature: isEmpty && !Slow && !Disruptive && !Flaky'
       - name: PARALLEL
         value: "true"
       image: gcr.io/k8s-staging-test-infra/krte:v20250925-95b5a2c7a5-1.34
@@ -1202,6 +1202,7 @@ presubmits:
           --test-mode kind
         env:
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
         - name: PARALLEL
           value: "true"
@@ -1280,6 +1281,7 @@ presubmits:
           - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
         - name: PARALLEL
           value: "true"

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -70,7 +70,7 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -112,7 +112,7 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # enable IPV6 in bootstrap image
@@ -162,7 +162,7 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # enable IPV6 in bootstrap image
@@ -300,6 +300,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/beta":"true", "api/ga":"true"}'
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: "Feature: isSubsetOf OffByDefault && !Alpha && !Deprecated && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
@@ -345,11 +346,8 @@ presubmits:
           value: '{"AllBeta":true}'
         - name: RUNTIME_CONFIG
           value: '{"api/beta":"true", "api/ga":"true"}'
-        - name: FOCUS
-          value: ""
-        - name: SKIP
-          value: ""
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: "Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
@@ -395,11 +393,8 @@ presubmits:
           value: '{"AllBeta":true}'
         - name: RUNTIME_CONFIG
           value: '{"api/beta":"true", "api/ga":"true"}'
-        - name: FOCUS
-          value: ""
-        - name: SKIP
-          value: ""
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
@@ -447,6 +442,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/all":"true"}'
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
@@ -493,11 +489,8 @@ presubmits:
           value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
         - name: RUNTIME_CONFIG
           value: '{"api/all":"true"}'
-        - name: FOCUS
-          value: ""
-        - name: SKIP
-          value: ""
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: "Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
@@ -544,11 +537,8 @@ presubmits:
           value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
         - name: RUNTIME_CONFIG
           value: '{"api/all":"true"}'
-        - name: FOCUS
-          value: ""
-        - name: SKIP
-          value: ""
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
@@ -595,6 +585,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/all":"true"}'
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
@@ -653,6 +644,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/alpha":"true", "api/ga":"true"}'
         - name: LABEL_FILTER
+          # Includes serial tests for the sake of completeness.
           value: "Feature: isSubsetOf EventedPLEG && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"


### PR DESCRIPTION
All jobs using e2e-k8s.sh with PARALLEL=true automatically skipped serial tests even though technically they now could run in the job: https://github.com/kubernetes-sigs/kind/blame/d1eecc46e30cac9d35cd32dc52677ef75ec22e18/hack/ci/e2e-k8s.sh#L226-L234

https://github.com/kubernetes-sigs/kind/pull/4015 is changing that mandatory skip for jobs using LABEL_FILTER because it may be desirable to include serial tests, depending on the job. It's also better to be explicit about it in each job's LABEL_FILTER to avoid confusion and potential mistakes (not running tests that were expected to run).

To prepare for that change, jobs get updated based on the following principles:

- If a presubmit runs infrequently and is only invoked to test certain aspects, then including serial tests is desirable to get full test coverage of that aspect. Example: pull-kubernetes-e2e-kind-beta-features
- If a presubmit runs always, serial tests should be excluded. Example: pull-kubernetes-e2e-kind
- Periodic jobs should always run all supported tests, including the serial ones. Example: ci-kubernetes-e2e-kind
- Canary jobs match the behavior of the non-canary variant. Example: pull-kubernetes-e2e-kind-canary
- Jobs for release branches should better not change for the sake of preserving the old behavior (but that
  is debatable). Example: ci-kubernetes-e2e-kind-1-34

To make it more obvious where the upcoming e2e-k8s.sh will change test selection, "Includes serial tests for the sake of completeness." comments get added. Those are not true *right now*, but will be once the script is changed.