### PR TITLE
ci: k8s staging push-images job for agent-sandbox

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-agent-sandbox.yaml
+++ b/config/jobs/image-pushing/k8s-staging-agent-sandbox.yaml
@@ -1,0 +1,24 @@
+postsubmits:
+  kubernetes-sigs/agent-sandbox:
+  - name: post-agent-sandbox-push-images
+    cluster: k8s-infra-prow-build-trusted
+    annotations:
+      testgrid-dashboards: sig-apps-agent-sandbox, sig-k8s-infra-gcb
+    decorate: true
+    skip_branches:
+    # do not run on dependabot branches, these exist prior to merge
+    # only merged code should trigger these jobs
+    - '^dependabot'
+    spec:
+      serviceAccountName: gcb-builder
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20250914-3092127382
+        command:
+        - /run.sh
+        args:
+        - --project=k8s-staging-images
+        - --scratch-bucket=gs://k8s-staging-images-gcb
+        - --env-passthrough=PULL_BASE_REF
+        - --build-dir=.
+        - --with-git-dir
+        - .


### PR DESCRIPTION
This change adds a postsubmit job for agent-sandbox to publish an image to k8s-staging.

https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#prow-config-template

Ref: https://github.com/kubernetes-sigs/agent-sandbox/issues/53