### PR TITLE
cluster-autoscaler: E2E tests use Kubernetes 1.34

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -42,7 +42,7 @@ presubmits:
           - name: ADDITIONAL_ASO_CRDS
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
-            value: "1.33" # latest available in AKS
+            value: "1.34"
           - name: AKS_TIER
             value: "Premium" # required for LTS
           - name: AKS_SUPPORT_PLAN
@@ -160,7 +160,7 @@ presubmits:
           - name: ADDITIONAL_ASO_CRDS
             value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
           - name: KUBERNETES_VERSION
-            value: "1.33" # TODO update when 1.34 is available in AKS
+            value: "1.34"
           - name: AKS_TIER
             value: "Premium" # required for LTS
           - name: AKS_SUPPORT_PLAN


### PR DESCRIPTION
This PR updates CA test configs to use Kubernetes 1.34 for its 1.34 release branch and master branch E2E tests.