### PR TITLE
Change HPA tests to run less frequently

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -288,7 +288,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
     testgrid-tab-name: gci-gce-autoscaling
-- interval: 30m
+- interval: 24h
   name: ci-kubernetes-e2e-gci-gce-autoscaling-hpa-cm
   cluster: k8s-infra-prow-build
   labels:
@@ -324,7 +324,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
     testgrid-tab-name: gci-gce-autoscaling-hpa-cm
-- interval: 30m
+- interval: 24h
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs-hpa
   cluster: k8s-infra-prow-build
   labels:
@@ -360,7 +360,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
     testgrid-tab-name: gci-gce-autoscaling-migs-hpa
-- interval: 30m
+- interval: 24h
   name: ci-kubernetes-e2e-autoscaling-hpa-cpu
   cluster: k8s-infra-prow-build
   labels:
@@ -397,7 +397,7 @@ periodics:
     # TODO: add to release blocking dashboards once run is successful
     testgrid-dashboards: sig-autoscaling-hpa
     testgrid-tab-name: gce-cos-autoscaling-hpa-cpu
-- interval: 30m
+- interval: 24h
   name: ci-kubernetes-e2e-autoscaling-hpa-cpu-alpha-beta
   cluster: k8s-infra-prow-build
   labels:


### PR DESCRIPTION
Every 30 minutes is very frequent!
I don't know the reason these are like that, so I've gone a little cautious and changed them to only 6h.
I believe 24h should be fine, but one day when I get more familiar with the HPA e2e tests, I can look making that change

cc @omerap12 