### PR TITLE
update Bump go version 1.24.9 for kubekins-e2e/kubekins-e2e-v2/krte

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -11,21 +11,21 @@ variants:
     BAZEL_VERSION: 3.4.1
   '1.34':
     CONFIG: '1.34'
-    GO_VERSION: 1.24.7
+    GO_VERSION: 1.24.9
     K8S_RELEASE: latest-1.34
     BAZEL_VERSION: 3.4.1
   '1.33':
     CONFIG: '1.33'
-    GO_VERSION: 1.24.7
+    GO_VERSION: 1.24.9
     K8S_RELEASE: latest-1.33
     BAZEL_VERSION: 3.4.1
   '1.32':
     CONFIG: '1.32'
-    GO_VERSION: 1.23.12
+    GO_VERSION: 1.24.9
     K8S_RELEASE: latest-1.32
     BAZEL_VERSION: 3.4.1
   '1.31':
     CONFIG: '1.31'
-    GO_VERSION: 1.23.12
+    GO_VERSION: 1.24.9
     K8S_RELEASE: latest-1.31
     BAZEL_VERSION: 3.4.1


### PR DESCRIPTION
xref: https://github.com/kubernetes/release/issues/4159


/assign @dims @saschagrunert @Verolop 
cc @kubernetes/release-managers 