### PR TITLE
CAPA: run e2e-eks-gc only on 2.7 and 2.8 branches because they don't exist anymore since v2.9

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-main.yaml
@@ -393,51 +393,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-e2e-eks-main
       testgrid-num-columns-recent: '20'
-  - name: pull-cluster-api-provider-aws-e2e-eks-gc
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^main$
-    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
-    always_run: false
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 5h
-    rerun_auth_config:
-      github_team_slugs:
-        - org: kubernetes-sigs
-          slug: cluster-api-provider-aws-maintainers
-    max_concurrency: 1
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-service-account: "true"
-      preset-aws-ssh: "true"
-      preset-aws-credential: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-1.33
-          command:
-            - "runner.sh"
-            - "./scripts/ci-e2e-eks-gc.sh"
-          env:
-            - name: BOSKOS_HOST
-              value: "boskos.test-pods.svc.cluster.local"
-            - name: AWS_REGION
-              value: "us-west-2"
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 2
-              memory: "9Gi"
-            requests:
-              cpu: 2
-              memory: "9Gi"
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: pr-e2e-eks-gc-main
-      testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-eks-testing
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.9.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.9.yaml
@@ -393,51 +393,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-e2e-eks-release-2-9
       testgrid-num-columns-recent: '20'
-  - name: pull-cluster-api-provider-aws-e2e-eks-gc-release-2-9
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^release-2.9$
-    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
-    always_run: false
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 5h
-    rerun_auth_config:
-      github_team_slugs:
-        - org: kubernetes-sigs
-          slug: cluster-api-provider-aws-maintainers
-    max_concurrency: 1
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-service-account: "true"
-      preset-aws-ssh: "true"
-      preset-aws-credential: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-1.32
-          command:
-            - "runner.sh"
-            - "./scripts/ci-e2e-eks-gc.sh"
-          env:
-            - name: BOSKOS_HOST
-              value: "boskos.test-pods.svc.cluster.local"
-            - name: AWS_REGION
-              value: "us-west-2"
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 2
-              memory: "9Gi"
-            requests:
-              cpu: 2
-              memory: "9Gi"
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: pr-e2e-eks-gc-release-2-9
-      testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-eks-testing-release-2-9
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/templates/cluster-api-provider-aws-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/templates/cluster-api-provider-aws-presubmits.yaml.tpl
@@ -394,6 +394,8 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-e2e-eks-{{ ReplaceAll $.branch "." "-" }}
       testgrid-num-columns-recent: '20'
+{{- $onlyInBranch := list "release-2.7" "release-2.8" }}
+{{- if has $.branch $onlyInBranch  }}
   - name: pull-cluster-api-provider-aws-e2e-eks-gc{{ if ne $.branch "main" }}-{{ ReplaceAll $.branch "." "-" }}{{ end }}
     cluster: eks-prow-build-cluster
     branches:
@@ -439,6 +441,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-e2e-eks-gc-{{ ReplaceAll $.branch "." "-" }}
       testgrid-num-columns-recent: '20'
+{{- end }}
   - name: pull-cluster-api-provider-aws-e2e-eks-testing{{ if ne $.branch "main" }}-{{ ReplaceAll $.branch "." "-" }}{{ end }}
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5747#issuecomment-3541991077

This test was removed in https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5348 .