### PR TITLE
More updates to noendpoints job, use cloud-provider-kind

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -988,6 +988,10 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: "k8s.io/test-infra"
+  - org: kubernetes-sigs
+    repo: cloud-provider-kind
+    base_ref: main
+    path_alias: sigs.k8s.io/cloud-provider-kind
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/krte:v20250925-95b5a2c7a5-master
@@ -995,12 +999,18 @@ periodics:
       - wrapper.sh
       - bash
       - -c
+      # compile cloud-provider-kind with kubernetes changes on the PR
+      - set -o errexit;
+        set -o nounset;
+        set -o pipefail;
+        set -o xtrace;
+        cd $GOPATH/src/sigs.k8s.io/cloud-provider-kind;
       - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && $GOPATH/src/k8s.io/test-infra/experiment/kind-noendpoints-e2e.sh
       env:
       - name: LABEL_FILTER
-        value: "(Conformance || sig-network ) && !EndpointsController && !EndpointSliceMirroring && !Disruptive && !Flaky"
+        value: "(Conformance || sig-network ) && !Disruptive && !Flaky"
       - name: SKIP
-        value: SCTPConnectivity
+        value: Alpha|Beta|LoadBalancer.Service.without.NodePort|IPv6|SCTPConnectivity|EndpointsController|EndpointSliceMirroring
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
1. I was trying to use `LABEL_FILTER` in a way that doesn't actually work, and so not actually filtering out the Endpoints tests...
2. I failed to `SKIP` other tests that needed to be skipped (eg, Alpha, IPv6)
3. That also included not skipping the LoadBalancer tests, but I feel like we want the LoadBalancer tests here, so I added in the cloud-provider-kind support based on the kind loadbalancer job. (Though, I could go either way on this; we know kube-proxy doesn't care about Endpoints, so mostly this is just checking that the actual LoadBalancer tests themselves don't use Endpoints, which we pretty much also know. So we probably could just skip all of those tests to simplify the job...)

This should fix _most_ of the failures of the latest run (https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-kind-network-deprecate-endpoints/1981467525820452864), though not the apiserver proxying tests, which are probably failing because of an apiserver or e2e test bug, not a problem with the configuration here.

/assign @aojea