### PR TITLE
revert Ubuntu image used for DRA tests run with containerd 1.7

### DIFF
--- a/jobs/e2e_node/containerd/containerd-release-1.7/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.7/image-config.yaml
@@ -1,6 +1,7 @@
 images:
   ubuntu:
-    image_family: pipeline-1-32-amd64 # Use pipeline-1-32-amd64 to lock down what Ubuntu version is used with containerd 1.7, which aligns with Ubuntu's built-in containerd version
+    #image_family: pipeline-1-32-amd64 # Use pipeline-1-32-amd64 to lock down what Ubuntu version is used with containerd 1.7, which aligns with Ubuntu's built-in containerd version
+    image_family: pipeline-1-29 # The more appropriate image family (commented above) is having issues with DRA tests: https://github.com/kubernetes/kubernetes/issues/134819
     project: ubuntu-os-gke-cloud
     # the image regex is added so that only cgroupv2 images are selected.
     # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/134819