### PR TITLE
Increase parallelism in hpa-cpu test

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -393,14 +393,14 @@ periodics:
       - --timeout=240m
       - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Alpha\]|\[Beta\]
         --minStartupPods=8
-      - --ginkgo-parallel=1
+      - --ginkgo-parallel=3
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: 6Gi
         requests:
-          cpu: 2
+          cpu: 4
           memory: 6Gi
 
   annotations:


### PR DESCRIPTION
Enables parallelism in the HPA cpu e2e tests. This PR does not include any changes to the actual tests.

Also bumps up resources for test nodes.

Part of: https://github.com/kubernetes/kubernetes/issues/135026