### PR TITLE
update promo-tools job to use go 1.25

### DIFF
--- a/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
+++ b/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
@@ -168,7 +168,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
needed for https://github.com/kubernetes-sigs/promo-tools/pull/1652


/assign @puerco @saschagrunert @Verolop 
cc @kubernetes/release-managers 