### PR TITLE
[compatibility] change skip version test to use old node tests

### DIFF
--- a/experiment/compatibility-versions/e2e-skip-version-testing.sh
+++ b/experiment/compatibility-versions/e2e-skip-version-testing.sh
@@ -34,6 +34,7 @@ trap signal_handler INT TERM
 
 run_skip_version_tests() {
   export PARALLEL=true
+  initial_emulated_version="$EMULATED_VERSION"
   ret=0
   while ! version_gte "$EMULATED_VERSION" "$CURRENT_VERSION"; do
     echo "Running e2e with compatibility version set to ${EMULATED_VERSION}"
@@ -49,6 +50,11 @@ run_skip_version_tests() {
       return 1
     fi
     pushd "${PREV_RELEASE_REPO_PATH}"
+    if [[ "$EMULATED_VERSION" != "$initial_emulated_version" ]]; then
+      # overwrite node e2e tests with the node tests at the initial emulated version because Kubelet is still at that version.
+      echo "Replace ${EMULATED_VERSION} node tests with node tests at ${initial_emulated_version}"
+      rsync -av --delete "./test/e2e/node" "${TMP_DIR}/prev-release-k8s-${initial_emulated_version}/test/e2e/node"
+    fi
     build_test_bins "${PREV_RELEASE_BRANCH}" || ret=$?
     run_e2e_tests || ret=$?
     if [[ "$ret" -ne 0 ]]; then
@@ -66,6 +72,11 @@ run_skip_version_tests() {
   # Test removal of emulated version entirely.
   export PREV_RELEASE_BRANCH="release-${EMULATED_VERSION}"
   delete_emulation_version || ret=$?
+  if [[ "$EMULATED_VERSION" != "$initial_emulated_version" ]]; then
+    # overwrite node e2e tests with the node tests at the initial emulated version because Kubelet is still at that version.
+    echo "Replace ${EMULATED_VERSION} node tests with node tests at ${initial_emulated_version}"
+    rsync -av --delete "./test/e2e/node" "${TMP_DIR}/prev-release-k8s-${initial_emulated_version}/test/e2e/node"
+  fi
   build_test_bins "${PREV_RELEASE_BRANCH}" || ret=$?
   run_e2e_tests || ret=$?
   return $ret


### PR DESCRIPTION
change skip version test to use old node tests to be consistent with the unupgraded kubelet

This should fix test failures like https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-skip-version-upgrade-n-minus-2/1989296027059884032 with `[MinimumKubeletVersion:1.34]`