### PR TITLE
azure scalability: use latest CAPZ release

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
@@ -17,7 +17,7 @@ periodics:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.20
+      base_ref: release-1.21
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     - org: kubernetes-sigs
       repo: cloud-provider-azure


### PR DESCRIPTION
This PR updates the version of CAPZ that we use to build SIG Scalability cluster scenarios uses the latest release branch of CAPZ following the release of v1.21.0:

- https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.21.0