### PR TITLE
cri-o: switch serial tests to use canary

### DIFF
--- a/jobs/e2e_node/crio/crio_canary.ign
+++ b/jobs/e2e_node/crio/crio_canary.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dcae4e9ac33013ddcd57b258dfe6b845533f2fc84%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D14e7ced5d93fb2dedf7afd65111dc6f739301f23%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/latest/image-config-serial.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-serial.yaml
@@ -3,4 +3,4 @@ images:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     machine: e2-standard-4
-    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_canary.ign"

--- a/jobs/e2e_node/crio/templates/base/env-canary.yaml
+++ b/jobs/e2e_node/crio/templates/base/env-canary.yaml
@@ -7,4 +7,4 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
+          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"

--- a/jobs/e2e_node/crio/templates/crio_canary.yaml
+++ b/jobs/e2e_node/crio/templates/crio_canary.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=cae4e9ac33013ddcd57b258dfe6b845533f2fc84"
+          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
 systemd:
   units:
     - name: configure-sysctl.service


### PR DESCRIPTION
Test the new canary version for serial jobs. If the tests succeed we will follow-up updating the rest of the jobs to the new version as well.

Refers to https://github.com/kubernetes/kubernetes/pull/135369