### PR TITLE
CRI-O: use crun as default runtime

### DIFF
--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7SQsW7zMAyEdz0F4X/+7b1Atu5ZuhWBIcu0pVYmDZJKExR990Jx2qFAiiydBBE83t33HCRxmxY/48FpmslbEexXzimcYQdNhxa6utRts/ZFmRrnNqEUsrTgwWWe+4xHzFUz4lDmxo3Ca59oEt8HE9jB5LOiG3HyJVt/1VaBFAo/b3692gYpdHDXb796i5dgRaXLacATXgPWvcYtTMlYfttjWmqHf/C0f9w/QPTHRDNYRKgnQMsQZuGywiDoXxUsJoXAOWOwxASCCx9xG79FJLDoDZLClE44fhf0RGy+KhR28H6p2XJIrZ7VcBlbLcPFp6k5G/i4SaDyuYfAxvF+Arf8DNX+R09jRvkL388AAAD//4dbqrt2AgAA"
+          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
         },
         "mode": 420
       },
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dcae4e9ac33013ddcd57b258dfe6b845533f2fc84%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_canary.ign
+++ b/jobs/e2e_node/crio/crio_canary.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7SQsW7zMAyEdz0F4X/+7b1Atu5ZuhWBIcu0pVYmDZJKExR990Jx2qFAiiydBBE83t33HCRxmxY/48FpmslbEexXzimcYQdNhxa6utRts/ZFmRrnNqEUsrTgwWWe+4xHzFUz4lDmxo3Ca59oEt8HE9jB5LOiG3HyJVt/1VaBFAo/b3692gYpdHDXb796i5dgRaXLacATXgPWvcYtTMlYfttjWmqHf/C0f9w/QPTHRDNYRKgnQMsQZuGywiDoXxUsJoXAOWOwxASCCx9xG79FJLDoDZLClE44fhf0RGy+KhR28H6p2XJIrZ7VcBlbLcPFp6k5G/i4SaDyuYfAxvF+Arf8DNX+R09jRvkL388AAAD//4dbqrt2AgAA"
+          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
         },
         "mode": 420
       },
@@ -53,14 +53,6 @@
         "contents": {
           "compression": "",
           "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dcae4e9ac33013ddcd57b258dfe6b845533f2fc84%22%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/99-crun.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adefault_runtime%20%3D%20%22crun%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_drop_infra_ctr.ign
+++ b/jobs/e2e_node/crio/crio_drop_infra_ctr.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7SQsW7zMAyEdz0F4X/+7b1Atu5ZuhWBIcu0pVYmDZJKExR990Jx2qFAiiydBBE83t33HCRxmxY/48FpmslbEexXzimcYQdNhxa6utRts/ZFmRrnNqEUsrTgwWWe+4xHzFUz4lDmxo3Ca59oEt8HE9jB5LOiG3HyJVt/1VaBFAo/b3692gYpdHDXb796i5dgRaXLacATXgPWvcYtTMlYfttjWmqHf/C0f9w/QPTHRDNYRKgnQMsQZuGywiDoXxUsJoXAOWOwxASCCx9xG79FJLDoDZLClE44fhf0RGy+KhR28H6p2XJIrZ7VcBlbLcPFp6k5G/i4SaDyuYfAxvF+Arf8DNX+R09jRvkL388AAAD//4dbqrt2AgAA"
+          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
         },
         "mode": 420
       },
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dcae4e9ac33013ddcd57b258dfe6b845533f2fc84%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_eventedpleg.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7SQsW7zMAyEdz0F4X/+7b1Atu5ZuhWBIcu0pVYmDZJKExR990Jx2qFAiiydBBE83t33HCRxmxY/48FpmslbEexXzimcYQdNhxa6utRts/ZFmRrnNqEUsrTgwWWe+4xHzFUz4lDmxo3Ca59oEt8HE9jB5LOiG3HyJVt/1VaBFAo/b3692gYpdHDXb796i5dgRaXLacATXgPWvcYtTMlYfttjWmqHf/C0f9w/QPTHRDNYRKgnQMsQZuGywiDoXxUsJoXAOWOwxASCCx9xG79FJLDoDZLClE44fhf0RGy+KhR28H6p2XJIrZ7VcBlbLcPFp6k5G/i4SaDyuYfAxvF+Arf8DNX+R09jRvkL388AAAD//4dbqrt2AgAA"
+          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
         },
         "mode": 420
       },
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dcae4e9ac33013ddcd57b258dfe6b845533f2fc84%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_hugepages.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7SQsW7zMAyEdz0F4X/+7b1Atu5ZuhWBIcu0pVYmDZJKExR990Jx2qFAiiydBBE83t33HCRxmxY/48FpmslbEexXzimcYQdNhxa6utRts/ZFmRrnNqEUsrTgwWWe+4xHzFUz4lDmxo3Ca59oEt8HE9jB5LOiG3HyJVt/1VaBFAo/b3692gYpdHDXb796i5dgRaXLacATXgPWvcYtTMlYfttjWmqHf/C0f9w/QPTHRDNYRKgnQMsQZuGywiDoXxUsJoXAOWOwxASCCx9xG79FJLDoDZLClE44fhf0RGy+KhR28H6p2XJIrZ7VcBlbLcPFp6k5G/i4SaDyuYfAxvF+Arf8DNX+R09jRvkL388AAAD//4dbqrt2AgAA"
+          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
         },
         "mode": 420
       },
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dcae4e9ac33013ddcd57b258dfe6b845533f2fc84%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_imagefs.ign
+++ b/jobs/e2e_node/crio/crio_imagefs.ign
@@ -47,7 +47,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7SQsW7zMAyEdz0F4X/+7b1Atu5ZuhWBIcu0pVYmDZJKExR990Jx2qFAiiydBBE83t33HCRxmxY/48FpmslbEexXzimcYQdNhxa6utRts/ZFmRrnNqEUsrTgwWWe+4xHzFUz4lDmxo3Ca59oEt8HE9jB5LOiG3HyJVt/1VaBFAo/b3692gYpdHDXb796i5dgRaXLacATXgPWvcYtTMlYfttjWmqHf/C0f9w/QPTHRDNYRKgnQMsQZuGywiDoXxUsJoXAOWOwxASCCx9xG79FJLDoDZLClE44fhf0RGy+KhR28H6p2XJIrZ7VcBlbLcPFp6k5G/i4SaDyuYfAxvF+Arf8DNX+R09jRvkL388AAAD//4dbqrt2AgAA"
+          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
         },
         "mode": 420
       },
@@ -70,7 +70,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dcae4e9ac33013ddcd57b258dfe6b845533f2fc84%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_splitfs.ign
+++ b/jobs/e2e_node/crio/crio_splitfs.ign
@@ -47,7 +47,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7SQsW7zMAyEdz0F4X/+7b1Atu5ZuhWBIcu0pVYmDZJKExR990Jx2qFAiiydBBE83t33HCRxmxY/48FpmslbEexXzimcYQdNhxa6utRts/ZFmRrnNqEUsrTgwWWe+4xHzFUz4lDmxo3Ca59oEt8HE9jB5LOiG3HyJVt/1VaBFAo/b3692gYpdHDXb796i5dgRaXLacATXgPWvcYtTMlYfttjWmqHf/C0f9w/QPTHRDNYRKgnQMsQZuGywiDoXxUsJoXAOWOwxASCCx9xG79FJLDoDZLClE44fhf0RGy+KhR28H6p2XJIrZ7VcBlbLcPFp6k5G/i4SaDyuYfAxvF+Arf8DNX+R09jRvkL388AAAD//4dbqrt2AgAA"
+          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
         },
         "mode": 420
       },
@@ -70,7 +70,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dcae4e9ac33013ddcd57b258dfe6b845533f2fc84%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7SQsW7zMAyEdz0F4X/+7b1Atu5ZuhWBIcu0pVYmDZJKExR990Jx2qFAiiydBBE83t33HCRxmxY/48FpmslbEexXzimcYQdNhxa6utRts/ZFmRrnNqEUsrTgwWWe+4xHzFUz4lDmxo3Ca59oEt8HE9jB5LOiG3HyJVt/1VaBFAo/b3692gYpdHDXb796i5dgRaXLacATXgPWvcYtTMlYfttjWmqHf/C0f9w/QPTHRDNYRKgnQMsQZuGywiDoXxUsJoXAOWOwxASCCx9xG79FJLDoDZLClE44fhf0RGy+KhR28H6p2XJIrZ7VcBlbLcPFp6k5G/i4SaDyuYfAxvF+Arf8DNX+R09jRvkL388AAAD//4dbqrt2AgAA"
+          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
         },
         "mode": 420
       },
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dcae4e9ac33013ddcd57b258dfe6b845533f2fc84%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_userns.ign
+++ b/jobs/e2e_node/crio/crio_userns.ign
@@ -39,7 +39,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7SQsW7zMAyEdz0F4X/+7b1Atu5ZuhWBIcu0pVYmDZJKExR990Jx2qFAiiydBBE83t33HCRxmxY/48FpmslbEexXzimcYQdNhxa6utRts/ZFmRrnNqEUsrTgwWWe+4xHzFUz4lDmxo3Ca59oEt8HE9jB5LOiG3HyJVt/1VaBFAo/b3692gYpdHDXb796i5dgRaXLacATXgPWvcYtTMlYfttjWmqHf/C0f9w/QPTHRDNYRKgnQMsQZuGywiDoXxUsJoXAOWOwxASCCx9xG79FJLDoDZLClE44fhf0RGy+KhR28H6p2XJIrZ7VcBlbLcPFp6k5G/i4SaDyuYfAxvF+Arf8DNX+R09jRvkL388AAAD//4dbqrt2AgAA"
+          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
         },
         "mode": 420
       },
@@ -62,7 +62,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dcae4e9ac33013ddcd57b258dfe6b845533f2fc84%22%0A"
         },
         "mode": 420
       },
@@ -81,14 +81,6 @@
         "contents": {
           "compression": "gzip",
           "source": "data:;base64,H4sIAAAAAAAC/0zMQa6DIBSF4TmrOIkTNXkJaNRXxk5chtaLklpo4JJ2+Q22g05Pzv8VSJGCNjZEnkZ99ckxvME0RlHguVMgUeAP3wNsRN91bY8aDUrnGbwTFtqsc9ZtOc3D6VRn+UvmXCmJciUzp4Nxn194+DVWqD+uuKWFDmKtWiWHRg+N/L/0UrwDAAD///9e1jyoAAAA"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/crio/crio.conf.d/99-crun.conf",
-        "contents": {
-          "compression": "",
-          "source": "data:,%5Bcrio.runtime%5D%0Adefault_runtime%20%3D%20%22crun%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/templates/base/20-crio.conf
+++ b/jobs/e2e_node/crio/templates/base/20-crio.conf
@@ -4,7 +4,7 @@ signature_policy = "/etc/crio/policy.json"
 [crio.runtime]
 log_level = "debug"
 drop_infra_ctr = false
-default_runtime = "runc"
+default_runtime = "crun"
 
 [crio.runtime.runtimes.crun]
 runtime_path = "/usr/libexec/crio/crun"

--- a/jobs/e2e_node/crio/templates/base/99-crun.conf
+++ b/jobs/e2e_node/crio/templates/base/99-crun.conf
@@ -1,2 +1,0 @@
-[crio.runtime]
-default_runtime = "crun"

--- a/jobs/e2e_node/crio/templates/base/crun-enabled.yaml
+++ b/jobs/e2e_node/crio/templates/base/crun-enabled.yaml
@@ -1,7 +1,0 @@
----
-storage:
-  files:
-    - path: /etc/crio/crio.conf.d/99-crun.conf
-      contents:
-        local: 99-crun.conf
-      mode: 0644

--- a/jobs/e2e_node/crio/templates/base/env.yaml
+++ b/jobs/e2e_node/crio/templates/base/env.yaml
@@ -6,5 +6,5 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
-          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
+          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"

--- a/jobs/e2e_node/crio/templates/crio.yaml
+++ b/jobs/e2e_node/crio/templates/crio.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
-          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
+          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_canary.yaml
+++ b/jobs/e2e_node/crio/templates/crio_canary.yaml
@@ -34,10 +34,6 @@ storage:
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
           DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
-    - path: /etc/crio/crio.conf.d/99-crun.conf
-      contents:
-        local: 99-crun.conf
-      mode: 0644
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_drop_infra_ctr.yaml
+++ b/jobs/e2e_node/crio/templates/crio_drop_infra_ctr.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
-          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
+          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
     - path: /etc/crio/crio.conf.d/30-crio-drop-infra-ctr.conf
       contents:
         local: 30-crio-drop-infra-ctr.conf

--- a/jobs/e2e_node/crio/templates/crio_eventedpleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_eventedpleg.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
-          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
+          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
     - path: /etc/crio/crio.conf.d/40-evented-pleg.conf
       contents:
         local: 40-evented-pleg.conf

--- a/jobs/e2e_node/crio/templates/crio_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_hugepages.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
-          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
+          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_imagefs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_imagefs.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
-          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
+          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
     - path: /etc/containers/storage.conf
       contents:
         local: 50-storage.conf

--- a/jobs/e2e_node/crio/templates/crio_splitfs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_splitfs.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
-          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
+          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
     - path: /etc/containers/storage.conf
       contents:
         local: 60-storage-split-disk.conf

--- a/jobs/e2e_node/crio/templates/crio_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_swap1g.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
-          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
+          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_userns.yaml
+++ b/jobs/e2e_node/crio/templates/crio_userns.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
-          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
+          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
     # Note: this ignition file assumes FCOS has shadow-utils installed.
     # As of the time of writing this, it does.
     - path: /etc/subuid
@@ -46,10 +46,6 @@ storage:
         local: 50-subid.toml
       mode: 0644
       overwrite: true
-    - path: /etc/crio/crio.conf.d/99-crun.conf
-      contents:
-        local: 99-crun.conf
-      mode: 0644
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -26,13 +26,13 @@ fi
 declare -A CONFIGURATIONS=(
     ["crio"]="root env"
     ["crio_eventedpleg"]="root env eventedpleg"
-    ["crio_canary"]="root env-canary crun-enabled"
+    ["crio_canary"]="root env-canary"
     ["crio_drop_infra_ctr"]="root env drop-infra-ctr"
     ["crio_swap1g"]="root env swap-1G"
     ["crio_imagefs"]="root env imagefs"
     ["crio_splitfs"]="root env splitfs"
     ["crio_hugepages"]="root env hugepages"
-    ["crio_userns"]="root env userns crun-enabled"
+    ["crio_userns"]="root env userns"
 )
 
 CONTAINER_RUNTIME=$(which podman 2>/dev/null || which nerdctl 2>/dev/null || which docker 2>/dev/null)


### PR DESCRIPTION
Follow-up on https://github.com/kubernetes/test-infra/pull/35782

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135253/pull-kubernetes-node-crio-e2e-canary/1988580689410265088

/hold

cc @kubernetes/sig-node-cri-o-test-maintainers 

Fixes https://github.com/kubernetes/test-infra/issues/35758 

Requires https://github.com/kubernetes/test-infra/pull/35903