### PR TITLE
correct the testgrid alerts emails

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -31,7 +31,7 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-node-node-problem-detector
-    testgrid-alert-email: zhenw@google.com,lantaol@google.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, zhenw@google.com,lantaol@google.com
     testgrid-num-failures-to-alert: '12'
     testgrid-alert-stale-results-hours: '24'
     testgrid-num-columns-recent: '30'
@@ -66,7 +66,7 @@ periodics:
           memory: 4Gi
   annotations:
     testgrid-dashboards: sig-node-node-problem-detector
-    testgrid-alert-email: zhenw@google.com,lantaol@google.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, zhenw@google.com,lantaol@google.com
     testgrid-num-failures-to-alert: '12'
     testgrid-alert-stale-results-hours: '24'
     testgrid-num-columns-recent: '30'
@@ -120,7 +120,7 @@ periodics:
           memory: 4Gi
   annotations:
     testgrid-dashboards: sig-node-node-problem-detector
-    testgrid-alert-email: zhenw@google.com,lantaol@google.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, zhenw@google.com,lantaol@google.com
     testgrid-num-failures-to-alert: '12'
     testgrid-alert-stale-results-hours: '24'
     testgrid-num-columns-recent: '30'
@@ -165,7 +165,7 @@ periodics:
           memory: 4Gi
   annotations:
     testgrid-dashboards: sig-node-node-problem-detector
-    testgrid-alert-email: zhenw@google.com,lantaol@google.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, zhenw@google.com,lantaol@google.com
     testgrid-num-failures-to-alert: '12'
     testgrid-alert-stale-results-hours: '24'
     testgrid-num-columns-recent: '30'
@@ -210,7 +210,7 @@ periodics:
           memory: 4Gi
   annotations:
     testgrid-dashboards: sig-node-node-problem-detector
-    testgrid-alert-email: zhenw@google.com,lantaol@google.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, zhenw@google.com,lantaol@google.com
     testgrid-num-failures-to-alert: '12'
     testgrid-alert-stale-results-hours: '24'
     testgrid-num-columns-recent: '30'
@@ -257,7 +257,7 @@ periodics:
           memory: 4Gi
   annotations:
     testgrid-dashboards: sig-node-node-problem-detector
-    testgrid-alert-email: zhenw@google.com,lantaol@google.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, zhenw@google.com,lantaol@google.com
     testgrid-num-failures-to-alert: '12'
     testgrid-alert-stale-results-hours: '24'
     testgrid-num-columns-recent: '30'
@@ -304,7 +304,7 @@ periodics:
           memory: 4Gi
   annotations:
     testgrid-dashboards: sig-node-node-problem-detector
-    testgrid-alert-email: zhenw@google.com,lantaol@google.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, zhenw@google.com,lantaol@google.com
     testgrid-num-failures-to-alert: '12'
     testgrid-alert-stale-results-hours: '24'
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -11,7 +11,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-node-kubelet
     testgrid-tab-name: kubeadm-kinder-kubelet-1-34-on-latest
-    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "8"
@@ -55,7 +55,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-node-kubelet
     testgrid-tab-name: kubeadm-kinder-kubelet-1-33-on-latest
-    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "8"
@@ -99,7 +99,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-node-kubelet
     testgrid-tab-name: kubeadm-kinder-kubelet-1-32-on-latest
-    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "8"
@@ -143,7 +143,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-node-kubelet
     testgrid-tab-name: kubeadm-kinder-kubelet-1-33-on-1-34
-    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "4"
@@ -187,7 +187,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-node-kubelet
     testgrid-tab-name: kubeadm-kinder-kubelet-1-32-on-1-34
-    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "4"
@@ -231,7 +231,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-node-kubelet
     testgrid-tab-name: kubeadm-kinder-kubelet-1-31-on-1-34
-    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "4"
@@ -275,7 +275,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-node-kubelet
     testgrid-tab-name: kubeadm-kinder-kubelet-1-32-on-1-33
-    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "4"
@@ -319,7 +319,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-node-kubelet
     testgrid-tab-name: kubeadm-kinder-kubelet-1-31-on-1-33
-    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "4"
@@ -363,7 +363,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kubeadm, sig-node-kubelet
     testgrid-tab-name: kubeadm-kinder-kubelet-1-31-on-1-32
-    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, kubernetes-sig-node-test-failures+testgrid@googlegroups.com
+    testgrid-alert-email: sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io, sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-cluster-lifecycle (kinder), sig-node (kubelet); Uses kubeadm/kinder to create a cluster with kubelet version skew and run kubeadm-e2e and the conformance suite"
     testgrid-num-columns-recent: "20"
     testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -88,6 +88,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-ubuntu
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-cos-cgroupv1-containerd-node-e2e
   cluster: k8s-infra-prow-build
   interval: 1h
@@ -139,7 +140,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cos-cgroupv1-containerd-node-e2e
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-cos-cgroupv1-containerd-node-e2e-features
   cluster: k8s-infra-prow-build
   interval: 1h
@@ -191,6 +192,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cos-cgroupv1-containerd-node-features
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-cos-cgroupv1-containerd-node-e2e-serial
   cluster: k8s-infra-prow-build
   interval: 12h
@@ -242,6 +244,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cos-cgroupv1-containerd-node-e2e-serial
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-containerd-node-e2e-1-6
   cluster: k8s-infra-prow-build
   interval: 24h
@@ -293,6 +296,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-e2e-1.6
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-containerd-node-e2e-1-7
   cluster: k8s-infra-prow-build
   interval: 24h
@@ -344,6 +348,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-e2e-1.7
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-containerd-node-e2e-features-1-6
   cluster: k8s-infra-prow-build
   interval: 24h
@@ -395,6 +400,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-e2e-features-1.6
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-containerd-node-e2e-features-1-7
   cluster: k8s-infra-prow-build
   interval: 24h
@@ -446,6 +452,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-e2e-features-1.7
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
   cluster: k8s-infra-prow-build
@@ -504,6 +511,7 @@ periodics:
     testgrid-tab-name: e2e-cos-device-plugin-gpu
     testgrid-num-failures-to-alert: '8'
     testgrid-alert-stale-results-hours: '24'
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 
 - name: ci-kubernetes-node-kubelet-containerd-eviction
   cluster: k8s-infra-prow-build
@@ -552,7 +560,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-kubelet-containerd-eviction
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Uses kubetest to run node-e2e Eviction tests"
 
 - name: ci-cri-containerd-node-e2e-features
@@ -606,6 +614,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-e2e-features
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-cri-containerd-node-e2e-unlabelled
   cluster: k8s-infra-prow-build
   interval: 12h
@@ -658,6 +667,7 @@ periodics:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-e2e-unlabelled
     description: "Contains all uncategorized tests, these are tests which are not marked with a [Node] tag. All node tests should be marked with [Feature] or [NodeConformance] classification. Also skipped are [Flaky], [Benchmark], [Legacy]."
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - interval: 1h
   name: ci-cos-containerd-e2e-cos-gce
   cluster: k8s-infra-prow-build
@@ -696,6 +706,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-cos-e2e
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - interval: 1h
   name: ci-cos-containerd-e2e-ubuntu-gce
   cluster: k8s-infra-prow-build
@@ -733,6 +744,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-ubuntu-e2e
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-cos-containerd-node-e2e
   cluster: k8s-infra-prow-build
   interval: 1h
@@ -780,6 +792,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-node-e2e
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-cos-containerd-node-e2e-features
   cluster: k8s-infra-prow-build
   interval: 1h
@@ -827,6 +840,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-node-features
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-cos-cgroupv2-containerd-node-e2e-features
   cluster: k8s-infra-prow-build
   interval: 1h
@@ -878,7 +892,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cos-cgroupv2-containerd-node-features
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-cos-cgroupv2-containerd-node-e2e
   cluster: k8s-infra-prow-build
   interval: 12h
@@ -930,6 +944,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cos-cgroupv2-containerd-node-e2e
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-cgroup-systemd-containerd-node-e2e
   cluster: k8s-infra-prow-build
   interval: 1h
@@ -981,7 +996,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cgroup-systemd-containerd-node-e2e
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - interval: 12h
   name: ci-cos-cgroupv2-containerd-e2e-gce
   cluster: k8s-infra-prow-build
@@ -1039,6 +1054,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cos-cgroupv2-containerd-e2e
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - interval: 12h
   name: ci-cos-cgroupv1-containerd-e2e-gce
   cluster: k8s-infra-prow-build
@@ -1095,6 +1111,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cos-cgroupv1-containerd-e2e
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-cos-cgroupv2-containerd-node-e2e-serial
   cluster: k8s-infra-prow-build
   interval: 12h
@@ -1146,6 +1163,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cos-cgroupv2-containerd-node-e2e-serial
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-containerd
   cluster: k8s-infra-prow-build
@@ -1186,6 +1204,7 @@ periodics:
     testgrid-dashboards: google-gce, sig-storage-kubernetes
     testgrid-tab-name: gce-containerd
     description: node gce e2e tests for master branch using containerd
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-kubernetes-node-kubelet-containerd-resource-managers
   interval: 4h
   cluster: k8s-infra-prow-build
@@ -1233,7 +1252,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-kubelet-containerd-resource-managers
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Executes CPU, Memory and Topology manager e2e tests"
 - name: ci-kubernetes-node-kubelet-containerd-hugepages
   cluster: k8s-infra-prow-build
@@ -1282,7 +1301,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-kubelet-containerd-hugepages
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Executes hugepages e2e tests"
 
 - name: ci-kubernetes-node-swap-ubuntu
@@ -1334,7 +1353,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: kubelet-gce-e2e-swap-ubuntu
-    testgrid-alert-email: ehashman@redhat.com, mkmir@google.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: Executes E2E suite with swap enabled on Ubuntu
 - name: ci-kubernetes-node-kubelet-containerd-performance-test
   cluster: k8s-infra-prow-build
@@ -1387,7 +1406,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-kubelet-containerd-performance-test
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Executes performance e2e tests"
 - name: ci-kubernetes-node-kubelet-lock-contention
   cluster: k8s-infra-prow-build
@@ -1436,6 +1455,7 @@ periodics:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: kubelet-gce-e2e-lock-contention
     description: "Contains disruptive tests for the Lock Contention feature."
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-kubernetes-node-kubelet-credential-provider
   cluster: k8s-infra-prow-build
   interval: 6h
@@ -1483,6 +1503,7 @@ periodics:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: kubelet-credential-provider
     description: "tests feature kubelet image credential provider"
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
 - name: ci-kubernetes-e2e-gcp-credential-provider
   cluster: k8s-infra-prow-build
   interval: 24h
@@ -1525,3 +1546,4 @@ periodics:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: gcp-kubelet-credential-provider
     description: "tests feature gcp kubelet image credential provider"
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io

--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -21,7 +21,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-features
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-node; runs Features e2e tests with crio master and cgroup v2"
   spec:
     containers:
@@ -76,7 +76,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-unlabelled
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Contains all uncategorized tests, these are tests which are not marked with a [Node] tag. All node tests should be marked with [Feature] or [NodeConformance] classification. Also skipped are [Flaky], [Benchmark], [Legacy]."
   spec:
     containers:
@@ -131,7 +131,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-eviction
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
   spec:
     containers:
@@ -187,7 +187,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: node-kubelet-crio-cgroupv2-performance-test
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
   spec:
     containers:
@@ -243,7 +243,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-node-cri-o, sig-node-release-blocking
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-conformance
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com, release-team@kubernetes.io
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v2"
   spec:
     containers:
@@ -299,7 +299,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-resource-managers
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Executes CPU, Memory and Topology manager e2e tests with cgroup v2"
   spec:
     containers:
@@ -357,7 +357,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv2-node-e2e-hugepages
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Executes hugepages e2e tests"
   spec:
     containers:
@@ -415,7 +415,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-crio-cgroupv2-userns-e2e-serial
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Executes userns E2E tests with ProcMountType and UserNamespacesSupport feature gates"
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -18,7 +18,7 @@ periodics:
     annotations:
       testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv2-containerd-node-e2e-ec2
-      testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+      testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     labels:
       preset-e2e-containerd-ec2: "true"
     cluster: eks-prow-build-cluster
@@ -63,7 +63,7 @@ periodics:
     annotations:
       testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-kubernetes-node-arm64-e2e-containerd-ec2
-      testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+      testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     labels:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
@@ -116,6 +116,7 @@ periodics:
     annotations:
       testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv2-containerd-node-arm64-e2e-serial-ec2
+      testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     labels:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
@@ -170,6 +171,7 @@ periodics:
     annotations:
       testgrid-dashboards: sig-node-containerd,amazon-ec2-node
       testgrid-tab-name: ci-cgroupv2-containerd-node-e2e-serial-ec2
+      testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     labels:
       preset-e2e-containerd-ec2: "true"
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
+++ b/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
@@ -46,7 +46,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-release-blocking
     testgrid-tab-name: node-conformance-release-1.31
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: Node conformance tests in release branch 1.31
 - name: ci-kubernetes-node-release-branch-1-32
   cluster: k8s-infra-prow-build
@@ -95,7 +95,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-release-blocking
     testgrid-tab-name: node-conformance-release-1.32
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: Node conformance tests in release branch 1.32
 - name: ci-kubernetes-node-release-branch-1-33
   cluster: k8s-infra-prow-build
@@ -147,7 +147,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-release-blocking
     testgrid-tab-name: node-conformance-release-1.33
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: Node conformance tests in release branch 1.33
 - name: ci-kubernetes-node-release-branch-1-34
   cluster: k8s-infra-prow-build
@@ -199,5 +199,5 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-release-blocking
     testgrid-tab-name: node-conformance-release-1.34
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: Node conformance tests in release branch 1.34

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -51,7 +51,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-node-release-blocking, sig-node-containerd
     testgrid-tab-name: ci-node-e2e
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com, release-team@kubernetes.io
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, release-team@kubernetes.io
     description: "Uses kubetest to run node-e2e tests (+NodeConformance, -Flaky|Slow|Serial)"
 
 - name: ci-kubernetes-node-kubelet-serial-containerd
@@ -108,7 +108,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-release-blocking
     testgrid-tab-name: node-kubelet-serial-containerd
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Uses kubetest to run serial node-e2e tests (+Serial, -Flaky|Benchmark|Node*Feature)"
 
 - name: ci-kubernetes-node-kubelet-containerd-flaky
@@ -163,7 +163,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-kubelet-containerd-flaky
-    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Uses kubetest to run serial node-e2e tests (+Serial|+Flaky, (Benchmark|Node*Feature)"
 
 
@@ -217,7 +217,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: node-kubelet-cgroupv2-serial-crio
-    testgrid-alert-email: skclark@redhat.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Uses kubetest to run serial node-e2e tests with cgroupv2 (+Serial, -Flaky|Benchmark|Node*Feature)"
 
 - name: ci-kubernetes-node-arm64-ubuntu-serial
@@ -226,6 +226,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: kubelet-gce-e2e-arm64-ubuntu-serial
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Run serial node e2e tests on ARM64 environment on Ubuntu"
   decorate: true
   extra_refs:
@@ -331,7 +332,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet, sig-node-cri-o
     testgrid-tab-name: kubelet-gce-e2e-swap-fedora
-    testgrid-alert-email: ehashman@redhat.com, ikema@google.com
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: Executes E2E suite with swap enabled on Fedora
 
 - name: ci-kubernetes-node-swap-ubuntu-serial
@@ -340,6 +341,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: kubelet-gce-e2e-swap-ubuntu-serial
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Run serial node e2e tests with swap environment on Ubuntu"
   labels:
     preset-service-account: "true"
@@ -396,6 +398,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet, sig-node-cri-o
     testgrid-tab-name: kubelet-gce-e2e-swap-fedora-serial
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Run serial node e2e tests with swap environment on Fedora"
   labels:
     preset-service-account: "true"
@@ -448,6 +451,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: kubelet-swap-conformance-ubuntu-serial
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Run serial swap conformance e2e tests with swap environment on Ubuntu"
   labels:
     preset-service-account: "true"
@@ -505,6 +509,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet, sig-node-cri-o
     testgrid-tab-name: kubelet-swap-conformance-fedora-serial
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Run serial swap conformance e2e tests with swap environment on Fedora"
   labels:
     preset-service-account: "true"
@@ -560,6 +565,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: kubelet-gce-e2e-fsquota-ubuntu
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Run node e2e tests with fsquota environment on Ubuntu"
   labels:
     preset-service-account: "true"
@@ -665,6 +671,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-release-blocking
     testgrid-tab-name: node-kubelet-containerd-standalone-mode-all-alpha
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Runs kubelet in standalone mode with all alpha features enabled"
 
 - name: ci-kubernetes-node-e2e-containerd-standalone-mode
@@ -723,6 +730,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-release-blocking
     testgrid-tab-name: node-kubelet-containerd-standalone-mode
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Runs kubelet in standalone mode"
 
 - name: ci-kubernetes-node-kubelet-serial-topology-manager
@@ -731,6 +739,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: kubelet-serial-gce-e2e-topology-manager
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -784,6 +793,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: kubelet-serial-gce-e2e-cpu-manager
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -837,6 +847,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: kubelet-serial-gce-e2e-memory-manager
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -890,6 +901,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-cri-proxy
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Use cri proxy"
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Migrate  kubernetes-sig-node-test-failures@googlegroups.com to sig-node-ci+testgrid@kubernetes.io for SIG Node periodics

/sig node
/kind cleanup