### PR TITLE
sig-testing: add alpha/beta enabled and conformance periodic jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -105,9 +105,9 @@ periodics:
   name: ci-kubernetes-e2e-kind-beta-features
   annotations:
     testgrid-dashboards: sig-release-master-informing, sig-testing-kind
-    testgrid-tab-name: kind-master-beta
+    testgrid-tab-name: kind-master-beta-features
     description: Runs tests with no special requirements other than beta feature gates in a KinD cluster where beta feature gates and APIs are enabled.
-    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,release-team@kubernetes.io
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,patrick.ohly@intel.com,release-team@kubernetes.io
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
@@ -151,12 +151,12 @@ periodics:
 
 - interval: 4h
   cluster: k8s-infra-prow-build
-  name: ci-kubernetes-e2e-kind-alpha-beta-features
+  name: ci-kubernetes-e2e-kind-beta-enabled
   annotations:
-    testgrid-dashboards: sig-release-master-informing, sig-testing-kind
-    testgrid-tab-name: kind-master-alpha-beta
-    description: Runs tests with no special requirements other than alpha or beta feature gates in a KinD cluster where alpha and beta feature gates and APIs are enabled.
-    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,release-team@kubernetes.io
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: kind-master-beta-enabled
+    description: Runs tests with no special requirements in a KinD cluster where beta feature gates and APIs are enabled, i.e. this does not include tests for off-by-default beta features.
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,patrick.ohly@intel.com
     testgrid-num-columns-recent: '6'
   labels:
     preset-dind-enabled: "true"
@@ -178,11 +178,210 @@ periodics:
       - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       - name: FEATURE_GATES
+        value: '{"AllBeta":true}'
+      - name: RUNTIME_CONFIG
+        value: '{"api/beta":"true", "api/ga":"true"}'
+      - name: LABEL_FILTER
+        value: "Feature: isEmpty && !Alpha && !Deprecated && !Slow && !Disruptive && !Flaky"
+      - name: PARALLEL
+        value: "true"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7
+
+- interval: 4h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-e2e-kind-beta-enabled-conformance
+  annotations:
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: kind-master-beta-enabled-conformance
+    description: Runs conformance tests in a KinD cluster where beta feature gates and APIs are enabled.
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,patrick.ohly@intel.com
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20250925-95b5a2c7a5-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+      - name: FEATURE_GATES
+        value: '{"AllBeta":true}'
+      - name: RUNTIME_CONFIG
+        value: '{"api/beta":"true", "api/ga":"true"}'
+      - name: LABEL_FILTER
+        value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky"
+      - name: PARALLEL
+        value: "true"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7
+
+- interval: 4h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-e2e-kind-alpha-beta-features
+  annotations:
+    testgrid-dashboards: sig-release-master-informing, sig-testing-kind
+    testgrid-tab-name: kind-master-alpha-beta-features
+    description: Runs tests with no special requirements other than alpha or beta feature gates in a KinD cluster where alpha and beta feature gates and APIs are enabled.
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,patrick.ohly@intel.com,release-team@kubernetes.io
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20250925-95b5a2c7a5-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+        # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
+      - name: FEATURE_GATES
         value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG": false}'
       - name: RUNTIME_CONFIG
         value: '{"api/all":"true"}'
       - name: LABEL_FILTER
         value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
+      - name: PARALLEL
+        value: "true"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7
+
+- interval: 4h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-e2e-kind-alpha-beta-enabled
+  annotations:
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: kind-master-alpha-beta-enabled
+    description: Runs tests with no special requirements in a KinD cluster where alpha and beta feature gates and APIs are enabled, i.e. this does not include tests for alpha features and off-by-default beta features.
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,patrick.ohly@intel.com
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20250925-95b5a2c7a5-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+        # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
+      - name: FEATURE_GATES
+        value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG": false}'
+      - name: RUNTIME_CONFIG
+        value: '{"api/all":"true"}'
+      - name: LABEL_FILTER
+        value: "Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky"
+      - name: PARALLEL
+        value: "true"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 9Gi
+          cpu: 7
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: 9Gi
+          cpu: 7
+
+- interval: 4h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-e2e-kind-alpha-beta-conformance
+  annotations:
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: kind-master-alpha-beta-enabled-conformance
+    description: Runs conformance tests in a KinD cluster where alpha and beta feature gates and APIs are enabled.
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,patrick.ohly@intel.com
+    testgrid-num-columns-recent: '6'
+  labels:
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20250925-95b5a2c7a5-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+        # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
+      - name: FEATURE_GATES
+        value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG": false}'
+      - name: RUNTIME_CONFIG
+        value: '{"api/all":"true"}'
+      - name: LABEL_FILTER
+        value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
This mirrors the presubmit counterparts that were added in https://github.com/kubernetes/test-infra/pull/35534 and tested in https://github.com/kubernetes/kubernetes/pull/134250.

I can help monitor the existing alpha/beta features jobs. Those need to be renamed in testgrid to avoid confusion. Other than that they remain unchanged for now.

Potential future work:

- Changes related to serial and/or slow jobs.

  Serial tests are excluded implicitly by e2e-k8s.sh because the jobs enables PARALLEL (https://github.com/kubernetes/test-infra/pull/35594).

  Slow jobs are disabled in LABEL_FILTER because that is what the existing periodics did. We might be able to run them because as long as they overlap with other tests there shouldn't be much impact on overall job duration (same applies to presubmits!). Scheduling of slow tests may be relevant (https://github.com/onsi/ginkgo/issues/1599).

- Release informing/blocking.

  The existing jobs are release informing. alpha-beta-features shouldn't be because breaking alpha tests is not something that the release team should have to deal with. Instead, the new jobs should get promoted once they are known to be stable. beta-features can remain release informing, tests for beta features (even if off-by-default) need to be stable.

- Decision about "enabled-conformance".

  The conformance jobs got included because it was suggested on Slack. They run a subset of the tests run by their "enabled" counterparts. It remains to be seen whether having two jobs instead of one really provides a better release signal.

/assign @aojea @BenTheElder 