### PR TITLE
fix: more cpu for CAPG

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -17,10 +17,10 @@ presubmits:
         - "./scripts/ci-test.sh"
         resources:
           limits:
-            cpu: 16
+            cpu: 7
             memory: 16Gi
           requests:
-            cpu: 16
+            cpu: 7
             memory: 16Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
@@ -42,10 +42,10 @@ presubmits:
         - "./scripts/ci-build.sh"
         resources:
           limits:
-            cpu: 16
+            cpu: 7
             memory: 16Gi
           requests:
-            cpu: 16
+            cpu: 7
             memory: 16Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp


### PR DESCRIPTION
Quick follow up from: https://github.com/kubernetes/test-infra/pull/35945

Moving down from 16 to 7 CPUs due to https://github.com/kubernetes/test-infra/pull/35945?notification_referrer_id=NT_kwDOAErNDbMyMDYwNjQzNDk1Mzo0OTAyMTU3#discussion_r2548782491