### PR TITLE
updated go lang version

### DIFF
--- a/config/jobs/kubernetes-sigs/ibm-vpc-block-csi-driver/ibm-vpc-block-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/ibm-vpc-block-csi-driver/ibm-vpc-block-csi-driver.yaml
@@ -42,7 +42,7 @@ presubmits:
       description: Unit tests in ibm-vpc-block-csi-driver repo.
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23.12
+      - image: public.ecr.aws/docker/library/golang:1.25.3
         command:
         - make
         args:
@@ -68,7 +68,7 @@ presubmits:
       description: ibm-vpc-block-csi-driver basic code verification.
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23.12
+      - image: public.ecr.aws/docker/library/golang:1.25.3
         command:
         - make
         args:
@@ -94,7 +94,7 @@ presubmits:
       description: ibm-vpc-block-csi-driver sanity execution.
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.23.12
+      - image: public.ecr.aws/docker/library/golang:1.25.3
         command:
         - make
         args:


### PR DESCRIPTION
Task Detail :->

go lang base upgraded due to reported VA.

Compliance Issue Details :->

[CVE-2025-61725](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2025-61725)
[CVE-2025-58189](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2025-58189)

Updation Area :->

 go 1.23.12 to  go 1.25.3 