### PR TITLE
cleanup remaining GA_ONLY references

### DIFF
--- a/experiment/compatibility-versions/common.sh
+++ b/experiment/compatibility-versions/common.sh
@@ -35,16 +35,12 @@ CONTROL_PLANE_COMPONENTS="kube-apiserver kube-controller-manager kube-scheduler"
 # parallel testing is enabled. Using LABEL_FILTER instead of combining SKIP and
 # FOCUS is recommended (more expressive, easier to read than regexp).
 #
-# GA_ONLY: true  - limit to GA APIs/features as much as possible
-#          false - (default) APIs and features left at defaults
 # FEATURE_GATES:
 #          JSON or YAML encoding of a string/bool map: {"FeatureGateA": true, "FeatureGateB": false}
 #          Enables or disables feature gates in the entire cluster.
-#          Cannot be used when GA_ONLY=true.
 # RUNTIME_CONFIG:
 #          JSON or YAML encoding of a string/string (!) map: {"apia.example.com/v1alpha1": "true", "apib.example.com/v1beta1": "false"}
 #          Enables API groups in the apiserver via --runtime-config.
-#          Cannot be used when GA_ONLY=true.
 
 # cleanup logic for cleanup on exit
 CLEANED_UP=false
@@ -133,30 +129,6 @@ create_cluster() {
   feature_gates="${FEATURE_GATES:-{\}}"
   # --runtime-config argument value passed to the API server, again as a map
   runtime_config="${RUNTIME_CONFIG:-{\}}"
-
-  case "${GA_ONLY:-false}" in
-  false)
-    :
-    ;;
-  true)
-    if [ "${feature_gates}" != "{}" ]; then
-      echo "GA_ONLY=true and FEATURE_GATES=${feature_gates} are mutually exclusive."
-      return 1
-    fi
-    if [ "${runtime_config}" != "{}" ]; then
-      echo "GA_ONLY=true and RUNTIME_CONFIG=${runtime_config} are mutually exclusive."
-      return 1
-    fi
-
-    echo "Limiting to GA APIs and features for ${PREV_VERSION}"
-    feature_gates='{"AllAlpha":false,"AllBeta":false}'
-    runtime_config='{"api/alpha":"false", "api/beta":"false"}'
-    ;;
-  *)
-    echo "\$GA_ONLY set to '${GA_ONLY}'; supported values are true and false (default)"
-    return 1
-    ;;
-  esac
 
   # create the config file
   cat <<EOF > "${ARTIFACTS}/kind-config.yaml"

--- a/experiment/compatibility-versions/compatibility-versions-feature-gate-test.sh
+++ b/experiment/compatibility-versions/compatibility-versions-feature-gate-test.sh
@@ -21,18 +21,14 @@ set -o errexit -o nounset -o pipefail
 set -o xtrace
 
 # Settings:
-# GA_ONLY: true  - limit to GA APIs/features as much as possible
-#          false - (default) APIs and features left at defaults
 
 # FEATURE_GATES:
 #          JSON or YAML encoding of a string/bool map: {"FeatureGateA": true, "FeatureGateB": false}
 #          Enables or disables feature gates in the entire cluster.
-#          Cannot be used when GA_ONLY=true.
 
 # RUNTIME_CONFIG:
 #          JSON or YAML encoding of a string/string (!) map: {"apia.example.com/v1alpha1": "true", "apib.example.com/v1beta1": "false"}
 #          Enables API groups in the apiserver via --runtime-config.
-#          Cannot be used when GA_ONLY=true.
 
 # cleanup logic for cleanup on exit
 CLEANED_UP=false
@@ -118,30 +114,6 @@ create_cluster() {
   feature_gates="${FEATURE_GATES:-{\}}"
   # --runtime-config argument value passed to the API server, again as a map
   runtime_config="${RUNTIME_CONFIG:-{\}}"
-
-  case "${GA_ONLY:-false}" in
-  false)
-    :
-    ;;
-  true)
-    if [ "${feature_gates}" != "{}" ]; then
-      echo "GA_ONLY=true and FEATURE_GATES=${feature_gates} are mutually exclusive."
-      exit 1
-    fi
-    if [ "${runtime_config}" != "{}" ]; then
-      echo "GA_ONLY=true and RUNTIME_CONFIG=${runtime_config} are mutually exclusive."
-      exit 1
-    fi
-
-    echo "Limiting to GA APIs and features for ${KUBE_VERSION}"
-    feature_gates='{"AllAlpha":false,"AllBeta":false}'
-    runtime_config='{"api/alpha":"false", "api/beta":"false"}'
-    ;;
-  *)
-    echo "\$GA_ONLY set to '${GA_ONLY}'; supported values are true and false (default)"
-    exit 1
-    ;;
-  esac
 
   # create the config file
   cat <<EOF > "${ARTIFACTS}/kind-config.yaml"

--- a/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
+++ b/experiment/compatibility-versions/e2e-k8s-compatibility-versions.sh
@@ -28,16 +28,12 @@ set -o errexit -o nounset -o xtrace
 # parallel testing is enabled. Using LABEL_FILTER instead of combining SKIP and
 # FOCUS is recommended (more expressive, easier to read than regexp).
 #
-# GA_ONLY: true  - limit to GA APIs/features as much as possible
-#          false - (default) APIs and features left at defaults
 # FEATURE_GATES:
 #          JSON or YAML encoding of a string/bool map: {"FeatureGateA": true, "FeatureGateB": false}
 #          Enables or disables feature gates in the entire cluster.
-#          Cannot be used when GA_ONLY=true.
 # RUNTIME_CONFIG:
 #          JSON or YAML encoding of a string/string (!) map: {"apia.example.com/v1alpha1": "true", "apib.example.com/v1beta1": "false"}
 #          Enables API groups in the apiserver via --runtime-config.
-#          Cannot be used when GA_ONLY=true.
 
 COMMON_SCRIPT="${COMMON_SCRIPT:-${PWD}/../test-infra/experiment/compatibility-versions/common.sh}"
 source "${COMMON_SCRIPT}"

--- a/experiment/compatibility-versions/e2e-two-steps-upgrade.sh
+++ b/experiment/compatibility-versions/e2e-two-steps-upgrade.sh
@@ -28,16 +28,12 @@ set -o errexit -o nounset -o xtrace
 # parallel testing is enabled. Using LABEL_FILTER instead of combining SKIP and
 # FOCUS is recommended (more expressive, easier to read than regexp).
 #
-# GA_ONLY: true  - limit to GA APIs/features as much as possible
-#          false - (default) APIs and features left at defaults
 # FEATURE_GATES:
 #          JSON or YAML encoding of a string/bool map: {"FeatureGateA": true, "FeatureGateB": false}
 #          Enables or disables feature gates in the entire cluster.
-#          Cannot be used when GA_ONLY=true.
 # RUNTIME_CONFIG:
 #          JSON or YAML encoding of a string/string (!) map: {"apia.example.com/v1alpha1": "true", "apib.example.com/v1beta1": "false"}
 #          Enables API groups in the apiserver via --runtime-config.
-#          Cannot be used when GA_ONLY=true.
 
 COMMON_SCRIPT="${COMMON_SCRIPT:-${PWD}/../test-infra/experiment/compatibility-versions/common.sh}"
 source "${COMMON_SCRIPT}"

--- a/experiment/kind-detect-local-e2e.sh
+++ b/experiment/kind-detect-local-e2e.sh
@@ -22,8 +22,6 @@ set -o errexit -o nounset -o xtrace
 # Settings:
 # SKIP: ginkgo skip regex
 # FOCUS: ginkgo focus regex
-# GA_ONLY: true  - limit to GA APIs/features as much as possible
-#          false - (default) APIs and features left at defaults
 #
 
 # cleanup logic for cleanup on exit
@@ -113,35 +111,6 @@ create_cluster() {
   feature_gates="{}"
   # --runtime-config argument value passed to the API server
   runtime_config="{}"
-
-  case "${GA_ONLY:-false}" in
-  false)
-    feature_gates="{}"
-    runtime_config="{}"
-    ;;
-  true)
-    case "${KUBE_VERSION}" in
-    v1.1[0-7].*)
-      echo "GA_ONLY=true is only supported on versions >= v1.18, got ${KUBE_VERSION}"
-      exit 1
-      ;;
-    v1.18.*)
-      echo "Limiting to GA APIs and features (plus certificates.k8s.io/v1beta1 and RotateKubeletClientCertificate) for ${KUBE_VERSION}"
-      feature_gates='{"AllAlpha":false,"AllBeta":false,"RotateKubeletClientCertificate":true}'
-      runtime_config='{"api/alpha":"false", "api/beta":"false", "certificates.k8s.io/v1beta1":"true"}'
-      ;;
-    *)
-      echo "Limiting to GA APIs and features for ${KUBE_VERSION}"
-      feature_gates='{"AllAlpha":false,"AllBeta":false}'
-      runtime_config='{"api/alpha":"false", "api/beta":"false"}'
-      ;;
-    esac
-    ;;
-  *)
-    echo "\$GA_ONLY set to '${GA_ONLY}'; supported values are true and false (default)"
-    exit 1
-    ;;
-  esac
 
   # create the config file
   cat <<EOF > "${ARTIFACTS}/kind-config.yaml"

--- a/experiment/kind-logs-e2e-k8s.sh
+++ b/experiment/kind-logs-e2e-k8s.sh
@@ -22,16 +22,12 @@ set -o errexit -o nounset -o xtrace
 # Settings:
 # SKIP: ginkgo skip regex
 # FOCUS: ginkgo focus regex
-# GA_ONLY: true  - limit to GA APIs/features as much as possible
-#          false - (default) APIs and features left at defaults
 # FEATURE_GATES:
 #          JSON or YAML encoding of a string/bool map: {"FeatureGateA": true, "FeatureGateB": false}
 #          Enables or disables feature gates in the entire cluster.
-#          Cannot be used when GA_ONLY=true.
 # RUNTIME_CONFIG:
 #          JSON or YAML encoding of a string/string (!) map: {"apia.example.com/v1alpha1": "true", "apib.example.com/v1beta1": "false"}
 #          Enables API groups in the apiserver via --runtime-config.
-#          Cannot be used when GA_ONLY=true.
 
 # cleanup logic for cleanup on exit
 CLEANED_UP=false
@@ -119,30 +115,6 @@ create_cluster() {
   feature_gates="${FEATURE_GATES:-{\}}"
   # --runtime-config argument value passed to the API server, again as a map
   runtime_config="${RUNTIME_CONFIG:-{\}}"
-
-  case "${GA_ONLY:-false}" in
-  false)
-    :
-    ;;
-  true)
-    if [ "${feature_gates}" != "{}" ]; then
-      echo "GA_ONLY=true and FEATURE_GATES=${feature_gates} are mutually exclusive."
-      exit 1
-    fi
-    if [ "${runtime_config}" != "{}" ]; then
-      echo "GA_ONLY=true and RUNTIME_CONFIG=${runtime_config} are mutually exclusive."
-      exit 1
-    fi
-
-    echo "Limiting to GA APIs and features for ${KUBE_VERSION}"
-    feature_gates='{"AllAlpha":false,"AllBeta":false}'
-    runtime_config='{"api/alpha":"false", "api/beta":"false"}'
-    ;;
-  *)
-    echo "\$GA_ONLY set to '${GA_ONLY}'; supported values are true and false (default)"
-    exit 1
-    ;;
-  esac
 
   # create the config file
   cat <<EOF > "${ARTIFACTS}/kind-config.yaml"

--- a/experiment/kind-multizone-e2e.sh
+++ b/experiment/kind-multizone-e2e.sh
@@ -22,8 +22,6 @@ set -o errexit -o nounset -o xtrace
 # Settings:
 # SKIP: ginkgo skip regex
 # FOCUS: ginkgo focus regex
-# GA_ONLY: true  - limit to GA APIs/features as much as possible
-#          false - (default) APIs and features left at defaults
 # 
 
 # cleanup logic for cleanup on exit
@@ -113,35 +111,6 @@ create_cluster() {
   feature_gates="{}"
   # --runtime-config argument value passed to the API server
   runtime_config="{}"
-
-  case "${GA_ONLY:-false}" in
-  false)
-    feature_gates="{}"
-    runtime_config="{}"
-    ;;
-  true)
-    case "${KUBE_VERSION}" in
-    v1.1[0-7].*)
-      echo "GA_ONLY=true is only supported on versions >= v1.18, got ${KUBE_VERSION}"
-      exit 1
-      ;;
-    v1.18.*)
-      echo "Limiting to GA APIs and features (plus certificates.k8s.io/v1beta1 and RotateKubeletClientCertificate) for ${KUBE_VERSION}"
-      feature_gates='{"AllAlpha":false,"AllBeta":false,"RotateKubeletClientCertificate":true}'
-      runtime_config='{"api/alpha":"false", "api/beta":"false", "certificates.k8s.io/v1beta1":"true"}'
-      ;;
-    *)
-      echo "Limiting to GA APIs and features for ${KUBE_VERSION}"
-      feature_gates='{"AllAlpha":false,"AllBeta":false}'
-      runtime_config='{"api/alpha":"false", "api/beta":"false"}'
-      ;;
-    esac
-    ;;
-  *)
-    echo "\$GA_ONLY set to '${GA_ONLY}'; supported values are true and false (default)"
-    exit 1
-    ;;
-  esac
 
   # create the config file with 2 nodes per zone
   cat <<EOF > "${ARTIFACTS}/kind-config.yaml"

--- a/experiment/kind-noendpoints-e2e.sh
+++ b/experiment/kind-noendpoints-e2e.sh
@@ -28,16 +28,12 @@ set -o errexit -o nounset -o xtrace
 # parallel testing is enabled. Using LABEL_FILTER instead of combining SKIP and
 # FOCUS is recommended (more expressive, easier to read than regexp).
 #
-# GA_ONLY: true  - limit to GA APIs/features as much as possible
-#          false - (default) APIs and features left at defaults
 # FEATURE_GATES:
 #          JSON or YAML encoding of a string/bool map: {"FeatureGateA": true, "FeatureGateB": false}
 #          Enables or disables feature gates in the entire cluster.
-#          Cannot be used when GA_ONLY=true.
 # RUNTIME_CONFIG:
 #          JSON or YAML encoding of a string/string (!) map: {"apia.example.com/v1alpha1": "true", "apib.example.com/v1beta1": "false"}
 #          Enables API groups in the apiserver via --runtime-config.
-#          Cannot be used when GA_ONLY=true.
 
 # cleanup logic for cleanup on exit
 CLEANED_UP=false
@@ -129,30 +125,6 @@ create_cluster() {
   feature_gates="${FEATURE_GATES:-{\}}"
   # --runtime-config argument value passed to the API server, again as a map
   runtime_config="${RUNTIME_CONFIG:-{\}}"
-
-  case "${GA_ONLY:-false}" in
-  false)
-    :
-    ;;
-  true)
-    if [ "${feature_gates}" != "{}" ]; then
-      echo "GA_ONLY=true and FEATURE_GATES=${feature_gates} are mutually exclusive."
-      exit 1
-    fi
-    if [ "${runtime_config}" != "{}" ]; then
-      echo "GA_ONLY=true and RUNTIME_CONFIG=${runtime_config} are mutually exclusive."
-      exit 1
-    fi
-
-    echo "Limiting to GA APIs and features for ${KUBE_VERSION}"
-    feature_gates='{"AllAlpha":false,"AllBeta":false}'
-    runtime_config='{"api/alpha":"false", "api/beta":"false"}'
-    ;;
-  *)
-    echo "\$GA_ONLY set to '${GA_ONLY}'; supported values are true and false (default)"
-    exit 1
-    ;;
-  esac
 
   # create the config file
   cat <<EOF > "${ARTIFACTS}/kind-config.yaml"

--- a/experiment/kubelet-serving-certificates/e2e-k8s.sh
+++ b/experiment/kubelet-serving-certificates/e2e-k8s.sh
@@ -29,16 +29,12 @@ set -o errexit -o nounset -o xtrace
 # parallel testing is enabled. Using LABEL_FILTER instead of combining SKIP and
 # FOCUS is recommended (more expressive, easier to read than regexp).
 #
-# GA_ONLY: true  - limit to GA APIs/features as much as possible
-#          false - (default) APIs and features left at defaults
 # FEATURE_GATES:
 #          JSON or YAML encoding of a string/bool map: {"FeatureGateA": true, "FeatureGateB": false}
 #          Enables or disables feature gates in the entire cluster.
-#          Cannot be used when GA_ONLY=true.
 # RUNTIME_CONFIG:
 #          JSON or YAML encoding of a string/string (!) map: {"apia.example.com/v1alpha1": "true", "apib.example.com/v1beta1": "false"}
 #          Enables API groups in the apiserver via --runtime-config.
-#          Cannot be used when GA_ONLY=true.
 
 # cleanup logic for cleanup on exit
 CLEANED_UP=false
@@ -132,30 +128,6 @@ create_cluster() {
   feature_gates="${FEATURE_GATES:-{\}}"
   # --runtime-config argument value passed to the API server, again as a map
   runtime_config="${RUNTIME_CONFIG:-{\}}"
-
-  case "${GA_ONLY:-false}" in
-  false)
-    :
-    ;;
-  true)
-    if [ "${feature_gates}" != "{}" ]; then
-      echo "GA_ONLY=true and FEATURE_GATES=${feature_gates} are mutually exclusive."
-      exit 1
-    fi
-    if [ "${runtime_config}" != "{}" ]; then
-      echo "GA_ONLY=true and RUNTIME_CONFIG=${runtime_config} are mutually exclusive."
-      exit 1
-    fi
-
-    echo "Limiting to GA APIs and features for ${KUBE_VERSION}"
-    feature_gates='{"AllAlpha":false,"AllBeta":false}'
-    runtime_config='{"api/alpha":"false", "api/beta":"false"}'
-    ;;
-  *)
-    echo "\$GA_ONLY set to '${GA_ONLY}'; supported values are true and false (default)"
-    exit 1
-    ;;
-  esac
 
   # create the config file
   cat <<EOF > "${ARTIFACTS}/kind-config.yaml"


### PR DESCRIPTION
See: https://github.com/kubernetes/test-infra/pull/35830

No jobs use this env, it was copy-pasted from an earlier iteration of e2e-k8s.sh from the kind repo

Broken out from larger simplification of these scripts, ahead of https://github.com/kubernetes-sigs/kind/issues/3847