### PR TITLE
Change node size of hpa-cpu periodic job

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -379,6 +379,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-central1-b
       - --gcp-node-image=gci
+      - --gcp-node-size=e2-standard-4
       - --extract=ci/latest
       - --timeout=240m
       - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Alpha\]|\[Beta\]
@@ -387,10 +388,10 @@ periodics:
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251021-e2c2c9806f-master
       resources:
         limits:
-          cpu: 4
+          cpu: 2
           memory: 6Gi
         requests:
-          cpu: 4
+          cpu: 2
           memory: 6Gi
 
   annotations:


### PR DESCRIPTION
Reverts the resource change of the test pod running in CI for the hpa-cpu periodic. Instead, we should have change the instance type of the spawned gce test nodes.

This PR changes it to `e2-standard-4`: https://gcloud-compute.com/e2-standard-4.html 

Partially reverts: https://github.com/kubernetes/test-infra/pull/35847