### PR TITLE
Add `gke-gcloud-auth-plugin` to `kubekins-e2e-v2` image

### DIFF
--- a/images/kubekins-e2e-v2/Dockerfile
+++ b/images/kubekins-e2e-v2/Dockerfile
@@ -73,7 +73,7 @@ RUN wget -O google-cloud-sdk.tar.gz -q $GCLOUD_SDK_URL && \
         --path-update=false \
         --usage-reporting=false; \
     fi && \
-    gcloud components install alpha beta && \
+    gcloud components install alpha beta gke-gcloud-auth-plugin && \
     gcloud info | tee /workspace/gcloud-info.txt
 
 


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/issues/26609

Found when migrating scalability tests (kubetest + cl2) from kubekins-e2e to kubekins-e2e-v2.