### PR TITLE
kustomize: update actions name that used in branch protection rule

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -622,9 +622,7 @@ branch-protection:
           required_status_checks:
             contexts:
               - Lint
-              - Test Linux
-              - Test MacOS
-              - Test Windows
+              - Test Summary
         lwkd:
           exclude:
             - "^20\\d+" # don't protect weekly article dev branch


### PR DESCRIPTION
I changed the name of the GitHub Actions running the test, so I want to update the branch protection rule.
ref: https://github.com/kubernetes-sigs/kustomize/pull/6020

/cc @varshaprasad96