### PR TITLE
kind-alpha-beta-features: not release informing, serial experiment

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -153,7 +153,7 @@ periodics:
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-e2e-kind-alpha-beta-features
   annotations:
-    testgrid-dashboards: sig-release-master-informing, sig-testing-kind
+    testgrid-dashboards: sig-testing-kind
     testgrid-tab-name: kind-master-alpha-beta
     description: Runs tests with no special requirements other than alpha or beta feature gates in a KinD cluster where alpha and beta feature gates and APIs are enabled.
     testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,release-team@kubernetes.io
@@ -175,7 +175,9 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      # Modified e2e-k8s.sh from https://github.com/kubernetes-sigs/kind/pull/4015/files.
+      # It gets pulled here to try out that modification for a while *before* merging it.
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && curl -sSLO https://raw.githubusercontent.com/pohly/kind/46d774ce34846c9522efd9de1150b0d3cfa585c8/hack/ci/e2e-k8s.sh && chmod u+x e2e-k8s.sh && ./e2e-k8s.sh
       env:
       - name: FEATURE_GATES
         value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG": false}'


### PR DESCRIPTION
The experiment is meant to determine whether running serial tests in the same job as the parallel tests works and how much slower it becomes.

Even long term the job probably shouldn't be release informing because the alpha tests can break it at any time, without affecting the release. What needs to become release informing instead are the kind-alpha-beta-enabled and/or kind-alpha-beta-enabled-conformance jobs (to be determined after we are done with setting everything up and they proof to be stable).

/assign @aojea 
/cc @BenTheElder 

From [Slack](https://kubernetes.slack.com/archives/C09QZ4DQB/p1758876583450659):

> do we already have guarantee the Serial decorator to make the behavior to run after the parallel tests? do we know it is working correctly?

[...]So that part should work. But you are right, we haven't really exercised that much. [...] Looking at [my list](https://github.com/kubernetes-sigs/kind/pull/4015) I don't see any canaries for ci jobs. [...] Modifying ci-kubernetes-e2e-kind-alpha-beta-features instead of creating a new periodic seems safe enough.