### PR TITLE
reduce ppc64le release integration jobs resources to 4 vCPU

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -98,10 +98,10 @@ periodics:
           privileged: true
         resources:
           limits:
-            cpu: 6
+            cpu: 4
             memory: 20Gi
           requests:
-            cpu: 6
+            cpu: 4
             memory: 20Gi
       nodeSelector:
         feature.node.kubernetes.io/ppc64le.smtlevel: "4"
@@ -134,10 +134,10 @@ periodics:
           privileged: true
         resources:
           limits:
-            cpu: 6
+            cpu: 4
             memory: 20Gi
           requests:
-            cpu: 6
+            cpu: 4
             memory: 20Gi
       nodeSelector:
         feature.node.kubernetes.io/ppc64le.smtlevel: "4"

--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/kubernetes-ppc64le-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/kubernetes-ppc64le-presubmits.yaml
@@ -20,10 +20,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 6
+            cpu: 4
             memory: 20Gi
           requests:
-            cpu: 6
+            cpu: 4
             memory: 20Gi
       nodeSelector:
         feature.node.kubernetes.io/ppc64le.smtlevel: "4"


### PR DESCRIPTION
-After a subset of underlying nodes have been changed to SMT4, the jobs running on these nodes need to match the resource requests and limits