### PR TITLE
fix typo on GPU jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -41,10 +41,10 @@ presubmits:
         - --build
         - --up
         - --down
-        - --target-build-arch=linux/amd64
         - --node-size=g2-standard-24
         - --num-nodes=2
-        - --env=NODE_ACCELERATORS='type=nvidia-l4,count=2'
+        - --boskos-resource-type=gpu-project
+        - --node-accelerators=type=nvidia-l4,count=2
         - --test=ginkgo
         - --
         - --provider=gce

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -52,7 +52,8 @@ periodics:
       - --down
       - --node-size=g2-standard-24
       - --num-nodes=2
-      - --env=NODE_ACCELERATORS='type=nvidia-l4,count=2'
+      - --boskos-resource-type=gpu-project
+      - --node-accelerators=type=nvidia-l4,count=2
       - --kubernetes-version=https://dl.k8s.io/ci/latest.txt
       - --test=ginkgo
       - --


### PR DESCRIPTION
`--env=NODE_ACCELERATORS='type=nvidia-l4,count=2'` wasn't working correctly so I swapped it for a different flag. 