### PR TITLE
create new kops scale jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1619,8 +1619,6 @@ def generate_presubmits_scale():
                 'CL2_NETWORK_PROGRAMMING_LATENCY_THRESHOLD': "20s",
                 'CL2_ENABLE_DNSTESTS': "false",
                 'CL2_USE_ADVANCED_DNSTEST': "false",
-                'SMALL_STATEFUL_SETS_PER_NAMESPACE': 0,
-                'MEDIUM_STATEFUL_SETS_PER_NAMESPACE': 0
             }
         ),
         presubmit_test(
@@ -1665,7 +1663,6 @@ def generate_presubmits_scale():
             always_run=False,
             artifacts='$(ARTIFACTS)',
             test_timeout_minutes=450,
-            use_preset_for_account_creds='preset-aws-credential-boskos-scale-001-kops',
             env={
                 'CNI_PLUGIN': "gce",
                 'KUBE_NODE_COUNT': "5000",
@@ -1674,7 +1671,8 @@ def generate_presubmits_scale():
                 'CL2_RATE_LIMIT_POD_CREATION': "false",
                 'NODE_MODE': "master",
                 'CONTROL_PLANE_COUNT': "1",
-                'CONTROL_PLANE_SIZE': "c3-standard-88",
+                'CONTROL_PLANE_SIZE': "c4-standard-96",
+                'KUBE_PROXY_MODE': 'nftables',
                 'PROMETHEUS_SCRAPE_KUBE_PROXY': "true",
                 'CL2_ENABLE_DNS_PROGRAMMING': "true",
                 'CL2_ENABLE_API_AVAILABILITY_MEASUREMENT': "true",
@@ -1687,8 +1685,7 @@ def generate_presubmits_scale():
                 'CL2_NETWORK_PROGRAMMING_LATENCY_THRESHOLD': "20s",
                 'CL2_ENABLE_DNSTESTS': "false",
                 'CL2_USE_ADVANCED_DNSTEST': "false",
-                'SMALL_STATEFUL_SETS_PER_NAMESPACE': 0,
-                'MEDIUM_STATEFUL_SETS_PER_NAMESPACE': 0
+                'BOSKOS_RESOURCE_TYPE': "scalability-scale-project",
             }
         ),
         presubmit_test(
@@ -1705,7 +1702,8 @@ def generate_presubmits_scale():
                 'KUBE_NODE_COUNT': "500",
                 'CL2_SCHEDULER_THROUGHPUT_THRESHOLD': "20",
                 'CONTROL_PLANE_COUNT': "1",
-                'CONTROL_PLANE_SIZE': "c3-standard-88",
+                'KUBE_PROXY_MODE': 'nftables',
+                'CONTROL_PLANE_SIZE': "c4-standard-48",
                 'CL2_LOAD_TEST_THROUGHPUT': "50",
                 'CL2_DELETE_TEST_THROUGHPUT': "50",
                 'CL2_RATE_LIMIT_POD_CREATION': "false",
@@ -1718,6 +1716,7 @@ def generate_presubmits_scale():
                 'ENABLE_PROMETHEUS_SERVER': "true",
                 'PROMETHEUS_PVC_STORAGE_CLASS': "ssd-csi",
                 'CL2_NETWORK_LATENCY_THRESHOLD': "0.5s",
+                'BOSKOS_RESOURCE_TYPE': "scalability-scale-project",
                 'CL2_ENABLE_VIOLATIONS_FOR_NETWORK_PROGRAMMING_LATENCIES': "true",
                 'CL2_NETWORK_PROGRAMMING_LATENCY_THRESHOLD': "20s"
             }

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -152,10 +152,6 @@ presubmits:
           value: "false"
         - name: CL2_USE_ADVANCED_DNSTEST
           value: "false"
-        - name: SMALL_STATEFUL_SETS_PER_NAMESPACE
-          value: "0"
-        - name: MEDIUM_STATEFUL_SETS_PER_NAMESPACE
-          value: "0"
         - name: CLOUD_PROVIDER
           value: "aws"
         - name: CLUSTER_NAME
@@ -338,7 +334,9 @@ presubmits:
         - name: CONTROL_PLANE_COUNT
           value: "1"
         - name: CONTROL_PLANE_SIZE
-          value: "c3-standard-88"
+          value: "c4-standard-96"
+        - name: KUBE_PROXY_MODE
+          value: "nftables"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
@@ -363,10 +361,8 @@ presubmits:
           value: "false"
         - name: CL2_USE_ADVANCED_DNSTEST
           value: "false"
-        - name: SMALL_STATEFUL_SETS_PER_NAMESPACE
-          value: "0"
-        - name: MEDIUM_STATEFUL_SETS_PER_NAMESPACE
-          value: "0"
+        - name: BOSKOS_RESOURCE_TYPE
+          value: "scalability-scale-project"
         - name: CLOUD_PROVIDER
           value: "gce"
         resources:
@@ -434,8 +430,10 @@ presubmits:
           value: "20"
         - name: CONTROL_PLANE_COUNT
           value: "1"
+        - name: KUBE_PROXY_MODE
+          value: "nftables"
         - name: CONTROL_PLANE_SIZE
-          value: "c3-standard-88"
+          value: "c4-standard-48"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT
@@ -460,6 +458,8 @@ presubmits:
           value: "ssd-csi"
         - name: CL2_NETWORK_LATENCY_THRESHOLD
           value: "0.5s"
+        - name: BOSKOS_RESOURCE_TYPE
+          value: "scalability-scale-project"
         - name: CL2_ENABLE_VIOLATIONS_FOR_NETWORK_PROGRAMMING_LATENCIES
           value: "true"
         - name: CL2_NETWORK_PROGRAMMING_LATENCY_THRESHOLD

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-gce.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-gce.yaml
@@ -1,0 +1,406 @@
+periodics:
+- name: ci-kubernetes-e2e-kops-gce-100-ipalias-using-cl2
+  tags:
+  - "perfDashPrefix: kops-gcp-100Nodes"
+  - "perfDashBuildsCount: 270"
+  - "perfDashJobType: performance"
+  cluster: k8s-infra-prow-build
+  interval: 3h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 480m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    path_alias: k8s.io/kops
+    workdir: true
+  annotations:
+    test.kops.k8s.io/cloud: gce
+    test.kops.k8s.io/distro: u2404
+    test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/networking: ipalias
+    testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-gce
+    testgrid-tab-name: gce-master-scale-performance-100
+    # testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, eks-scalability@amazon.com, release-team@kubernetes.io
+  spec:
+    serviceAccountName: prow-build
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250925-95b5a2c7a5-master
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - ./tests/e2e/scenarios/scalability/run-test.sh
+      securityContext:
+        privileged: true
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/ssh-key-secret/ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      - name: GOPATH
+        value: /home/prow/go
+      - name: ARTIFACTS
+        value: $(ARTIFACTS)
+      - name: CNI_PLUGIN
+        value: gce
+      - name: KUBE_NODE_COUNT
+        value: "100"
+      - name: CL2_LOAD_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_DELETE_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_RATE_LIMIT_POD_CREATION
+        value: "false"
+      - name: NODE_MODE
+        value: "master"
+      - name: KUBE_PROXY_MODE
+        value: "nftables"
+      - name: CONTROL_PLANE_COUNT
+        value: "1"
+      - name: CONTROL_PLANE_SIZE
+        value: "c4-standard-48"
+      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+        value: "true"
+      - name: CL2_ENABLE_DNS_PROGRAMMING
+        value: "true"
+      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+        value: "true"
+      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+        value: "99.5"
+      - name: CL2_ALLOWED_SLOW_API_CALLS
+        value: "1"
+      - name: ENABLE_PROMETHEUS_SERVER
+        value: "true"
+      - name: PROMETHEUS_PVC_STORAGE_CLASS
+        value: "ssd-csi"
+      - name: CLOUD_PROVIDER
+        value: "gce"
+      - name: BOSKOS_RESOURCE_TYPE
+        value: "scalability-project"
+      resources:
+        requests:
+          cpu: "7"
+          memory: "28Gi"
+        limits:
+          cpu: "7"
+          memory: "28Gi"
+
+- name: ci-kubernetes-e2e-kops-gce-3000-ipalias-using-cl2
+  tags:
+  - "perfDashPrefix: gcp-3000Nodes"
+  - "perfDashBuildsCount: 270"
+  - "perfDashJobType: performance"
+  cluster: k8s-infra-prow-build
+  cron: '0 2,14 * * *' # Run twice a day at 02:00 and 14:00 UTC
+  labels:
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 480m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    path_alias: k8s.io/kops
+    workdir: true
+  annotations:
+    test.kops.k8s.io/cloud: gce
+    test.kops.k8s.io/distro: u2404
+    test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/networking: ipalias
+    testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-gce
+    testgrid-tab-name: gce-master-scale-performance-3000
+    # testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, eks-scalability@amazon.com, release-team@kubernetes.io
+  spec:
+    serviceAccountName: prow-build
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250925-95b5a2c7a5-master
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - ./tests/e2e/scenarios/scalability/run-test.sh
+      securityContext:
+        privileged: true
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/ssh-key-secret/ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      - name: GOPATH
+        value: /home/prow/go
+      - name: ARTIFACTS
+        value: $(ARTIFACTS)
+      - name: CNI_PLUGIN
+        value: gce
+      - name: KUBE_NODE_COUNT
+        value: "3000"
+      - name: KUBE_PROXY_MODE
+        value: "nftables"
+      - name: CL2_LOAD_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_DELETE_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_RATE_LIMIT_POD_CREATION
+        value: "false"
+      - name: NODE_MODE
+        value: "master"
+      - name: CONTROL_PLANE_COUNT
+        value: "1"
+      - name: CONTROL_PLANE_SIZE
+        value: "c4-standard-96"
+      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+        value: "true"
+      - name: CL2_ENABLE_DNS_PROGRAMMING
+        value: "true"
+      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+        value: "true"
+      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+        value: "99.5"
+      - name: CL2_ALLOWED_SLOW_API_CALLS
+        value: "1"
+      - name: ENABLE_PROMETHEUS_SERVER
+        value: "true"
+      - name: PROMETHEUS_PVC_STORAGE_CLASS
+        value: "ssd-csi"
+      - name: CLOUD_PROVIDER
+        value: "gce"
+      - name: GCP_PROJECT
+        value: "k8s-infra-e2e-boskos-scale-28"
+      # - name: BOSKOS_RESOURCE_TYPE
+      #   value: "scalability-scale-project"
+      resources:
+        requests:
+          cpu: "7"
+          memory: "28Gi"
+        limits:
+          cpu: "7"
+          memory: "28Gi"
+
+- name: ci-kubernetes-e2e-kops-gce-4000-ipalias-using-cl2
+  tags:
+  - "perfDashPrefix: gcp-4000Nodes"
+  - "perfDashBuildsCount: 270"
+  - "perfDashJobType: performance"
+  cluster: k8s-infra-prow-build
+  cron: '0 6,18 * * *' # Run twice a day at 06:00 and 18:00 UTC
+  labels:
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 480m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    path_alias: k8s.io/kops
+    workdir: true
+  annotations:
+    test.kops.k8s.io/cloud: gce
+    test.kops.k8s.io/distro: u2404
+    test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/networking: ipalias
+    testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-gce
+    testgrid-tab-name: gce-master-scale-performance-4000
+    # testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, eks-scalability@amazon.com, release-team@kubernetes.io
+  spec:
+    serviceAccountName: prow-build
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250925-95b5a2c7a5-master
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - ./tests/e2e/scenarios/scalability/run-test.sh
+      securityContext:
+        privileged: true
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/ssh-key-secret/ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      - name: GOPATH
+        value: /home/prow/go
+      - name: ARTIFACTS
+        value: $(ARTIFACTS)
+      - name: CNI_PLUGIN
+        value: gce
+      - name: KUBE_NODE_COUNT
+        value: "4000"
+      - name: CL2_LOAD_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_DELETE_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_RATE_LIMIT_POD_CREATION
+        value: "false"
+      - name: NODE_MODE
+        value: "master"
+      - name: KUBE_PROXY_MODE
+        value: "nftables"
+      - name: CONTROL_PLANE_COUNT
+        value: "1"
+      - name: CONTROL_PLANE_SIZE
+        value: "c4-standard-96"
+      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+        value: "true"
+      - name: CL2_ENABLE_DNS_PROGRAMMING
+        value: "true"
+      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+        value: "true"
+      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+        value: "99.5"
+      - name: CL2_ALLOWED_SLOW_API_CALLS
+        value: "1"
+      - name: ENABLE_PROMETHEUS_SERVER
+        value: "true"
+      - name: PROMETHEUS_PVC_STORAGE_CLASS
+        value: "ssd-csi"
+      - name: CLOUD_PROVIDER
+        value: "gce"
+      - name: GCP_PROJECT
+        value: "k8s-infra-e2e-boskos-scale-29"
+      # - name: BOSKOS_RESOURCE_TYPE
+      #   value: "scalability-scale-project"
+      resources:
+        requests:
+          cpu: "7"
+          memory: "28Gi"
+        limits:
+          cpu: "7"
+          memory: "28Gi"
+
+- name: ci-kubernetes-e2e-kops-gce-5000-ipalias-using-cl2
+  tags:
+  - "perfDashPrefix: kops-gcp-5000Nodes"
+  - "perfDashBuildsCount: 270"
+  - "perfDashJobType: performance"
+  cluster: k8s-infra-prow-build
+  cron: '0 10,22 * * *' # Run twice a day at 10:00 and 22:00 UTC
+  labels:
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 480m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    path_alias: k8s.io/kops
+    workdir: true
+  annotations:
+    test.kops.k8s.io/cloud: gce
+    test.kops.k8s.io/distro: u2404
+    test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/networking: ipalias
+    testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-gce
+    testgrid-tab-name: gce-master-scale-performance-5000
+    # testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, eks-scalability@amazon.com, release-team@kubernetes.io
+  spec:
+    serviceAccountName: prow-build
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250925-95b5a2c7a5-master
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - ./tests/e2e/scenarios/scalability/run-test.sh
+      securityContext:
+        privileged: true
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/ssh-key-secret/ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      - name: GOPATH
+        value: /home/prow/go
+      - name: ARTIFACTS
+        value: $(ARTIFACTS)
+      - name: CNI_PLUGIN
+        value: gce
+      - name: KUBE_NODE_COUNT
+        value: "5000"
+      - name: CL2_LOAD_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_DELETE_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_RATE_LIMIT_POD_CREATION
+        value: "false"
+      - name: NODE_MODE
+        value: "master"
+      - name: CONTROL_PLANE_COUNT
+        value: "1"
+      - name: CONTROL_PLANE_SIZE
+        value: "c4-standard-96"
+      - name: KUBE_PROXY_MODE
+        value: "nftables"
+      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+        value: "true"
+      - name: CL2_ENABLE_DNS_PROGRAMMING
+        value: "true"
+      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+        value: "true"
+      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+        value: "99.5"
+      - name: CL2_ALLOWED_SLOW_API_CALLS
+        value: "1"
+      - name: ENABLE_PROMETHEUS_SERVER
+        value: "true"
+      - name: PROMETHEUS_PVC_STORAGE_CLASS
+        value: "ssd-csi"
+      - name: CLOUD_PROVIDER
+        value: "gce"
+      - name: GCP_PROJECT
+        value: "k8s-infra-e2e-boskos-scale-30"
+      # - name: BOSKOS_RESOURCE_TYPE
+      #   value: "scalability-scale-project"
+      resources:
+        requests:
+          cpu: "7"
+          memory: "28Gi"
+        limits:
+          cpu: "7"
+          memory: "28Gi"


### PR DESCRIPTION
We'll spend the rest of the year getting these new scale jobs green so they can eventually replace the gce kubeup scale tests.

The 3000/4000/5000 jobs will run in the k8s-infra-e2e-boskos-scale-28|39|30 projects to catch all quota errors and they will be added to main 5k boskos pool.

