### PR TITLE
add minikube bootcamp image to registry

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-minikube.yaml
+++ b/config/jobs/image-pushing/k8s-staging-minikube.yaml
@@ -15,7 +15,7 @@ postsubmits:
               - /run.sh
             args:
               - --project=k8s-staging-images
-              - --scratch-bucket=gs://k8s-staging-minikube-gcb
+              - --scratch-bucket=gs://k8s-staging-images-gcb
               - --env-passthrough=PULL_BASE_REF
               - --gcb-config=hack/prow/image/kubernetes-bootcamp/cloudbuild.yaml
               - .


### PR DESCRIPTION
Following https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md
Changes are also being made simultaneously on minikube side  https://github.com/kubernetes/minikube/pull/21904
(There will be a file called hack/prow/image/kubernetes-bootcamp/cloudbuild.yaml in minikube)