### PR TITLE
etcd: add protodoc pre and postsubmits

### DIFF
--- a/config/jobs/etcd/protodoc-postsubmits.yaml
+++ b/config/jobs/etcd/protodoc-postsubmits.yaml
@@ -1,0 +1,24 @@
+---
+postsubmits:
+  etcd-io/protodoc:
+  - name: post-protodoc-test
+    cluster: eks-prow-build-cluster
+    branches:
+    - master
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-protodoc-postsubmits
+      testgrid-tab-name: post-protodoc-test
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250925-95b5a2c7a5-master
+        command:
+        - runner.sh
+        args: ['make', 'test']
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"

--- a/config/jobs/etcd/protodoc-presubmits.yaml
+++ b/config/jobs/etcd/protodoc-presubmits.yaml
@@ -1,0 +1,25 @@
+---
+presubmits:
+  etcd-io/protodoc:
+    - name: pull-protodoc-test
+      cluster: eks-prow-build-cluster
+      always_run: true
+      branches:
+        - master
+      decorate: true
+      annotations:
+        testgrid-dashboards: sig-etcd-protodoc-presubmits
+        testgrid-tab-name: pull-protodoc-test
+      spec:
+        containers:
+          - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250925-95b5a2c7a5-master
+            command:
+              - runner.sh
+            args: ['make', 'test']
+            resources:
+              requests:
+                cpu: "4"
+                memory: "4Gi"
+              limits:
+                cpu: "4"
+                memory: "4Gi"

--- a/config/testgrids/kubernetes/sig-etcd/config.yaml
+++ b/config/testgrids/kubernetes/sig-etcd/config.yaml
@@ -14,6 +14,8 @@ dashboard_groups:
   - sig-etcd-raft-presubmits
   - sig-etcd-operator-presubmits
   - sig-etcd-operator-postsubmits
+  - sig-etcd-protodoc-presubmits
+  - sig-etcd-protodoc-postsubmits
 
 dashboards:
   - name: sig-etcd-amd64
@@ -160,3 +162,5 @@ dashboards:
   - name: sig-etcd-raft-presubmits
   - name: sig-etcd-operator-presubmits
   - name: sig-etcd-operator-postsubmits
+  - name: sig-etcd-protodoc-presubmits
+  - name: sig-etcd-protodoc-postsubmits


### PR DESCRIPTION
Enables the CI for the protodoc project. I've been manually running the tests for new PRs (all of them Go version bumps). It would be nice to automate this process.

/cc @jmhbnz 