### PR TITLE
enable cherrypick plugin in gateway-api-inference-extension

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -2100,6 +2100,12 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes-sigs/gateway-api-inference-extension:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker  
   containerd/containerd:
   - name: needs-rebase
     events:


### PR DESCRIPTION
enables cherrypicker plugin for `kubernetes-sigs/gateway-api-inference-extension`

ref https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/1783