### PR TITLE
chore(cluster-capacity): update presubmits for 1.34 release

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.34.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.34.yaml
@@ -1,17 +1,17 @@
 # sigs.k8s.io/cluster-capacity presubmits
 presubmits:
   kubernetes-sigs/cluster-capacity:
-  - name: pull-cluster-capacity-verify-gofmt-release-1-30
+  - name: pull-cluster-capacity-verify-gofmt-release-1-34
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.30$
+    - ^release-1.34$
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22.3
+      - image: public.ecr.aws/docker/library/golang:1.24.6
         command:
         - make
         args:
@@ -23,17 +23,17 @@ presubmits:
           limits:
             cpu: 2
             memory: 4Gi
-  - name: pull-cluster-capacity-verify-build-release-1-30
+  - name: pull-cluster-capacity-verify-build-release-1-34
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.30$
+    - ^release-1.34$
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22.3
+      - image: public.ecr.aws/docker/library/golang:1.24.6
         command:
         - make
         args:
@@ -45,17 +45,17 @@ presubmits:
           limits:
             cpu: 2
             memory: 4Gi
-  - name: pull-cluster-capacity-unit-test-release-1-30
+  - name: pull-cluster-capacity-unit-test-release-1-34
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
     branches:
     # The script this job runs is not in all branches.
-    - ^release-1.30$
+    - ^release-1.34$
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.22.3
+      - image: public.ecr.aws/docker/library/golang:1.24.6
         command:
         - make
         args:
@@ -67,11 +67,11 @@ presubmits:
           limits:
             cpu: 2
             memory: 4Gi
-  - name: pull-cluster-capacity-test-e2e-k8s-release-1-30-1-30
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-34-1-34
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.30-1.30
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.34-1.34
     decorate: true
     decoration_config:
       timeout: 20m
@@ -81,7 +81,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.30
+    - release-1.34
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
@@ -90,7 +90,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.30.4"
+          value: "v1.34.0"
         - name: KIND_E2E
           value: "true"
         args:
@@ -106,11 +106,11 @@ presubmits:
           limits:
             cpu: 2
             memory: 4Gi
-  - name: pull-cluster-capacity-test-e2e-k8s-release-1-30-1-29
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-34-1-33
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.30-1.29
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.34-1.33
     decorate: true
     decoration_config:
       timeout: 20m
@@ -120,7 +120,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.30
+    - release-1.34
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
@@ -129,7 +129,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.29.8"
+          value: "v1.33.0"
         - name: KIND_E2E
           value: "true"
         args:
@@ -145,11 +145,11 @@ presubmits:
           limits:
             cpu: 2
             memory: 4Gi
-  - name: pull-cluster-capacity-test-e2e-k8s-release-1-30-1-28
+  - name: pull-cluster-capacity-test-e2e-k8s-release-1-34-1-32
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.30-1.28
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.34-1.32
     decorate: true
     decoration_config:
       timeout: 20m
@@ -159,7 +159,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     branches:
-    - release-1.30
+    - release-1.34
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
@@ -168,7 +168,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBERNETES_VERSION
-          value: "v1.28.9"
+          value: "v1.32.3"
         - name: KIND_E2E
           value: "true"
         args:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24.2
+      - image: public.ecr.aws/docker/library/golang:1.24.6
         command:
         - make
         args:
@@ -33,7 +33,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24.2
+      - image: public.ecr.aws/docker/library/golang:1.24.6
         command:
         - make
         args:
@@ -55,11 +55,50 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24.2
+      - image: public.ecr.aws/docker/library/golang:1.24.6
         command:
         - make
         args:
         - test-unit
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+          limits:
+            cpu: 2
+            memory: 4Gi
+  - name: pull-cluster-capacity-test-e2e-k8s-master-1-34
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.34
+    decorate: true
+    decoration_config:
+      timeout: 20m
+    path_alias: sigs.k8s.io/cluster-capacity
+    always_run: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        env:
+        - name: KUBERNETES_VERSION
+          value: "v1.34.0"
+        - name: KIND_E2E
+          value: "true"
+        args:
+        - make
+        - test-e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
         resources:
           requests:
             cpu: 2
@@ -130,45 +169,6 @@ presubmits:
         env:
         - name: KUBERNETES_VERSION
           value: "v1.32.3"
-        - name: KIND_E2E
-          value: "true"
-        args:
-        - make
-        - test-e2e
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 2
-            memory: 4Gi
-          limits:
-            cpu: 2
-            memory: 4Gi
-  - name: pull-cluster-capacity-test-e2e-k8s-master-1-31
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.31
-    decorate: true
-    decoration_config:
-      timeout: 20m
-    path_alias: sigs.k8s.io/cluster-capacity
-    always_run: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    branches:
-    - master
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        env:
-        - name: KUBERNETES_VERSION
-          value: "v1.31.6"
         - name: KIND_E2E
           value: "true"
         args:


### PR DESCRIPTION
Previous 1.33 PR: https://github.com/kubernetes/test-infra/pull/34785