### PR TITLE
use T4 GPUs for testing gpu device-plugin drivers

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -7,7 +7,7 @@ presets:
   - name: CREATE_CUSTOM_NETWORK
     value: "true"
   - name: NODE_SIZE
-    value: e2-standard-2
+    value: n1-standard-2
 
 presubmits:
   kubernetes/kubernetes:
@@ -41,12 +41,12 @@ presubmits:
         - --build
         - --up
         - --down
-        - --node-size=g2-standard-24
+        - --node-size=n1-standard-2
         - --num-nodes=2
         - --gcp-zone=us-east1-b
         - --env=KUBE_CLUSTER_INITIALIZATION_TIMEOUT=900
         - --boskos-resource-type=gpu-project
-        - --node-accelerators=type=nvidia-l4,count=2
+        - --node-accelerators=type=nvidia-tesla-t4,count=2
         - --test=ginkgo
         - --
         - --provider=gce

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -43,11 +43,11 @@ periodics:
       - --legacy-mode
       - --up
       - --down
-      - --node-size=g2-standard-24
+      - --node-size=n1-standard-2
       - --num-nodes=2
       - --gcp-zone=us-east1-b
       - --boskos-resource-type=gpu-project
-      - --node-accelerators=type=nvidia-l4,count=2
+      - --node-accelerators=type=nvidia-tesla-t4,count=2
       - --env=KUBE_CLUSTER_INITIALIZATION_TIMEOUT=900
       - --kubernetes-version=https://dl.k8s.io/ci/latest.txt
       - --test=ginkgo


### PR DESCRIPTION
L4 GPUs aren't as readily available in us-east1-b, so the jobs are being set back to use T4 GPUs.

@adilGhaffarDev 

