### PR TITLE
Move the exploratory resource size test by 12 hours to avoid conflict with ci-kubernetes-e2e-gce-scale-correctness

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1168,7 +1168,7 @@ periodics:
           memory: "8Gi"
 
 # Exploratory tests for resource size limit as proposed in https://github.com/kubernetes/kubernetes/issues/134375
-- cron: '1 17 2-31/2 * *' # Run on even days at 9:01PST (17:01 UTC)
+- cron: '1 5 2-31/2 * *' # Run on even days at 5:01 UTC
   name: ci-kubernetes-e2e-gce-scale-resource-size
   tags:
   - "perfDashPrefix: gce-5000Nodes-ResourceSize"


### PR DESCRIPTION
Got failure `Something went wrong: failed to prepare test environment: --provider=gce boskos failed to acquire project: resources not found` in https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/1978869040168308736

:( 
/assign @wojtek-t @mborsz 