### PR TITLE
CRI-O: use crun as default runtime for canary

### DIFF
--- a/jobs/e2e_node/crio/crio_canary.ign
+++ b/jobs/e2e_node/crio/crio_canary.ign
@@ -55,6 +55,14 @@
           "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D90bb7766f61c0fef6a071ca933ad917242b9bd52%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D8beeed1ea9357cd8adb05bbc394eb23a02807ff7%22%0A"
         },
         "mode": 420
+      },
+      {
+        "path": "/etc/crio/crio.conf.d/99-crun.conf",
+        "contents": {
+          "compression": "",
+          "source": "data:,%5Bcrio.runtime%5D%0Adefault_runtime%20%3D%20%22crun%22%0A"
+        },
+        "mode": 420
       }
     ]
   },

--- a/jobs/e2e_node/crio/templates/crio_canary.yaml
+++ b/jobs/e2e_node/crio/templates/crio_canary.yaml
@@ -34,6 +34,10 @@ storage:
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=90bb7766f61c0fef6a071ca933ad917242b9bd52"
           DefaultEnvironment="CRIO_COMMIT=8beeed1ea9357cd8adb05bbc394eb23a02807ff7"
+    - path: /etc/crio/crio.conf.d/99-crun.conf
+      contents:
+        local: 99-crun.conf
+      mode: 0644
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -27,7 +27,7 @@ fi
 declare -A CONFIGURATIONS=(
     ["crio"]="root env"
     ["crio_eventedpleg"]="root env eventedpleg"
-    ["crio_canary"]="root env-canary"
+    ["crio_canary"]="root env-canary crun-enabled"
     ["crio_drop_infra_ctr"]="root env drop-infra-ctr"
     ["crio_swap1g"]="root env swap-1G"
     ["crio_imagefs"]="root env imagefs"


### PR DESCRIPTION
cc @kubernetes/sig-node-cri-o-test-maintainers 

Refers to https://github.com/kubernetes/test-infra/issues/35758

Should affect the following job for now:
- https://prow.k8s.io/?job=pull-kubernetes-node-crio-e2e-canary