### PR TITLE
CRI-O: bump canary jobs

### DIFF
--- a/jobs/e2e_node/crio/crio_canary.ign
+++ b/jobs/e2e_node/crio/crio_canary.ign
@@ -52,7 +52,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D90bb7766f61c0fef6a071ca933ad917242b9bd52%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D8beeed1ea9357cd8adb05bbc394eb23a02807ff7%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dcae4e9ac33013ddcd57b258dfe6b845533f2fc84%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_userns.ign
+++ b/jobs/e2e_node/crio/crio_userns.ign
@@ -62,7 +62,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D90bb7766f61c0fef6a071ca933ad917242b9bd52%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D8beeed1ea9357cd8adb05bbc394eb23a02807ff7%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3D0936ec4f6d77fba3a42432adaf8aa57b629c06cf%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D5655aea0470e126bbb0dd9a5092efb32fb4e12d1%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/templates/base/env-canary.yaml
+++ b/jobs/e2e_node/crio/templates/base/env-canary.yaml
@@ -6,5 +6,5 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=90bb7766f61c0fef6a071ca933ad917242b9bd52"
-          DefaultEnvironment="CRIO_COMMIT=8beeed1ea9357cd8adb05bbc394eb23a02807ff7"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
+          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"

--- a/jobs/e2e_node/crio/templates/crio_canary.yaml
+++ b/jobs/e2e_node/crio/templates/crio_canary.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=90bb7766f61c0fef6a071ca933ad917242b9bd52"
-          DefaultEnvironment="CRIO_COMMIT=8beeed1ea9357cd8adb05bbc394eb23a02807ff7"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
+          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
     - path: /etc/crio/crio.conf.d/99-crun.conf
       contents:
         local: 99-crun.conf

--- a/jobs/e2e_node/crio/templates/crio_userns.yaml
+++ b/jobs/e2e_node/crio/templates/crio_userns.yaml
@@ -32,8 +32,8 @@ storage:
       contents:
         inline: |
           [Manager]
-          DefaultEnvironment="CRIO_SCRIPT_COMMIT=90bb7766f61c0fef6a071ca933ad917242b9bd52"
-          DefaultEnvironment="CRIO_COMMIT=8beeed1ea9357cd8adb05bbc394eb23a02807ff7"
+          DefaultEnvironment="CRIO_SCRIPT_COMMIT=0936ec4f6d77fba3a42432adaf8aa57b629c06cf"
+          DefaultEnvironment="CRIO_COMMIT=5655aea0470e126bbb0dd9a5092efb32fb4e12d1"
     # Note: this ignition file assumes FCOS has shadow-utils installed.
     # As of the time of writing this, it does.
     - path: /etc/subuid

--- a/jobs/e2e_node/crio/templates/generate
+++ b/jobs/e2e_node/crio/templates/generate
@@ -32,7 +32,7 @@ declare -A CONFIGURATIONS=(
     ["crio_imagefs"]="root env imagefs"
     ["crio_splitfs"]="root env splitfs"
     ["crio_hugepages"]="root env hugepages"
-    ["crio_userns"]="root env-canary userns crun-enabled"
+    ["crio_userns"]="root env userns crun-enabled"
 )
 
 CONTAINER_RUNTIME=$(which podman 2>/dev/null || which nerdctl 2>/dev/null || which docker 2>/dev/null)


### PR DESCRIPTION
Update the canary jobs to the latest available build.

PTAL @kubernetes/sig-node-cri-o-test-maintainers 