### PR TITLE
update dra 5k nodes test with right qps,burst and maxInFlightRequests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -609,6 +609,16 @@ periodics:
           value: "gcr.io/k8s-staging-perf-tests/sleep:v0.0.3"
         - name: KOPS_CL2_TEST_CONFIG
           value: testing/dra/config.yaml
+        - name: KOPS_SCHEDULER_QPS
+          value: "1200"
+        - name: KOPS_SCHEDULER_BURST
+          value: "1200"
+        - name: KOPS_CONTROLLER_MANAGER_QPS
+          value: "1000"
+        - name: KOPS_CONTROLLER_MANAGER_BURST
+          value: "1000"
+        - name: KOPS_APISERVER_MAX_REQUESTS_INFLIGHT
+          value: "1600"
         resources:
           requests:
             cpu: "7"


### PR DESCRIPTION
This is blocked by kops PR: https://github.com/kubernetes/kops/pull/17742