### PR TITLE
sig-testing: remove KUBE_GORUNNER_IMAGE override

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -605,11 +605,6 @@ presubmits:
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
           value: kube-apiserver kube-controller-manager kube-scheduler
-        # KUBE_GORUNNER_IMAGE is the default for the images of those components.
-        # We need something with libc. The same kubekins as for the job is used
-        # because it is expected to get updated automatically.
-        - name: KUBE_GORUNNER_IMAGE
-          value: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250925-95b5a2c7a5-master
         # At the default verbosity level 4 some logs become so large (for example, kube-apiserver
         # logs each HTTP request) that a post-run analysis only sees an incomplete tail of the
         # logs. Let's use the "recommended default log level for most systems" (https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use).


### PR DESCRIPTION
To support running dynamically linked control plane components, the base image had to be
overridden. https://github.com/kubernetes/kubernetes/pull/133972 ensures that this happens automatically, so we no longer need to do it in the job. That's good because it's not clear in the job which image should be used.
