### PR TITLE
try to fix NPD cgroupv1 issue

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -231,6 +231,7 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
       command:
       - runner.sh
+      # TODO: we need to specify to only use cgroupv2 images, but for now allow both v1 and v2
       args:
       - bash
       - -c
@@ -244,7 +245,8 @@ periodics:
         --gcp-node-image=ubuntu
         --gcp-zone=us-central1-b
         --ginkgo-parallel=30
-        --image-family=pipeline-1-24
+        --image-family=pipeline-1-34-amd64
+        --env=KUBELET_ARGS="--fail-cgroupv1=false"
         --image-project=ubuntu-os-gke-cloud
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
@@ -278,6 +280,7 @@ periodics:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
       command:
       - runner.sh
+      # TODO: we need to specify to only use cgroupv2 images, but for now allow both v1 and v2
       args:
       - bash
       - -c
@@ -291,7 +294,8 @@ periodics:
         --gcp-node-image=ubuntu
         --gcp-zone=us-central1-b
         --ginkgo-parallel=30
-        --image-family=pipeline-1-24
+        --image-family=pipeline-1-34-amd64
+        --env=KUBELET_ARGS="--fail-cgroupv1=false"
         --image-project=ubuntu-os-gke-cloud
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -301,6 +301,7 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
         command:
         - runner.sh
+        # TODO: we need to specify to only use cgroupv2 images, but for now allow both v1 and v2
         args:
         - bash
         - -c
@@ -314,7 +315,8 @@ presubmits:
           --gcp-node-image=ubuntu
           --gcp-zone=us-central1-b
           --ginkgo-parallel=30
-          --image-family=pipeline-1-24
+          --image-family=pipeline-1-34-amd64
+          --env=KUBELET_ARGS="--fail-cgroupv1=false"
           --image-project=ubuntu-os-gke-cloud
           --test_args=--ginkgo.focus=NodeProblemDetector
           --timeout=60m
@@ -348,6 +350,7 @@ presubmits:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
         command:
         - runner.sh
+        # TODO: we need to specify to only use cgroupv2 images, but for now allow both v1 and v2
         args:
         - bash
         - -c
@@ -361,7 +364,8 @@ presubmits:
           --gcp-node-image=ubuntu
           --gcp-zone=us-central1-b
           --ginkgo-parallel=30
-          --image-family=pipeline-1-24
+          --image-family=pipeline-1-34-amd64
+          --env=KUBELET_ARGS="--fail-cgroupv1=false"
           --image-project=ubuntu-os-gke-cloud
           --test_args=--ginkgo.focus=NodeProblemDetector
           --timeout=60m


### PR DESCRIPTION
This should fix the https://github.com/kubernetes/node-problem-detector/issues/1161

Better fix will be to specify cgroupv2-only images. But there is no regex support via arguments as far as I can tell. We need to switch to node image file as a follow up