### PR TITLE
Migrate to `registry.k8s.io`

### DIFF
--- a/config/jobs/README.md
+++ b/config/jobs/README.md
@@ -36,7 +36,7 @@ Some good examples include:
 - [pull-release-notes-lint] uses `node:11` to run `npm ci && npm lint`
 - [pull-org-test-all] uses `launcher.gcr.io/google/bazel:0.26.0` to run `bazel test //...`
 
-Many jobs use `registry.k8s.io/k8s-testimages/foo` images that are built from source in
+Many jobs use `registry.k8s.io/foo` images that are built from source in
 [`images/`]. Some of these have evolved organically, with way more dependencies
 than needed, and will be periodically bumped by PRs. These are sources of
 technical debt that are often not very well maintained. Use at your own risk,

--- a/config/jobs/README.md
+++ b/config/jobs/README.md
@@ -36,7 +36,7 @@ Some good examples include:
 - [pull-release-notes-lint] uses `node:11` to run `npm ci && npm lint`
 - [pull-org-test-all] uses `launcher.gcr.io/google/bazel:0.26.0` to run `bazel test //...`
 
-Many jobs use `gcr.io/k8s-testimages/foo` images that are built from source in
+Many jobs use `registry.k8s.io/k8s-testimages/foo` images that are built from source in
 [`images/`]. Some of these have evolved organically, with way more dependencies
 than needed, and will be periodically bumped by PRs. These are sources of
 technical debt that are often not very well maintained. Use at your own risk,

--- a/config/jobs/kubernetes/repo-infra/repo-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/repo-infra/repo-infra-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:latest-kubernetes-master
+      - image: registry.k8s.io/k8s-testimages/launcher.gcr.io/google/bazel:latest-kubernetes-master
         command:
         - ./presubmit.sh
         imagePullPolicy: Always

--- a/config/jobs/kubernetes/repo-infra/repo-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/repo-infra/repo-infra-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: registry.k8s.io/k8s-testimages/launcher.gcr.io/google/bazel:latest-kubernetes-master
+      - image: registry.k8s.io/launcher.gcr.io/google/bazel:latest-kubernetes-master
         command:
         - ./presubmit.sh
         imagePullPolicy: Always

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: registry.k8s.io/k8s-testimages/gubernator:latest
+      - image: registry.k8s.io/gubernator:latest
         command:
         - ./gubernator/test-gubernator.sh
         env:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: registry.k8s.io/k8s-testimages/gubernator:v20230111-cd1b3caf9c
+      - image: registry.k8s.io/k8s-testimages/gubernator:latest
         command:
         - ./gubernator/test-gubernator.sh
         env:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gubernator:v20230111-cd1b3caf9c
+      - image: registry.k8s.io/k8s-testimages/gubernator:v20230111-cd1b3caf9c
         command:
         - ./gubernator/test-gubernator.sh
         env:

--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -28,7 +28,7 @@ extraFiles:
 targetVersion: "latest"
 prefixes:
   - name: "k8s-testimages images"
-    prefix: "gcr.io/k8s-testimages/"
+    prefix: "registry.k8s.io/k8s-testimages/"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
     consistentImages: false

--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -28,7 +28,7 @@ extraFiles:
 targetVersion: "latest"
 prefixes:
   - name: "k8s-testimages images"
-    prefix: "registry.k8s.io/k8s-testimages/"
+    prefix: "registry.k8s.io/"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
     consistentImages: false

--- a/docs/post-mortems/2019-03-26.md
+++ b/docs/post-mortems/2019-03-26.md
@@ -296,7 +296,7 @@ Is the fact that boskos is a statefulset relevant?
 (why is it a statefulset? how does applying changes to a statefulset differ from a deployment?)
 >
 >Katharine   [9:09 AM]  
-Checked the audit logs, pod was indeed still running `gcr.io/k8s-testimages/boskos:v20180405-12e892d69` until yesterday despite the statefulset being changed.
+Checked the audit logs, pod was indeed still running `registry.k8s.io/k8s-testimages/boskos:v20180405-12e892d69` until yesterday despite the statefulset being changed.
 >
 >fejta   [9:11 AM]  
 IMO we should switch it to a deployment

--- a/docs/post-mortems/2019-03-26.md
+++ b/docs/post-mortems/2019-03-26.md
@@ -296,7 +296,7 @@ Is the fact that boskos is a statefulset relevant?
 (why is it a statefulset? how does applying changes to a statefulset differ from a deployment?)
 >
 >Katharine   [9:09 AM]  
-Checked the audit logs, pod was indeed still running `registry.k8s.io/k8s-testimages/boskos:v20180405-12e892d69` until yesterday despite the statefulset being changed.
+Checked the audit logs, pod was indeed still running `gcr.io/k8s-testimages/boskos:v20180405-12e892d69` until yesterday despite the statefulset being changed.
 >
 >fejta   [9:11 AM]  
 IMO we should switch it to a deployment

--- a/experiment/pod.yaml
+++ b/experiment/pod.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   containers:
   - name: k8s-e2e-test
-    image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170929-9413e407
+    image: registry.k8s.io/k8s-testimages/kubekins-e2e-prow:v20170929-9413e407
     args:
     - "--timeout=60"
     env:

--- a/experiment/pod.yaml
+++ b/experiment/pod.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   containers:
   - name: k8s-e2e-test
-    image: registry.k8s.io/k8s-testimages/kubekins-e2e-prow:latest
+    image: registry.k8s.io/kubekins-e2e-prow:latest
     args:
     - "--timeout=60"
     env:

--- a/experiment/pod.yaml
+++ b/experiment/pod.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   containers:
   - name: k8s-e2e-test
-    image: registry.k8s.io/k8s-testimages/kubekins-e2e-prow:v20170929-9413e407
+    image: registry.k8s.io/k8s-testimages/kubekins-e2e-prow:latest
     args:
     - "--timeout=60"
     env:

--- a/images/README.md
+++ b/images/README.md
@@ -1,6 +1,6 @@
 # Images
 
-Each subdirectory corresponds to an image that is automatically built and pushed to registry.k8s.io/k8s-testimages when PRs that touch them merge using [postsubmit prowjobs](https://testgrid.k8s.io/sig-testing-image-pushes) that run the [image-builder](/images/builder)
+Each subdirectory corresponds to an image that is automatically built and pushed to registry.k8s.io/ when PRs that touch them merge using [postsubmit prowjobs](https://testgrid.k8s.io/sig-testing-image-pushes) that run the [image-builder](/images/builder)
 
 ## Updating test-infra images
 
@@ -39,7 +39,7 @@ There is no automated testing pipeline for images:
 
 1. Merge a PR changing something in the image directory.
 
-1. Grep the [prowjob configs](/config/jobs) to find out which jobs are using `registry.k8s.io/k8s-testimages/<image-name>:latest` and monitor [TestGrid](http://testgrid.k8s.io) for new failures corresponding to your change.
+1. Grep the [prowjob configs](/config/jobs) to find out which jobs are using `registry.k8s.io/<image-name>:latest` and monitor [TestGrid](http://testgrid.k8s.io) for new failures corresponding to your change.
 
     * On failure, send a new PR to rollback your last one or a fix if you know immediately.
     * Some of these images might be presubmits; you could monitor them at http://prow.k8s.io

--- a/images/README.md
+++ b/images/README.md
@@ -1,6 +1,6 @@
 # Images
 
-Each subdirectory corresponds to an image that is automatically built and pushed to gcr.io/k8s-testimages when PRs that touch them merge using [postsubmit prowjobs](https://testgrid.k8s.io/sig-testing-image-pushes) that run the [image-builder](/images/builder)
+Each subdirectory corresponds to an image that is automatically built and pushed to registry.k8s.io/k8s-testimages when PRs that touch them merge using [postsubmit prowjobs](https://testgrid.k8s.io/sig-testing-image-pushes) that run the [image-builder](/images/builder)
 
 ## Updating test-infra images
 
@@ -39,7 +39,7 @@ There is no automated testing pipeline for images:
 
 1. Merge a PR changing something in the image directory.
 
-1. Grep the [prowjob configs](/config/jobs) to find out which jobs are using `gcr.io/k8s-testimages/<image-name>:latest` and monitor [TestGrid](http://testgrid.k8s.io) for new failures corresponding to your change.
+1. Grep the [prowjob configs](/config/jobs) to find out which jobs are using `registry.k8s.io/k8s-testimages/<image-name>:latest` and monitor [TestGrid](http://testgrid.k8s.io) for new failures corresponding to your change.
 
     * On failure, send a new PR to rollback your last one or a fix if you know immediately.
     * Some of these images might be presubmits; you could monitor them at http://prow.k8s.io

--- a/logexporter/cluster/logexporter-daemonset.yaml
+++ b/logexporter/cluster/logexporter-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: gcr.io/k8s-testimages/logexporter:v20220831-a9d3b0ad39
+        image: registry.k8s.io/k8s-testimages/logexporter:v20220831-a9d3b0ad39
         env:
         - name: NODE_NAME
           valueFrom:

--- a/logexporter/cluster/logexporter-daemonset.yaml
+++ b/logexporter/cluster/logexporter-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: registry.k8s.io/k8s-testimages/logexporter:v20220831-a9d3b0ad39
+        image: registry.k8s.io/k8s-testimages/logexporter:latest
         env:
         - name: NODE_NAME
           valueFrom:

--- a/logexporter/cluster/logexporter-daemonset.yaml
+++ b/logexporter/cluster/logexporter-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: registry.k8s.io/k8s-testimages/logexporter:latest
+        image: registry.k8s.io/logexporter:latest
         env:
         - name: NODE_NAME
           valueFrom:

--- a/logexporter/cluster/logexporter-pod.yaml
+++ b/logexporter/cluster/logexporter-pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
   - name: logexporter-test
-    image: registry.k8s.io/k8s-testimages/logexporter:v0.1.6
+    image: registry.k8s.io/logexporter:v0.1.6
     env:
     - name: NODE_NAME
       valueFrom:

--- a/logexporter/cluster/logexporter-pod.yaml
+++ b/logexporter/cluster/logexporter-pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
   - name: logexporter-test
-    image: gcr.io/k8s-testimages/logexporter:v0.1.6
+    image: registry.k8s.io/k8s-testimages/logexporter:v0.1.6
     env:
     - name: NODE_NAME
       valueFrom:


### PR DESCRIPTION
This PR fixes #34922 

This PR migrates from `gcr.io/k8s-testimages` which is a legacy Google-owned _GCR/AR_ deprecated repo to `registry.k8s.io/` a Kubernetes community-owned.

