### PR TITLE
chore: increase memory (and CPU) for CAPG apidiff job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -333,12 +333,12 @@ presubmits:
         args:
           - ./scripts/ci-apidiff.sh
         resources:
-          limits:
-            cpu: 4
-            memory: 4Gi
           requests:
-            cpu: 4
-            memory: 4Gi
+            cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-apidiff-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-10.yaml
@@ -270,12 +270,12 @@ presubmits:
         args:
           - ./scripts/ci-apidiff.sh
         resources:
-          limits:
-            cpu: 4
-            memory: 4Gi
           requests:
-            cpu: 4
-            memory: 4Gi
+            cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-apidiff-main-release-1-10

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-9.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-9.yaml
@@ -269,12 +269,12 @@ presubmits:
         args:
           - ./scripts/ci-apidiff.sh
         resources:
-          limits:
-            cpu: 4
-            memory: 4Gi
           requests:
-            cpu: 4
-            memory: 4Gi
+            cpu: 7300m
+            memory: 9Gi
+          limits:
+            cpu: 7300m
+            memory: 9Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-apidiff-main-release-1-9


### PR DESCRIPTION
We have been obviously hitting memory limits on this job recently.

This mirrors the resource settings for the CAPA apidiff job.
