### PR TITLE
autoscaling: use AKS LTS for Azure CA tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -102,6 +102,10 @@ presubmits:
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
             value: "1.32"
+          - name: AKS_TIER
+            value: "Premium" # required for LTS
+          - name: AKS_SUPPORT_PLAN
+            value: "AKSLongTermSupport" # Use LTS
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode
@@ -157,6 +161,10 @@ presubmits:
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
             value: "1.33" # TODO update when 1.34 is available in AKS
+          - name: AKS_TIER
+            value: "Premium" # required for LTS
+          - name: AKS_SUPPORT_PLAN
+            value: "AKSLongTermSupport" # Use LTS
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode
@@ -212,6 +220,10 @@ presubmits:
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
             value: "1.33"
+          - name: AKS_TIER
+            value: "Premium" # required for LTS
+          - name: AKS_SUPPORT_PLAN
+            value: "AKSLongTermSupport" # Use LTS
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode
@@ -267,6 +279,10 @@ presubmits:
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
             value: "1.31"
+          - name: AKS_TIER
+            value: "Premium" # required for LTS
+          - name: AKS_SUPPORT_PLAN
+            value: "AKSLongTermSupport" # Use LTS
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode
@@ -322,6 +338,10 @@ presubmits:
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
             value: "1.30"
+          - name: AKS_TIER
+            value: "Premium" # required for LTS
+          - name: AKS_SUPPORT_PLAN
+            value: "AKSLongTermSupport" # Use LTS
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode
@@ -377,6 +397,10 @@ presubmits:
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
             value: "1.29"
+          - name: AKS_TIER
+            value: "Premium" # required for LTS
+          - name: AKS_SUPPORT_PLAN
+            value: "AKSLongTermSupport" # Use LTS
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode
@@ -432,61 +456,10 @@ presubmits:
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
             value: "1.28"
-          - name: CLUSTER_TEMPLATE
-            value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 4
-            memory: "9Gi"
-          limits:
-            cpu: 4
-            memory: "9Gi"
-  - name: pull-cluster-autoscaler-e2e-azure-1-27
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-autoscaling-cluster-autoscaler
-      testgrid-tab-name: cloudprovider-azure-1.27
-    always_run: false
-    optional: true
-    run_if_changed: 'cluster-autoscaler\/cloudprovider\/azure'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-community: "true"
-    decorate: true
-    decoration_config:
-      timeout: 5h
-    path_alias: k8s.io/autoscaler
-    branches:
-      - cluster-autoscaler-release-1.27
-    extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-azure
-      base_ref: release-1.18
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      workdir: true
-    spec:
-      serviceAccountName: azure
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-1164926229-1.27
-        command:
-          - runner.sh
-          - ./scripts/ci-entrypoint.sh
-        args:
-          - bash
-          - -c
-          - |
-            cd ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test
-            make test-e2e TAG=$(git rev-parse --short HEAD)
-        env:
-          # CAPZ config
-          - name: ADDITIONAL_ASO_CRDS
-            value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
-          - name: KUBERNETES_VERSION
-            value: "1.27"
+          - name: AKS_TIER
+            value: "Premium" # required for LTS
+          - name: AKS_SUPPORT_PLAN
+            value: "AKSLongTermSupport" # Use LTS
           - name: CLUSTER_TEMPLATE
             value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
This PR enables configuration to build AKS LTS clusters for all versions that are currently supported.

E2E test config for the release-1.27 branch is removed because LTS support for that version of Kubernetes has expired in AKS and we can't build 1.27 clusters anymore. Ref:

- https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#lts-versions