### PR TITLE
Refine vgs jobs

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
@@ -60,6 +60,7 @@ presubmits:
     decorate: true
     path_alias: k8s.io/kubernetes
     cluster: eks-prow-build-cluster
+    run_if_changed: '^(test\/e2e\/storage|test\/e2e\/testing-manifests\/storage-csi)'
     skip_branches:
     - release-\d+\.\d+
     annotations:
@@ -78,57 +79,12 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/run_group_snapshot_e2e.sh
-        env:
-        - name: RUNTIME_CONFIG
-          value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
-        - name: FOCUS
-          value: \[Feature:volumegroupsnapshot\]
-        - name: PARALLEL
-          value: "true"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "2"
-            memory: "6Gi"
-          limits:
-            cpu: "2"
-            memory: "6Gi"
-
-  # This temporary job used for refine the vgs tests fast iterations
-  - name: pull-kubernetes-e2e-storage-kind-vgs
-    always_run: false
-    optional: true
-    decorate: true
-    path_alias: k8s.io/kubernetes
-    cluster: eks-prow-build-cluster
-    skip_branches:
-    - release-\d+\.\d+
-    annotations:
-      testgrid-dashboards: presubmits-kubernetes-nonblocking
-      testgrid-tab-name: pull-kubernetes-e2e-storage-kind-vgs
-      testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-      description: Run storage tests volume group snapshots in a KIND cluster.
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20250925-95b5a2c7a5-master
-        command:
-        - wrapper.sh
-        - bash
-        - -c
         - |
-          set -ex
-          # Download prow.sh from csi-release-tools
-          # TODO: Back to use the official repo after finish fast iterations
-          curl -fsSL https://raw.githubusercontent.com/Phaow/csi-release-tools/dev/prow.sh -o prow.sh
-          chmod +x prow.sh
-          ./prow.sh
+          # Download prow.sh and filter-junit.go  from csi-release-tools
+          curl -fsSL https://raw.githubusercontent.com/kubernetes-csi/csi-release-tools/master/prow.sh -o prow.sh
+          curl -fsSL https://raw.githubusercontent.com/kubernetes-csi/csi-release-tools/master/filter-junit.go -o filter-junit.go
+          source prow.sh
+          main
         env:
         - name: CSI_PROW_DRIVER_VERSION
           value: "v1.17.0"
@@ -138,8 +94,6 @@ presubmits:
           value: "v8.3.0"
         - name: CSI_PROW_ENABLE_GROUP_SNAPSHOT
           value: "true"
-        - name: CSI_PROW_E2E_FOCUS
-          value: \[Feature:volumegroupsnapshot\]
         - name: CSI_PROW_TESTS
           value: "serial parallel"
         # we need privileged mode in order to do docker in docker
@@ -376,14 +330,23 @@ periodics:
         - wrapper.sh
         - bash
         - -c
-        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/run_group_snapshot_e2e.sh
+        - |
+          # Download prow.sh and filter-junit.go  from csi-release-tools
+          curl -fsSL https://raw.githubusercontent.com/kubernetes-csi/csi-release-tools/master/prow.sh -o prow.sh
+          curl -fsSL https://raw.githubusercontent.com/kubernetes-csi/csi-release-tools/master/filter-junit.go -o filter-junit.go
+          source prow.sh
+          main
         env:
-        - name: RUNTIME_CONFIG
-          value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
-        - name: FOCUS
-          value: \[Feature:volumegroupsnapshot\]
-        - name: PARALLEL
+        - name: CSI_PROW_DRIVER_VERSION
+          value: "v1.17.0"
+        - name: CSI_PROW_DEPLOYMENT_SUFFIX
+          value: ""
+        - name: CSI_SNAPSHOTTER_VERSION
+          value: "v8.3.0"
+        - name: CSI_PROW_ENABLE_GROUP_SNAPSHOT
           value: "true"
+        - name: CSI_PROW_TESTS
+          value: "serial parallel"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
- Unify the vgs tests trigger step for both k/k and external sidecars.
- Follow up of https://github.com/kubernetes-csi/csi-release-tools/pull/283 and https://github.com/kubernetes/kubernetes/pull/134214, so it needs to merge after them.