### PR TITLE
use the correct Ubuntu pipeline (latest whenever possible)

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -100,7 +100,7 @@ presubmits:
         - --gcp-node-image=ubuntu
         - --gcp-region=us-central1
         - --ginkgo-parallel=30
-        - --image-family=pipeline-1-29
+        - --image-family=pipeline-1-34-amd64
         - --image-project=ubuntu-os-gke-cloud
         - --provider=gce
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -462,7 +462,7 @@ periodics:
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
-      - --image-family=pipeline-1-29
+      - --image-family=pipeline-1-34-amd64
       - --image-project=ubuntu-os-gke-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Feature:RuntimeHandler\] --minStartupPods=8

--- a/jobs/e2e_node/arm/image-config-serial.yaml
+++ b/jobs/e2e_node/arm/image-config-serial.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: pipeline-1-29-arm64
+    image_family: pipeline-1-34-amd64
     machine: t2a-standard-2 # These tests need a lot of memory
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
     project: ubuntu-os-gke-cloud

--- a/jobs/e2e_node/containerd/containerd-main/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/containerd/containerd-release-1.7/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.7/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-32-amd64 # Use pipeline-1-32-amd64 to lock down what Ubuntu version is used with containerd 1.7, which aligns with Ubuntu's built-in containerd version
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/containerd/containerd-release-2.0/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-2.0/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-33-amd64 # Use pipeline-1-33-amd64 to lock down what Ubuntu version is used with containerd 2.0, which aligns with Ubuntu's built-in containerd version
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64 # Use pipeline-1-34-amd64 to lock down what Ubuntu version is used with containerd 2.1, which aligns with Ubuntu's built-in containerd version
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/containerd/image-cadvisor.yaml
+++ b/jobs/e2e_node/containerd/image-cadvisor.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/containerd/image-config-serial-hugepages.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-hugepages.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/containerd/image-config-serial.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/containerd/image-config-systemd.yaml
+++ b/jobs/e2e_node/containerd/image-config-systemd.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/containerd/image-config.yaml
+++ b/jobs/e2e_node/containerd/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+++ b/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-32-amd64 # Use pipeline-1-32-amd64 to lock down what Ubuntu version is used with containerd 1.7, which aligns with Ubuntu's built-in containerd version
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+++ b/jobs/e2e_node/image-config-serial-cpu-manager.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/image-config-serial-hugepages.yaml
+++ b/jobs/e2e_node/image-config-serial-hugepages.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/image-config-serial.yaml
+++ b/jobs/e2e_node/image-config-serial.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix

--- a/jobs/e2e_node/swap/image-config-swap.yaml
+++ b/jobs/e2e_node/swap/image-config-swap.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: pipeline-1-29
+    image_family: pipeline-1-34-amd64
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix


### PR DESCRIPTION
/sig node

Aligning the Ubuntu releases with k8s releases we test on them