### PR TITLE
Cluster API Provider AWS: image-pushing bump timeout

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -102,6 +102,9 @@ postsubmits:
         testgrid-dashboards: sig-cluster-lifecycle-image-pushes, sig-k8s-infra-gcb
         testgrid-alert-email: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
       decorate: true
+      decoration_config:
+        timeout: 120m
+        grace_period: 10m
       branches:
         - ^main
         - ^release-0.4$


### PR DESCRIPTION
Currently facing timeout issues

```
Your build timed out. Use the [--timeout=DURATION] flag to change the timeout threshold.
ERROR: (gcloud.builds.submit) build ef58c2b2-9e25-4987-9c79-97e2ba87f0a3 completed with status "TIMEOUT"
```

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cluster-api-provider-aws-push-images/1976637049523933184#