### PR TITLE
Revert "Ensure ppc64le integration jobs run on SMT-4 Nodes"

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -103,8 +103,6 @@ periodics:
           requests:
             cpu: 4
             memory: 20Gi
-      nodeSelector:
-        feature.node.kubernetes.io/ppc64le.smtlevel: "4"
 
   - name: ci-kubernetes-integration-1-33-ppc64le
     interval: 6h # bump to 24h after initial debugging
@@ -139,8 +137,7 @@ periodics:
           requests:
             cpu: 4
             memory: 20Gi
-      nodeSelector:
-        feature.node.kubernetes.io/ppc64le.smtlevel: "4"
+
 
   - name: ci-kubernetes-ppc64le-conformance-latest-kubetest2
     interval: 3h

--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/kubernetes-ppc64le-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/kubernetes-ppc64le-presubmits.yaml
@@ -25,5 +25,3 @@ presubmits:
           requests:
             cpu: 4
             memory: 20Gi
-      nodeSelector:
-        feature.node.kubernetes.io/ppc64le.smtlevel: "4"


### PR DESCRIPTION
Reverts kubernetes/test-infra#35665

All nodes in the cluster now run SMT4 configuration.
We do not need an explicit node-selector