### PR TITLE
Update etcd presubmit e2e jobs to enable minimal E2E tests

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -213,7 +213,7 @@ presubmits:
         - |
           set -euo pipefail
           make gofail-enable
-          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true E2E_TEST_MINIMAL=true make test-e2e-release
         resources:
           requests:
             cpu: "4"
@@ -243,7 +243,7 @@ presubmits:
         - -c
         - |
           set -euo pipefail
-          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true make test-e2e
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true E2E_TEST_MINIMAL=true make test-e2e
         resources:
           requests:
             cpu: "4"
@@ -272,7 +272,7 @@ presubmits:
         - -c
         - |
           set -euo pipefail
-          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true E2E_TEST_MINIMAL=true make test-e2e-release
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
## What

- Update etcd presubmit e2e jobs to enable minimal E2E tests


According to [etcd/Makefile](https://github.com/etcd-io/etcd/blob/5ec40e3bf21418adc9637b39de40a0cbdbc124e9/Makefile), these three commands run e2e tests under https://github.com/etcd-io/etcd/tree/main/tests/common. However, `make test` does not exist in `config/jobs/etcd/etcd-presubmits.yaml`.
- make test
- make test-e2e
- make test-e2e-release


So, the commands that need to be passed `E2E_TEST_MINIMAL=true` are
- make test-e2e
- make test-e2e-release





## Why

Context: https://github.com/etcd-io/etcd/issues/18983

- To minimize the E2E test matrix in presumits and reduce CI runtime.


## Related link
- https://github.com/etcd-io/etcd/pull/20733