### PR TITLE
dra 5k test, update branch to bump wati for job timeout

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -531,9 +531,9 @@ periodics:
       repo: kubernetes
       base_ref: master
       path_alias: k8s.io/kubernetes
-    - org: kubernetes
+    - org: alaypatel07
       repo: perf-tests
-      base_ref: master
+      base_ref: dra-scalability-bump-timeout
       path_alias: k8s.io/perf-tests
     - org: kubernetes
       repo: kops


### PR DESCRIPTION
The 5k node test needs to wait for longer time for jobs to finish.

The jobs are starting still within the SLO it just takes more time at that scale.