### PR TITLE
Double MASTER_SIZE for resource size test to ensure API server fits.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1246,6 +1246,8 @@ periodics:
       - --env=APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0
       - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true
       - --env=CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD=99.5
+      # Override MASTER_SIZE to get additional memory to fit larger resource size.
+      - --env=MASTER_SIZE=n2-standard-64
       - --env=CL2_DAEMONSET_POD_PAYLOAD_SIZE=5120
       - --env=CL2_DEPLOYMENT_POD_PAYLOAD_SIZE=5120
       - --env=CL2_STATEFULSET_POD_PAYLOAD_SIZE=5120


### PR DESCRIPTION
Observed that with 1.5GB resource size, tests memory usage is around 120GB with 140GB limit. In case of failures master memory hits limit 140GB and we get OOM kills.

/assign @mborsz