### PR TITLE
Ensure ppc64le integration jobs run on SMT-4 Nodes

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -103,6 +103,8 @@ periodics:
           requests:
             cpu: 6
             memory: 20Gi
+      nodeSelector:
+        feature.node.kubernetes.io/ppc64le.smtlevel: "4"
 
   - name: ci-kubernetes-integration-1-33-ppc64le
     interval: 6h # bump to 24h after initial debugging
@@ -137,7 +139,8 @@ periodics:
           requests:
             cpu: 6
             memory: 20Gi
-
+      nodeSelector:
+        feature.node.kubernetes.io/ppc64le.smtlevel: "4"
 
   - name: ci-kubernetes-ppc64le-conformance-latest-kubetest2
     interval: 3h

--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/kubernetes-ppc64le-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/kubernetes-ppc64le-presubmits.yaml
@@ -25,3 +25,5 @@ presubmits:
           requests:
             cpu: 6
             memory: 20Gi
+      nodeSelector:
+        feature.node.kubernetes.io/ppc64le.smtlevel: "4"


### PR DESCRIPTION
**Problem**: Release branch 1.33 and 1.34 have consistent flakes due to timeout. This has been occurring due to few resources like apiserver being overcrowded from initial tests leading to the heavier tests failing in later stages. 

Master branch runs on Go 1.25 with automatic setting for GOMAXPROCS which keeps the workload efficient, but no the same on the release branches. 

**Solution**: Align the underlying ppc64le nodes to run on SMT4 setting (default SMT8) to have ensure less concurrency clashes and more streamlined execution of heavy tests.

Currently, 4 nodes (compute-6,7,8,9) have been changed to SMT4 configuration and labelled with same. 
This is used as node selector for release integration jobs.