### PR TITLE
update Bump go version 1.25.3 for kubekins-e2e/kubekins-e2e-v2/krte

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,12 +1,12 @@
 variants:
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.25.1
+    GO_VERSION: 1.25.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   master:
     CONFIG: master
-    GO_VERSION: 1.25.1
+    GO_VERSION: 1.25.3
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   '1.34':


### PR DESCRIPTION
xref: https://github.com/kubernetes/release/issues/4159


/assign @dims @saschagrunert @Verolop 
cc @kubernetes/release-managers 