### PR TITLE
Azure scale: bump CAPZ to 1.21

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
@@ -17,7 +17,7 @@ periodics:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.20
+      base_ref: release-1.21
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     - org: kubernetes-sigs
       repo: cloud-provider-azure


### PR DESCRIPTION
The CAPZ release-1.20 branch is currently failing to build clusters for the ci-kubernetes-e2e-azure-scalability job since the removal of the kubelet's `--pod-infra-container-image` flag in https://github.com/kubernetes/kubernetes/pull/133779, e.g. https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-azure-scalability/1986706943242145792.

This PR bumps CAPZ to the release-1.21 branch which includes https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5961 to reference newer VM images built with https://github.com/kubernetes-sigs/image-builder/pull/1866 that no longer set that flag.

