### PR TITLE
CAPI: Bump CoreDNS to v1.13.1 for Kubernetes 1.35

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-upgrades.yaml
@@ -323,7 +323,7 @@ periodics:
       - name: ETCD_VERSION_UPGRADE_TO
         value: "3.6.4-0"
       - name: COREDNS_VERSION_UPGRADE_TO
-        value: "v1.12.1"
+        value: "v1.13.1"
       - name: GINKGO_LABEL_FILTER
         value: "(Conformance && K8s-Upgrade)"
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
@@ -335,7 +335,7 @@ periodics:
           - name: ETCD_VERSION_UPGRADE_TO
             value: 3.6.4-0
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: v1.12.1
+            value: v1.13.1
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -369,7 +369,7 @@ presubmits:
           - name: ETCD_VERSION_UPGRADE_TO
             value: "3.6.4-0"
           - name: COREDNS_VERSION_UPGRADE_TO
-            value: "v1.12.1"
+            value: "v1.13.1"
           - name: GINKGO_LABEL_FILTER
             value: "(Conformance && K8s-Upgrade)"
         # we need privileged mode in order to do docker in docker
@@ -516,7 +516,7 @@ presubmits:
         - name: ETCD_VERSION_UPGRADE_TO
           value: 3.6.4-0
         - name: COREDNS_VERSION_UPGRADE_TO
-          value: v1.12.1
+          value: v1.13.1
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-prowjob-gen.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-prowjob-gen.yaml
@@ -162,5 +162,5 @@ prow_ignored:
       k8sRelease: "stable-1.34"
     "1.35":
       etcd: "3.6.4-0"
-      coreDNS: "v1.12.1"
+      coreDNS: "v1.13.1"
       k8sRelease: "ci/latest-1.35"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com