### PR TITLE
LWS: update go version to 1.25

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -41,7 +41,7 @@ presubmits:
       description: "Run lws integration tests"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         command:
         - make
         args:
@@ -221,7 +221,7 @@ presubmits:
       description: "Run lws verify checks"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         command:
         - make
         args:


### PR DESCRIPTION
LWS: update go version to 1.25

Related: 

- https://github.com/kubernetes-sigs/lws/issues/677
- https://github.com/kubernetes-sigs/lws/pull/678