### PR TITLE
cluster-capacity: Run general `verify` target

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.34.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.34.yaml
@@ -1,7 +1,7 @@
 # sigs.k8s.io/cluster-capacity presubmits
 presubmits:
   kubernetes-sigs/cluster-capacity:
-  - name: pull-cluster-capacity-verify-gofmt-release-1-34
+  - name: pull-cluster-capacity-verify-release-1-34
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
@@ -15,7 +15,7 @@ presubmits:
         command:
         - make
         args:
-        - verify-gofmt
+        - verify
         resources:
           requests:
             cpu: 2
@@ -23,7 +23,7 @@ presubmits:
           limits:
             cpu: 2
             memory: 4Gi
-  - name: pull-cluster-capacity-verify-build-release-1-34
+  - name: pull-cluster-capacity-build-release-1-34
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
@@ -45,7 +45,7 @@ presubmits:
           limits:
             cpu: 2
             memory: 4Gi
-  - name: pull-cluster-capacity-unit-test-release-1-34
+  - name: pull-cluster-capacity-test-unit-release-1-34
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
@@ -1,7 +1,7 @@
 # sigs.k8s.io/cluster-capacity presubmits
 presubmits:
   kubernetes-sigs/cluster-capacity:
-  - name: pull-cluster-capacity-verify-gofmt
+  - name: pull-cluster-capacity-verify
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
@@ -15,7 +15,7 @@ presubmits:
         command:
         - make
         args:
-        - verify-gofmt
+        - verify
         resources:
           requests:
             cpu: 2
@@ -23,7 +23,7 @@ presubmits:
           limits:
             cpu: 2
             memory: 4Gi
-  - name: pull-cluster-capacity-verify-build
+  - name: pull-cluster-capacity-build
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity
@@ -45,7 +45,7 @@ presubmits:
           limits:
             cpu: 2
             memory: 4Gi
-  - name: pull-cluster-capacity-unit-test
+  - name: pull-cluster-capacity-test-unit
     cluster: eks-prow-build-cluster
     decorate: true
     path_alias: sigs.k8s.io/cluster-capacity


### PR DESCRIPTION
This just switches the `make verify-gofmt` task to `make verify`, which includes extra checks (currently just boilerplate).