### PR TITLE
autoscaling: validate CA 1.30 branch builds on 1.31 cluster

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -317,7 +317,7 @@ presubmits:
           - name: ADDITIONAL_ASO_CRDS
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
-            value: "1.30"
+            value: "1.31" # TODO update to 1.30 LTS when https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/5953 is resolved
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
This PR enables us to get some functional signal for a proposed 1.30.7 release of Cluster Autoscaler in Azure on a 1.31 AKS cluster. The set of tested functionality in CA E2E is not sensitive to +/- 1 versions of Kubernetes, and so this is an acceptable temporary fix until we enable testing of AKS LTS versions (which would allow us to pin exact CA-k8s minor version compatibility for older branches like 1.30).