### PR TITLE
Increase worker count for VPA actuation jobs

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -41,6 +41,9 @@ periodics:
         requests:
           cpu: 2
           memory: 6Gi
+      env:
+      - name: NUMPROC
+        value: "8"
 
   annotations:
     testgrid-dashboards: sig-autoscaling-vpa

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -281,6 +281,8 @@ presubmits:
             cpu: 2
             memory: 6Gi
         env:
+        - name: NUMPROC
+          value: "8"
         - name: FEATURE_GATES
           value: "InPlaceOrRecreate=true"
   - name: pull-autoscaling-e2e-vpa-admission-controller


### PR DESCRIPTION
This job suits more workers since a lot of the tests contain a sleep
This should being the time down to 40 minutes