### PR TITLE
autoscaler: updated required checks

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -242,7 +242,8 @@ branch-protection:
         autoscaler:
           required_status_checks:
             contexts:
-            - test-and-verify
+            - test
+            - verify
             - Helm chart
             - Helm Docs
           branches:


### PR DESCRIPTION
This PR updates the required checks for the kubernetes/autoscaler repo to use recently renamed status checks:

- https://github.com/kubernetes/autoscaler/blob/master/.github/workflows/ca-test.yaml#L20
- https://github.com/kubernetes/autoscaler/blob/master/.github/workflows/vpa-test.yaml#L20
- https://github.com/kubernetes/autoscaler/blob/master/.github/workflows/verify.yaml#L16