### PR TITLE
Update plugins.yaml for k/website 1.35 milestone applier for dev-1.35 branch

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -597,7 +597,7 @@ milestone_applier:
   kubernetes-sigs/boskos:
     master: v1.23
   kubernetes/website:
-    dev-1.34: 1.34
+    dev-1.35: 1.35
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
Add 1.35 milestone applier configuration for the k/website dev-1.35 branch
/cc @kubernetes/sig-docs-leads