### PR TITLE
dra 5000 node test update qps/burst of kube-scheduler and maxInFlight requests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -610,15 +610,11 @@ periodics:
         - name: KOPS_CL2_TEST_CONFIG
           value: testing/dra/config.yaml
         - name: KOPS_SCHEDULER_QPS
-          value: "1200"
+          value: "2000"
         - name: KOPS_SCHEDULER_BURST
-          value: "1200"
-        - name: KOPS_CONTROLLER_MANAGER_QPS
-          value: "1000"
-        - name: KOPS_CONTROLLER_MANAGER_BURST
-          value: "1000"
+          value: "2000"
         - name: KOPS_APISERVER_MAX_REQUESTS_INFLIGHT
-          value: "1600"
+          value: "4000"
         resources:
           requests:
             cpu: "7"


### PR DESCRIPTION
In yesterdays run, we still had client-side rate limiting in scheduler.

This PR bumps the number, while removing the bump in controller-manager as it is not needed.