### PR TITLE
Disable periodic enhancements sync for v1.35

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -1,8 +1,8 @@
 periodics:
 - name: periodic-sync-enhancements-github-project-1-35
   # temporarily disable job by with an impossible cron date instead of deleting it
-  #cron: '0 0 31 2 *'
-  interval: 6h
+  cron: '0 0 31 2 *'
+  #interval: 6h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   annotations:


### PR DESCRIPTION
Disable the syncing of lead-opted-in KEPs to the https://github.com/orgs/kubernetes/projects/229/.

Opening this PR early to get approvals. We can remove the hold once PRR Freeze is in effect (Thursday 9th October 2025 (AoE) / Friday 10th October 2025, 12:00 UTC)

cc: @drewhagen @katcosgrove 

/hold
