### PR TITLE
kOps: Stop using preset-dind-enabled

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -72,7 +72,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1377,7 +1376,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1439,7 +1437,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1503,7 +1500,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1565,7 +1561,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1627,7 +1622,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
@@ -9,7 +9,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -79,7 +78,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -149,7 +147,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -219,7 +216,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -295,7 +291,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -365,7 +360,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -435,7 +429,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -505,7 +498,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -575,7 +567,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -645,7 +636,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -721,7 +711,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -791,7 +780,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -867,7 +855,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -937,7 +924,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1013,7 +999,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1083,7 +1068,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1159,7 +1143,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1229,7 +1212,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1305,7 +1287,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1375,7 +1356,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1451,7 +1431,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1521,7 +1500,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1597,7 +1575,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1667,7 +1644,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1743,7 +1719,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1813,7 +1788,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1889,7 +1863,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -1959,7 +1932,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2035,7 +2007,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2105,7 +2076,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2181,7 +2151,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2251,7 +2220,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2327,7 +2295,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2397,7 +2364,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2473,7 +2439,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2543,7 +2508,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2619,7 +2583,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2689,7 +2652,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2765,7 +2727,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2835,7 +2796,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2911,7 +2871,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -2981,7 +2940,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -15,7 +15,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -82,7 +81,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -148,7 +146,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -214,7 +211,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -280,7 +276,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -347,7 +342,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -413,7 +407,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -480,7 +473,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -547,7 +539,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -613,7 +604,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -680,7 +670,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -747,7 +736,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -813,7 +801,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -879,7 +866,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -15,7 +15,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -84,7 +83,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -154,7 +152,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -220,7 +217,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -287,7 +283,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -754,7 +749,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -823,7 +817,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -880,7 +873,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -937,7 +929,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -994,7 +985,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1061,7 +1051,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1128,7 +1117,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1195,7 +1183,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1264,7 +1251,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1331,7 +1317,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1464,7 +1449,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1531,7 +1515,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1599,7 +1582,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1667,7 +1649,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1733,7 +1714,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1799,7 +1779,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1865,7 +1844,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1931,7 +1909,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1997,7 +1974,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2063,7 +2039,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -2120,7 +2095,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2189,7 +2163,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2259,7 +2232,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -2329,7 +2301,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-aws-ssh: "true"
-      preset-dind-enabled: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -2385,7 +2356,6 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-aws-ssh: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -16,7 +16,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -83,7 +82,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -151,7 +149,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -286,7 +283,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -354,7 +350,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -553,7 +548,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -621,7 +615,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -689,7 +682,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -757,7 +749,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -825,7 +816,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -895,7 +885,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1030,7 +1019,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     decorate: true
     decoration_config:
       timeout: 90m

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -15,7 +15,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-dind-enabled: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -82,7 +81,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential-boskos-scale-001-kops: "true"
-      preset-dind-enabled: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -193,7 +191,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential-boskos-scale-001-kops: "true"
-      preset-dind-enabled: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes/kops/templates/periodic-scenario.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/periodic-scenario.yaml.jinja
@@ -8,7 +8,6 @@
     {%- if build_cluster == "default" %}
     preset-aws-credential: "true"
     {%- endif %}
-    preset-dind-enabled: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/kops/templates/presubmit-scenario.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit-scenario.yaml.jinja
@@ -18,7 +18,6 @@
       {%- elif not boskos_resource_type %}
       preset-aws-credential: "true"
       {%- endif %}
-      preset-dind-enabled: "true"
       {%- else %}
       preset-k8s-ssh: "true"
       {%- endif %}

--- a/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
@@ -16,7 +16,6 @@
       {%- if not boskos_resource_type %}
       preset-aws-credential: "true"
       {%- endif %}
-      preset-dind-enabled: "true"
       {%- elif cloud == "azure" %}
       preset-service-account: "true"
       preset-kops-azure-cred-wi: "true"


### PR DESCRIPTION
I am not aware of kOps using Docker anywhere these days.

/cc @rifelpet @ameukam 