### PR TITLE
fix output in logs to point to right path

### DIFF
--- a/hack/make-rules/verify/misspell.sh
+++ b/hack/make-rules/verify/misspell.sh
@@ -61,7 +61,7 @@ if find -L . -type f -not \( \
 fi
 
 
-trap 'echo ERROR: bad spelling, fix with hack/update/misspell.sh' ERR
+trap 'echo ERROR: bad spelling, fix with hack/make-rules/update/misspell.sh' ERR
 
 echo "Check for spelling..."
 # Unit test: lang auge (remove space)


### PR DESCRIPTION
Found a minor issue in logs telling you to run misspell but hack/update/misspell does not exist anymore.

