### PR TITLE
kro-push-images: set build-dir

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kro.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kro.yaml
@@ -21,4 +21,5 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-images-gcb
               - --env-passthrough=PULL_BASE_REF
               - --with-git-dir
+              - --build-dir=.
               - dev/ci/builds/push-images/


### PR DESCRIPTION
We want to build from the root, but cloudbuild.yaml is in a subdir.
