### PR TITLE
fix incorrect ssh username for kops scale jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -459,7 +459,7 @@ periodics:
         - name: KUBE_SSH_KEY_PATH
           value: /etc/ssh-key-secret/ssh-private
         - name: KUBE_SSH_USER
-          value: ubuntu
+          value: prow
         - name: GOPATH
           value: /home/prow/go
         - name: ARTIFACTS
@@ -570,7 +570,7 @@ periodics:
         - name: KUBE_SSH_KEY_PATH
           value: /etc/ssh-key-secret/ssh-private
         - name: KUBE_SSH_USER
-          value: ubuntu
+          value: prow
         - name: GOPATH
           value: /home/prow/go
         - name: ARTIFACTS

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-gce.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-gce.yaml
@@ -50,7 +50,7 @@ periodics:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: prow
       - name: GOPATH
         value: /home/prow/go
       - name: ARTIFACTS
@@ -150,7 +150,7 @@ periodics:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: prow
       - name: GOPATH
         value: /home/prow/go
       - name: ARTIFACTS
@@ -252,7 +252,7 @@ periodics:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: prow
       - name: GOPATH
         value: /home/prow/go
       - name: ARTIFACTS
@@ -354,7 +354,7 @@ periodics:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
       - name: KUBE_SSH_USER
-        value: ubuntu
+        value: prow
       - name: GOPATH
         value: /home/prow/go
       - name: ARTIFACTS


### PR DESCRIPTION
ssh is failing because the username is prow and not ubuntu for GCE jobs