### PR TITLE
CRI-O: fix evented pleg ignition path and README.md

### DIFF
--- a/jobs/e2e_node/crio/README.md
+++ b/jobs/e2e_node/crio/README.md
@@ -17,22 +17,22 @@ defines an associative array `CONFIGURATIONS` which defines each ignition file.
 For example the configuration:
 
 ```bash
-    ["crio_cgroupv1"]="root cgroupv1"
+    ["crio_cgroupv2"]="root env"
 ```
 
-Will generate the [`crio_cgroupv1.ign`](./crio_cgroupv1.ign) configuration
+Will generate the [`crio_cgroupv2.ign`](./crio_cgroupv2.ign) configuration
 containing the following base configurations in order:
 
 1. [root.yaml](./templates/base/root.yaml)
-1. [cgroupv1.yaml](./templates/base/cgroupv1.yaml)
+1. [env.yaml](./templates/base/env.yaml)
 
 When running `make` within this directory, an intermediate
-[`./templates/crio_cgroupv1.yaml`](./templates/crio_cgroupv1.yaml)
+[`./templates/crio_cgroupv2.yaml`](./templates/crio_cgroupv2.yaml)
 [butane](https://coreos.github.io/butane) configuration will be generated which
 then gets transformed into the resulting ignition file
-[`crio_cgroupv1.ign`](./crio_cgroupv1.ign).
+[`crio_cgroupv2.ign`](./crio_cgroupv2.ign).
 The ignition file will be then referenced from image configurations like
-[`./latest/image-config-cgroupv1.yaml`](./latest/image-config-cgroupv1.yaml).
+[`./latest/image-config-cgroupv2.yaml`](./latest/image-config-cgroupv2.yaml).
 
 This means modifying, adding or removing jobs should always result in running
 `make` as well as committing all changes into this repository.
@@ -54,7 +54,7 @@ Then spawn the instance via:
 ```sh
 gcloud compute instances create \
     --zone europe-west1-b \
-    --metadata-from-file user-data=/path/to/crio_cgroupv1.ign \
+    --metadata-from-file user-data=/path/to/crio_cgroupv2.ign \
     --image-project fedora-coreos-cloud \
     --image-family fedora-coreos-stable my-instance
 ```

--- a/jobs/e2e_node/crio/latest/image-config-cgroupv2-evented-pleg.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-cgroupv2-evented-pleg.yaml
@@ -2,4 +2,4 @@ images:
   fedora:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
-    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupv1_eventedpleg.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_cgroupv2_eventedpleg.ign"


### PR DESCRIPTION
- Fix the path for the evented PLEG ignition file
- Update README.md to point to cgroupv2

PTAL @kubernetes/sig-node-cri-o-test-maintainers 