### PR TITLE
sig windows: update to latest CAPZ release branch

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.31-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.31-windows-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-1.31
     decorate: true
     extra_refs:
-    - base_ref: release-1.19
+    - base_ref: release-1.21
       org: kubernetes-sigs
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.31-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.31-windows.yaml
@@ -9,7 +9,7 @@ periodics:
   decoration_config:
     timeout: 4h0m0s
   extra_refs:
-  - base_ref: release-1.19
+  - base_ref: release-1.21
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -65,7 +65,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.19
+    base_ref: release-1.21
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.32-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.32-windows.yaml
@@ -9,7 +9,7 @@ periodics:
   decoration_config:
     timeout: 4h0m0s
   extra_refs:
-  - base_ref: release-1.19
+  - base_ref: release-1.21
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -65,7 +65,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.19
+    base_ref: release-1.21
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-1.33
     decorate: true
     extra_refs:
-    - base_ref: release-1.19
+    - base_ref: release-1.21
       org: kubernetes-sigs
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows.yaml
@@ -9,7 +9,7 @@ periodics:
   decoration_config:
     timeout: 4h0m0s
   extra_refs:
-  - base_ref: release-1.19
+  - base_ref: release-1.21
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -65,7 +65,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.19
+    base_ref: release-1.21
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-1.34
     decorate: true
     extra_refs:
-    - base_ref: release-1.19
+    - base_ref: release-1.21
       org: kubernetes-sigs
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows.yaml
@@ -9,7 +9,7 @@ periodics:
   decoration_config:
     timeout: 4h0m0s
   extra_refs:
-  - base_ref: release-1.19
+  - base_ref: release-1.21
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -65,7 +65,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.19
+    base_ref: release-1.21
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs


### PR DESCRIPTION
This PR moves SIG Windows tests that use the 1.19 release branch to 1.21 (the latest)