### PR TITLE
capz: exclude Windows from CAPZ E2E periodic

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -292,7 +292,7 @@ periodics:
         - name: GINKGO_FOCUS
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
-          value: \[Managed Kubernetes\]
+          value: \[Managed Kubernetes\]|\[WINDOWS\]
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
This PR removes Windows scenarios from periodic CAZ E2E tests so we don't have to revert to an older version of Kubernetes (in order to get a Windows E2E to pass).