### PR TITLE
Fix bug in compatibility version script: kubelet not upgraded

### DIFF
--- a/experiment/compatibility-versions/emulated-version-upgrade.sh
+++ b/experiment/compatibility-versions/emulated-version-upgrade.sh
@@ -31,6 +31,8 @@ CONTROL_PLANE_COMPONENTS="kube-apiserver kube-controller-manager kube-scheduler"
 # Assume go installed
 KUBE_ROOT="."
 source "${KUBE_ROOT}/hack/lib/version.sh"
+source "${KUBE_ROOT}/hack/lib/logging.sh"
+source "${KUBE_ROOT}/hack/lib/util.sh"
 kube::version::get_version_vars
 DOCKER_TAG=${KUBE_GIT_VERSION/+/_}
 DOCKER_REGISTRY=${KUBE_DOCKER_REGISTRY:-registry.k8s.io}
@@ -80,7 +82,7 @@ check_emulated_version_removed(){
 }
 
 # Main
-KUBELET_BINARY=$(find ${KUBE_ROOT}/_output/ -type f -name kubelet | head -n 1)
+KUBELET_BINARY=$(kube::util::find-binary kubelet)
 
 if [[ "$UPDATE_CONTROL_PLANE" == "true" ]]; then
   upgrade_emulated_version

--- a/experiment/compatibility-versions/kind-upgrade.sh
+++ b/experiment/compatibility-versions/kind-upgrade.sh
@@ -32,6 +32,9 @@ CONTROL_PLANE_COMPONENTS="kube-apiserver kube-controller-manager kube-scheduler"
 KUBE_ROOT="."
 # KUBE_ROOT="$(go env GOPATH)/src/k8s.io/kubernetes"
 source "${KUBE_ROOT}/hack/lib/version.sh"
+source "${KUBE_ROOT}/hack/lib/logging.sh"
+source "${KUBE_ROOT}/hack/lib/util.sh"
+
 DOCKER_TAG=${LATEST_VERSION/+/_}
 DOCKER_REGISTRY=${KUBE_DOCKER_REGISTRY:-registry.k8s.io}
 export GOFLAGS="-tags=providerless"
@@ -117,7 +120,7 @@ pushd $TMP_DIR
 download_images
 popd
 IMAGES_PATH="${TMP_DIR}/kubernetes/server/bin"
-KUBELET_BINARY=$(find ${TMP_DIR}/kubernetes/server/bin/ -type f -name kubelet | head -n 1)
+KUBELET_BINARY=$(kube::util::find-binary kubelet)
 
 if [[ "$UPDATE_CONTROL_PLANE" == "true" ]]; then
   update_control_plane "true"


### PR DESCRIPTION
Noticed a warning message in the upgrade script:

```
docker: 'docker cp' requires 2 arguments

Usage:  docker cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-
	docker cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH

Run 'docker cp --help' for more information
```

On further inspection, find returns two variables that get passed to docker cp which causes an error. 

```
jying@jefftree ~/w/k/kubernetes ❯❯❯ find ./_output/ -type f -name kubelet                                                             
./_output/dockerized/bin/linux/amd64/kubelet
./_output/dockerized/go/bin/kubelet
```

Even in the logs of successful runs (https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-two-steps-upgrade-n-minus-1/1991867497766195200/build-log.txt), "Updated kubelet" never appears in the logs.

This addresses an orthogonal issue that isn't directly tied to the flake

/hold