### PR TITLE
autoscaling: use sig name for prow job prefix

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-autoscaling-e2e-gci-gce
+  - name: pull-kubernetes-e2e-gci-gce-autoscaling
     cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-cluster-autoscaler
@@ -56,7 +56,7 @@ presubmits:
             cpu: 2
             memory: 6Gi
 
-  - name: pull-autoscaling-e2e-hpa-cpu
+  - name: pull-kubernetes-e2e-autoscaling-hpa-cpu
     cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa
@@ -102,7 +102,7 @@ presubmits:
             cpu: 2
             memory: 6Gi
 
-  - name: pull-autoscaling-e2e-hpa-cpu-alpha-beta
+  - name: pull-kubernetes-e2e-autoscaling-hpa-cpu-alpha-beta
     cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa
@@ -148,7 +148,7 @@ presubmits:
             cpu: 2
             memory: 6Gi
 
-  - name: pull-autoscaling-e2e-hpa-cm
+  - name: pull-kubernetes-e2e-autoscaling-hpa-cm
     cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-gci-gce-autoscaling
+  - name: pull-autoscaling-e2e-gci-gce
     cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-cluster-autoscaler
@@ -56,7 +56,7 @@ presubmits:
             cpu: 2
             memory: 6Gi
 
-  - name: pull-kubernetes-e2e-autoscaling-hpa-cpu
+  - name: pull-autoscaling-e2e-hpa-cpu
     cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa
@@ -102,7 +102,7 @@ presubmits:
             cpu: 2
             memory: 6Gi
 
-  - name: pull-kubernetes-e2e-autoscaling-hpa-cpu-alpha-beta
+  - name: pull-autoscaling-e2e-hpa-cpu-alpha-beta
     cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa
@@ -148,7 +148,7 @@ presubmits:
             cpu: 2
             memory: 6Gi
 
-  - name: pull-kubernetes-e2e-autoscaling-hpa-cm
+  - name: pull-autoscaling-e2e-hpa-cm
     cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-hpa
@@ -197,7 +197,7 @@ presubmits:
             memory: 6Gi
 
   kubernetes/autoscaler:
-  - name: pull-kubernetes-e2e-autoscaling-vpa-full
+  - name: pull-autoscaling-e2e-vpa-full
     cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-vpa
@@ -240,7 +240,7 @@ presubmits:
         env:
         - name: FEATURE_GATES
           value: "InPlaceOrRecreate=true"
-  - name: pull-kubernetes-e2e-autoscaling-ca-build
+  - name: pull-autoscaling-e2e-ca-build
     cluster: k8s-infra-prow-build
     annotations:
       testgrid-dashboards: sig-autoscaling-cluster-autoscaler


### PR DESCRIPTION
As per https://github.com/kubernetes/test-infra/pull/35629#discussion_r2400462623 we update SIG Autoscaling prow jobs to reflect the `{ci,pull}-$repo-` standard prefix pattern.