### PR TITLE
CRI-O: Cleanup cgroupv2 job names

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -692,7 +692,7 @@ presubmits:
             cpu: 2
             memory: 6Gi
 
-  - name: pull-kubernetes-node-e2e-crio-cgrpv2-dra-canary
+  - name: pull-kubernetes-node-e2e-crio-dra-canary
     cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+\.\d+  # per-release image
@@ -704,7 +704,7 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-cri-o
-      description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O using cgroup v2
+      description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -577,7 +577,7 @@ periodics:
             cpu: 2
             memory: 6Gi
 
-  - name: ci-node-e2e-crio-cgrpv2-dra
+  - name: ci-node-e2e-crio-dra
     cluster: k8s-infra-prow-build
     interval: 6h
     labels:
@@ -585,7 +585,7 @@ periodics:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o, sig-release-master-informing
-      description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O using cgroup v2
+      description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -705,7 +705,7 @@ presubmits:
             cpu: 2
             memory: 6Gi
 
-  - name: pull-kubernetes-node-e2e-crio-cgrpv2-dra
+  - name: pull-kubernetes-node-e2e-crio-dra
     cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+\.\d+  # per-release image
@@ -717,7 +717,7 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-cri-o
-      description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O using cgroup v2
+      description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
     decorate: true

--- a/config/jobs/kubernetes/sig-node/dra.generate.conf
+++ b/config/jobs/kubernetes/sig-node/dra.generate.conf
@@ -104,12 +104,12 @@ need_kubernetes_repo = true
 cluster = eks-prow-build-cluster
 run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*.go
 
-# This job is the same as ci-node-e2e-cgrpv1-crio-dra, but for cgroup v2
-[node-e2e-crio-cgrpv2-dra]
+# This job runs the node e2e tests for DRA with CRI-O
+[node-e2e-crio-dra]
 job_type = node
 need_kubernetes_repo = true
 need_test_infra_repo = true
-description = Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O using cgroup v2
+description = Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O
 image_config_file = /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config.yaml
 inject_ssh_public_key = true
 release_informing = true

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1251,7 +1251,7 @@ presubmits:
             env:
               - name: GOPATH
                 value: /go
-    - name: pull-kubernetes-node-crio-cgrpv2-imagefs-e2e
+    - name: pull-kubernetes-node-crio-imagefs-e2e
       cluster: k8s-infra-prow-build
       always_run: false
       optional: true
@@ -1274,7 +1274,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-cgrpv2-imagefs-e2e
+        testgrid-tab-name: pr-crio-imagefs-e2e
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
@@ -1305,9 +1305,9 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-kubernetes-node-crio-cgrpv2-userns-e2e-serial
+    - name: pull-kubernetes-node-crio-userns-e2e-serial
       cluster: k8s-infra-prow-build
-      # explicitly needs /test pull-kubernetes-node-crio-cgrpv2-userns-e2e-serial to run
+      # explicitly needs /test pull-kubernetes-node-crio-userns-e2e-serial to run
       always_run: false
       optional: true
       max_concurrency: 12
@@ -1329,7 +1329,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-cgrpv2-userns-e2e-serial
+        testgrid-tab-name: pr-crio-userns-e2e-serial
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
@@ -1358,7 +1358,7 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-kubernetes-node-crio-cgrpv2-splitfs-e2e
+    - name: pull-kubernetes-node-crio-splitfs-e2e
       cluster: k8s-infra-prow-build
       always_run: false
       optional: true
@@ -1381,7 +1381,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-cgrpv2-splitfs-e2e
+        testgrid-tab-name: pr-crio-splitfs-e2e
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
@@ -1412,9 +1412,9 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-kubernetes-node-crio-cgrpv2-evented-pleg-e2e
+    - name: pull-kubernetes-node-crio-evented-pleg-e2e
       cluster: k8s-infra-prow-build
-      # explicitly needs /test pull-kubernetes-node-crio-cgrpv2-evented-pleg-e2e to run
+      # explicitly needs /test pull-kubernetes-node-crio-evented-pleg-e2e to run
       always_run: false
       optional: true
       skip_branches:
@@ -1435,7 +1435,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-cgrpv2-evented-pleg-gce-e2e
+        testgrid-tab-name: pr-crio-evented-pleg-gce-e2e
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
@@ -1465,9 +1465,9 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-kubernetes-node-crio-cgrpv2-e2e
+    - name: pull-kubernetes-node-crio-e2e
       cluster: k8s-infra-prow-build
-      # explicitly needs /test pull-kubernetes-node-crio-cgrpv2-e2e to run
+      # explicitly needs /test pull-kubernetes-node-crio-e2e to run
       always_run: false
       # if at all it is run and fails, don't block the PR
       optional: true
@@ -1491,7 +1491,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-cgrpv2-gce-e2e
+        testgrid-tab-name: pr-crio-gce-e2e
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
@@ -1521,9 +1521,9 @@ presubmits:
               - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:PodLevelResources\]|\[Alpha\]
               - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
               - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config.yaml
-    - name: pull-kubernetes-node-crio-cgrpv2-e2e-canary
+    - name: pull-kubernetes-node-crio-e2e-canary
       cluster: k8s-infra-prow-build
-      # explicitly needs /test pull-kubernetes-node-crio-cgrpv2-e2e-canary to run
+      # explicitly needs /test pull-kubernetes-node-crio-e2e-canary to run
       always_run: false
       # if at all it is run and fails, don't block the PR
       optional: true
@@ -1547,7 +1547,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-cgrpv2-gce-e2e-canary
+        testgrid-tab-name: pr-crio-gce-e2e-canary
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
@@ -1808,9 +1808,9 @@ presubmits:
             env:
               - name: GOPATH
                 value: /go
-    - name: pull-kubernetes-crio-node-memoryqos-cgrpv2
+    - name: pull-kubernetes-crio-node-memoryqos
       cluster: k8s-infra-prow-build
-      # explicitly needs /test pull-kubernetes-crio-node-memoryqos-cgrpv2 to run
+      # explicitly needs /test pull-kubernetes-crio-node-memoryqos to run
       always_run: false
       optional: true
       max_concurrency: 12
@@ -1833,7 +1833,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-node-memoryqos-cgrpv2
+        testgrid-tab-name: pr-crio-node-memoryqos
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -229,7 +229,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-node-e2e-crio-cgrpv2-dra-1-33
+  name: ci-node-e2e-crio-dra-1-33
   spec:
     containers:
     - args:
@@ -1461,7 +1461,7 @@ presubmits:
     branches:
     - release-1.33
     cluster: k8s-infra-prow-build
-    context: pull-kubernetes-node-e2e-crio-cgrpv2-dra
+    context: pull-kubernetes-node-e2e-crio-dra
     decorate: true
     decoration_config:
       timeout: 1h30m0s
@@ -1473,7 +1473,7 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
-    name: pull-kubernetes-node-e2e-crio-cgrpv2-dra
+    name: pull-kubernetes-node-e2e-crio-dra
     optional: true
     path_alias: k8s.io/kubernetes
     spec:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -509,7 +509,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-node-e2e-crio-cgrpv2-dra-1-34
+  name: ci-node-e2e-crio-dra-1-34
   spec:
     containers:
     - args:
@@ -2271,7 +2271,7 @@ presubmits:
     branches:
     - release-1.34
     cluster: k8s-infra-prow-build
-    context: pull-kubernetes-node-e2e-crio-cgrpv2-dra
+    context: pull-kubernetes-node-e2e-crio-dra
     decorate: true
     decoration_config:
       timeout: 1h30m0s
@@ -2283,7 +2283,7 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
-    name: pull-kubernetes-node-e2e-crio-cgrpv2-dra
+    name: pull-kubernetes-node-e2e-crio-dra
     optional: true
     path_alias: k8s.io/kubernetes
     spec:


### PR DESCRIPTION
Follow-up on https://github.com/kubernetes/test-infra/pull/35757 to cleanup all cgroupv2 related namings in jobs.

cc @SergeyKanzhelev @kubernetes/sig-node-cri-o-test-maintainers 