### PR TITLE
Stop requesting reviewers for kubernetes-sigs/headlamp repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -375,6 +375,8 @@ blockades:
 blunderbuss:
   max_request_count: 2
   use_status_availability: true
+  ignore_repos:
+  - kubernetes-sigs/headlamp
 
 cat:
   key_path: /etc/cat-api/api-key


### PR DESCRIPTION
The bot is overloading our contributors github notifications.
For many PRs all of our reviewers are added.

cc @joaquimrocha 