### PR TITLE
Edit ci-kubernetes-unit-ppc64le

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -26,6 +26,9 @@ periodics:
           env:
             - name: KUBE_TIMEOUT
               value: "-timeout=300s"
+              # TODO - Will enable race after https://github.com/golang/go/issues/76051 is fixed.
+            - name: KUBE_RACE
+              value: ""
           securityContext:
             allowPrivilegeEscalation: false
           resources:


### PR DESCRIPTION
Skipping the `-race` flag until https://github.com/golang/go/issues/76051 is fixed and picked up in the golang version that k8s UT job uses.