### PR TITLE
remove kubelet scrapes for 5k nodes dra job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -599,8 +599,6 @@ periodics:
           value: "nftables"
         - name: ENABLE_PROMETHEUS_SERVER
           value: "true"
-        - name: PROMETHEUS_SCRAPE_KUBELETS
-          value: "true"
         - name: PROMETHEUS_PVC_STORAGE_CLASS
           value: "ssd-csi"
         - name: CLOUD_PROVIDER


### PR DESCRIPTION
The perf-tests repository, hardcodes prometheus memory to 10Gig if kubelet scrapes are enabled.

This is leading to prometheus pod OOMing. Removing the kubelet scrape will mean the job will not collect driver mertics, but doing that is favorable for now to unblock the 5k test run. In the future there is a need to find a way to collect kubelet metrics without hardcoding prometheus memory to 10 gigs

Ref: https://github.com/kubernetes/test-infra/pull/35700#issuecomment-3480901280