### PR TITLE
create a pull-kubernetes-e2e-gce-kubetest2 job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -434,6 +434,60 @@ presubmits:
           securityContext:
             privileged: true
 
+  - name: pull-kubernetes-e2e-gce-kubetest2
+    cluster: k8s-infra-prow-build
+    optional: true
+    always_run: false
+    skip_branches:
+      - release-\d+\.\d+ # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: google-gce
+    labels:
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    decorate: true
+    decoration_config:
+      timeout: 110m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+        - command:
+            - runner.sh
+            - kubetest2
+            - gce
+          args:
+            - -v=2
+            - --build
+            - --up
+            - --down
+            - --legacy-mode
+            - --test=ginkgo
+            - --target-build-arch=linux/amd64
+            - --master-size=e2-standard-2
+            - --node-size=e2-standard-2
+            - --env=KUBE_OS_DISTRIBUTION=ubuntu
+            - --env=KUBE_GCE_IMAGE_FAMILY=ubuntu-2404-lts-amd64
+            - --env=KUBE_GCE_IMAGE_PROJECT=ubuntu-os-cloud
+            - --
+            - --provider=gce
+            - --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+            - --timeout=80m
+            - --use-built-binaries=true
+            - --parallel=30
+          image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250925-95b5a2c7a5-master
+          resources:
+            limits:
+              cpu: 4
+              memory: "14Gi"
+            requests:
+              cpu: 4
+              memory: "14Gi"
+          securityContext:
+            privileged: true
+
   - name: pull-kubernetes-e2e-gce-cos-alpha-features
     cluster: k8s-infra-prow-build
     optional: true

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -56,6 +56,7 @@ periodics:
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
           --test=ginkgo \
           -- \
+          --provider=gce \
           --test-package-url=https://dl.k8s.io \
           --test-package-dir=ci \
           --test-package-marker=latest.txt \


### PR DESCRIPTION
I'm using this job to flush out some bugs in kubetest2 + kubeup scripts.

The intention is to migrate all the kubernetes_e2e.py jobs to kubetest2 using kubeup for now.