### PR TITLE
update gimme to latest

### DIFF
--- a/hack/third_party/gimme/gimme
+++ b/hack/third_party/gimme/gimme
@@ -285,7 +285,7 @@ _extract() {
 
 # _setup_bootstrap
 _setup_bootstrap() {
-	local versions=("1.14" "1.13" "1.12" "1.11" "1.10" "1.9" "1.8" "1.7" "1.6" "1.5" "1.4")
+	local versions=("1.23" "1.22" "1.21" "1.20" "1.19" "1.18" "1.17" "1.16" "1.15" "1.14" "1.13" "1.12" "1.11" "1.10" "1.9" "1.8" "1.7" "1.6" "1.5" "1.4")
 
 	# try existing
 	for v in "${versions[@]}"; do
@@ -785,7 +785,7 @@ _to_goarch() {
 : "${GIMME_GO_GIT_REMOTE:=https://github.com/golang/go.git}"
 : "${GIMME_TYPE:=auto}" # 'auto', 'binary', 'source', or 'git'
 : "${GIMME_BINARY_OSX:=osx10.8}"
-: "${GIMME_DOWNLOAD_BASE:=https://storage.googleapis.com/golang}"
+: "${GIMME_DOWNLOAD_BASE:=https://dl.google.com/go}"
 : "${GIMME_LIST_KNOWN:=https://golang.org/dl}"
 : "${GIMME_KNOWN_CACHE_MAX:=10800}"
 


### PR DESCRIPTION
https://github.com/travis-ci/gimme/commit/288eaa6ab9a8330034445696df2cb853b8728044

follow-up #35756 https://github.com/kubernetes/test-infra/issues/35755

x-ref https://github.com/kubernetes-sigs/kind/pull/4038#issuecomment-3445107054


> It's only broken in test-infra, which has:
> 
> : "${GIMME_DOWNLOAD_BASE:=[https://storage.googleapis.com/golang}](https://storage.googleapis.com/golang%7D)"
> 
> in kind and kubernetes/kubernetes we have:
> 
> : "${GIMME_DOWNLOAD_BASE:=[https://dl.google.com/go}](https://dl.google.com/go%7D)"
> 
> Technically downloads are now at https://go.dev/dl/ which redirect to https://dl.google.com/go