### PR TITLE
feat(cluster-capacity): Prow config template for image pushing

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-capacity.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-capacity.yaml
@@ -1,0 +1,33 @@
+postsubmits:
+  # This is the github repo we'll build from. This block needs to be repeated
+  # for each repo.
+  kubernetes-sigs/cluster-capacity:
+    # The name should be changed to match the repo name above
+    - name: post-cluster-capacity-push-images
+      rerun_auth_config:
+        github_users:
+        - ingvagabund
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        # This is the name of some testgrid dashboard to report to.
+        testgrid-dashboards: sig-scheduling, sig-k8s-infra-gcb
+      decorate: true
+      branches:
+        - ^master$
+        - ^release-.*
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20250914-3092127382
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-cluster-capacity
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-cluster-capacity-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .

--- a/config/jobs/image-pushing/k8s-staging-cluster-capacity.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-capacity.yaml
@@ -20,7 +20,7 @@ postsubmits:
       spec:
         serviceAccountName: gcb-builder
         containers:
-          - image: gcr.io/k8s-staging-test-infra/image-builder:v20250914-3092127382
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20260419-39c657fdbf
             command:
               - /run.sh
             args:


### PR DESCRIPTION
Following https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#cloudbuildyaml and Duplicating https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-descheduler.yaml.

- cloudconfig created through https://github.com/kubernetes-sigs/cluster-capacity/pull/194
- new staging group through: https://github.com/kubernetes/k8s.io/pull/7030

Part of https://github.com/kubernetes-sigs/cluster-capacity/issues/181