### PR TITLE
[Feature Cleanup] Remove APIServerIdentity from test, bump api group to beta

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -26,8 +26,8 @@ presubmits:
         - --test-cmd=../test/e2e/test-fully-automated.sh
         - --test-cmd-args=--focus=\[Disruptive\]
         - --timeout=50m
-        - --runtime-config=internal.apiserver.k8s.io/v1alpha1=true
-        - --env=KUBE_FEATURE_GATES=StorageVersionAPI=true,APIServerIdentity=true
+        - --runtime-config=internal.apiserver.k8s.io/v1beta1=true
+        - --env=KUBE_FEATURE_GATES=StorageVersionAPI=true
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -26,7 +26,7 @@ presubmits:
         - --test-cmd=../test/e2e/test-fully-automated.sh
         - --test-cmd-args=--focus=\[Disruptive\]
         - --timeout=50m
-        - --runtime-config=internal.apiserver.k8s.io/v1beta1=true
+        - --runtime-config=internal.apiserver.k8s.io/v1alpha1=true
         - --env=KUBE_FEATURE_GATES=StorageVersionAPI=true
         # docker-in-docker needs privileged mode
         securityContext:

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -87,6 +87,7 @@ presubmits:
         - --test-cmd=../test/e2e/test-fully-automated.sh
         - --test-cmd-args=--skip=\[Disruptive\]
         - --timeout=50m
+        - --runtime-config=internal.apiserver.k8s.io/v1alpha1=true
         - --env=KUBE_FEATURE_GATES=StorageVersionAPI=true
         # docker-in-docker needs privileged mode
         securityContext:

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -87,8 +87,7 @@ presubmits:
         - --test-cmd=../test/e2e/test-fully-automated.sh
         - --test-cmd-args=--skip=\[Disruptive\]
         - --timeout=50m
-        - --runtime-config=internal.apiserver.k8s.io/v1alpha1=true
-        - --env=KUBE_FEATURE_GATES=StorageVersionAPI=true,APIServerIdentity=true
+        - --env=KUBE_FEATURE_GATES=StorageVersionAPI=true
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
/kind cleanup

Continuing the efforts of https://github.com/kubernetes/kubernetes/issues/134172
Correspinding to PR https://github.com/kubernetes/kubernetes/pull/135360

Currently as draft so I can run the specific test jobs and compare the output to see if the env variable is enabled by default and if the API should be set to beta or can be removed. 

cc: @SergeyKanzhelev @roycaihw 