### PR TITLE
autoscaler: Remove test-and-verify

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -242,9 +242,11 @@ branch-protection:
         autoscaler:
           required_status_checks:
             contexts:
-            - test-and-verify
             - Helm chart
             - Helm Docs
+            - unit tests
+            - golangci-lint
+            - verify
           branches:
             gh-pages:
               protect: false


### PR DESCRIPTION
Add unit tests, golangci-lint and verify

Relates to the changes made in 

- https://github.com/kubernetes/autoscaler/pull/8669
- https://github.com/kubernetes/autoscaler/pull/8736