### PR TITLE
capz: explicit TEST_WINDOWS=true for Windows test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -187,6 +187,8 @@ presubmits:
             value: \[WINDOWS\]
           - name: GINKGO_SKIP
             value: ""
+          - name: TEST_WINDOWS
+            value: "true"
         resources:
           limits:
             cpu: 4

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -205,6 +205,8 @@ presubmits:
             value: \[WINDOWS\]
           - name: GINKGO_SKIP
             value: ""
+          - name: TEST_WINDOWS
+            value: "true"
         resources:
           limits:
             cpu: 6


### PR DESCRIPTION
This PR pairs with https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5906 to ensure that we grab the right Kubernetes version when building a CAPZ cluster that will include Windows nodes.