### PR TITLE
Add label for k-sigs/contributor-playground

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -16,6 +16,7 @@
 - [Labels that apply to kubernetes-sigs/cluster-api-provider-azure, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscluster-api-provider-azure-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/cluster-api-provider-gcp, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscluster-api-provider-gcp-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/cluster-api-provider-vsphere, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscluster-api-provider-vsphere-for-both-issues-and-prs)
+- [Labels that apply to kubernetes-sigs/contributor-playground, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscontributor-playground-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/contributor-tweets, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscontributor-tweets-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/controller-runtime, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscontroller-runtime-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/gateway-api, only for issues](#labels-that-apply-to-kubernetes-sigsgateway-api-only-for-issues)
@@ -307,6 +308,27 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="area/govmomi" href="#area/govmomi">`area/govmomi`</a> | Issues or PRs related to the govmomi mode| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
 | <a id="area/supervisor" href="#area/supervisor">`area/supervisor`</a> | Issues or PRs related to the supervisor mode| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+
+## Labels that apply to kubernetes-sigs/contributor-playground, for both issues and PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="area/aotearoa" href="#area/aotearoa">`area/aotearoa`</a> | Issues or PRs related to Aotearoa region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/australia" href="#area/australia">`area/australia`</a> | Issues or PRs related to Australia region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/austria" href="#area/austria">`area/austria`</a> | Issues or PRs related to Austria region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/barcelona" href="#area/barcelona">`area/barcelona`</a> | Issues or PRs related to Barcelona region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/bay-area" href="#area/bay-area">`area/bay-area`</a> | Issues or PRs related to Bay Area| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/beijing" href="#area/beijing">`area/beijing`</a> | Issues or PRs related to Beijing region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/brazil" href="#area/brazil">`area/brazil`</a> | Issues or PRs related to Brazil region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/czechia" href="#area/czechia">`area/czechia`</a> | Issues or PRs related to Czechia region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/denmark" href="#area/denmark">`area/denmark`</a> | Issues or PRs related to Denmark region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/denver" href="#area/denver">`area/denver`</a> | Issues or PRs related to Denver region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/india" href="#area/india">`area/india`</a> | Issues or PRs related to India region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/japan" href="#area/japan">`area/japan`</a> | Issues or PRs related to Japan region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/paris" href="#area/paris">`area/paris`</a> | Issues or PRs related to Paris region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/remote" href="#area/remote">`area/remote`</a> | Issues or PRs related to remote events or activities| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/sandiego" href="#area/sandiego">`area/sandiego`</a> | Issues or PRs related to San Diego region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/seattle" href="#area/seattle">`area/seattle`</a> | Issues or PRs related to Seattle region| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
 
 ## Labels that apply to kubernetes-sigs/contributor-tweets, for both issues and PRs
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -2243,3 +2243,101 @@ repos:
         target: prs
         prowPlugin: label
         addedBy: approvers or reviewers or members
+  kubernetes-sigs/contributor-playground:
+    labels:
+      - color: 0052cc
+        description: Issues or PRs related to Aotearoa region
+        name: area/aotearoa
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Australia region
+        name: area/australia
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Austria region
+        name: area/austria
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Barcelona region
+        name: area/barcelona
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Bay Area
+        name: area/bay-area
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Beijing region
+        name: area/beijing
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Brazil region
+        name: area/brazil
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Czechia region
+        name: area/czechia
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Denmark region
+        name: area/denmark
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Denver region
+        name: area/denver
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to India region
+        name: area/india
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Japan region
+        name: area/japan
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Paris region
+        name: area/paris
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to remote events or activities
+        name: area/remote
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to San Diego region
+        name: area/sandiego
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
+        description: Issues or PRs related to Seattle region
+        name: area/seattle
+        target: both
+        prowPlugin: label
+        addedBy: anyone


### PR DESCRIPTION
ref. https://github.com/kubernetes-sigs/contributor-playground/pull/2177

**What this PR does / why we need it:**

- to create some `area/` labels for k-sigs/contributor-playground 
