### PR TITLE
capz: remove WINDOWS and TEST_WINDOWS env vars

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -741,11 +741,6 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        env:
-          - name: TEST_WINDOWS
-            value: "" # disabled
-          - name: WINDOWS_SERVER_VERSION
-            value: "windows-2022"
         resources:
           limits:
             cpu: 4
@@ -920,8 +915,6 @@ presubmits:
           # CAPZ variables
         - name: TEST_K8S
           value: "true"
-        - name: WINDOWS
-          value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-load.yaml"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
@@ -932,8 +925,6 @@ presubmits:
           value: "Standard_D8s_v3"
         - name: NODE_MACHINE_TYPE
           value: "Standard_D8s_v3"
-        - name: TEST_WINDOWS
-          value: "false"
         - name: "CONTROL_PLANE_MACHINE_COUNT"
           value: "5"
         - name: WINDOWS_WORKER_MACHINE_COUNT
@@ -1026,8 +1017,6 @@ presubmits:
         # CAPZ variables
         - name: TEST_K8S
           value: "true"
-        - name: WINDOWS
-          value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-load-dra.yaml"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
@@ -1038,8 +1027,6 @@ presubmits:
           value: "Standard_D8s_v3"
         - name: NODE_MACHINE_TYPE
           value: "Standard_D8s_v3"
-        - name: TEST_WINDOWS
-          value: "false"
         # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy
         - name: DEPLOY_AZURE_CSI_DRIVER
           value: "false"
@@ -1129,8 +1116,6 @@ presubmits:
           # CAPZ variables
         - name: TEST_K8S
           value: "true"
-        - name: WINDOWS
-          value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-load.yaml"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
@@ -1141,8 +1126,6 @@ presubmits:
           value: "Standard_D8s_v3"
         - name: NODE_MACHINE_TYPE
           value: "Standard_D8s_v3"
-        - name: TEST_WINDOWS
-          value: "false"
         - name: "CONTROL_PLANE_MACHINE_COUNT"
           value: "5"
         - name: WINDOWS_WORKER_MACHINE_COUNT

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -389,11 +389,6 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        env:
-          - name: TEST_WINDOWS
-            value: "" # disabled
-          - name: WINDOWS_SERVER_VERSION
-            value: "windows-2022"
         resources:
           limits:
             cpu: 6

--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -58,8 +58,6 @@ periodics:
         # CAPZ variables
         - name: TEST_K8S
           value: "true"
-        - name: WINDOWS
-          value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
@@ -70,8 +68,6 @@ periodics:
           value: "Standard_D8s_v3"
         - name: NODE_MACHINE_TYPE
           value: "Standard_D8s_v3"
-        - name: TEST_WINDOWS
-          value: "false"
         - name: MONITORING_MACHINE_COUNT # This is the number of dedicated nodes for prometheus server
           value: "1" # We use the same VM size as control plane nodes, see CONTROL_PLANE_MACHINE_TYPE
         - name: AZURE_LOCATION
@@ -180,8 +176,6 @@ periodics:
             # CAPZ variables
             - name: TEST_K8S
               value: "true"
-            - name: WINDOWS
-              value: "false"
             - name: CLUSTER_TEMPLATE
               value: "templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml"
             - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
@@ -192,8 +186,6 @@ periodics:
               value: "Standard_D8s_v3"
             - name: NODE_MACHINE_TYPE
               value: "Standard_D8s_v3"
-            - name: TEST_WINDOWS
-              value: "false"
             - name: MONITORING_MACHINE_COUNT # This is the number of dedicated nodes for prometheus server
               value: "1" # We use the same VM size as control plane nodes, see CONTROL_PLANE_MACHINE_TYPE
             - name: AZURE_LOCATION

--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-presubmit-dra-capz.yaml
@@ -58,8 +58,6 @@ presubmits:
         # CAPZ variables
         - name: TEST_K8S
           value: "true"
-        - name: WINDOWS
-          value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
@@ -70,8 +68,6 @@ presubmits:
           value: "Standard_D8s_v3"
         - name: NODE_MACHINE_TYPE
           value: "Standard_D8s_v3"
-        - name: TEST_WINDOWS
-          value: "false"
         - name: MONITORING_MACHINE_COUNT # This is the number of dedicated nodes for prometheus server
           value: "1" # We use the same VM size as control plane nodes, see CONTROL_PLANE_MACHINE_TYPE
         # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy
@@ -169,8 +165,6 @@ presubmits:
         # CAPZ variables
         - name: TEST_K8S
           value: "true"
-        - name: WINDOWS
-          value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
@@ -181,8 +175,6 @@ presubmits:
           value: "Standard_D8s_v3"
         - name: NODE_MACHINE_TYPE
           value: "Standard_D8s_v3"
-        - name: TEST_WINDOWS
-          value: "false"
         - name: MONITORING_MACHINE_COUNT # This is the number of dedicated nodes for prometheus server
           value: "1" # We use the same VM size as control plane nodes, see CONTROL_PLANE_MACHINE_TYPE
         # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy
@@ -286,8 +278,6 @@ presubmits:
         # CAPZ variables
         - name: TEST_K8S
           value: "true"
-        - name: WINDOWS
-          value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
@@ -298,8 +288,6 @@ presubmits:
           value: "Standard_D2s_v3"
         - name: NODE_MACHINE_TYPE
           value: "Standard_D2s_v3"
-        - name: TEST_WINDOWS
-          value: "false"
         - name: MONITORING_MACHINE_COUNT # This is the number of dedicated nodes for prometheus server
           value: "1" # We use the same VM size as control plane nodes, see CONTROL_PLANE_MACHINE_TYPE
         # Don't install Azure disk CSI driver as it's installed using a HelmChartProxy

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
@@ -61,8 +61,6 @@ periodics:
         # CAPZ variables
         - name: TEST_K8S
           value: "true"
-        - name: WINDOWS
-          value: "false"
         - name: CLUSTER_TEMPLATE
           value: "templates/test/dev/cluster-template-custom-builds-load.yaml"
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
@@ -73,8 +71,6 @@ periodics:
           value: "Standard_D8s_v3"
         - name: NODE_MACHINE_TYPE
           value: "Standard_D8s_v3"
-        - name: TEST_WINDOWS
-          value: "false"
         - name: "CONTROL_PLANE_MACHINE_COUNT"
           value: "5"
         - name: WINDOWS_WORKER_MACHINE_COUNT


### PR DESCRIPTION
When not requiring Windows infra for tests in CAPZ, you don't have to explicitly set any configuration. This simplifies the jobs so that explicit usages like `WINDOWS=false` or `TEST_WINDOWS=false` are removed.