### PR TITLE
Add presubmit for RestartAllContainers alpha feature

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -505,7 +505,7 @@ presubmits:
             args:
               - --deployment=node
               - --gcp-zone=us-central1-b
-              - '--node-test-args=--feature-gates=ContainerRestartRules=true,RestartAllContainersOnContainerExits=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              - '--node-test-args=--service-feature-gates="ContainerRestartRules=true,RestartAllContainersOnContainerExits=true" --feature-gates="ContainerRestartRules=true,RestartAllContainersOnContainerExits=true" --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
               - --node-tests=true
               - --provider=gce
               - --test_args=--nodes=1 --focus="\[Feature:RestartAllContainersOnContainerExits\]" --skip="\[Flaky\]"


### PR DESCRIPTION
New Prow presubmit job for SIG Node named `pull-kubernetes-node-e2e-restartallcontainers` with the feature gates:
- ContainerRestartRules=true
- RestartAllContainersOnContainerExits=true

It can be run with the command
  '`/test pull-kubernetes-node-e2e-restartallcontainers`' on a PR

cc: @SergeyKanzhelev @yuanwang04