### PR TITLE
Kueue: CI for 0.14

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-14.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-14.yaml
@@ -1,10 +1,10 @@
 periodics:
   - interval: 12h
-    name: periodic-kueue-test-unit-release-0-12
+    name: periodic-kueue-test-unit-release-0-14
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-unit-release-0-12
+      testgrid-tab-name: periodic-kueue-test-unit-release-0-14
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic kueue unit tests"
@@ -15,7 +15,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0.12
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -40,11 +40,11 @@ periodics:
               cpu: "4"
               memory: "6Gi"
   - interval: 12h
-    name: periodic-kueue-test-integration-release-0-12
+    name: periodic-kueue-test-integration-release-0-14
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-integration-release-0-12
+      testgrid-tab-name: periodic-kueue-test-integration-release-0-14
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic kueue test-integration"
@@ -55,7 +55,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0.12
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -78,11 +78,11 @@ periodics:
               cpu: "6"
               memory: "9Gi"
   - interval: 12h
-    name: periodic-kueue-test-integration-multikueue-release-0-12
+    name: periodic-kueue-test-integration-multikueue-release-0-14
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-integration-multikueue-release-0-12
+      testgrid-tab-name: periodic-kueue-test-integration-multikueue-release-0-14
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic kueue test-multikueue-integration"
@@ -93,7 +93,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0.12
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -116,11 +116,11 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-scheduling-perf-release-0-12
+    name: periodic-kueue-test-scheduling-perf-release-0-14
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-scheduling-perf-release-0-12
+      testgrid-tab-name: periodic-kueue-test-scheduling-perf-release-0-14
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic kueue test-scheduling-perf"
@@ -131,7 +131,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0.12
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -154,11 +154,11 @@ periodics:
               cpu: "6"
               memory: "9Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-release-0-12-1-31
+    name: periodic-kueue-test-e2e-release-0-14-1-31
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-release-0-12-1-31
+      testgrid-tab-name: periodic-kueue-test-e2e-release-0-14-1-31
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic kueue end to end tests for Kubernetes 1.31"
@@ -169,7 +169,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0.12
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -200,11 +200,11 @@ periodics:
               cpu: "10"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-release-0-12-1-32
+    name: periodic-kueue-test-e2e-release-0-14-1-32
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-release-0-12-1-32
+      testgrid-tab-name: periodic-kueue-test-e2e-release-0-14-1-32
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic kueue end to end tests for Kubernetes 1.32"
@@ -215,7 +215,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0.12
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -246,11 +246,103 @@ periodics:
               cpu: "10"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-multikueue-release-0-12
+    name: periodic-kueue-test-e2e-release-0-14-1-33
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-release-0-12
+      testgrid-tab-name: periodic-kueue-test-e2e-release-0-14-1-33
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue end to end tests for Kubernetes 1.33"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.14
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.33"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "10"
+              memory: "10Gi"
+            limits:
+              cpu: "10"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-release-0-14-1-34
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-release-0-14-1-34
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue end to end tests for Kubernetes 1.34"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.14
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.34"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "10"
+              memory: "10Gi"
+            limits:
+              cpu: "10"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-multikueue-release-0-14
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-release-0-14
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic multikueue end to end tests"
@@ -261,7 +353,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0.12
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -271,7 +363,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.32"
+              value: "1.34"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -292,11 +384,11 @@ periodics:
               cpu: "10"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-tas-release-0-12
+    name: periodic-kueue-test-e2e-tas-release-0-14
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-tas-release-0-12
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-release-0-14
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic tas end to end tests"
@@ -307,7 +399,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0.12
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -317,7 +409,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.32"
+              value: "1.34"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -338,11 +430,11 @@ periodics:
               cpu: "10"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-customconfigs-release-0-12
+    name: periodic-kueue-test-e2e-customconfigs-release-0-14
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-customconfigs-release-0-12
+      testgrid-tab-name: periodic-kueue-test-e2e-customconfigs-release-0-14
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic customconfigs end to end tests"
@@ -353,7 +445,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0.12
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -363,7 +455,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.32"
+              value: "1.34"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -384,11 +476,11 @@ periodics:
               cpu: "10"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-certmanager-release-0-12
+    name: periodic-kueue-test-e2e-certmanager-release-0-14
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-certmanager-release-0-12
+      testgrid-tab-name: periodic-kueue-test-e2e-certmanager-release-0-14
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic certmanager end to end tests"
@@ -399,7 +491,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0.12
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -409,7 +501,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.32"
+              value: "1.34"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -430,11 +522,11 @@ periodics:
               cpu: "10"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-kueueviz-release-0-12
+    name: periodic-kueue-test-e2e-kueueviz-release-0-14
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-kueueviz-release-0-12
+      testgrid-tab-name: periodic-kueue-test-e2e-kueueviz-release-0-14
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic kueueviz end to end tests"
@@ -445,7 +537,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: release-0.12
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -455,7 +547,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.32"
+              value: "1.34"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.14.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.14.yaml
@@ -1,13 +1,13 @@
 periodics:
   - interval: 12h
-    name: periodic-kueue-build-s390x-ppc64le-release-0-12
+    name: periodic-kueue-build-s390x-ppc64le-release-0-14
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-build-s390x-ppc64le-release-0-12
+      testgrid-tab-name: periodic-kueue-build-s390x-ppc64le-release-0-14
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run s390x & power periodic to build kueue image"
+      description: "Run s390x & power periodic job to build kueue image"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -15,7 +15,7 @@ periodics:
     extra_refs:
       - org: kubernetes-sigs
         repo: kueue
-        base_ref: main
+        base_ref: release-0.14
         path_alias: kubernetes-sigs/kueue
     decorate: true
     decoration_config:
@@ -25,7 +25,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.33"
+              value: "1.34"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-14.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-14.yaml
@@ -1,15 +1,15 @@
 presubmits:
   kubernetes-sigs/kueue:
-  - name: pull-kueue-test-unit-release-0-12
+  - name: pull-kueue-test-unit-release-0-14
     cluster: eks-prow-build-cluster
     branches:
-    - ^release-0.12
+    - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-unit-release-0-12
+      testgrid-tab-name: pull-kueue-test-unit-release-0-14
       description: "Run kueue unit tests"
     spec:
       containers:
@@ -30,16 +30,16 @@ presubmits:
           limits:
             cpu: "4"
             memory: "6Gi"
-  - name: pull-kueue-test-integration-baseline-release-0-12
+  - name: pull-kueue-test-integration-baseline-release-0-14
     cluster: eks-prow-build-cluster
     branches:
-    - ^release-0.12
+    - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-integration-baseline-release-0-12
+      testgrid-tab-name: pull-kueue-test-integration-baseline-release-0-14
       description: "Run kueue test-integration-baseline"
     spec:
       containers:
@@ -58,16 +58,16 @@ presubmits:
           limits:
             cpu: "7"
             memory: "10Gi"
-  - name: pull-kueue-test-integration-extended-release-0-12
+  - name: pull-kueue-test-integration-extended-release-0-14
     cluster: eks-prow-build-cluster
     branches:
-      - ^release-0.12
+      - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-integration-extended-release-0-12
+      testgrid-tab-name: pull-kueue-test-integration-extended-release-0-14
       description: "Run kueue test-integration-extended"
     spec:
       containers:
@@ -86,16 +86,16 @@ presubmits:
             limits:
               cpu: "7"
               memory: "10Gi"
-  - name: pull-kueue-test-integration-multikueue-release-0-12
+  - name: pull-kueue-test-integration-multikueue-release-0-14
     cluster: eks-prow-build-cluster
     branches:
-    - ^release-0.12
+    - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-integration-multikueue-release-0-12
+      testgrid-tab-name: pull-kueue-test-integration-multikueue-release-0-14
       description: "Run kueue test-multikueue-integration"
     spec:
       containers:
@@ -114,16 +114,16 @@ presubmits:
           limits:
             cpu: "7"
             memory: "10Gi"
-  - name: pull-kueue-test-e2e-release-0-12-1-31
+  - name: pull-kueue-test-e2e-release-0-14-1-31
     cluster: eks-prow-build-cluster
     branches:
-      - ^release-0.12
+      - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-release-0-12-1-31
+      testgrid-tab-name: pull-kueue-test-e2e-release-0-14-1-31
       description: "Run kueue end to end tests for Kubernetes 1.31"
     labels:
       preset-dind-enabled: "true"
@@ -152,16 +152,16 @@ presubmits:
             limits:
               cpu: "10"
               memory: "10Gi"
-  - name: pull-kueue-test-e2e-release-0-12-1-32
+  - name: pull-kueue-test-e2e-release-0-14-1-32
     cluster: eks-prow-build-cluster
     branches:
-      - ^release-0.12
+      - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-release-0-12-1-32
+      testgrid-tab-name: pull-kueue-test-e2e-release-0-14-1-32
       description: "Run kueue end to end tests for Kubernetes 1.32"
     labels:
       preset-dind-enabled: "true"
@@ -190,16 +190,92 @@ presubmits:
             limits:
               cpu: "10"
               memory: "10Gi"
-  - name: pull-kueue-test-e2e-multikueue-release-0-12
+  - name: pull-kueue-test-e2e-release-0-14-1-33
     cluster: eks-prow-build-cluster
     branches:
-      - ^release-0.12
+      - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-multikueue-release-0-12
+      testgrid-tab-name: pull-kueue-test-e2e-release-0-14-1-33
+      description: "Run kueue end to end tests for Kubernetes 1.33"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.33"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "10"
+              memory: "10Gi"
+            limits:
+              cpu: "10"
+              memory: "10Gi"
+  - name: pull-kueue-test-e2e-release-0-14-1-34
+    cluster: eks-prow-build-cluster
+    branches:
+      - ^release-0.14
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+    decorate: true
+    path_alias: sigs.k8s.io/kueue
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-kueue-test-e2e-release-0-14-1-34
+      description: "Run kueue end to end tests for Kubernetes 1.34"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.34"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "10"
+              memory: "10Gi"
+            limits:
+              cpu: "10"
+              memory: "10Gi"
+  - name: pull-kueue-test-e2e-multikueue-release-0-14
+    cluster: eks-prow-build-cluster
+    branches:
+      - ^release-0.14
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+    decorate: true
+    path_alias: sigs.k8s.io/kueue
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-kueue-test-e2e-multikueue-release-0-14
       description: "Run multikueue end to end tests"
     labels:
       preset-dind-enabled: "true"
@@ -208,7 +284,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.32"
+              value: "1.34"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -228,16 +304,16 @@ presubmits:
             limits:
               cpu: "10"
               memory: "10Gi"
-  - name: pull-kueue-test-e2e-tas-release-0-12
+  - name: pull-kueue-test-e2e-tas-release-0-14
     cluster: eks-prow-build-cluster
     branches:
-      - ^release-0.12
+      - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-tas-release-0-12
+      testgrid-tab-name: pull-kueue-test-e2e-tas-release-0-14
       description: "Run tas end to end tests"
     labels:
       preset-dind-enabled: "true"
@@ -246,7 +322,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.32"
+              value: "1.34"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -266,16 +342,16 @@ presubmits:
             limits:
               cpu: "10"
               memory: "10Gi"
-  - name: pull-kueue-test-e2e-customconfigs-release-0-12
+  - name: pull-kueue-test-e2e-customconfigs-release-0-14
     cluster: eks-prow-build-cluster
     branches:
-      - ^release-0.12
+      - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-customconfigs-release-0-12
+      testgrid-tab-name: pull-kueue-test-e2e-customconfigs-release-0-14
       description: "Run customconfigs end to end tests"
     labels:
       preset-dind-enabled: "true"
@@ -284,7 +360,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.32"
+              value: "1.34"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -304,16 +380,16 @@ presubmits:
             limits:
               cpu: "10"
               memory: "10Gi"
-  - name: pull-kueue-test-e2e-certmanager-release-0-12
+  - name: pull-kueue-test-e2e-certmanager-release-0-14
     cluster: eks-prow-build-cluster
     branches:
-      - ^release-0.12
+      - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-certmanager-release-0-12
+      testgrid-tab-name: pull-kueue-test-e2e-certmanager-release-0-14
       description: "Run cert-manager end to end tests"
     labels:
       preset-dind-enabled: "true"
@@ -322,7 +398,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.32"
+              value: "1.34"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -342,16 +418,16 @@ presubmits:
             limits:
               cpu: "10"
               memory: "10Gi"
-  - name: pull-kueue-test-e2e-kueueviz-release-0-12
+  - name: pull-kueue-test-e2e-kueueviz-release-0-14
     cluster: eks-prow-build-cluster
     branches:
-      - ^release-0.12
+      - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-kueueviz-release-0-12
+      testgrid-tab-name: pull-kueue-test-e2e-kueueviz-release-0-14
       description: "Run kueueviz end to end tests"
     labels:
       preset-dind-enabled: "true"
@@ -360,7 +436,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.32"
+              value: "1.34"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -380,16 +456,16 @@ presubmits:
             limits:
               cpu: "10"
               memory: "10Gi"
-  - name: pull-kueue-verify-release-0-12
+  - name: pull-kueue-verify-release-0-14
     cluster: eks-prow-build-cluster
     branches:
-    - ^release-0.12
+    - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|^(README|LICENSE|OWNERS)$"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-verify-release-0-12
+      testgrid-tab-name: pull-kueue-verify-release-0-14
       description: "Run kueue verify checks"
     labels:
       preset-dind-enabled: "true"
@@ -413,16 +489,16 @@ presubmits:
           limits:
             cpu: "6"
             memory: "8Gi"
-  - name: pull-kueue-build-image-release-0-12
+  - name: pull-kueue-build-image-release-0-14
     cluster: eks-prow-build-cluster
     branches:
-    - ^release-0.12
+    - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-build-image-release-0-12
+      testgrid-tab-name: pull-kueue-build-image-release-0-14
       description: "Build container image of kueue"
     labels:
       preset-dind-enabled: "true"
@@ -450,16 +526,16 @@ presubmits:
           limits:
             cpu: "2"
             memory: "6Gi"
-  - name: pull-kueue-test-scheduling-perf-release-0-12
+  - name: pull-kueue-test-scheduling-perf-release-0-14
     cluster: eks-prow-build-cluster
     branches:
-    - ^release-0.12
+    - ^release-0.14
     skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
     decorate: true
     path_alias: sigs.k8s.io/kueue
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-scheduling-perf-release-0-12
+      testgrid-tab-name: pull-kueue-test-scheduling-perf-release-0-14
       description: "Run kueue test-scheduling-perf"
     spec:
       containers:


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/kueue/issues/6756

Copied the main configs and replaced in order:

^main -> ^release-0.14
-main -> -release-0-14
main -> release-0.14

After that, I removed the configs for release-0.12.