### PR TITLE
use workload identity and create a presubmit job using the latest ubuntu lts

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -434,7 +434,7 @@ presubmits:
           securityContext:
             privileged: true
 
-  - name: pull-kubernetes-e2e-gce-kubetest2
+  - name: pull-kubernetes-e2e-gce-ubuntu-canary
     cluster: k8s-infra-prow-build
     optional: true
     always_run: false
@@ -453,6 +453,7 @@ presubmits:
       timeout: 110m
     path_alias: k8s.io/kubernetes
     spec:
+      serviceAccountName: prow-build
       containers:
         - command:
             - runner.sh
@@ -473,7 +474,62 @@ presubmits:
             - --env=KUBE_GCE_IMAGE_PROJECT=ubuntu-os-cloud
             - --
             - --provider=gce
-            - --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+            - --skip-regex=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+            - --timeout=80m
+            - --use-built-binaries=true
+            - --parallel=30
+          image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250925-95b5a2c7a5-master
+          resources:
+            limits:
+              cpu: 4
+              memory: "14Gi"
+            requests:
+              cpu: 4
+              memory: "14Gi"
+          securityContext:
+            privileged: true
+
+  - name: pull-kubernetes-e2e-gce-kubetest2
+    cluster: k8s-infra-prow-build
+    optional: true
+    always_run: false
+    skip_branches:
+      - release-\d+\.\d+ # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: google-gce
+    labels:
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    decorate: true
+    decoration_config:
+      timeout: 110m
+    path_alias: k8s.io/kubernetes
+    spec:
+      serviceAccountName: prow-build
+      containers:
+        - command:
+            - runner.sh
+            - kubetest2
+            - gce
+          args:
+            - -v=2
+            - --build
+            - --up
+            - --down
+            - --legacy-mode
+            - --test=ginkgo
+            - --target-build-arch=linux/amd64
+            - --master-size=e2-standard-2
+            - --node-size=e2-standard-2
+            - --env=KUBE_OS_DISTRIBUTION=ubuntu
+            - --env=KUBE_GCE_IMAGE_FAMILY=ubuntu-2204-lts
+            - --env=KUBE_GCE_IMAGE_PROJECT=ubuntu-os-cloud
+            - --
+            - --provider=gce
+            - --skip-regex=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
             - --timeout=80m
             - --use-built-binaries=true
             - --parallel=30


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/35650 is failing because it uses 24.04, but we use 22.04 in CI, so I set that job to 22.04 to test the script changes and then figure out how to get 24.04 green.

Also, both jobs can use Workload Identity so `preset-service-account` isn't required.

@ameukam