### PR TITLE
Add image config file for evented pleg

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1404,7 +1404,7 @@ presubmits:
               - --focus-regex=\[NodeConformance\]|\[Feature:.+\]|\[Feature\]
               - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:UserNamespacesSupport\]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:PodLevelResources\]|\[Alpha\]
               - '--test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --feature-gates=EventedPLEG=true --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
-              - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
+              - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-evented-pleg.yaml
             resources:
               limits:
                 cpu: 4

--- a/jobs/e2e_node/containerd/image-config-evented-pleg.yaml
+++ b/jobs/e2e_node/containerd/image-config-evented-pleg.yaml
@@ -1,0 +1,10 @@
+#  containerd 1.7 does not fully support the EventedPLEG feature. Testing the EventedPLEG feature on containerd 1.7 would cause the tests to fail. 
+# Therefore, we need to provide a testing environment for EventedPLEG based on containerd 2.x, which requires a separate image configuration file.
+images:
+  ubuntu:
+    image_family: pipeline-1-34-amd64
+    project: ubuntu-os-gke-cloud
+    # the image regex is added so that only cgroupv2 images are selected.
+    # currently all images with cgroupv1 from gke have a -cgroupsv1 suffix
+    image_regex: ".*[^-cgroupsv1]$"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"


### PR DESCRIPTION
The EventedPLEG does not support containerd 1.7, so we don't need to test it, we only need to test Ubuntu. If we test containerd 1.7 simultaneously, the test job will fail, so we need to add an image configuration file that only uses Ubuntu for it.

Sorry for submit the PR once more. I'm not very familiar with the k8s testing mechanism and only realized this file needed modification after encountering the error.


