### PR TITLE
cluster-api: add presubmit job on gke prow cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -289,6 +289,52 @@ presubmits:
     annotations:
       testgrid-dashboards: cluster-api-core-main
       testgrid-tab-name: capi-pr-e2e-main
+  - name: pull-cluster-api-e2e-main-gke
+    cluster: k8s-infra-prow-build
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    decorate: true
+    decoration_config:
+      timeout: 180m
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    path_alias: sigs.k8s.io/cluster-api
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-1.34
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
+          - name: GINKGO_LABEL_FILTER
+            value: "!Conformance"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 3000m
+            memory: 8Gi
+          limits:
+            cpu: 3000m
+            memory: 8Gi
+    annotations:
+      testgrid-dashboards: cluster-api-core-main
+      testgrid-tab-name: capi-pr-e2e-main-gke
   - name: pull-cluster-api-e2e-upgrade-1-34-1-35-main
     cluster: eks-prow-build-cluster
     labels:


### PR DESCRIPTION
CI is 1h faster on GKE so giving the maintainers the option to choose which cloud to run the presubmit on.