### PR TITLE
Bump hydrophone e2e test expectations

### DIFF
--- a/config/jobs/kubernetes-sigs/hydrophone/hydrophone-periodic.yaml
+++ b/config/jobs/kubernetes-sigs/hydrophone/hydrophone-periodic.yaml
@@ -23,7 +23,7 @@ periodics:
             - name: CONFORMANCE
               value: "true"
             - name: EXPECTED_NUM_TESTS
-              value: "388" # This is the number of specs expected to run. This will change with each version of Kubernetes.
+              value: "424" # This is the number of specs expected to run. This will change with each version of Kubernetes.
           args:
             - bash
             - -c
@@ -69,7 +69,7 @@ periodics:
             - name: SKIP
               value: '\[Serial\]|\[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist'
             - name: EXPECTED_NUM_TESTS
-              value: "354" # This is the number of specs expected to run. This may change with each version of Kubernetes.
+              value: "389" # This is the number of specs expected to run. This may change with each version of Kubernetes.
           args:
             - bash
             - -c


### PR DESCRIPTION
Hydrophone tests were updated to run against k8s v1.34. With this we need to update the expected tests for conformance and e2e. 