### PR TITLE
Do not fail when pending_eligible_endpoints.yaml is empty

### DIFF
--- a/experiment/audit/audit_log_parser.py
+++ b/experiment/audit/audit_log_parser.py
@@ -92,6 +92,11 @@ def _process_yaml_data(yaml_data, endpoint_type):
     """
     endpoints = set()
 
+    # Handle empty YAML files (yaml_data is None)
+    if yaml_data is None:
+        print(f"Loaded {len(endpoints)} {endpoint_type} (empty file)")
+        return endpoints
+
     if isinstance(yaml_data, list):
         for item in yaml_data:
             if isinstance(item, dict):


### PR DESCRIPTION
Fixing the scenario found here:
- Log: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135067/pull-kubernetes-audit-kind-conformance/1985455043473575936
- PR: https://github.com/kubernetes/kubernetes/pull/135067

We should be ok when there's nothing pending!