### PR TITLE
CAPZ: upgrade test should be required if run

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -683,7 +683,7 @@ presubmits:
       preset-azure-community: "true"
     decorate: true
     run_if_changed: 'go.mod|templates\/test|^scripts\/|test\/e2e|Makefile'
-    optional: true
+    optional: false
     always_run: false
     decoration_config:
       timeout: 4h


### PR DESCRIPTION
This PR updates the CAPZ upgrade presubmit test against main to be required if run. This matches the test config for the equivalent job against release branches:

- https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml#L506