### PR TITLE
[sig node] fix test args for unlabelled test job

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -384,7 +384,7 @@ periodics:
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-driver=systemd --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=1 --skip=\[Flaky\]|\[NodeConformance\]|\[Conformance\]|\[Serial\]|\[Feature:.+\]|\[Feature\]|\[Legacy:.+\]|\[Benchmark\]
+      - --test_args=--nodes=1 --skip="\[Flaky\]|\[NodeConformance\]|\[Conformance\]|\[Serial\]|\[Feature:.+\]|\[Feature\]|\[Legacy:.+\]|\[Benchmark\]"
       - --timeout=300m
       env:
       - name: GOPATH


### PR DESCRIPTION
This job has been failing since 11/5: https://testgrid.k8s.io/sig-node-containerd#node-e2e-unlabelled

I suspect it is due to https://github.com/kubernetes/test-infra/commit/2123faa925fe2559b8e5258ab94a7ab3f9966cbc.

I took a look around some other jobs and noted that almost all other jobs use double quotes around the string passed to `--skip`, see https://github.com/search?q=repo%3Akubernetes%2Ftest-infra+--skip%3D&type=code. The commit https://github.com/kubernetes/test-infra/commit/2123faa925fe2559b8e5258ab94a7ab3f9966cbc had removed the double quotes, this PR adds them back. 

/sig node
/assign @mariafromano-25 @SergeyKanzhelev 