### PR TITLE
SIG testing: disable serial tests in canary

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -303,7 +303,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-testing-kind
     testgrid-tab-name: kind-master-alpha-beta-features-canary
-    description: Runs tests with no special requirements other than alpha or beta feature gates in a KinD cluster where alpha and beta feature gates and APIs are enabled. In contrast to ci-kubernetes-e2e-kind-alpha-beta-features it really runs all such tests, with flaky tests being the only exception.
+    description: Runs tests with no special requirements other than alpha or beta feature gates in a KinD cluster where alpha and beta feature gates and APIs are enabled. In contrast to ci-kubernetes-e2e-kind-alpha-beta-features it really runs all such tests, with serial and flaky tests being the only exceptions.
     testgrid-alert-email: patrick.ohly@intel.com
     testgrid-num-columns-recent: '6'
   labels:
@@ -334,7 +334,10 @@ periodics:
       - name: LABEL_FILTER
         # Full coverage. The only exception are known flaky tests
         # and deprecated features because those don't get enabled by AllAlpha/Beta.
-        value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Flaky"
+        #
+        # Serial tests get disabled temporarily to make it more comparable with ci-kubernetes-e2e-kind-alpha-beta-features
+        # (https://github.com/onsi/ginkgo/issues/1599#issuecomment-3441247598) and could be enabled again later.
+        value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Flaky && !Serial"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
Ginkgo now has support for scheduling slow tests sooner in a parallel run. To see the effect of that we need a CI job which includes slow tests. The canary job is right for that, but including serial tests affects the overall runtime too much at the moment. Let's disable them, experiment with prioritization of slow jobs, then come back to serial later.

/assign @aojea 