### PR TITLE
Sync labels from k/k github repo into labels.yaml

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -518,17 +518,96 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="area/HA" href="#area/HA">`area/HA`</a> | | label | |
+| <a id="area/admission-control" href="#area/admission-control">`area/admission-control`</a> | | label | |
+| <a id="area/apiserver" href="#area/apiserver">`area/apiserver`</a> | | label | |
+| <a id="area/app-lifecycle" href="#area/app-lifecycle">`area/app-lifecycle`</a> | | label | |
 | <a id="area/artifacts" href="#area/artifacts">`area/artifacts`</a> | Issues or PRs related to the hosting of release artifacts for subprojects| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="area/audit" href="#area/audit">`area/audit`</a> | | label | |
+| <a id="area/batch" href="#area/batch">`area/batch`</a> | | label | |
+| <a id="area/build-release" href="#area/build-release">`area/build-release`</a> | | label | |
+| <a id="area/cadvisor" href="#area/cadvisor">`area/cadvisor`</a> | | label | |
+| <a id="area/client-libraries" href="#area/client-libraries">`area/client-libraries`</a> | | label | |
+| <a id="area/cloudprovider" href="#area/cloudprovider">`area/cloudprovider`</a> | | label | |
+| <a id="area/code-generation" href="#area/code-generation">`area/code-generation`</a> | | label | |
 | <a id="area/code-organization" href="#area/code-organization">`area/code-organization`</a> | Issues or PRs related to kubernetes code organization| label | |
+| <a id="area/code-organization/future-dependencies" href="#area/code-organization/future-dependencies">`area/code-organization/future-dependencies`</a> | Issues related to upcoming dependency or golang updates| label | |
+| <a id="area/configmap-api" href="#area/configmap-api">`area/configmap-api`</a> | | label | |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
+| <a id="area/controller-manager" href="#area/controller-manager">`area/controller-manager`</a> | | label | |
+| <a id="area/custom-resources" href="#area/custom-resources">`area/custom-resources`</a> | | label | |
+| <a id="area/declarative-configuration" href="#area/declarative-configuration">`area/declarative-configuration`</a> | | label | |
 | <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
+| <a id="area/dns" href="#area/dns">`area/dns`</a> | | label | |
+| <a id="area/docker" href="#area/docker">`area/docker`</a> | | label | |
+| <a id="area/downward-api" href="#area/downward-api">`area/downward-api`</a> | | label | |
 | <a id="area/e2e-test-framework" href="#area/e2e-test-framework">`area/e2e-test-framework`</a> | Issues or PRs related to refactoring the kubernetes e2e test framework| label | |
+| <a id="area/ecosystem" href="#area/ecosystem">`area/ecosystem`</a> | | label | |
+| <a id="area/etcd" href="#area/etcd">`area/etcd`</a> | | label | |
+| <a id="area/example" href="#area/example">`area/example`</a> | | label | |
+| <a id="area/example/cassandra" href="#area/example/cassandra">`area/example/cassandra`</a> | | label | |
+| <a id="area/extensibility" href="#area/extensibility">`area/extensibility`</a> | | label | |
+| <a id="area/federation" href="#area/federation">`area/federation`</a> | | label | |
+| <a id="area/hw-accelerators" href="#area/hw-accelerators">`area/hw-accelerators`</a> | | label | |
+| <a id="area/images-registry" href="#area/images-registry">`area/images-registry`</a> | | label | |
+| <a id="area/ingress" href="#area/ingress">`area/ingress`</a> | | label | |
+| <a id="area/introspection" href="#area/introspection">`area/introspection`</a> | | label | |
+| <a id="area/ipv6" href="#area/ipv6">`area/ipv6`</a> | | label | |
+| <a id="area/ipvs" href="#area/ipvs">`area/ipvs`</a> | | label | |
+| <a id="area/isolation" href="#area/isolation">`area/isolation`</a> | | label | |
+| <a id="area/kube-proxy" href="#area/kube-proxy">`area/kube-proxy`</a> | | label | |
+| <a id="area/kubeadm" href="#area/kubeadm">`area/kubeadm`</a> | | label | |
+| <a id="area/kubectl" href="#area/kubectl">`area/kubectl`</a> | | label | |
+| <a id="area/kubelet" href="#area/kubelet">`area/kubelet`</a> | | label | |
+| <a id="area/kubelet-api" href="#area/kubelet-api">`area/kubelet-api`</a> | | label | |
+| <a id="area/logging" href="#area/logging">`area/logging`</a> | | label | |
+| <a id="area/monitoring" href="#area/monitoring">`area/monitoring`</a> | | label | |
 | <a id="area/network-policy" href="#area/network-policy">`area/network-policy`</a> | Issues or PRs related to Network Policy subproject| label | |
+| <a id="area/node-e2e" href="#area/node-e2e">`area/node-e2e`</a> | | label | |
 | <a id="area/node-lifecycle" href="#area/node-lifecycle">`area/node-lifecycle`</a> | Issues or PRs related to Node lifecycle| label | |
+| <a id="area/nodecontroller" href="#area/nodecontroller">`area/nodecontroller`</a> | | label | |
+| <a id="area/os/coreos" href="#area/os/coreos">`area/os/coreos`</a> | | label | |
+| <a id="area/os/fedora" href="#area/os/fedora">`area/os/fedora`</a> | | label | |
+| <a id="area/os/ubuntu" href="#area/os/ubuntu">`area/os/ubuntu`</a> | | label | |
+| <a id="area/platform/gce" href="#area/platform/gce">`area/platform/gce`</a> | | label | |
+| <a id="area/platform/mesos" href="#area/platform/mesos">`area/platform/mesos`</a> | | label | |
+| <a id="area/platform/vagrant" href="#area/platform/vagrant">`area/platform/vagrant`</a> | | label | |
 | <a id="area/pod-lifecycle" href="#area/pod-lifecycle">`area/pod-lifecycle`</a> | Issues or PRs related to Pod lifecycle| label | |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
+| <a id="area/reliability" href="#area/reliability">`area/reliability`</a> | | label | |
+| <a id="area/rkt" href="#area/rkt">`area/rkt`</a> | | label | |
+| <a id="area/secret-api" href="#area/secret-api">`area/secret-api`</a> | | label | |
+| <a id="area/security" href="#area/security">`area/security`</a> | | label | |
 | <a id="area/stable-metrics" href="#area/stable-metrics">`area/stable-metrics`</a> | Issues or PRs involving stable metrics| label | |
+| <a id="area/stateful-apps" href="#area/stateful-apps">`area/stateful-apps`</a> | | label | |
+| <a id="area/swagger" href="#area/swagger">`area/swagger`</a> | | label | |
+| <a id="area/system-requirement" href="#area/system-requirement">`area/system-requirement`</a> | | label | |
+| <a id="area/teardown" href="#area/teardown">`area/teardown`</a> | | label | |
+| <a id="area/test" href="#area/test">`area/test`</a> | | label | |
+| <a id="area/test-infra" href="#area/test-infra">`area/test-infra`</a> | | label | |
+| <a id="area/ui" href="#area/ui">`area/ui`</a> | | label | |
+| <a id="area/upgrade" href="#area/upgrade">`area/upgrade`</a> | | label | |
+| <a id="area/usability" href="#area/usability">`area/usability`</a> | | label | |
+| <a id="area/workload-api/cronjob" href="#area/workload-api/cronjob">`area/workload-api/cronjob`</a> | | label | |
+| <a id="area/workload-api/daemonset" href="#area/workload-api/daemonset">`area/workload-api/daemonset`</a> | | label | |
+| <a id="area/workload-api/deployment" href="#area/workload-api/deployment">`area/workload-api/deployment`</a> | | label | |
+| <a id="area/workload-api/job" href="#area/workload-api/job">`area/workload-api/job`</a> | | label | |
+| <a id="area/workload-api/replicaset" href="#area/workload-api/replicaset">`area/workload-api/replicaset`</a> | | label | |
+| <a id="kind/design" href="#kind/design">`kind/design`</a> | Categorizes issue or PR as related to design.| humans | |
+| <a id="milestone/incomplete-labels" href="#milestone/incomplete-labels">`milestone/incomplete-labels`</a> | | humans | |
+| <a id="milestone/needs-approval" href="#milestone/needs-approval">`milestone/needs-approval`</a> | | humans | |
+| <a id="milestone/needs-attention" href="#milestone/needs-attention">`milestone/needs-attention`</a> | | humans | |
+| <a id="milestone/removed" href="#milestone/removed">`milestone/removed`</a> | | humans | |
 | <a id="official-cve-feed" href="#official-cve-feed">`official-cve-feed`</a> | Issues or PRs related to CVEs officially announced by Security Response Committee (SRC)| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="release-blocker" href="#release-blocker">`release-blocker`</a> | | humans | |
+| <a id="sig/service-catalog" href="#sig/service-catalog">`sig/service-catalog`</a> | Categorizes an issue or PR as relevant to SIG Service Catalog.| humans | |
+| <a id="sig/usability" href="#sig/usability">`sig/usability`</a> | Categorizes an issue or PR as relevant to SIG Usability.| humans | |
+| <a id="status/approved-for-milestone" href="#status/approved-for-milestone">`status/approved-for-milestone`</a> | | humans | |
+| <a id="wg/cluster-api" href="#wg/cluster-api">`wg/cluster-api`</a> | Categorizes an issue or PR as relevant to wg-cluster-api.| humans | |
+| <a id="wg/component-standard" href="#wg/component-standard">`wg/component-standard`</a> | Categorizes an issue or PR as relevant to WG Component Standard.| humans | |
+| <a id="wg/lts" href="#wg/lts">`wg/lts`</a> | Categorizes an issue or PR as relevant to WG LTS.| humans | |
+| <a id="wg/machine-learning" href="#wg/machine-learning">`wg/machine-learning`</a> | Categorizes an issue or PR as relevant to WG Machine Learning.| humans | |
+| <a id="wg/security-audit" href="#wg/security-audit">`wg/security-audit`</a> | Categorizes an issue or PR as relevant to WG Security Audit.| humans | |
 
 ## Labels that apply to kubernetes/kubernetes, only for issues
 
@@ -541,6 +620,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="dependencies" href="#dependencies">`dependencies`</a> | Pull requests that update a dependency file| github | |
 | <a id="do-not-merge/contains-merge-commits" href="#do-not-merge/contains-merge-commits">`do-not-merge/contains-merge-commits`</a> | Indicates a PR which contains merge commits.| prow |  [mergecommitblocker](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/mergecommitblocker) |
 | <a id="do-not-merge/needs-kind" href="#do-not-merge/needs-kind">`do-not-merge/needs-kind`</a> | Indicates a PR lacks a `kind/foo` label and requires one.| prow |  [require-matching-label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/require-matching-label) |
 | <a id="do-not-merge/needs-sig" href="#do-not-merge/needs-sig">`do-not-merge/needs-sig`</a> | Indicates an issue or PR lacks a `sig/foo` label and requires one.| prow |  [require-matching-label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/require-matching-label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1131,14 +1131,30 @@ repos:
   kubernetes/kubernetes:
     labels:
       - color: 0052cc
+        name: area/HA
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Indicates an issue on admin area.
         name: area/admin
         target: issues
         addedBy: label
       - color: 0052cc
+        name: area/admission-control
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Indicates an issue on api area.
         name: area/api
         target: issues
+        addedBy: label
+      - color: 0052cc
+        name: area/apiserver
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/app-lifecycle
+        target: both
         addedBy: label
       - color: 0052cc
         description: Issues or PRs related to the hosting of release artifacts for subprojects
@@ -1147,8 +1163,46 @@ repos:
         prowPlugin: label
         addedBy: anyone
       - color: 0052cc
+        name: area/audit
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/batch
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/build-release
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/cadvisor
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/client-libraries
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/cloudprovider
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: ""
+        name: area/code-generation
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to kubernetes code organization
         name: area/code-organization
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues related to upcoming dependency or golang updates
+        name: area/code-organization/future-dependencies
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/configmap-api
         target: both
         addedBy: label
       - color: 0052cc
@@ -1157,8 +1211,32 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        name: area/controller-manager
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/custom-resources
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/declarative-configuration
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to deflaking kubernetes tests
         name: area/deflake
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/dns
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/docker
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/downward-api
         target: both
         addedBy: label
       - color: 0052cc
@@ -1167,13 +1245,125 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        name: area/ecosystem
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/etcd
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/example
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/example/cassandra
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/extensibility
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/federation
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/hw-accelerators
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/images-registry
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/ingress
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/introspection
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/ipv6
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/ipvs
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/isolation
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/kube-proxy
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/kubeadm
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/kubectl
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/kubelet
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/kubelet-api
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/logging
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/monitoring
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to Network Policy subproject
         name: area/network-policy
         target: both
         addedBy: label
       - color: 0052cc
+        name: area/node-e2e
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to Node lifecycle
         name: area/node-lifecycle
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/nodecontroller
+        target: both
+        addedBy: label
+      - color: d4c5f9
+        name: area/os/coreos
+        target: both
+        addedBy: label
+      - color: d4c5f9
+        name: area/os/fedora
+        target: both
+        addedBy: label
+      - color: d4c5f9
+        name: area/os/ubuntu
+        target: both
+        addedBy: label
+      - color: d4c5f9
+        name: area/platform/gce
+        target: both
+        addedBy: label
+      - color: d4c5f9
+        name: area/platform/mesos
+        target: both
+        addedBy: label
+      - color: d4c5f9
+        name: area/platform/vagrant
         target: both
         addedBy: label
       - color: 0052cc
@@ -1189,10 +1379,87 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        name: area/reliability
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/rkt
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/secret-api
+        target: both
+        addedBy: label
+      - color: d93f0b
+        name: area/security
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs involving stable metrics
         name: area/stable-metrics
         target: both
         addedBy: label
+      - color: 0052cc
+        name: area/stateful-apps
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/swagger
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/system-requirement
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/teardown
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/test
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/test-infra
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/ui
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/upgrade
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/usability
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/workload-api/cronjob
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/workload-api/daemonset
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/workload-api/deployment
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/workload-api/job
+        target: both
+        addedBy: label
+      - color: 0052cc
+        name: area/workload-api/replicaset
+        target: both
+        addedBy: label
+      - color: 0366d6
+        description: Pull requests that update a dependency file
+        name: dependencies
+        target: prs
+        addedBy: github
       - color: e11d21
         description: Indicates a PR which contains merge commits.
         name: do-not-merge/contains-merge-commits
@@ -1217,12 +1484,76 @@ repos:
         target: prs
         prowPlugin: require-matching-label
         addedBy: prow
+      - color: c7def8
+        description: Categorizes issue or PR as related to design.
+        name: kind/design
+        target: both
+        addedBy: humans
+      - color: ededed
+        name: milestone/incomplete-labels
+        target: both
+        addedBy: humans
+      - color: ededed
+        name: milestone/needs-approval
+        target: both
+        addedBy: humans
+      - color: ededed
+        name: milestone/needs-attention
+        target: both
+        addedBy: humans
+      - color: ededed
+        name: milestone/removed
+        target: both
+        addedBy: humans
       - color: 0052cc
         description: Issues or PRs related to CVEs officially announced by Security Response Committee (SRC)
         name: official-cve-feed
         target: both
         prowPlugin: label
         addedBy: anyone
+      - color: d93f0b
+        name: release-blocker
+        target: both
+        addedBy: humans
+      - color: d2b48c
+        description: Categorizes an issue or PR as relevant to SIG Service Catalog.
+        name: sig/service-catalog
+        target: both
+        addedBy: humans
+      - color: d2b48c
+        description: Categorizes an issue or PR as relevant to SIG Usability.
+        name: sig/usability
+        target: both
+        addedBy: humans
+      - color: ededed
+        name: status/approved-for-milestone
+        target: both
+        addedBy: humans
+      - color: d2b48c
+        description: Categorizes an issue or PR as relevant to wg-cluster-api.
+        name: wg/cluster-api
+        target: both
+        addedBy: humans
+      - color: d2b48c
+        description: Categorizes an issue or PR as relevant to WG Component Standard.
+        name: wg/component-standard
+        target: both
+        addedBy: humans
+      - color: d2b48c
+        description: Categorizes an issue or PR as relevant to WG LTS.
+        name: wg/lts
+        target: both
+        addedBy: humans
+      - color: d2b48c
+        description: Categorizes an issue or PR as relevant to WG Machine Learning.
+        name: wg/machine-learning
+        target: both
+        addedBy: humans
+      - color: d2b48c
+        description: Categorizes an issue or PR as relevant to WG Security Audit.
+        name: wg/security-audit
+        target: both
+        addedBy: humans
 
   kubernetes/org:
     labels:


### PR DESCRIPTION
We were talking about adding a new label in:
https://kubernetes.slack.com/archives/C01672LSZL0/p1761349473910879

@cblecker pointed out that:
> PRs, consensus, all that [@dims](https://kubernetes.slack.com/team/U0Y7A2MME) ;)

Since the labels didn't reflect what's currently in the repo, let's do that first!

There's TONS of things we can delete. We can do that too in a later PR.

Essentially with this PR, we have synchronized all 209 labels from kubernetes/kubernetes GitHub repository into label_sync/labels.yaml