### PR TITLE
Add insecure registry configuration for localhost:5000 in CRI-O e2e tests

### DIFF
--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -34,6 +34,14 @@
         "mode": 420
       },
       {
+        "path": "/etc/containers/registries.conf.d/99-localhost-insecure.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/1SOMUsFMRCE+/yK4b06cAg2wussLEVed1wR4t5lMWR1d+Nx/14MnGA5zDDfd8Wzymfkhixt5a1rcpYGF6RaZQc3o9yV8HK/v0JpY3M9sIqiSk61iPnT4zRN4Yo3+uqs9D5aeiA4mRu6cdvghbCmD4rnRzTSb1LshXPBCDYoUVo9Qpjnc7ks4Zc1xG64/Odewp/iDa6dwk8AAAD//6EsFVnUAAAA"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/sysctl.d/99-e2e-sysctl.conf",
         "contents": {
           "compression": "gzip",

--- a/jobs/e2e_node/crio/crio_canary.ign
+++ b/jobs/e2e_node/crio/crio_canary.ign
@@ -34,6 +34,14 @@
         "mode": 420
       },
       {
+        "path": "/etc/containers/registries.conf.d/99-localhost-insecure.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/1SOMUsFMRCE+/yK4b06cAg2wussLEVed1wR4t5lMWR1d+Nx/14MnGA5zDDfd8Wzymfkhixt5a1rcpYGF6RaZQc3o9yV8HK/v0JpY3M9sIqiSk61iPnT4zRN4Yo3+uqs9D5aeiA4mRu6cdvghbCmD4rnRzTSb1LshXPBCDYoUVo9Qpjnc7ks4Zc1xG64/Odewp/iDa6dwk8AAAD//6EsFVnUAAAA"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/sysctl.d/99-e2e-sysctl.conf",
         "contents": {
           "compression": "gzip",

--- a/jobs/e2e_node/crio/crio_drop_infra_ctr.ign
+++ b/jobs/e2e_node/crio/crio_drop_infra_ctr.ign
@@ -34,6 +34,14 @@
         "mode": 420
       },
       {
+        "path": "/etc/containers/registries.conf.d/99-localhost-insecure.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/1SOMUsFMRCE+/yK4b06cAg2wussLEVed1wR4t5lMWR1d+Nx/14MnGA5zDDfd8Wzymfkhixt5a1rcpYGF6RaZQc3o9yV8HK/v0JpY3M9sIqiSk61iPnT4zRN4Yo3+uqs9D5aeiA4mRu6cdvghbCmD4rnRzTSb1LshXPBCDYoUVo9Qpjnc7ks4Zc1xG64/Odewp/iDa6dwk8AAAD//6EsFVnUAAAA"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/sysctl.d/99-e2e-sysctl.conf",
         "contents": {
           "compression": "gzip",

--- a/jobs/e2e_node/crio/crio_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_eventedpleg.ign
@@ -34,6 +34,14 @@
         "mode": 420
       },
       {
+        "path": "/etc/containers/registries.conf.d/99-localhost-insecure.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/1SOMUsFMRCE+/yK4b06cAg2wussLEVed1wR4t5lMWR1d+Nx/14MnGA5zDDfd8Wzymfkhixt5a1rcpYGF6RaZQc3o9yV8HK/v0JpY3M9sIqiSk61iPnT4zRN4Yo3+uqs9D5aeiA4mRu6cdvghbCmD4rnRzTSb1LshXPBCDYoUVo9Qpjnc7ks4Zc1xG64/Odewp/iDa6dwk8AAAD//6EsFVnUAAAA"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/sysctl.d/99-e2e-sysctl.conf",
         "contents": {
           "compression": "gzip",

--- a/jobs/e2e_node/crio/crio_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_hugepages.ign
@@ -34,6 +34,14 @@
         "mode": 420
       },
       {
+        "path": "/etc/containers/registries.conf.d/99-localhost-insecure.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/1SOMUsFMRCE+/yK4b06cAg2wussLEVed1wR4t5lMWR1d+Nx/14MnGA5zDDfd8Wzymfkhixt5a1rcpYGF6RaZQc3o9yV8HK/v0JpY3M9sIqiSk61iPnT4zRN4Yo3+uqs9D5aeiA4mRu6cdvghbCmD4rnRzTSb1LshXPBCDYoUVo9Qpjnc7ks4Zc1xG64/Odewp/iDa6dwk8AAAD//6EsFVnUAAAA"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/sysctl.d/99-e2e-sysctl.conf",
         "contents": {
           "compression": "gzip",

--- a/jobs/e2e_node/crio/crio_imagefs.ign
+++ b/jobs/e2e_node/crio/crio_imagefs.ign
@@ -52,6 +52,14 @@
         "mode": 420
       },
       {
+        "path": "/etc/containers/registries.conf.d/99-localhost-insecure.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/1SOMUsFMRCE+/yK4b06cAg2wussLEVed1wR4t5lMWR1d+Nx/14MnGA5zDDfd8Wzymfkhixt5a1rcpYGF6RaZQc3o9yV8HK/v0JpY3M9sIqiSk61iPnT4zRN4Yo3+uqs9D5aeiA4mRu6cdvghbCmD4rnRzTSb1LshXPBCDYoUVo9Qpjnc7ks4Zc1xG64/Odewp/iDa6dwk8AAAD//6EsFVnUAAAA"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/sysctl.d/99-e2e-sysctl.conf",
         "contents": {
           "compression": "gzip",

--- a/jobs/e2e_node/crio/crio_splitfs.ign
+++ b/jobs/e2e_node/crio/crio_splitfs.ign
@@ -52,6 +52,14 @@
         "mode": 420
       },
       {
+        "path": "/etc/containers/registries.conf.d/99-localhost-insecure.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/1SOMUsFMRCE+/yK4b06cAg2wussLEVed1wR4t5lMWR1d+Nx/14MnGA5zDDfd8Wzymfkhixt5a1rcpYGF6RaZQc3o9yV8HK/v0JpY3M9sIqiSk61iPnT4zRN4Yo3+uqs9D5aeiA4mRu6cdvghbCmD4rnRzTSb1LshXPBCDYoUVo9Qpjnc7ks4Zc1xG64/Odewp/iDa6dwk8AAAD//6EsFVnUAAAA"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/sysctl.d/99-e2e-sysctl.conf",
         "contents": {
           "compression": "gzip",

--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -34,6 +34,14 @@
         "mode": 420
       },
       {
+        "path": "/etc/containers/registries.conf.d/99-localhost-insecure.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/1SOMUsFMRCE+/yK4b06cAg2wussLEVed1wR4t5lMWR1d+Nx/14MnGA5zDDfd8Wzymfkhixt5a1rcpYGF6RaZQc3o9yV8HK/v0JpY3M9sIqiSk61iPnT4zRN4Yo3+uqs9D5aeiA4mRu6cdvghbCmD4rnRzTSb1LshXPBCDYoUVo9Qpjnc7ks4Zc1xG64/Odewp/iDa6dwk8AAAD//6EsFVnUAAAA"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/sysctl.d/99-e2e-sysctl.conf",
         "contents": {
           "compression": "gzip",

--- a/jobs/e2e_node/crio/crio_userns.ign
+++ b/jobs/e2e_node/crio/crio_userns.ign
@@ -44,6 +44,14 @@
         "mode": 420
       },
       {
+        "path": "/etc/containers/registries.conf.d/99-localhost-insecure.conf",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/1SOMUsFMRCE+/yK4b06cAg2wussLEVed1wR4t5lMWR1d+Nx/14MnGA5zDDfd8Wzymfkhixt5a1rcpYGF6RaZQc3o9yV8HK/v0JpY3M9sIqiSk61iPnT4zRN4Yo3+uqs9D5aeiA4mRu6cdvghbCmD4rnRzTSb1LshXPBCDYoUVo9Qpjnc7ks4Zc1xG64/Odewp/iDa6dwk8AAAD//6EsFVnUAAAA"
+        },
+        "mode": 420
+      },
+      {
         "path": "/etc/sysctl.d/99-e2e-sysctl.conf",
         "contents": {
           "compression": "gzip",

--- a/jobs/e2e_node/crio/templates/base/99-localhost-insecure.conf
+++ b/jobs/e2e_node/crio/templates/base/99-localhost-insecure.conf
@@ -1,0 +1,6 @@
+# Drop-in configuration to allow insecure HTTP registry for localhost:5000
+# Required for e2e tests using the fake-registry-server which serves HTTP-only
+
+[[registry]]
+location = "localhost:5000"
+insecure = true

--- a/jobs/e2e_node/crio/templates/base/root.yaml
+++ b/jobs/e2e_node/crio/templates/base/root.yaml
@@ -18,6 +18,10 @@ storage:
       contents:
         local: 20-crio.conf
       mode: 0644
+    - path: /etc/containers/registries.conf.d/99-localhost-insecure.conf
+      contents:
+        local: 99-localhost-insecure.conf
+      mode: 0644
     - path: /etc/sysctl.d/99-e2e-sysctl.conf
       contents:
         local: 99-e2e-sysctl.conf

--- a/jobs/e2e_node/crio/templates/crio.yaml
+++ b/jobs/e2e_node/crio/templates/crio.yaml
@@ -18,6 +18,10 @@ storage:
       contents:
         local: 20-crio.conf
       mode: 0644
+    - path: /etc/containers/registries.conf.d/99-localhost-insecure.conf
+      contents:
+        local: 99-localhost-insecure.conf
+      mode: 0644
     - path: /etc/sysctl.d/99-e2e-sysctl.conf
       contents:
         local: 99-e2e-sysctl.conf

--- a/jobs/e2e_node/crio/templates/crio_canary.yaml
+++ b/jobs/e2e_node/crio/templates/crio_canary.yaml
@@ -18,6 +18,10 @@ storage:
       contents:
         local: 20-crio.conf
       mode: 0644
+    - path: /etc/containers/registries.conf.d/99-localhost-insecure.conf
+      contents:
+        local: 99-localhost-insecure.conf
+      mode: 0644
     - path: /etc/sysctl.d/99-e2e-sysctl.conf
       contents:
         local: 99-e2e-sysctl.conf

--- a/jobs/e2e_node/crio/templates/crio_drop_infra_ctr.yaml
+++ b/jobs/e2e_node/crio/templates/crio_drop_infra_ctr.yaml
@@ -18,6 +18,10 @@ storage:
       contents:
         local: 20-crio.conf
       mode: 0644
+    - path: /etc/containers/registries.conf.d/99-localhost-insecure.conf
+      contents:
+        local: 99-localhost-insecure.conf
+      mode: 0644
     - path: /etc/sysctl.d/99-e2e-sysctl.conf
       contents:
         local: 99-e2e-sysctl.conf

--- a/jobs/e2e_node/crio/templates/crio_eventedpleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_eventedpleg.yaml
@@ -18,6 +18,10 @@ storage:
       contents:
         local: 20-crio.conf
       mode: 0644
+    - path: /etc/containers/registries.conf.d/99-localhost-insecure.conf
+      contents:
+        local: 99-localhost-insecure.conf
+      mode: 0644
     - path: /etc/sysctl.d/99-e2e-sysctl.conf
       contents:
         local: 99-e2e-sysctl.conf

--- a/jobs/e2e_node/crio/templates/crio_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_hugepages.yaml
@@ -18,6 +18,10 @@ storage:
       contents:
         local: 20-crio.conf
       mode: 0644
+    - path: /etc/containers/registries.conf.d/99-localhost-insecure.conf
+      contents:
+        local: 99-localhost-insecure.conf
+      mode: 0644
     - path: /etc/sysctl.d/99-e2e-sysctl.conf
       contents:
         local: 99-e2e-sysctl.conf

--- a/jobs/e2e_node/crio/templates/crio_imagefs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_imagefs.yaml
@@ -18,6 +18,10 @@ storage:
       contents:
         local: 20-crio.conf
       mode: 0644
+    - path: /etc/containers/registries.conf.d/99-localhost-insecure.conf
+      contents:
+        local: 99-localhost-insecure.conf
+      mode: 0644
     - path: /etc/sysctl.d/99-e2e-sysctl.conf
       contents:
         local: 99-e2e-sysctl.conf

--- a/jobs/e2e_node/crio/templates/crio_splitfs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_splitfs.yaml
@@ -18,6 +18,10 @@ storage:
       contents:
         local: 20-crio.conf
       mode: 0644
+    - path: /etc/containers/registries.conf.d/99-localhost-insecure.conf
+      contents:
+        local: 99-localhost-insecure.conf
+      mode: 0644
     - path: /etc/sysctl.d/99-e2e-sysctl.conf
       contents:
         local: 99-e2e-sysctl.conf

--- a/jobs/e2e_node/crio/templates/crio_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_swap1g.yaml
@@ -18,6 +18,10 @@ storage:
       contents:
         local: 20-crio.conf
       mode: 0644
+    - path: /etc/containers/registries.conf.d/99-localhost-insecure.conf
+      contents:
+        local: 99-localhost-insecure.conf
+      mode: 0644
     - path: /etc/sysctl.d/99-e2e-sysctl.conf
       contents:
         local: 99-e2e-sysctl.conf

--- a/jobs/e2e_node/crio/templates/crio_userns.yaml
+++ b/jobs/e2e_node/crio/templates/crio_userns.yaml
@@ -18,6 +18,10 @@ storage:
       contents:
         local: 20-crio.conf
       mode: 0644
+    - path: /etc/containers/registries.conf.d/99-localhost-insecure.conf
+      contents:
+        local: 99-localhost-insecure.conf
+      mode: 0644
     - path: /etc/sysctl.d/99-e2e-sysctl.conf
       contents:
         local: 99-e2e-sysctl.conf


### PR DESCRIPTION
This configures CRI-O to allow HTTP connections to localhost:5000, which is required for e2e tests that use the fake-registry-server. The fake-registry-server only serves HTTP, but CRI-O defaults to HTTPS for all registries, causing image pull failures.

This fixes test failures in:
- [sig-node] Ensure Credential Pulled Images
- [sig-node] Container Runtime Conformance Test (private registry tests)

Refers to https://github.com/kubernetes/kubernetes/pull/135369