### PR TITLE
cloud-provider-gcp: run cloud-provider-gcp-tests by calling script

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -18,24 +18,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
         command:
-        - /bin/bash
-        args:
-        - -c
-        - |
-          if [ -f Makefile ]; then
-            make test
-          else
-            REPO_ROOT=$(git rev-parse --show-toplevel);
-            if [[ -f "${REPO_ROOT}/.bazelversion" ]]; then
-              export BAZEL_VERSION=$(cat "${REPO_ROOT}/.bazelversion");
-              echo "BAZEL_VERSION set to ${BAZEL_VERSION}";
-            else
-              export BAZEL_VERSION="5.3.0";
-              echo "BAZEL_VERSION - Falling back to 5.3.0";
-            fi;
-            /workspace/test-infra/images/kubekins-e2e/install-bazel.sh;
-            bazel test --test_output=errors -- //... -//vendor/...
-          fi
+        - dev/ci/presubmits/cloud-provider-gcp-tests
         resources:
           limits:
             cpu: 4


### PR DESCRIPTION
We have a script that defines the desired content of this job,
in `dev/ci/presubmits/cloud-provider-gcp-tests`.

In general, we want to keep the logic in our own repo,
and keep (only) prow configuration in prow.
