### PR TITLE
Add missing image-config-file arg

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -509,6 +509,7 @@ presubmits:
               - --provider=gce
               - --test_args=--nodes=1 --focus="\[Feature:RestartAllContainersOnContainerExits\]" --skip="\[Flaky\]"
               - --timeout=65m
+              - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
             env:
               - name: GOPATH
                 value: /go


### PR DESCRIPTION
The test target is missing argument:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/133654/pull-kubernetes-node-e2e-restartallcontainers/1986534438833491968

```
Will use ginkgo flags as: --nodes=1 --focus="\[Feature:RestartAllContainersOnContainerExits\]" --skip="\[Flaky\]" --no-color -vF1106 20:43:18.027704    6277 gce_runner.go:103] Must specify one of --image-config-file, --hosts, --images.
```

Adding the serial image config file because some tests will be serial and have interruptions.