### PR TITLE
azuredisk-csi-driver: 1.34.0 for e2e-capz test

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -536,7 +536,7 @@ presubmits:
         workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.33
+        base_ref: release-1.34
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
     spec:
@@ -571,7 +571,7 @@ presubmits:
             - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
             - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.33.2"
+              value: "v1.34.0"
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
       testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz


### PR DESCRIPTION
This PR reverts this change:

- https://github.com/kubernetes/test-infra/pull/35675

This update to test templates + config in CAPZ should enable this to work, as we are no longer building a Windows node pool when you don't explicitly pass `TEST_WINDOWS="true"`:

- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5923