### PR TITLE
Use cgroup v2 for ubuntu by default.

### DIFF
--- a/jobs/e2e_node/arm/image-config-serial.yaml
+++ b/jobs/e2e_node/arm/image-config-serial.yaml
@@ -7,4 +7,7 @@ images:
     machine: t2a-standard-2 # These tests need a lot of memory
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
 

--- a/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
@@ -2,6 +2,9 @@ images:
   ubuntu:
     image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     machine: e2-standard-16  # node performance tests will be skipped on smaller machines
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env"
   cos:

--- a/jobs/e2e_node/containerd/image-cadvisor.yaml
+++ b/jobs/e2e_node/containerd/image-cadvisor.yaml
@@ -2,6 +2,9 @@ images:
   ubuntu:
     image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
   cos:
     image_family: cos-125-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml

--- a/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+++ b/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
@@ -2,6 +2,9 @@ images:
   ubuntu:
     image_family: pipeline-1-29
     project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/init-containerd-1.7.yaml"
   cos:
     image_family: cos-117-lts # Use cos-117-lts to lock down what COS version is used with containerd 1.7 - it alignes with COS's built-in containerd version


### PR DESCRIPTION
Looking at test grid I am seeing a few failures on cgroup v1. These jobs do not need to use cgroup v1.

Used code claude for this.