### PR TITLE
rollback image used in gateway api inference extension ci due to failues

### DIFF
--- a/config/jobs/kubernetes-sigs/gateway-api-inference-extension/inference-extension-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/gateway-api-inference-extension/inference-extension-periodics-main.yaml
@@ -17,7 +17,7 @@ periodics:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250922-af75983448-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -51,7 +51,7 @@ periodics:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250922-af75983448-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/gateway-api-inference-extension/inference-extension-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/gateway-api-inference-extension/inference-extension-presubmit-main.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250922-af75983448-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -42,7 +42,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250922-af75983448-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -71,7 +71,7 @@ presubmits:
       description: "Run inference extension verify checks"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250922-af75983448-master
         command:
         - runner.sh
         args:


### PR DESCRIPTION
the image used in CI was bumped yesterday automatically by a robot.
from the moment this change was merged, all incoming PRs are failing.
a first naive try is to rollback to previous image version.

/cc @kfswain @ahg-g 