### PR TITLE
Reduce frequency of CAPZ DRA scale job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -8,7 +8,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 3h
-    interval: 3h
+    interval: 12h
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
This job was running more frequently as we were iterating on stabilizing it and to ensure DRA stayed performant as we were closing in on the 1.34 release. Those things have been accomplished, so we can scale back this job.

See https://kubernetes.slack.com/archives/CCK68P2Q2/p1758732626617229