### PR TITLE
promote kind-master-beta-features to release-blocking

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -104,7 +104,7 @@ periodics:
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-e2e-kind-beta-features
   annotations:
-    testgrid-dashboards: sig-release-master-informing, sig-testing-kind
+    testgrid-dashboards: sig-release-master-blocking, sig-testing-kind
     testgrid-tab-name: kind-master-beta-features
     description: Runs tests with no special requirements other than beta feature gates in a KinD cluster where beta feature gates and APIs are enabled.
     testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,patrick.ohly@intel.com,release-team@kubernetes.io


### PR DESCRIPTION
See: https://github.com/kubernetes/sig-release/issues/2889, https://github.com/kubernetes/kubernetes/issues/131040

/hold

We (SIG Testing TLs -- Myself, @pohly, @aojea) have:
- Maintained this job to be stable
- Filed https://github.com/kubernetes/sig-release/issues/2889 with all required details
- Posted to dev@kubernetes.io and the SIG release mailinglists
- Posted the mailinglist thread to sig-release slack
- Posted again to the mailinglists and slack
- CCed specific teams and individuals on the github thread
- CCed here @kubernetes/sig-release-leads @drewhagen @tico88612

We are approaching 4 weeks of this, which will still be ahead of code freeze.

This coverage is important for preventing regressions in beta features.

