### PR TITLE
switch to use cgroup v2 for ubuntu images

### DIFF
--- a/jobs/e2e_node/containerd/containerd-main/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/image-config.yaml
@@ -2,6 +2,9 @@ images:
   ubuntu:
     image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env"
   cos:
     image_family: cos-125-lts # keep as close to the COS version that has containerd version closest to the main branch as possible

--- a/jobs/e2e_node/containerd/containerd-release-1.7/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.7/image-config.yaml
@@ -1,7 +1,10 @@
 images:
   ubuntu:
-    image: ubuntu-gke-2204-1-24-v20220623
+    image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-1.7/env"
   cos:
     image_family: cos-117-lts # Use cos-117-lts to lock down what COS version is used with containerd 1.7, which aligns with COS's built-in containerd version

--- a/jobs/e2e_node/containerd/containerd-release-2.0/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-2.0/image-config.yaml
@@ -1,7 +1,10 @@
 images:
   ubuntu:
-    image: ubuntu-gke-2204-1-24-v20220623
+    image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.0/env"
   cos:
     image_family: cos-121-lts # Use cos-121-lts to lock down what COS version is used with containerd 2.0, which aligns with COS's built-in containerd version

--- a/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
@@ -1,7 +1,10 @@
 images:
   ubuntu:
-    image: ubuntu-gke-2204-1-24-v20220623
+    image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/env"
   cos:
     image_family: cos-125-lts # Use cos-125-lts to lock down what COS version is used with containerd 2.1, which aligns with COS's built-in containerd version

--- a/jobs/e2e_node/containerd/image-config-serial-hugepages.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-hugepages.yaml
@@ -5,6 +5,9 @@ images:
   ubuntu:
     image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/ubuntu-init-hugepages-1G-allocation.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
     # Using `e2-standard-2` to have enough memory for 1Gb huge pages allocation
     machine: e2-standard-2

--- a/jobs/e2e_node/containerd/image-config.yaml
+++ b/jobs/e2e_node/containerd/image-config.yaml
@@ -2,6 +2,9 @@ images:
   ubuntu:
     image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
   cos:
     image_family: cos-125-lts

--- a/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+++ b/jobs/e2e_node/image-config-serial-cpu-manager.yaml
@@ -3,8 +3,11 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-2204-1-24-v20220623
+    image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     # Using `e2-standard-4` to enable CPU manager node e2e tests.
     machine: e2-standard-4
   cos:

--- a/jobs/e2e_node/image-config-serial-hugepages.yaml
+++ b/jobs/e2e_node/image-config-serial-hugepages.yaml
@@ -3,8 +3,11 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-2204-1-24-v20220623
+    image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/ubuntu-hugepages-1G-allocation.yaml"
     # Using `e2-standard-2` to have enough memory for 1Gb huge pages allocation
     machine: e2-standard-2

--- a/jobs/e2e_node/image-config-serial.yaml
+++ b/jobs/e2e_node/image-config-serial.yaml
@@ -3,9 +3,12 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-2204-1-24-v20220623
-    machine: e2-standard-2 # These tests need a lot of memory
+    image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
+    machine: e2-standard-2 # These tests need a lot of memory
   cos:
     image_family: cos-125-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
     project: cos-cloud


### PR DESCRIPTION
Fix #https://github.com/kubernetes/kubernetes/issues/134616

Ubuntu should use cgroup v2 nodes.

We did not intend for these to test cgroup v1. Updating the configs to pick a cgroup v2 node.