### PR TITLE
cluster-autoscaler: use CAPZ 1.18 for v1.30 and below

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -296,7 +296,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.18
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:
@@ -351,7 +351,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.18
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:
@@ -406,7 +406,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.18
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:
@@ -461,7 +461,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.18
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:


### PR DESCRIPTION
This PR reverts the CAPZ version bump for older versions of CAS E2E tests:

https://github.com/kubernetes/test-infra/pull/35566

This particular series of messages in particular:

```
Warning: infrastructure.cluster.x-k8s.io/v1alpha1 AzureASOManagedControlPlane is deprecated. infrastructure.cluster.x-k8s.io/v1beta1 is equivalent and should be used instead.
azureasomanagedcontrolplane.infrastructure.cluster.x-k8s.io/capz-opeffr created
Warning: infrastructure.cluster.x-k8s.io/v1alpha1 AzureASOManagedCluster is deprecated. infrastructure.cluster.x-k8s.io/v1beta1 is equivalent and should be used instead.
azureasomanagedcluster.infrastructure.cluster.x-k8s.io/capz-opeffr created
machinepool.cluster.x-k8s.io/capz-opeffr-pool0 created
Warning: infrastructure.cluster.x-k8s.io/v1alpha1 AzureASOManagedMachinePool is deprecated. infrastructure.cluster.x-k8s.io/v1beta1 is equivalent and should be used instead.
```

I'll look into this further, in the meantime to unblock CAS releases let's revert the version bump for these versions.