### PR TITLE
Setup release-0.24 branch jobs for CAPI Operator

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-24.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-24.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-operator-test-release-0-23
+- name: periodic-cluster-api-operator-test-release-0-24
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
@@ -8,7 +8,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-operator
-    base_ref: release-0.23
+    base_ref: release-0.24
     path_alias: sigs.k8s.io/cluster-api-operator
   spec:
     containers:
@@ -24,10 +24,10 @@ periodics:
           memory: "2Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
-    testgrid-tab-name: capi-operator-test-release-0-23
+    testgrid-tab-name: capi-operator-test-release-0-24
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-operator-e2e-release-0-23
+- name: periodic-cluster-api-operator-e2e-release-0-24
   cluster: eks-prow-build-cluster
   interval: 24h
   decorate: true
@@ -39,7 +39,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-operator
-    base_ref: release-0.23
+    base_ref: release-0.24
     path_alias: sigs.k8s.io/cluster-api-operator
   spec:
     containers:
@@ -59,6 +59,6 @@ periodics:
           memory: "2Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
-    testgrid-tab-name: capi-operator-e2e-release-0-23
+    testgrid-tab-name: capi-operator-e2e-release-0-24
     testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-24.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-24.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes-sigs/cluster-api-operator:
-  - name: pull-cluster-api-operator-build-release-0-23
+  - name: pull-cluster-api-operator-build-release-0-24
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -9,7 +9,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.23$
+    - ^release-0.24$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-1164926229-1.27
@@ -25,8 +25,8 @@ presubmits:
             memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
-      testgrid-tab-name: capi-operator-pr-build-release-0-23
-  - name: pull-cluster-api-operator-make-release-0-23
+      testgrid-tab-name: capi-operator-pr-build-release-0-24
+  - name: pull-cluster-api-operator-make-release-0-24
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -36,7 +36,7 @@ presubmits:
       preset-dind-enabled: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.23$
+    - ^release-0.24$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-1164926229-1.27
@@ -55,8 +55,8 @@ presubmits:
             memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
-      testgrid-tab-name: capi-operator-pr-make-release-0-23
-  - name: pull-cluster-api-operator-apidiff-release-0-23
+      testgrid-tab-name: capi-operator-pr-make-release-0-24
+  - name: pull-cluster-api-operator-apidiff-release-0-24
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -65,7 +65,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.23$
+    - ^release-0.24$
     run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
@@ -82,8 +82,8 @@ presubmits:
             memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
-      testgrid-tab-name: capi-operator-pr-apidiff-release-0-23
-  - name: pull-cluster-api-operator-verify-release-0-23
+      testgrid-tab-name: capi-operator-pr-apidiff-release-0-24
+  - name: pull-cluster-api-operator-verify-release-0-24
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -92,7 +92,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.23$
+    - ^release-0.24$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-1164926229-1.27
@@ -108,8 +108,8 @@ presubmits:
             memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
-      testgrid-tab-name: capi-operator-pr-verify-release-0-23
-  - name: pull-cluster-api-operator-test-release-0-23
+      testgrid-tab-name: capi-operator-pr-verify-release-0-24
+  - name: pull-cluster-api-operator-test-release-0-24
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-operator
@@ -117,7 +117,7 @@ presubmits:
       preset-service-account: "true"
     branches:
     # The script this job runs is not in all branches.
-    - ^release-0.23$
+    - ^release-0.24$
     run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
@@ -134,8 +134,8 @@ presubmits:
             memory: "2Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
-      testgrid-tab-name: capi-operator-pr-test-release-0-23
-  - name: pull-cluster-api-operator-e2e-release-0-23
+      testgrid-tab-name: capi-operator-pr-test-release-0-24
+  - name: pull-cluster-api-operator-e2e-release-0-24
     cluster: eks-prow-build-cluster
     path_alias: "sigs.k8s.io/cluster-api-operator"
     optional: false
@@ -146,7 +146,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - ^release-0.23$
+    - ^release-0.24$
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-1164926229-1.27
@@ -166,4 +166,4 @@ presubmits:
             memory: "8Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
-      testgrid-tab-name: capi-operator-pr-e2e-release-0-23
+      testgrid-tab-name: capi-operator-pr-e2e-release-0-24


### PR DESCRIPTION
Bump release branch jobs to track the [release-0.24](https://github.com/kubernetes-sigs/cluster-api-operator/tree/release-0.24), the latest operator minor release branch.