### PR TITLE
autoscaling: use AKS LTS for CAPZ E2E tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -43,6 +43,10 @@ presubmits:
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
             value: "1.33" # latest available in AKS
+          - name: AKS_TIER
+            value: "Premium" # required for LTS
+          - name: AKS_SUPPORT_PLAN
+            value: "AKSLongTermSupport" # Use LTS
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
This PR enables us to test AKS LTS against this PR: https://github.com/kubernetes/autoscaler/pull/8722/files