### PR TITLE
fix failing arm test

### DIFF
--- a/jobs/e2e_node/arm/image-config-serial.yaml
+++ b/jobs/e2e_node/arm/image-config-serial.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image_family: pipeline-1-34-amd64
+    image_family: pipeline-1-34-arm64
     machine: t2a-standard-2 # These tests need a lot of memory
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config-systemd.toml"
     project: ubuntu-os-gke-cloud


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-arm64-ubuntu-serial/1981534719673634816

Digging into this,

```
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - Invalid resource usage: 'Requested boot disk architecture (X86_64) is not compatible with machine type architecture (ARM64).'.
```

We just need to revert the change made in the arm folder [here](https://github.com/kubernetes/test-infra/commit/25e451675fd45756608e15f42f4d646c2612e863#diff-b8a94d4b5bf71129ba6dab09829c3f6dc463eb74d6148f03366b2ffbda709e34).

cc @SergeyKanzhelev 