### PR TITLE
Increase memory of Control Plane node on which e2e default

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -344,7 +344,7 @@ periodics:
 
               set +o errexit
               set -o xtrace
-              export TF_VAR_controlplane_powervs_memory=16
+              export TF_VAR_controlplane_powervs_memory=32
               kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} --powervs-ssh-key k8s-prow-sshkey \
@@ -355,7 +355,7 @@ periodics:
                 --extra-vars=feature_gates:AllAlpha=true,AllBeta=true,EventedPLEG=false \
                 --extra-vars=runtime_config:api/all=true \
                 --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt) \
-                --test=ginkgo -- --parallel 25 --test-package-dir ci --test-package-marker latest.txt \
+                --test=ginkgo -- --parallel 15 --test-package-dir ci --test-package-marker latest.txt \
                 --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|KubeProxy.should.update.metric"; rc=$?
 
               [ -z "${BOSKOS_HOST:-}" ] || release_account >> "$ARTIFACTS/boskos.log" 2>&1
@@ -410,7 +410,7 @@ periodics:
               set +o errexit
               set -o xtrace
               export TF_VAR_powervs_system_type=e980
-              export TF_VAR_controlplane_powervs_memory=16
+              export TF_VAR_controlplane_powervs_memory=32
               kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} --powervs-ssh-key k8s-prow-sshkey \
@@ -419,7 +419,7 @@ periodics:
                 --up --down --auto-approve --retry-on-tf-failure 3 --ignore-destroy-errors \
                 --break-kubetest-on-upfail true \
                 --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt) \
-                --test=ginkgo -- --parallel 25 --test-package-dir ci --test-package-marker latest.txt \
+                --test=ginkgo -- --parallel 15 --test-package-dir ci --test-package-marker latest.txt \
                 --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|KubeProxy.should.update.metric"; rc=$?
 
               [ -z "${BOSKOS_HOST:-}" ] || release_account >> "$ARTIFACTS/boskos.log" 2>&1


### PR DESCRIPTION
While executing the E2E test [sig-node] [DRA] ResourceSlice Controller creates slices [ConformanceCandidate] in jobs [ci-kubernetes-e2e-ppc64le-default](https://testgrid.k8s.io/ibm-ppc64le-e2e#ci-kubernetes-e2e-ppc64le-default) and [ci-kubernetes-ppc64le-e2e-alpha-enabled-default](https://testgrid.k8s.io/ibm-ppc64le-e2e#ci-kubernetes-ppc64le-e2e-alpha-enabled-default), The master node of k8s cluster seems to crash with below error, and eventually the job fails.
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-ppc64le-default/1988245344147738624

[64129.275460] oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),cpuset=user.slice,mems_allowed=0,global_oom,task_memcg=/user.slice/user-0.slice/session-11.scope,task=e2e.test,pid=684933,uid=0
[64129.275643] Out of memory: Killed process 684933 (e2e.test) total-vm:3323456kB, anon-rss:1881472kB, file-rss:0kB, shmem-rss:0kB, UID:0 pgtables:296kB oom_score_adj:0
Hence, increasing the memory value of master node from current 16GB to 32GB.

Have manually verified that this test stopped flaking when memory is 32GB and flakes when it is 16GB.
Additionally, to further reduce API server load and memory pressure during these tests, the ginkgo parallelism has been reduced (from 25 down to 15).