### PR TITLE
Remove tekton shard from TestGrid merged config.

### DIFF
--- a/config/mergelists/canary.yaml
+++ b/config/mergelists/canary.yaml
@@ -8,8 +8,6 @@ sources:
   location: "gs://istio-testgrid/config"
 - name: "kubevirt"
   location: "gs://kubevirt-prow/testgrid/config"
-- name: "tekton"
-  location: "gs://tekton-prow/testgrid/config"
 - name: "cert-manager"
   location: "gs://cert-manager-prow-testgrid/config"
 - name: "gardener"

--- a/config/mergelists/prod.yaml
+++ b/config/mergelists/prod.yaml
@@ -8,8 +8,6 @@ sources:
   location: "gs://istio-testgrid/config"
 - name: "kubevirt"
   location: "gs://kubevirt-prow/testgrid/config"
-- name: "tekton"
-  location: "gs://tekton-prow/testgrid/config"
 - name: "cert-manager"
   location: "gs://cert-manager-prow-testgrid/config"
 - name: "gardener"


### PR DESCRIPTION
From config-merger errors, it looks like the config backing the tekton shard no longer exists, which is causing the rest of the configuration merge to fail and leading to stale config for the K8s TestGrid instance.

```
level=error msg="Update failed" component=config-merger error="can't
read config \"tekton\" at gs://tekton-prow/testgrid/config: failed to
open config: storage: object doesn't exist"
```

Remove the shard (we can re-add it later once the file exists if it's an issue).