### PR TITLE
Rotate kubectl skew and soak jobs from k8s-stable1 to k8s-stable2

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -1,55 +1,58 @@
 periodics:
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
+- annotations:
+    description: kubectl gce serial e2e tests for master branch
+    testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
+    testgrid-dashboards: sig-cli-master
+    testgrid-tab-name: gce-serial
   cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
-    timeout: 520m
+    timeout: 8h40m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
   spec:
     containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
+    - args:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\]
+        --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-cli-master
-    testgrid-tab-name: gce-serial
-    testgrid-alert-email: sig-cli@kubernetes.io
-    description: kubectl gce serial e2e tests for master branch
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gci-gce-sig-cli
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 70m
-  spec:
-    containers:
-    - command:
+      command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      args:
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+- annotations:
+    description: kubectl gce e2e tests for master branch
+    testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
+    testgrid-dashboards: sig-cli-master
+    testgrid-tab-name: gce
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h10m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gci-gce-sig-cli
+  spec:
+    containers:
+    - args:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-master-image=gci
@@ -58,39 +61,39 @@ periodics:
       - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+        --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-cli-master
-    testgrid-tab-name: gce
-    testgrid-alert-email: sig-cli@kubernetes.io
-    description: kubectl gce e2e tests for master branch
-
-- interval: 12h
-  name: ci-kubernetes-e2e-kops-aws-sig-cli
-  cluster: eks-prow-build-cluster
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-    preset-e2e-platform-aws: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
+      command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      args:
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+- annotations:
+    testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
+    testgrid-dashboards: sig-cli-master
+    testgrid-tab-name: aws
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  interval: 12h
+  labels:
+    preset-aws-credential: "true"
+    preset-aws-ssh: "true"
+    preset-e2e-platform-aws: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-kops-aws-sig-cli
+  spec:
+    containers:
+    - args:
       - --aws
       - --cluster=e2e-kops-aws-sig-cli.test-cncf-aws.k8s.io
       - --extract=ci/latest
@@ -98,469 +101,485 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 8Gi
-        requests:
-          cpu: 2
-          memory: 8Gi
-
-  # kubectl skew tests
-  annotations:
-    testgrid-dashboards: sig-cli-master
-    testgrid-tab-name: aws
-    testgrid-alert-email: sig-cli@kubernetes.io
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-latest-stable1-gci-kubectl-skew
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
+      command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      args:
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 8Gi
+        requests:
+          cpu: "2"
+          memory: 8Gi
+- annotations:
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-latest-stable2-gci-kubectl-skew
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-latest-stable2-gci-kubectl-skew
+  spec:
+    containers:
+    - args:
       - --check-leaked-resources
       - --check-version-skew=false
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-stable2
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-b
       - --ginkgo-parallel
       - --provider=gce
       - --skew
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\]
+        --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 1
-          memory: 6Gi
-        requests:
-          cpu: 1
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
-    testgrid-tab-name: gce-latest-stable1-gci-kubectl-skew
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-latest-stable1-gci-kubectl-skew-serial
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
+      command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      args:
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 6Gi
+- annotations:
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-latest-stable2-gci-kubectl-skew-serial
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-latest-stable2-gci-kubectl-skew-serial
+  spec:
+    containers:
+    - args:
       - --check-leaked-resources
       - --check-version-skew=false
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-stable2
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-b
       - --provider=gce
       - --skew
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\]
+        --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
-    testgrid-tab-name: gce-latest-stable1-gci-kubectl-skew-serial
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
+      command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --check-version-skew=false
-      - --extract=ci/k8s-stable1
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-b
-      - --ginkgo-parallel=25
-      - --provider=gce
-      - --skew
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
-      - --timeout=120m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
       resources:
         limits:
-          cpu: 1
+          cpu: "4"
           memory: 6Gi
         requests:
-          cpu: 1
+          cpu: "4"
           memory: 6Gi
-
-  annotations:
+- annotations:
+    description: stable1 e2e tests run against a master gce cluster using a stable1
+      kubectl binary
+    testgrid-alert-email: release-team@kubernetes.io, kubernetes-sig-cli@googlegroups.com
+    testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-master-blocking, sig-cli-master
-    testgrid-tab-name: skew-cluster-latest-kubectl-stable1-gce
-    testgrid-alert-email: "release-team@kubernetes.io, sig-cli@kubernetes.io"
-    description: "stable1 e2e tests run against a master gce cluster using a stable1 kubectl binary"
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "2"
-    testgrid-alert-stale-results-hours: "24"
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
+    testgrid-tab-name: skew-cluster-latest-kubectl-stable2-gce
   cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --check-version-skew=false
-      - --extract=ci/k8s-stable1
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-b
-      - --provider=gce
-      - --skew
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
-      - --timeout=120m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-cli-master
-    testgrid-tab-name: skew-cluster-latest-kubectl-stable1-gce-serial
-    description: stable1 serial tests run against a master gce cluster using a stable1 kubectl binary
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew
-  cluster: k8s-infra-prow-build
+    timeout: 2h20m0s
+  interval: 12h
   labels:
-    preset-service-account: "true"
     preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew
   spec:
     containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
+    - args:
       - --check-leaked-resources
       - --check-version-skew=false
+      - --extract=ci/k8s-stable2
       - --extract=ci/latest
-      - --extract=ci/k8s-stable1
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-b
       - --ginkgo-parallel=25
       - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --skew
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\]
+        --minStartupPods=8
       - --timeout=120m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
       resources:
         limits:
-          cpu: 4
+          cpu: "1"
           memory: 6Gi
         requests:
-          cpu: 4
+          cpu: "1"
           memory: 6Gi
-  annotations:
+- annotations:
+    description: stable1 serial tests run against a master gce cluster using a stable1
+      kubectl binary
     testgrid-dashboards: sig-cli-master
-    testgrid-tab-name: skew-cluster-stable1-kubectl-latest-gce
-    description: stable1 e2e tests run against a stable1 gce cluster using a master kubectl binary
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew-serial
+    testgrid-tab-name: skew-cluster-latest-kubectl-stable2-gce-serial
   cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --check-version-skew=false
-      - --extract=ci/latest
-      - --extract=ci/k8s-stable1
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
-      - --timeout=120m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-cli-master
-    testgrid-tab-name: skew-cluster-stable1-kubectl-latest-gce-serial
-    description: stable1 serial tests run against a stable1 gce cluster using a master kubectl binary
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-stable1-latest-gci-kubectl-skew
-  cluster: k8s-infra-prow-build
+    timeout: 2h20m0s
+  interval: 12h
   labels:
-    preset-service-account: "true"
     preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
   spec:
     containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --check-version-skew=false
-      - --extract=ci/latest
-      - --extract=ci/k8s-stable1
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-b
-      - --ginkgo-parallel
-      - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
-      - --timeout=120m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
-    testgrid-tab-name: gce-stable1-latest-gci-kubectl-skew
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-stable1-latest-gci-kubectl-skew-serial
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --check-version-skew=false
-      - --extract=ci/latest
-      - --extract=ci/k8s-stable1
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
-      - --timeout=120m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
-    testgrid-tab-name: gce-stable1-latest-gci-kubectl-skew-serial
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
+    - args:
       - --check-leaked-resources
       - --check-version-skew=false
       - --extract=ci/k8s-stable2
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-zone=us-central1-b
+      - --provider=gce
+      - --skew
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\]
+        --minStartupPods=8
+      - --timeout=120m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+- annotations:
+    description: stable1 e2e tests run against a stable1 gce cluster using a master
+      kubectl binary
+    testgrid-dashboards: sig-cli-master
+    testgrid-tab-name: skew-cluster-stable2-kubectl-latest-gce
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --check-version-skew=false
+      - --extract=ci/latest
+      - --extract=ci/k8s-stable2
+      - --gcp-node-image=gci
+      - --gcp-zone=us-central1-b
+      - --ginkgo-parallel=25
+      - --provider=gce
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\]
+        --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --timeout=120m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+- annotations:
+    description: stable1 serial tests run against a stable1 gce cluster using a master
+      kubectl binary
+    testgrid-dashboards: sig-cli-master
+    testgrid-tab-name: skew-cluster-stable2-kubectl-latest-gce-serial
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew-serial
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --check-version-skew=false
+      - --extract=ci/latest
+      - --extract=ci/k8s-stable2
+      - --gcp-node-image=gci
+      - --gcp-zone=us-central1-b
+      - --provider=gce
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\]
+        --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --timeout=120m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+- annotations:
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-stable2-latest-gci-kubectl-skew
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-stable2-latest-gci-kubectl-skew
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --check-version-skew=false
+      - --extract=ci/latest
+      - --extract=ci/k8s-stable2
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-b
       - --ginkgo-parallel
       - --provider=gce
-      - --skew
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\]
+        --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
       resources:
         limits:
-          cpu: 4
+          cpu: "4"
           memory: 6Gi
         requests:
-          cpu: 4
+          cpu: "4"
           memory: 6Gi
-  annotations:
+- annotations:
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-stable2-latest-gci-kubectl-skew-serial
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-stable2-latest-gci-kubectl-skew-serial
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --check-version-skew=false
+      - --extract=ci/latest
+      - --extract=ci/k8s-stable2
+      - --gcp-node-image=gci
+      - --gcp-zone=us-central1-b
+      - --provider=gce
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\]
+        --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --timeout=120m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+- annotations:
     testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
     testgrid-tab-name: gce-1.13-1.12-gci-kubectl-skew
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew-serial
   cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --check-version-skew=false
-      - --extract=ci/k8s-stable2
-      - --extract=ci/k8s-stable1
-      - --gcp-node-image=gci
-      - --gcp-zone=us-central1-b
-      - --provider=gce
-      - --skew
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
-      - --timeout=120m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
-    testgrid-tab-name: gce-1.13-1.12-gci-kubectl-skew-serial
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew
-  cluster: k8s-infra-prow-build
+    timeout: 2h20m0s
+  interval: 12h
   labels:
-    preset-service-account: "true"
     preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-stable2-stable3-gci-kubectl-skew
   spec:
     containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
+    - args:
       - --check-leaked-resources
       - --check-version-skew=false
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-stable3
       - --extract=ci/k8s-stable2
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-b
       - --ginkgo-parallel
       - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --skew
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\]
+        --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 4
-          memory: 6Gi
-        requests:
-          cpu: 4
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
-    testgrid-tab-name: gce-1.12-1.13-gci-kubectl-skew
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew-serial
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
+      command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      args:
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+- annotations:
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-1.13-1.12-gci-kubectl-skew-serial
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-stable2-stable3-gci-kubectl-skew-serial
+  spec:
+    containers:
+    - args:
       - --check-leaked-resources
       - --check-version-skew=false
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-stable3
       - --extract=ci/k8s-stable2
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --skew
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\]
+        --minStartupPods=8
       - --timeout=120m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
       resources:
         limits:
-          cpu: 4
+          cpu: "4"
           memory: 6Gi
         requests:
-          cpu: 4
+          cpu: "4"
           memory: 6Gi
-  annotations:
+- annotations:
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-1.12-1.13-gci-kubectl-skew
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-stable3-stable2-gci-kubectl-skew
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --check-version-skew=false
+      - --extract=ci/k8s-stable2
+      - --extract=ci/k8s-stable3
+      - --gcp-node-image=gci
+      - --gcp-zone=us-central1-b
+      - --ginkgo-parallel
+      - --provider=gce
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\]
+        --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --timeout=120m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+- annotations:
     testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
     testgrid-tab-name: gce-1.12-1.13-gci-kubectl-skew-serial
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-stable3-stable2-gci-kubectl-skew-serial
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --check-version-skew=false
+      - --extract=ci/k8s-stable2
+      - --extract=ci/k8s-stable3
+      - --gcp-node-image=gci
+      - --gcp-zone=us-central1-b
+      - --provider=gce
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\]
+        --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --timeout=120m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 6Gi
+        requests:
+          cpu: "4"
+          memory: 6Gi
+postsubmits: null
+presubmits: null

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -1,101 +1,614 @@
-presets:
-- labels:
-    preset-pull-kubernetes-e2e: "true"
-  env:
-  - name: KUBE_GCS_UPDATE_LATEST
-    value: "n"
-- labels:
-    preset-pull-kubernetes-e2e-gce: "true"
-  env:
-  - name: CREATE_CUSTOM_NETWORK
-    value: "true"
-
+periodics:
+- annotations:
+    description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature)
+      against a cluster created with cluster/kube-up.sh
+    testgrid-alert-email: release-team@kubernetes.io
+    testgrid-dashboards: sig-release-master-blocking
+    testgrid-num-failures-to-alert: "6"
+    testgrid-tab-name: gce-cos-master-default
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  interval: 30m
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gci-gce
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --extract=ci/fast/latest-fast
+      - --gcp-node-image=gci
+      - --gcp-region=us-central1
+      - --ginkgo-parallel=30
+      - --provider=gce
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+        --minStartupPods=8
+      - --timeout=120m
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature)
+      against a cluster (ubuntu based and uses containerd) created with cluster/kube-up.sh
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, release-team@kubernetes.io
+    testgrid-dashboards: sig-release-master-blocking
+    testgrid-num-failures-to-alert: "6"
+    testgrid-tab-name: gce-ubuntu-master-containerd
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h10m0s
+  interval: 120m
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-ubuntu-gce-containerd
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.1.0
+      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.3.0
+      - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+      - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
+      - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
+      - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
+      - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
+      - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
+      - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
+      - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+      - --extract=ci/fast/latest-fast
+      - --gcp-master-image=ubuntu
+      - --gcp-node-image=ubuntu
+      - --gcp-nodes=4
+      - --gcp-region=us-central1
+      - --ginkgo-parallel=30
+      - --provider=gce
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+        --minStartupPods=8
+      - --timeout=50m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    testgrid-dashboards: google-gce
+    testgrid-tab-name: gci-gce-alpha-enabled-default
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h40m0s
+  interval: 30m
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gci-gce-alpha-enabled-default
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
+      - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+      - --env=KUBE_PROXY_DAEMONSET=true
+      - --env=ENABLE_POD_PRIORITY=true
+      - --extract=ci/fast/latest-fast
+      - --gcp-node-image=gci
+      - --gcp-region=us-central1
+      - --ginkgo-parallel=30
+      - --provider=gce
+      - --runtime-config=api/all=true
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0
+        --minStartupPods=8
+      - --timeout=70m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    description: Uses kubetest to run e2e tests (+Feature:many, -many) against a cluster
+      created with cluster/kube-up.sh
+    testgrid-alert-email: release-team@kubernetes.io
+    testgrid-dashboards: sig-release-master-blocking, google-gce
+    testgrid-tab-name: gce-cos-master-alpha-features
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 3h20m0s
+  interval: 30m
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gci-gce-alpha-features
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+      - --env=KUBE_PROXY_DAEMONSET=true
+      - --env=ENABLE_POD_PRIORITY=true
+      - --extract=ci/fast/latest-fast
+      - --gcp-node-image=gci
+      - --gcp-region=us-central1
+      - --provider=gce
+      - --runtime-config=api/all=true
+      - --test_args=--ginkgo.focus=\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking
+        --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Example)\]|IPv6|csi-hostpath-v0
+        --minStartupPods=8
+      - --timeout=180m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi
+- annotations:
+    description: Same config as ci-kubernetes-e2e-gci-gce but with Flaky tests included,
+      intended to reproduce conditions that cause flakes to appear
+    testgrid-dashboards: sig-testing-misc
+    testgrid-tab-name: gce-cos-master-flaky-repro
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h10m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gci-gce-flaky-repro
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --extract=ci/latest
+      - --gcp-master-image=gci
+      - --gcp-node-image=gci
+      - --gcp-nodes=4
+      - --gcp-region=us-central1
+      - --ginkgo-parallel=30
+      - --provider=gce
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Feature:.+\]
+        --minStartupPods=8
+      - --timeout=50m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    testgrid-dashboards: google-gce
+    testgrid-tab-name: gci-gce-flaky
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 3h20m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gci-gce-flaky
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-region=us-central1
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Driver:.gcepd\]|\[Feature:.+\]
+        --minStartupPods=8
+      - --timeout=180m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi
+- annotations:
+    description: Uses kubetest to run a subset of e2e tests (+Feature:Reboot) against
+      a cluster created with cluster/kube-up.sh
+    testgrid-alert-email: gke-node-experience-team+alerts@google.com, release-team@kubernetes.io
+    testgrid-dashboards: sig-release-master-blocking, google-gce
+    testgrid-num-failures-to-alert: "6"
+    testgrid-tab-name: gce-cos-master-reboot
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 3h20m0s
+  interval: 30m
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gci-gce-reboot
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --extract=ci/fast/latest-fast
+      - --gcp-node-image=gci
+      - --gcp-region=us-central1
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
+      - --timeout=180m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi
+- annotations:
+    description: Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature)
+      against a cluster created with cluster/kube-up.sh
+    testgrid-alert-email: release-team@kubernetes.io
+    testgrid-dashboards: sig-release-master-informing
+    testgrid-num-failures-to-alert: "6"
+    testgrid-tab-name: gce-cos-master-serial
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 8h40m0s
+  interval: 30m
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gci-gce-serial
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --env=NODE_LOCAL_SSDS_EXT=1,scsi,fs
+      - --env=NODE_SIZE=n2-standard-2
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-region=us-central1
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\]
+        --minStartupPods=8
+      - --timeout=500m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi
+- annotations:
+    description: Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature)
+      against a cluster created with cluster/kube-up.sh
+    testgrid-alert-email: release-team@kubernetes.io
+    testgrid-dashboards: sig-release-master-informing
+    testgrid-num-failures-to-alert: "6"
+    testgrid-tab-name: gce-cos-master-slow
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h50m0s
+  interval: 30m
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gci-gce-slow
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-region=us-central1
+      - --ginkgo-parallel=30
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\]
+        --minStartupPods=8
+      - --timeout=150m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 6Gi
+- annotations:
+    testgrid-dashboards: google-gce
+    testgrid-tab-name: soak-gci-gce-1.15
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 23h40m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-soak-gci-gce-beta
+  spec:
+    containers:
+    - args:
+      - --down=false
+      - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
+      - --extract=ci/k8s-stable2
+      - --gcp-master-image=gci
+      - --gcp-node-image=gci
+      - --gcp-region=us-central1
+      - --provider=gce
+      - --soak
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\]
+        --clean-start=true --minStartupPods=8
+      - --timeout=1400m
+      - --up=false
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    testgrid-dashboards: google-gce
+    testgrid-tab-name: soak-gci-gce-1.14
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 23h40m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-soak-gci-gce-stable2
+  spec:
+    containers:
+    - args:
+      - --down=false
+      - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
+      - --extract=ci/k8s-stable2
+      - --gcp-node-image=gci
+      - --gcp-region=us-central1
+      - --provider=gce
+      - --soak
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\]
+        --clean-start=true --minStartupPods=8
+      - --timeout=1400m
+      - --up=false
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    testgrid-dashboards: google-gce
+    testgrid-tab-name: soak-gci-gce-1.13
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 23h40m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-soak-gci-gce-stable3
+  spec:
+    containers:
+    - args:
+      - --down=false
+      - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
+      - --extract=ci/k8s-stable3
+      - --gcp-node-image=gci
+      - --gcp-region=us-central1
+      - --provider=gce
+      - --soak
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\]
+        --clean-start=true --minStartupPods=8
+      - --timeout=1400m
+      - --up=false
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    testgrid-dashboards: google-gce
+    testgrid-tab-name: soak-gci-gce-1.12
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 23h40m0s
+  interval: 12h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-soak-gci-gce-stable4
+  spec:
+    containers:
+    - args:
+      - --down=false
+      - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
+      - --extract=ci/k8s-stable4
+      - --gcp-node-image=gci
+      - --gcp-region=us-central1
+      - --provider=gce
+      - --soak
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\]
+        --clean-start=true --minStartupPods=8
+      - --timeout=1400m
+      - --up=false
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+postsubmits: null
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-gce-cos
-    always_run: false
-    cluster: k8s-infra-prow-build
-    skip_branches:
-    - release-\d+\.\d+ # per-release image
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
       testgrid-num-failures-to-alert: "10"
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
-      timeout: 105m
-    path_alias: k8s.io/kubernetes
+      timeout: 1h45m0s
     extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
+    - base_ref: master
+      org: kubernetes
       path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce-cos
+    path_alias: k8s.io/kubernetes
+    skip_branches:
+    - release-\d+\.\d+
     spec:
       containers:
-      - command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-        args:
+      - args:
         - --build=quick
         - --gcp-node-image=gci
         - --gcp-region=us-central1
         - --ginkgo-parallel=30
         - --provider=gce
-        # Panic if anything mutates a shared informer cache
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-        # Panic if data inconsistency is detected
         - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
         - --env=ENABLE_KUBE_WATCHCACHE_CONSISTENCY_CHECKER=true
-        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-        - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
         resources:
-          requests:
-            cpu: 4
-            memory: 14Gi
           limits:
-            cpu: 4
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
             memory: 14Gi
         securityContext:
           privileged: true
-
-  - name: pull-cos-containerd-e2e-ubuntu-gce
-    always_run: false
-    cluster: k8s-infra-prow-build
-    skip_branches:
-    - release-\d+\.\d+ # per-release image
+  - always_run: false
     annotations:
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
       testgrid-num-failures-to-alert: "10"
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
-      timeout: 105m
-    path_alias: k8s.io/kubernetes
+      timeout: 1h45m0s
     extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
+    - base_ref: master
+      org: kubernetes
       path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-cos-containerd-e2e-ubuntu-gce
+    path_alias: k8s.io/kubernetes
+    skip_branches:
+    - release-\d+\.\d+
     spec:
       containers:
-      - command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-        args:
+      - args:
         - --build=quick
         - --gcp-node-image=ubuntu
         - --gcp-region=us-central1
@@ -104,475 +617,468 @@ presubmits:
         - --image-project=ubuntu-os-gke-cloud
         - --provider=gce
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-        # Panic if anything mutates a shared informer cache
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-        - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
         resources:
-          requests:
-            cpu: 4
-            memory: 14Gi
           limits:
-            cpu: 4
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
             memory: 14Gi
         securityContext:
           privileged: true
-
-  - name: pull-kubernetes-e2e-gce-cos-no-stage
-    always_run: false
-    cluster: k8s-infra-prow-build
+  - always_run: false
     annotations:
       testgrid-dashboards: presubmits-kubernetes-nonblocking
       testgrid-tab-name: pull-kubernetes-e2e-gce-cos-no-stage
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
-      timeout: 105m
-    path_alias: k8s.io/kubernetes
+      timeout: 1h45m0s
     extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
+    - base_ref: master
+      org: kubernetes
       path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce-cos-no-stage
+    path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-        args:
+      - args:
         - --build=quick
         - --gcp-node-image=gci
         - --gcp-region=us-central1
         - --ginkgo-parallel=30
         - --provider=gce
-        # Panic if anything mutates a shared informer cache
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-        # Panic if data inconsistency is detected
         - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
         - --env=ENABLE_KUBE_WATCHCACHE_CONSISTENCY_CHECKER=true
-        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-        - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
         resources:
-          requests:
-            cpu: 4
-            memory: 14Gi
           limits:
-            cpu: 4
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
             memory: 14Gi
         securityContext:
           privileged: true
-
-  - name: pull-kubernetes-e2e-gce-cos-canary
-    cluster: k8s-infra-prow-build
-    always_run: false
-    skip_report: true
-    skip_branches:
-    - release-\d+\.\d+ # per-release image
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
       testgrid-num-failures-to-alert: "10"
+    cluster: k8s-infra-prow-build
+    decorate: true
+    decoration_config:
+      timeout: 1h45m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
     labels:
       preset-dind-enabled: "true"
-      preset-service-account: "true"
       preset-k8s-ssh: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
-    decorate: true
-    decoration_config:
-      timeout: 105m
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce-cos-canary
     path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
-      path_alias: k8s.io/release
+    skip_branches:
+    - release-\d+\.\d+
+    skip_report: true
     spec:
       containers:
-      - command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-        args:
+      - args:
         - --build=quick
         - --gcp-node-image=gci
         - --gcp-region=us-central1
         - --ginkgo-parallel=30
         - --provider=gce
-        # Panic if anything mutates a shared informer cache
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-        # Panic if data inconsistency is detected
         - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
         - --env=ENABLE_KUBE_WATCHCACHE_CONSISTENCY_CHECKER=true
-        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-        - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
         env:
         - name: BOOTSTRAP_FETCH_TEST_INFRA
           value: "true"
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-        # we need privileged mode in order to do docker in docker
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
         securityContext:
           privileged: true
-        resources:
-          requests:
-            cpu: 4
-            memory: 14Gi
-          limits:
-            cpu: 4
-            memory: 14Gi
-
-  - name: pull-kubernetes-e2e-gce
-    cluster: k8s-infra-prow-build
-    always_run: true
-    skip_branches:
-      - release-\d+\.\d+ # per-release image
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
-      testgrid-num-failures-to-alert: "10"
       testgrid-dashboards: google-gce
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
+      testgrid-num-failures-to-alert: "10"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
-      timeout: 105m
-    path_alias: k8s.io/kubernetes
+      timeout: 1h45m0s
     extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
+    - base_ref: master
+      org: kubernetes
       path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce
+    path_alias: k8s.io/kubernetes
+    skip_branches:
+    - release-\d+\.\d+
     spec:
       containers:
-        - command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-          args:
-            - --build=quick
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.1.0
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.3.0
-            - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-            - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
-            - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
-            - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
-            - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
-            - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
-            - --gcp-master-image=ubuntu
-            - --gcp-node-image=ubuntu
-            - --gcp-region=us-central1
-            - --ginkgo-parallel=30
-            - --provider=gce
-            # Panic if anything mutates a shared informer cache
-            - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-            # Panic if data inconsistency is detected
-            - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
-            - --env=ENABLE_KUBE_WATCHCACHE_CONSISTENCY_CHECKER=true
-            - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-            - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-          resources:
-            limits:
-              cpu: 7.2
-              # NOTE: we don't need this much memory, but we're using ~all of the cores anyhow
-              # and this isn't even 2 GB / core ...
-              memory: "20Gi"
-            requests:
-              cpu: 7.2
-              memory: "20Gi"
-          securityContext:
-            privileged: true
-
-  # manual test for pull-through cache registry used with 5k node tests
-  - name: pull-kubernetes-e2e-gce-pull-through-cache
-    cluster: k8s-infra-prow-build
-    always_run: false
-    skip_branches:
-      - release-\d+\.\d+ # per-release image
+      - args:
+        - --build=quick
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.1.0
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.3.0
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+        - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
+        - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
+        - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
+        - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
+        - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+        - --gcp-master-image=ubuntu
+        - --gcp-node-image=ubuntu
+        - --gcp-region=us-central1
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHCACHE_CONSISTENCY_CHECKER=true
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
+        resources:
+          limits:
+            cpu: 7200m
+            memory: 20Gi
+          requests:
+            cpu: 7200m
+            memory: 20Gi
+        securityContext:
+          privileged: true
+  - always_run: false
     annotations:
       fork-per-release: "false"
       testgrid-dashboards: sig-k8s-infra-canaries
       testgrid-tab-name: pull-kubernetes-e2e-gce-pull-through-cache
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
-      timeout: 105m
-    path_alias: k8s.io/kubernetes
+      timeout: 1h45m0s
     extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
+    - base_ref: master
+      org: kubernetes
       path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce-pull-through-cache
+    path_alias: k8s.io/kubernetes
+    skip_branches:
+    - release-\d+\.\d+
     spec:
+      containers:
+      - args:
+        - --build=quick
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.1.0
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.3.0
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+        - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
+        - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
+        - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
+        - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
+        - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+        - --gcp-master-image=ubuntu
+        - --gcp-node-image=ubuntu
+        - --gcp-region=us-central1
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHCACHE_CONSISTENCY_CHECKER=true
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        env:
+        - name: KUBERNETES_REGISTRY_PULL_THROUGH_HOST
+          value: https://us-central1-docker.pkg.dev/v2/k8s-infra-e2e-scale-5k-project/k8s-5k-scale-cache/
+        - name: KUBERNETES_REGISTRY_PULL_THROUGH_BASIC_AUTH_TOKEN_PATH
+          value: /etc/registry-auth/token
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 14Gi
+          requests:
+            cpu: "7"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/registry-auth
+          name: cache-secret
+          readOnly: true
       volumes:
       - name: cache-secret
         secret:
           secretName: scale-pull-cache-token
-      containers:
-        - volumeMounts:
-          - name: cache-secret
-            readOnly: true
-            mountPath: /etc/registry-auth
-          env:
-          - name: KUBERNETES_REGISTRY_PULL_THROUGH_HOST
-            value: https://us-central1-docker.pkg.dev/v2/k8s-infra-e2e-scale-5k-project/k8s-5k-scale-cache/
-          - name: KUBERNETES_REGISTRY_PULL_THROUGH_BASIC_AUTH_TOKEN_PATH
-            value: /etc/registry-auth/token
-          command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-          args:
-            - --build=quick
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.1.0
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.3.0
-            - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-            - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
-            - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
-            - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
-            - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
-            - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
-            - --gcp-master-image=ubuntu
-            - --gcp-node-image=ubuntu
-            - --gcp-region=us-central1
-            - --ginkgo-parallel=30
-            - --provider=gce
-            # Panic if anything mutates a shared informer cache
-            - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-            # Panic if data inconsistency is detected
-            - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
-            - --env=ENABLE_KUBE_WATCHCACHE_CONSISTENCY_CHECKER=true
-            - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-            - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-          # TODO: increase CPU for the pull-kubernetes-e2e-gce, we spend a LONG time building kubernetes and it slows iteration
-          resources:
-            limits:
-              cpu: 7
-              memory: "14Gi"
-            requests:
-              cpu: 7
-              memory: "14Gi"
-          securityContext:
-            privileged: true
-
-  - name: pull-kubernetes-e2e-gce-canary
-    cluster: k8s-infra-prow-build
-    optional: true
-    always_run: false
-    skip_report: true
-    skip_branches:
-      - release-\d+\.\d+ # per-release image
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
-      testgrid-num-failures-to-alert: "10"
       testgrid-dashboards: google-gce
-    labels:
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
+      testgrid-num-failures-to-alert: "10"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
-      timeout: 110m
-    path_alias: k8s.io/kubernetes
+      timeout: 1h50m0s
     extra_refs:
-    - org: kubernetes
-      repo: kops
-      base_ref: master
+    - base_ref: master
+      org: kubernetes
       path_alias: k8s.io/kops
+      repo: kops
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+    name: pull-kubernetes-e2e-gce-canary
+    optional: true
+    path_alias: k8s.io/kubernetes
+    skip_branches:
+    - release-\d+\.\d+
+    skip_report: true
     spec:
+      containers:
+      - args:
+        - bash
+        - -c
+        - |
+          ARGS="--set=spec.containerd.runc.version=1.1.12 --set=spec.packages=nfs-common --set=spec.containerd.version=1.7.13"
+          make -C $GOPATH/src/k8s.io/kops test-e2e-install
+          kubetest2 kops -v=6 --cloud-provider=gce --up --down --build \
+            --build-kubernetes=true --target-build-arch=linux/amd64 \
+            --admin-access=0.0.0.0/0 \
+            --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
+            --create-args "$ARGS --networking=kubenet --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true" \
+            --test=kops \
+            -- \
+            --ginkgo-args="--debug" \
+            --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[KubeUp\]" \
+            --timeout=80m \
+            --use-built-binaries=true \
+            --parallel=30
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
       serviceAccountName: k8s-kops-test
-      containers:
-        - command:
-            - runner.sh
-          args:
-            - bash
-            - -c
-            - |
-              ARGS="--set=spec.containerd.runc.version=1.1.12 --set=spec.packages=nfs-common --set=spec.containerd.version=1.7.13"
-              make -C $GOPATH/src/k8s.io/kops test-e2e-install
-              kubetest2 kops -v=6 --cloud-provider=gce --up --down --build \
-                --build-kubernetes=true --target-build-arch=linux/amd64 \
-                --admin-access=0.0.0.0/0 \
-                --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
-                --create-args "$ARGS --networking=kubenet --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true" \
-                --test=kops \
-                -- \
-                --ginkgo-args="--debug" \
-                --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[KubeUp\]" \
-                --timeout=80m \
-                --use-built-binaries=true \
-                --parallel=30
-          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-          resources:
-            limits:
-              cpu: 4
-              memory: "14Gi"
-            requests:
-              cpu: 4
-              memory: "14Gi"
-          securityContext:
-            privileged: true
-
-  - name: pull-kubernetes-e2e-gce-ubuntu-canary
-    cluster: k8s-infra-prow-build
-    optional: true
-    always_run: false
-    skip_branches:
-      - release-\d+\.\d+ # per-release image
+  - always_run: false
     annotations:
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
-      testgrid-num-failures-to-alert: "10"
       testgrid-dashboards: google-gce
-    labels:
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
+      testgrid-num-failures-to-alert: "10"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
-      timeout: 110m
-    path_alias: k8s.io/kubernetes
-    spec:
-      serviceAccountName: prow-build
-      containers:
-        - command:
-            - runner.sh
-            - kubetest2
-            - gce
-          args:
-            - -v=2
-            - --build
-            - --up
-            - --down
-            - --legacy-mode
-            - --test=ginkgo
-            - --target-build-arch=linux/amd64
-            - --master-size=e2-standard-2
-            - --node-size=e2-standard-2
-            - --env=KUBE_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_IMAGE_FAMILY=ubuntu-2404-lts-amd64
-            - --env=KUBE_GCE_IMAGE_PROJECT=ubuntu-os-cloud
-            - --
-            - --provider=gce
-            - --skip-regex=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-            - --timeout=80m
-            - --use-built-binaries=true
-            - --parallel=30
-          image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251021-e2c2c9806f-master
-          resources:
-            limits:
-              cpu: 4
-              memory: "14Gi"
-            requests:
-              cpu: 4
-              memory: "14Gi"
-          securityContext:
-            privileged: true
-
-  - name: pull-kubernetes-e2e-gce-kubetest2
-    cluster: k8s-infra-prow-build
+      timeout: 1h50m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+    name: pull-kubernetes-e2e-gce-ubuntu-canary
     optional: true
-    always_run: false
+    path_alias: k8s.io/kubernetes
     skip_branches:
-      - release-\d+\.\d+ # per-release image
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - args:
+        - -v=2
+        - --build
+        - --up
+        - --down
+        - --legacy-mode
+        - --test=ginkgo
+        - --target-build-arch=linux/amd64
+        - --master-size=e2-standard-2
+        - --node-size=e2-standard-2
+        - --env=KUBE_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_IMAGE_FAMILY=ubuntu-2404-lts-amd64
+        - --env=KUBE_GCE_IMAGE_PROJECT=ubuntu-os-cloud
+        - --
+        - --provider=gce
+        - --skip-regex=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+        - --timeout=80m
+        - --use-built-binaries=true
+        - --parallel=30
+        command:
+        - runner.sh
+        - kubetest2
+        - gce
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251021-e2c2c9806f-master
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: prow-build
+  - always_run: false
     annotations:
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
-      testgrid-num-failures-to-alert: "10"
       testgrid-dashboards: google-gce
-    labels:
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
+      testgrid-num-failures-to-alert: "10"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
-      timeout: 110m
-    path_alias: k8s.io/kubernetes
-    spec:
-      serviceAccountName: prow-build
-      containers:
-        - command:
-            - runner.sh
-            - kubetest2
-            - gce
-          args:
-            - -v=2
-            - --build
-            - --up
-            - --down
-            - --legacy-mode
-            - --test=ginkgo
-            - --target-build-arch=linux/amd64
-            - --master-size=e2-standard-2
-            - --node-size=e2-standard-2
-            - --env=KUBE_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_IMAGE_FAMILY=ubuntu-2204-lts
-            - --env=KUBE_GCE_IMAGE_PROJECT=ubuntu-os-cloud
-            - --
-            - --provider=gce
-            - --skip-regex=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-            - --timeout=80m
-            - --use-built-binaries=true
-            - --parallel=30
-          image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251021-e2c2c9806f-master
-          resources:
-            limits:
-              cpu: 4
-              memory: "14Gi"
-            requests:
-              cpu: 4
-              memory: "14Gi"
-          securityContext:
-            privileged: true
-
-  - name: pull-kubernetes-e2e-gce-cos-alpha-features
-    cluster: k8s-infra-prow-build
+      timeout: 1h50m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+    name: pull-kubernetes-e2e-gce-kubetest2
     optional: true
-    run_if_changed: '^.*feature.*\.go'
+    path_alias: k8s.io/kubernetes
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - args:
+        - -v=2
+        - --build
+        - --up
+        - --down
+        - --legacy-mode
+        - --test=ginkgo
+        - --target-build-arch=linux/amd64
+        - --master-size=e2-standard-2
+        - --node-size=e2-standard-2
+        - --env=KUBE_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_IMAGE_FAMILY=ubuntu-2204-lts
+        - --env=KUBE_GCE_IMAGE_PROJECT=ubuntu-os-cloud
+        - --
+        - --provider=gce
+        - --skip-regex=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+        - --timeout=80m
+        - --use-built-binaries=true
+        - --parallel=30
+        command:
+        - runner.sh
+        - kubetest2
+        - gce
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251021-e2c2c9806f-master
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: prow-build
+  - always_run: false
+    annotations:
+      testgrid-create-test-group: "true"
     branches:
-    # TODO(releng): Remove once repo default branch has been renamed
     - master
     - main
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
-      timeout: 200m
-    path_alias: k8s.io/kubernetes
+      timeout: 3h20m0s
     extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
+    - base_ref: master
+      org: kubernetes
       path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce-cos-alpha-features
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: ^.*feature.*\.go
     spec:
       containers:
-      - command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-        args:
+      - args:
         - --ginkgo-parallel=1
         - --build=quick
         - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
@@ -587,821 +1093,320 @@ presubmits:
         - --gcp-region=us-central1
         - --provider=gce
         - --runtime-config=api/all=true
-        - --test_args=--ginkgo.focus=\[Feature:(WatchList|InPlacePodVerticalScaling|APIServerTracing|StorageVersionAPI|PodPreset|PodLifecycleSleepAction|PodLifecycleSleepActionAllowZero|RecoverVolumeExpansionFailure)\] --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0|\[KubeUp\] --minStartupPods=8
+        - --test_args=--ginkgo.focus=\[Feature:(WatchList|InPlacePodVerticalScaling|APIServerTracing|StorageVersionAPI|PodPreset|PodLifecycleSleepAction|PodLifecycleSleepActionAllowZero|RecoverVolumeExpansionFailure)\]
+          --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0|\[KubeUp\]
+          --minStartupPods=8
         - --timeout=180m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
         resources:
           limits:
-            cpu: 4
-            memory: "14Gi"
+            cpu: "4"
+            memory: 14Gi
           requests:
-            cpu: 4
-            memory: "14Gi"
+            cpu: "4"
+            memory: 14Gi
         securityContext:
           privileged: true
-    annotations:
-      testgrid-create-test-group: 'true'
-
-  - name: pull-kubernetes-e2e-gce-serial
-    cluster: k8s-infra-prow-build
-    optional: true
-    always_run: false
-    skip_branches:
-      - release-\d+\.\d+ # per-release image
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
-      testgrid-num-failures-to-alert: "10"
       testgrid-dashboards: google-gce
+      testgrid-num-failures-to-alert: "10"
+    cluster: k8s-infra-prow-build
+    decorate: true
+    decoration_config:
+      timeout: 8h40m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
     labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
-    decorate: true
-    decoration_config:
-      timeout: 520m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
-      path_alias: k8s.io/release
-    spec:
-      containers:
-        - command:
-            - runner.sh
-            - /workspace/scenarios/kubernetes_e2e.py
-          args:
-            - --build=quick
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.1.0
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.3.0
-            - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-            - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
-            - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
-            - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
-            - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
-            - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
-            - --gcp-master-image=ubuntu
-            - --gcp-node-image=ubuntu
-            - --gcp-region=us-central1
-            - --ginkgo-parallel=1
-            - --provider=gce
-            - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-            - --timeout=500m
-          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-          resources:
-            limits:
-              cpu: 4
-              memory: "14Gi"
-            requests:
-              cpu: 4
-              memory: "14Gi"
-          securityContext:
-            privileged: true
-
-  - name: pull-kubernetes-e2e-gce-serial-canary
-    cluster: k8s-infra-prow-build
-    optional: true
-    always_run: false
-    skip_branches:
-      - release-\d+\.\d+ # per-release image
-    annotations:
-      fork-per-release: "true"
-      testgrid-alert-stale-results-hours: "24"
-      testgrid-create-test-group: "true"
-      testgrid-num-failures-to-alert: "10"
-      testgrid-dashboards: google-gce
-    labels:
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-      preset-storage-e2e-service-account: "true"
-    decorate: true
-    decoration_config:
-      timeout: 530m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: kops
-      base_ref: master
-      path_alias: k8s.io/kops
-    spec:
-      serviceAccountName: k8s-kops-test
-      containers:
-        - command:
-            - runner.sh
-          args:
-            - bash
-            - -c
-            - |
-              ARGS="--set=spec.containerd.runc.version=1.1.12  --set=spec.packages=nfs-common --set=spec.containerd.version=1.7.13"
-              make -C $GOPATH/src/k8s.io/kops test-e2e-install
-              kubetest2 kops -v=6 --cloud-provider=gce --up --down --build \
-                --build-kubernetes=true --target-build-arch=linux/amd64 \
-                --admin-access=0.0.0.0/0 \
-                --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
-                --create-args "$ARGS --node-count=3 --networking=kubenet --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true" \
-                --test=kops \
-                -- \
-                --test-args="-test.timeout=800m --num-nodes=3 --master-os-distro=ubuntu --node-os-distro=ubuntu" \
-                --focus-regex="\[Serial\]" \
-                --skip-regex="\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[KubeUp\]" \
-                --timeout=500m \
-                --use-built-binaries=true \
-                --parallel=1
-          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-          resources:
-            limits:
-              cpu: 4
-              memory: "14Gi"
-            requests:
-              cpu: 4
-              memory: "14Gi"
-          securityContext:
-            privileged: true
-
-  - name: pull-kubernetes-e2e-gce-disruptive-canary
-    cluster: k8s-infra-prow-build
-    optional: true
-    always_run: false
-    skip_branches:
-      - release-\d+\.\d+ # per-release image
-    annotations:
-      fork-per-release: "true"
-      testgrid-alert-stale-results-hours: "24"
-      testgrid-create-test-group: "true"
-      testgrid-num-failures-to-alert: "10"
-      testgrid-dashboards: google-gce
-    labels:
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-      preset-storage-e2e-service-account: "true"
-    decorate: true
-    decoration_config:
-      timeout: 630m
-    path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: kops
-      base_ref: master
-      path_alias: k8s.io/kops
-    spec:
-      serviceAccountName: k8s-kops-test
-      containers:
-        - command:
-            - runner.sh
-          args:
-            - bash
-            - -c
-            - |
-              ARGS="--set=spec.containerd.runc.version=1.1.12  --set=spec.packages=nfs-common --set=spec.containerd.version=1.7.13"
-              make -C $GOPATH/src/k8s.io/kops test-e2e-install
-              kubetest2 kops -v=6 --cloud-provider=gce --up --down --build \
-                --build-kubernetes=true --target-build-arch=linux/amd64 \
-                --admin-access=0.0.0.0/0 \
-                --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
-                --create-args "$ARGS --node-count=3 --networking=kubenet --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true" \
-                --test=kops \
-                -- \
-                --test-args="-test.timeout=600m --num-nodes=3 --master-os-distro=ubuntu --node-os-distro=ubuntu" \
-                --focus-regex="\[Disruptive\]" \
-                --skip-regex="\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[KubeUp\]" \
-                --timeout=500m \
-                --use-built-binaries=true \
-                --parallel=1
-          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-          resources:
-            limits:
-              cpu: 4
-              memory: "14Gi"
-            requests:
-              cpu: 4
-              memory: "14Gi"
-          securityContext:
-            privileged: true
-
-  - name: pull-e2e-gce-cloud-provider-disabled
-    cluster: k8s-infra-prow-build
-    optional: true
-    always_run: false
-    skip_branches:
-      - release-\d+\.\d+ # per-release image
-    annotations:
-      fork-per-release: "true"
-      testgrid-alert-stale-results-hours: "24"
-      testgrid-create-test-group: "true"
-      testgrid-num-failures-to-alert: "10"
-      testgrid-dashboards: google-gce
-    labels:
       preset-service-account: "true"
-      preset-k8s-ssh: "true"
+    name: pull-kubernetes-e2e-gce-serial
+    optional: true
+    path_alias: k8s.io/kubernetes
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.1.0
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.3.0
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+        - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
+        - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
+        - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
+        - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
+        - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+        - --gcp-master-image=ubuntu
+        - --gcp-node-image=ubuntu
+        - --gcp-region=us-central1
+        - --ginkgo-parallel=1
+        - --provider=gce
+        - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=500m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: google-gce
+      testgrid-num-failures-to-alert: "10"
+    cluster: k8s-infra-prow-build
+    decorate: true
+    decoration_config:
+      timeout: 8h50m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kops
+      repo: kops
+    labels:
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-storage-e2e-service-account: "true"
+    name: pull-kubernetes-e2e-gce-serial-canary
+    optional: true
+    path_alias: k8s.io/kubernetes
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - args:
+        - bash
+        - -c
+        - |
+          ARGS="--set=spec.containerd.runc.version=1.1.12  --set=spec.packages=nfs-common --set=spec.containerd.version=1.7.13"
+          make -C $GOPATH/src/k8s.io/kops test-e2e-install
+          kubetest2 kops -v=6 --cloud-provider=gce --up --down --build \
+            --build-kubernetes=true --target-build-arch=linux/amd64 \
+            --admin-access=0.0.0.0/0 \
+            --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
+            --create-args "$ARGS --node-count=3 --networking=kubenet --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true" \
+            --test=kops \
+            -- \
+            --test-args="-test.timeout=800m --num-nodes=3 --master-os-distro=ubuntu --node-os-distro=ubuntu" \
+            --focus-regex="\[Serial\]" \
+            --skip-regex="\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[KubeUp\]" \
+            --timeout=500m \
+            --use-built-binaries=true \
+            --parallel=1
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: k8s-kops-test
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: google-gce
+      testgrid-num-failures-to-alert: "10"
+    cluster: k8s-infra-prow-build
+    decorate: true
+    decoration_config:
+      timeout: 10h30m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kops
+      repo: kops
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-storage-e2e-service-account: "true"
+    name: pull-kubernetes-e2e-gce-disruptive-canary
+    optional: true
+    path_alias: k8s.io/kubernetes
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - args:
+        - bash
+        - -c
+        - |
+          ARGS="--set=spec.containerd.runc.version=1.1.12  --set=spec.packages=nfs-common --set=spec.containerd.version=1.7.13"
+          make -C $GOPATH/src/k8s.io/kops test-e2e-install
+          kubetest2 kops -v=6 --cloud-provider=gce --up --down --build \
+            --build-kubernetes=true --target-build-arch=linux/amd64 \
+            --admin-access=0.0.0.0/0 \
+            --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
+            --create-args "$ARGS --node-count=3 --networking=kubenet --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true" \
+            --test=kops \
+            -- \
+            --test-args="-test.timeout=600m --num-nodes=3 --master-os-distro=ubuntu --node-os-distro=ubuntu" \
+            --focus-regex="\[Disruptive\]" \
+            --skip-regex="\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[KubeUp\]" \
+            --timeout=500m \
+            --use-built-binaries=true \
+            --parallel=1
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: k8s-kops-test
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: google-gce
+      testgrid-num-failures-to-alert: "10"
+    cluster: k8s-infra-prow-build
+    decorate: true
+    decoration_config:
+      timeout: 2h0m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
-    decorate: true
-    decoration_config:
-      timeout: 120m
+      preset-service-account: "true"
+    name: pull-e2e-gce-cloud-provider-disabled
+    optional: true
     path_alias: k8s.io/kubernetes
-    extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
-      path_alias: k8s.io/release
+    skip_branches:
+    - release-\d+\.\d+
     spec:
       containers:
-        - command:
-            - runner.sh
-            - /workspace/scenarios/kubernetes_e2e.py
-          args:
-            - --build=quick
-            - --env=CLOUD_PROVIDER_FLAG=external
-            - --env=ENABLE_AUTH_PROVIDER_GCP=true
-            - --gcp-master-image=gci
-            - --gcp-node-image=gci
-            - --gcp-nodes=4
-            - --gcp-region=us-central1
-            - --ginkgo-parallel=30
-            - --provider=gce
-            - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-            - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-          resources:
-            limits:
-              cpu: 4
-              memory: "14Gi"
-            requests:
-              cpu: 4
-              memory: "14Gi"
-          securityContext:
-            privileged: true
-
-  - name: pull-e2e-gci-gce-alpha-enabled-default
-    cluster: k8s-infra-prow-build
-    optional: true
-    always_run: false
-    skip_branches:
-      - release-\d+\.\d+ # per-release image
+      - args:
+        - --build=quick
+        - --env=CLOUD_PROVIDER_FLAG=external
+        - --env=ENABLE_AUTH_PROVIDER_GCP=true
+        - --gcp-master-image=gci
+        - --gcp-node-image=gci
+        - --gcp-nodes=4
+        - --gcp-region=us-central1
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+  - always_run: false
     annotations:
       fork-per-release: "false"
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
-      testgrid-num-failures-to-alert: "10"
       testgrid-dashboards: google-gce
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
+      testgrid-num-failures-to-alert: "10"
+    cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
-      timeout: 120m
-    path_alias: k8s.io/kubernetes
+      timeout: 2h0m0s
     extra_refs:
-    - org: kubernetes
-      repo: release
-      base_ref: master
+    - base_ref: master
+      org: kubernetes
       path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-e2e-gci-gce-alpha-enabled-default
+    optional: true
+    path_alias: k8s.io/kubernetes
+    skip_branches:
+    - release-\d+\.\d+
     spec:
       containers:
-        - command:
-            - runner.sh
-            - /workspace/scenarios/kubernetes_e2e.py
-          args:
-            - --build=quick
-            - --check-leaked-resources
-            - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
-            - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
-            - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
-            - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-            - --env=KUBE_PROXY_DAEMONSET=true
-            - --env=ENABLE_POD_PRIORITY=true
-            - --gcp-node-image=gci
-            - --gcp-region=us-central1
-            - --ginkgo-parallel=30
-            - --provider=gce
-            - --runtime-config=api/all=true
-            - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0 --minStartupPods=8
-            - --timeout=70m
-          image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-          resources:
-            limits:
-              cpu: 4
-              memory: "14Gi"
-            requests:
-              cpu: 4
-              memory: "14Gi"
-          securityContext:
-            privileged: true
-
-periodics:
-- interval: 30m
-  name: ci-kubernetes-e2e-gci-gce
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --extract=ci/fast/latest-fast
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --ginkgo-parallel=30
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=120m
-      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-release-master-blocking
-    testgrid-tab-name: gce-cos-master-default
-    testgrid-num-failures-to-alert: '6'
-    testgrid-alert-email: release-team@kubernetes.io
-    description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh
-
-- interval: 120m
-  name: ci-kubernetes-e2e-ubuntu-gce-containerd
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 70m
-  spec:
-    containers:
-      - command:
-          - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-        args:
-          - --check-leaked-resources
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.1.0
-          - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.3.0
-          - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-          - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
-          - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-          - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20220712a
-          - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
-          - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-          - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20220712a
-          - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
-          - --extract=ci/fast/latest-fast
-          - --gcp-master-image=ubuntu
-          - --gcp-node-image=ubuntu
-          - --gcp-nodes=4
-          - --gcp-region=us-central1
-          - --ginkgo-parallel=30
-          - --provider=gce
-          - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-          - --timeout=50m
+      - args:
+        - --build=quick
+        - --check-leaked-resources
+        - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
+        - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
+        - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
+        - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+        - --env=KUBE_PROXY_DAEMONSET=true
+        - --env=ENABLE_POD_PRIORITY=true
+        - --gcp-node-image=gci
+        - --gcp-region=us-central1
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --runtime-config=api/all=true
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0
+          --minStartupPods=8
+        - --timeout=70m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
+        name: ""
         resources:
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: "4"
+            memory: 14Gi
           requests:
-            cpu: 2
-            memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-release-master-blocking
-    testgrid-tab-name: gce-ubuntu-master-containerd
-    testgrid-num-failures-to-alert: '6'
-    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, release-team@kubernetes.io
-    description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) against a cluster (ubuntu based and uses containerd) created with cluster/kube-up.sh
-
-- interval: 30m
-  name: ci-kubernetes-e2e-gci-gce-alpha-enabled-default
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 100m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
-      - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
-      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-      - --env=KUBE_PROXY_DAEMONSET=true
-      - --env=ENABLE_POD_PRIORITY=true
-      - --extract=ci/fast/latest-fast
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --ginkgo-parallel=30
-      - --provider=gce
-      - --runtime-config=api/all=true
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0 --minStartupPods=8
-      - --timeout=70m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: gci-gce-alpha-enabled-default
-
-- interval: 30m
-  name: ci-kubernetes-e2e-gci-gce-alpha-features
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 200m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
-      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-      - --env=KUBE_PROXY_DAEMONSET=true
-      - --env=ENABLE_POD_PRIORITY=true
-      - --extract=ci/fast/latest-fast
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --provider=gce
-      - --runtime-config=api/all=true
-      - --test_args=--ginkgo.focus=\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Example)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
-      - --timeout=180m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 1
-          memory: 3Gi
-        requests:
-          cpu: 1
-          memory: 3Gi
-  annotations:
-    testgrid-dashboards: sig-release-master-blocking, google-gce
-    testgrid-tab-name: gce-cos-master-alpha-features
-    testgrid-alert-email: release-team@kubernetes.io
-    description: Uses kubetest to run e2e tests (+Feature:many, -many) against a cluster created with cluster/kube-up.sh
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gci-gce-flaky-repro
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 70m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-nodes=4
-      - --gcp-region=us-central1
-      - --ginkgo-parallel=30
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=50m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-testing-misc
-    testgrid-tab-name: gce-cos-master-flaky-repro
-    description: Same config as ci-kubernetes-e2e-gci-gce but with Flaky tests included, intended to reproduce conditions that cause flakes to appear
-
-- interval: 12h
-  name: ci-kubernetes-e2e-gci-gce-flaky
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 200m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Driver:.gcepd\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=180m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 1
-          memory: 3Gi
-        requests:
-          cpu: 1
-          memory: 3Gi
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: gci-gce-flaky
-
-- interval: 30m
-  name: ci-kubernetes-e2e-gci-gce-reboot
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 200m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --extract=ci/fast/latest-fast
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
-      - --timeout=180m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 1
-          memory: 3Gi
-        requests:
-          cpu: 1
-          memory: 3Gi
-  annotations:
-    testgrid-dashboards: sig-release-master-blocking, google-gce
-    testgrid-tab-name: gce-cos-master-reboot
-    description: Uses kubetest to run a subset of e2e tests (+Feature:Reboot) against a cluster created with cluster/kube-up.sh
-    testgrid-alert-email: gke-node-experience-team+alerts@google.com, release-team@kubernetes.io
-    testgrid-num-failures-to-alert: '6'
-
-- interval: 30m
-  name: ci-kubernetes-e2e-gci-gce-serial
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 520m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --env=NODE_LOCAL_SSDS_EXT=1,scsi,fs
-      - --env=NODE_SIZE=n2-standard-2
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\] --minStartupPods=8
-      - --timeout=500m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 1
-          memory: 3Gi
-        requests:
-          cpu: 1
-          memory: 3Gi
-  annotations:
-    testgrid-dashboards: sig-release-master-informing
-    testgrid-tab-name: gce-cos-master-serial
-    testgrid-num-failures-to-alert: '6'
-    testgrid-alert-email: release-team@kubernetes.io
-    description: Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh
-
-- interval: 30m
-  name: ci-kubernetes-e2e-gci-gce-slow
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 170m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --check-leaked-resources
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --ginkgo-parallel=30
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --minStartupPods=8
-      - --timeout=150m
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 1
-          memory: 6Gi
-        requests:
-          cpu: 1
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: sig-release-master-informing
-    testgrid-tab-name: gce-cos-master-slow
-    testgrid-num-failures-to-alert: '6'
-    testgrid-alert-email: release-team@kubernetes.io
-    description: Uses kubetest to run e2e tests (+Slow, -Serial|Disruptive|Flaky|Feature) against a cluster created with cluster/kube-up.sh
-
-- interval: 12h
-  name: ci-kubernetes-soak-gci-gce-beta
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 1420m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --down=false
-      - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
-      - --extract=ci/k8s-beta
-      - --gcp-master-image=gci
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --provider=gce
-      - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --clean-start=true --minStartupPods=8
-      - --timeout=1400m
-      - --up=false
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: soak-gci-gce-1.15
-
-- interval: 12h
-  name: ci-kubernetes-soak-gci-gce-stable1
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 1420m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --down=false
-      - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
-      - --extract=ci/k8s-stable1
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --provider=gce
-      - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --clean-start=true --minStartupPods=8
-      - --timeout=1400m
-      - --up=false
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: soak-gci-gce-1.14
-
-- interval: 12h
-  name: ci-kubernetes-soak-gci-gce-stable2
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 1420m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --down=false
-      - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
-      - --extract=ci/k8s-stable2
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --provider=gce
-      - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --clean-start=true --minStartupPods=8
-      - --timeout=1400m
-      - --up=false
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: soak-gci-gce-1.13
-
-- interval: 12h
-  name: ci-kubernetes-soak-gci-gce-stable3
-  cluster: k8s-infra-prow-build
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 1420m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --down=false
-      - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
-      - --extract=ci/k8s-stable3
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --provider=gce
-      - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --clean-start=true --minStartupPods=8
-      - --timeout=1400m
-      - --up=false
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
-      resources:
-        limits:
-          cpu: 2
-          memory: 6Gi
-        requests:
-          cpu: 2
-          memory: 6Gi
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: soak-gci-gce-1.12
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true


### PR DESCRIPTION
The k8s-stable1 marker (https://storage.googleapis.com/k8s-release-dev/ci/k8s-stable1.txt)
is no longer being published (returns 404), causing test failures in sig-release-master-blocking
and other jobs that depend on it.

This is blocking the **sig-release-master-blocking** job `ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew`
and is a **release blocker** for 1.35.0-beta.0 (scheduled in 3 days).

### Changes
This PR rotates all affected jobs to use k8s-stable2 instead:
- All sig-cli kubectl skew test jobs (stable1 → stable2)
- All sig-cloud-provider soak test jobs (stable1 → stable2, stable2 → stable3, stable3 → stable4)

The rotation also properly handles cross-version skew tests:
- stable1-stable2 → stable2-stable3
- stable2-stable1 → stable3-stable2

Used the `config-rotator` tool as documented in config/jobs/README.md:
```bash
go run ./releng/config-rotator/main.go --config-file=... --old=stable1 --new=stable2
```
Then manually fixed duplicate job names created by the cascading rotation.

I guess it was introduced in b83adcd052.

Fixes: kubernetes/kubernetes#134938
Ref: https://kubernetes.slack.com/archives/C2GL57FJ4/p1762167598568149
