### PR TITLE
use general purpsoe FEATURES_GATES and RUNTIME_CONFIG instead of GA_ONLY

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -98,8 +98,11 @@ presubmits:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
           value: "true"
-        - name: GA_ONLY
-          value: "true"
+        # disable non-GA APIs and features
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":false,"AllBeta":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/alpha":"false", "api/beta":"false"}'
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.31.yaml
@@ -1912,8 +1912,11 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
           - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
-        - name: GA_ONLY
-          value: "true"
+        # disable non-GA APIs and features
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":false,"AllBeta":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/alpha":"false", "api/beta":"false"}'
         - name: PARALLEL
           value: "true"
         image: gcr.io/k8s-staging-test-infra/krte:v20251021-e2c2c9806f-1.31

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -2042,8 +2042,11 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
           - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
-        - name: GA_ONLY
-          value: "true"
+        # disable non-GA APIs and features
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":false,"AllBeta":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/alpha":"false", "api/beta":"false"}'
         - name: PARALLEL
           value: "true"
         image: gcr.io/k8s-staging-test-infra/krte:v20251021-e2c2c9806f-1.32

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -2609,8 +2609,11 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
           - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
-        - name: GA_ONLY
-          value: "true"
+        # disable non-GA APIs and features
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":false,"AllBeta":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/alpha":"false", "api/beta":"false"}'
         - name: PARALLEL
           value: "true"
         image: gcr.io/k8s-staging-test-infra/krte:v20251021-e2c2c9806f-1.33

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -3452,8 +3452,11 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
           - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
-        - name: GA_ONLY
-          value: "true"
+        # disable non-GA APIs and features
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":false,"AllBeta":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/alpha":"false", "api/beta":"false"}'
         - name: PARALLEL
           value: "true"
         image: gcr.io/k8s-staging-test-infra/krte:v20251021-e2c2c9806f-1.34

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -165,8 +165,11 @@ periodics:
       - -c
       - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
-      - name: GA_ONLY
-        value: "true"
+      # disable non-GA APIs and features
+      - name: FEATURE_GATES
+        value: '{"AllAlpha":false,"AllBeta":false}'
+      - name: RUNTIME_CONFIG
+        value: '{"api/alpha":"false", "api/beta":"false"}'
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -208,8 +208,11 @@ presubmits:
         - -c
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
-        - name: GA_ONLY
-          value: "true"
+        # disable non-GA APIs and features
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":false,"AllBeta":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/alpha":"false", "api/beta":"false"}'
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -247,8 +250,11 @@ presubmits:
         - -c
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
-        - name: GA_ONLY
-          value: "true"
+        # disable non-GA APIs and features
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":false,"AllBeta":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/alpha":"false", "api/beta":"false"}'
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
so we can streamline mainteance of e2e-k8s.sh which is also used as a template for other scripts that wind up inheriting its complexity


FYI @liggitt 

cc @aojea @dims @pohly @stmcginnis 

x-ref https://github.com/kubernetes/test-infra/pull/35829