### PR TITLE
DRA canary: fix indention, dump to ARTIFACTS

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -61,7 +61,10 @@ presubmits:
           if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
               echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
           fi
-          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd\n' /tmp/kind.yaml
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
 
           cat /tmp/kind.yaml
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
@@ -145,7 +148,10 @@ presubmits:
           if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
               echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
           fi
-          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd\n' /tmp/kind.yaml
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
 
           cat /tmp/kind.yaml
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
@@ -229,7 +235,10 @@ presubmits:
           if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
               echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
           fi
-          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd\n' /tmp/kind.yaml
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
 
           cat /tmp/kind.yaml
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
@@ -311,7 +320,10 @@ presubmits:
           if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
               echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
           fi
-          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd\n' /tmp/kind.yaml
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
 
           cat /tmp/kind.yaml
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
@@ -438,7 +450,10 @@ presubmits:
           if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
               echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
           fi
-          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd\n' /tmp/kind.yaml
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
 
           cat /tmp/kind.yaml
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
@@ -565,7 +580,10 @@ presubmits:
           if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
               echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
           fi
-          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd\n' /tmp/kind.yaml
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
 
           cat /tmp/kind.yaml
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -189,7 +189,10 @@ presubmits:
           if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
               echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
           fi
-          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '- |\n  kind: ClusterConfiguration\n  etcd:\n    local:\n      dataDir: /tmp/etcd\n' /tmp/kind.yaml
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           {% else %}
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.


### PR DESCRIPTION
The indention wasn't right (KYAML anyone?), but this only affected the canary jobs.

To align with other kind jobs, the kind.yaml now also gets preserved in ARTIFACTS. This is only done for canaries to avoid touch the other jobs, can be simplified during promotion.