### PR TITLE
vpa: make vpa-full a required job if it runs

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -202,7 +202,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-autoscaling-vpa
       testgrid-tab-name: autoscaling-vpa-full-presubmits
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 120m


### PR DESCRIPTION
This PR sets the "VPA full" job to required if it runs.

Fixes https://github.com/kubernetes/autoscaler/issues/8602