### PR TITLE
enable dependabot bumping of docker images

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/images/"
+    schedule:
+      interval: "daily"
+    labels:
+    - "skip-review"

--- a/images/bigquery/Dockerfile
+++ b/images/bigquery/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:22.04
+FROM ubuntu:jammy-20251001
 
 RUN apt-get update && apt-get install -y \
     git \

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -14,7 +14,7 @@
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
 
-FROM debian:bookworm
+FROM debian:bookworm-20251020
 
 WORKDIR /workspace
 RUN mkdir -p /workspace
@@ -65,10 +65,10 @@ RUN wget -O google-cloud-sdk.tar.gz -q $GCLOUD_SDK_URL && \
     tar xzf google-cloud-sdk.tar.gz -C / && \
     rm google-cloud-sdk.tar.gz && \
     /google-cloud-sdk/install.sh \
-        --disable-installation-options \
-        --bash-completion=false \
-        --path-update=false \
-        --usage-reporting=false && \
+    --disable-installation-options \
+    --bash-completion=false \
+    --path-update=false \
+    --usage-reporting=false && \
     gcloud components install alpha beta kubectl && \
     gcloud info | tee /workspace/gcloud-info.txt
 
@@ -127,7 +127,7 @@ RUN mkdir /docker-graph
 # env DOCKER_IN_DOCKER_ENABLED is set and similarly responsible for generating
 # .bazelrc files if bazel remote caching is enabled 
 COPY ["entrypoint.sh", "runner.sh", \
-        "/usr/local/bin/"]
+    "/usr/local/bin/"]
 
 # TODO(krzyzacy): Move the scenario scripts to kubekins v2
 # The bundled scenarios are for podutil jobs, bootstrap jobs will still use

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:alpine
+FROM google/cloud-sdk:545.0.0-alpine
 COPY builder run.sh /
 CMD ["/run.sh"]

--- a/images/git-custom-k8s-auth/Dockerfile
+++ b/images/git-custom-k8s-auth/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:491.0.0 as builder
+FROM google/cloud-sdk:545.0.0 as builder
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/Dockerfile
 
 ARG AWS_IAM_AUTHENTICATOR_VERSION
@@ -23,14 +23,14 @@ RUN curl -fsSL \
     chmod +x /aws-iam-authenticator
 
 RUN apt update && apt install -y unzip && curl -fsSLO https://github.com/Azure/kubelogin/releases/download/v${AZURE_KUBELOGIN_VERSION}/kubelogin-linux-amd64.zip \
- && unzip -j kubelogin-linux-amd64.zip -d / \
- && rm kubelogin-linux-amd64.zip
+    && unzip -j kubelogin-linux-amd64.zip -d / \
+    && rm kubelogin-linux-amd64.zip
 
 # Update the date below (check https://hub.docker.com/_/alpine/tags) to get the
 # alpine edge base image, which has a faster release cadence than alpine:latest
 # (which tracks alpine stable), to pick up security patches more quickly.
 # TODO: switch to Distroless https://github.com/GoogleContainerTools/distroless (help-wanted)
-FROM alpine:20240606
+FROM alpine:3.22.2
 
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}

--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -15,7 +15,7 @@
 # Update the date below (check https://hub.docker.com/_/alpine/tags) to get the
 # alpine edge base image, which has a faster release cadence than alpine:latest
 # (which tracks alpine stable), to pick up security patches more quickly.
-FROM alpine:20240606
+FROM alpine:3.22.2
 
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}

--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -16,7 +16,7 @@
 # NOTE: we attempt to avoid unnecessary tools and image layers while
 # supporting kubernetes builds, kind installation, etc.
 
-FROM debian:bookworm
+FROM debian:bookworm-20251020
 
 # arg that specifies the image name (for debugging)
 ARG IMAGE_ARG
@@ -51,57 +51,57 @@ COPY wrapper.sh /usr/local/bin/
 # Trying to remount these makes for a very noisy error block in the beginning of
 # the pod logs, so we just comment out the call to it... :shrug:
 RUN echo "Installing Packages ..." \
-        && apt-get update \
-        && apt-get install -y --no-install-recommends \
-            apt-transport-https \
-            build-essential \
-            ca-certificates \
-            curl \
-            file \
-            git \
-            gnupg2 \
-            iproute2 \
-            kmod \
-            lsb-release \
-            mercurial \
-            pkg-config \
-            procps \
-            python3 \
-            rsync \
-            software-properties-common \
-            unzip \
-        && rm -rf /var/lib/apt/lists/* \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    build-essential \
+    ca-certificates \
+    curl \
+    file \
+    git \
+    gnupg2 \
+    iproute2 \
+    kmod \
+    lsb-release \
+    mercurial \
+    pkg-config \
+    procps \
+    python3 \
+    rsync \
+    software-properties-common \
+    unzip \
+    && rm -rf /var/lib/apt/lists/* \
     && echo "Installing Go ..." \
-        && if [ -z "${GO_VERSION}" ]; then GO_VERSION=$(curl -fsSL https://go.dev/VERSION?m=text | grep -oP "go\K(.*)"); fi \
-        && export GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz" \
-        && curl -fsSL "https://go.dev/dl/${GO_TARBALL}" --output "${GO_TARBALL}" \
-        && tar xzf "${GO_TARBALL}" -C /usr/local \
-        && rm "${GO_TARBALL}"\
-        && mkdir -p "${GOPATH}/bin" \
+    && if [ -z "${GO_VERSION}" ]; then GO_VERSION=$(curl -fsSL https://go.dev/VERSION?m=text | grep -oP "go\K(.*)"); fi \
+    && export GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz" \
+    && curl -fsSL "https://go.dev/dl/${GO_TARBALL}" --output "${GO_TARBALL}" \
+    && tar xzf "${GO_TARBALL}" -C /usr/local \
+    && rm "${GO_TARBALL}"\
+    && mkdir -p "${GOPATH}/bin" \
     && echo "Installing gcloud SDK, kubectl ..." \
-        && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz --output google-cloud-sdk.tar.gz \
-        && tar xzf google-cloud-sdk.tar.gz -C / \
-        && rm google-cloud-sdk.tar.gz \
-        && /google-cloud-sdk/install.sh \
-            --disable-installation-options \
-            --bash-completion=false \
-            --path-update=false \
-            --usage-reporting=false \
-        && gcloud components install kubectl \
+    && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz --output google-cloud-sdk.tar.gz \
+    && tar xzf google-cloud-sdk.tar.gz -C / \
+    && rm google-cloud-sdk.tar.gz \
+    && /google-cloud-sdk/install.sh \
+    --disable-installation-options \
+    --bash-completion=false \
+    --path-update=false \
+    --usage-reporting=false \
+    && gcloud components install kubectl \
     && echo "Installing Docker ..." \
-        && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
-        && chmod a+r /etc/apt/keyrings/docker.gpg \
-        && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-            "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-            tee /etc/apt/sources.list.d/docker.list > /dev/null \
-        && apt-get update \
-        && apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin \
-        && rm -rf /var/lib/apt/lists/* \
-        && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
-        && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \
+    && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+    "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin \
+    && rm -rf /var/lib/apt/lists/* \
+    && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
+    && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \
     && echo "Ensuring Legacy Iptables ..." \
-        && update-alternatives --set iptables /usr/sbin/iptables-legacy \
-        && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
 # entrypoint is our wrapper script, in Prow you will need to explicitly re-specify this
 ENTRYPOINT ["wrapper.sh"]

--- a/images/kubekins-e2e-v2/Dockerfile
+++ b/images/kubekins-e2e-v2/Dockerfile
@@ -14,7 +14,7 @@
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
 
-FROM debian:bookworm
+FROM debian:bookworm-20251020
 ARG TARGETARCH
 
 WORKDIR /workspace
@@ -67,11 +67,11 @@ RUN wget -O google-cloud-sdk.tar.gz -q $GCLOUD_SDK_URL && \
     tar xzf google-cloud-sdk.tar.gz -C / && \
     rm google-cloud-sdk.tar.gz && \
     if [ "${TARGETARCH}" != "ppc64le" ] && [ "${TARGETARCH}" != "s390x" ]; then \
-        /google-cloud-sdk/install.sh \
-        --disable-installation-options \
-        --bash-completion=false \
-        --path-update=false \
-        --usage-reporting=false; \
+    /google-cloud-sdk/install.sh \
+    --disable-installation-options \
+    --bash-completion=false \
+    --path-update=false \
+    --usage-reporting=false; \
     fi && \
     gcloud components install alpha beta && \
     gcloud info | tee /workspace/gcloud-info.txt


### PR DESCRIPTION
key CI images are out of date, and I'm seeing a lot of CVEs reported by Datadog in our CI clusters.

https://us5.datadoghq.com/container-images?query=image_registry%3A%28gcr.io%20OR%20us-docker.pkg.dev%29&cols=name%2Ccontainer_count%2Csource%2Cvulns%2Ctag%2Crepo_digest%2Csize%2Cbuilt&sort=built

<img width="1510" height="848" alt="image" src="https://github.com/user-attachments/assets/8077ae98-e51b-4dc5-a74d-b75ccdda3fb3" />
