### PR TITLE
Add presubmit lint job for kro

### DIFF
--- a/config/jobs/kubernetes-sigs/kro/kro-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kro/kro-presubmits-main.yaml
@@ -25,6 +25,31 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cloud-provider-kro-presubmits
       testgrid-tab-name: presubmits-unit-tests
+  - name: presubmits-verify-lint
+    always_run: true
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    path_alias: "sigs.k8s.io/kro"
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^main$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-1.33
+        command:
+        - scripts/ci/presubmits/lint
+        resources:
+          limits:
+            cpu: 4
+            memory: 4Gi
+          requests:
+            cpu: 4
+            memory: 4Gi
+    annotations:
+      testgrid-dashboards: sig-cloud-provider-kro-presubmits
+      testgrid-tab-name: presubmits-verify-lint
   - name: presubmits-integration-tests
     always_run: true
     optional: false


### PR DESCRIPTION
Adds a new presubmit job that we use for linting (calls golangci-lint).