### PR TITLE
Allow prow to trigger github actions

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -40,6 +40,12 @@ triggers:
   join_org_url: "https://git.k8s.io/community/community-membership.md#member"
   only_org_members: true
   trigger_github_workflows: true
+- repos:
+  - kubernetes-sigs/gateway-api
+  - kubernetes-sigs/gateway-api-inference-extension
+  join_org_url: "https://git.k8s.io/community/community-membership.md#member"
+  only_org_members: true
+  trigger_github_workflows: true
 
 owners:
   mdyamlrepos:


### PR DESCRIPTION
Add the config for prow to trigger github actions for users when ok-to-test is added