### PR TITLE
workaround creating capz cluster failure due to windows 2019 image not found

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -564,8 +564,8 @@ presubmits:
           env:
             - name: ORCHESTRATION_MODE # CAPZ config
               value: "Uniform"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "false"
+            - name: WINDOWS_SERVER_VERSION # CAPZ config
+              value: "windows-2022"
             - name: EXP_MACHINE_POOL # CAPZ config
               value: "true"
             - name: NODE_MACHINE_TYPE # CAPZ config


### PR DESCRIPTION
original failure due to capz issue:

```
      scalesets failed to create or update. err: failed to create or update resource capz-mg359e/win-p-win (service: scalesets): PUT https://management.azure.com/subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/capz-mg359e/providers/Microsoft.Compute/virtualMachineScaleSets/win-p-win
      --------------------------------------------------------------------------------
      RESPONSE 404: 404 Not Found
      ERROR CODE: GalleryImageNotFound
      --------------------------------------------------------------------------------
      {
        "error": {
          "code": "GalleryImageNotFound",
          "message": "\"The gallery image /CommunityGalleries/ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019/Images/capi-win-2019-containerd/Versions/1.34.0 is not available in uksouth region. Please contact image owner to replicate to this region, or change your requested region.\"",
          "target": "imageReference"
        }
      }
      --------------------------------------------------------------------------------
```