### PR TITLE
Require PR review and approval for aws-efs-csi-driver

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -519,6 +519,8 @@ branch-protection:
             gh-pages:
               protect: false
         aws-efs-csi-driver:
+          required_pull_request_reviews:
+            required_approving_review_count: 1
           branches:
             gh-pages:
               protect: false


### PR DESCRIPTION
We would like to have stronger branch protection for aws-efs-csi-driver which requires PR review and at least 1 approval before merging.