### PR TITLE
Run resource-size everyday after DRA test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1168,7 +1168,7 @@ periodics:
           memory: "8Gi"
 
 # Exploratory tests for resource size limit as proposed in https://github.com/kubernetes/kubernetes/issues/134375
-- cron: '1 5 2-31/2 * *' # Run on even days at 5:01 UTC
+- cron: '0 10 * * *' # Run on even days at 10:00 UTC
   name: ci-kubernetes-e2e-gce-scale-resource-size
   tags:
   - "perfDashPrefix: gce-5000Nodes-ResourceSize"
@@ -1184,7 +1184,7 @@ periodics:
   job_queue_name: "5k-gce-scale-test" # DON'T REMOVE THIS
   decorate: true
   decoration_config:
-    timeout: 450m
+    timeout: 240m
   extra_refs:
   - org: kubernetes
     repo: kubernetes


### PR DESCRIPTION
Jobs using the 5k-gce-scale-test queue

| Job Name                                                                 | Cron Schedule     | Timeout | Notes (Frequency)                        |
| ------------------------------------------------------------------------ | ----------------- | ------- | ---------------------------------------- |
| ci-kubernetes-e2e-kops-gce-5000-node-dra-with-workload-ipalias-using-cl2 | 0 3 * * *         | 480m    | Runs daily at 03:00.                     |
| ci-kubernetes-e2e-gce-scale-resource-size                                | 0 10 * * *        | 240m    | Runs daily at 10:00.                     |
| ci-kubernetes-e2e-gce-scale-correctness                                  | 1 17 2-31/2 * *   | 270m    | Runs at 17:01 on even days of the month. |
| ci-kubernetes-e2e-gce-scale-performance                                  | 1 17 1-31/2 * *   | 450m    | Runs at 17:01 on odd days of the month.  |

Running resource-size daily on 10:00 ensures it will:
* Run after DRA test that runs 3:00-9:00
* Finish at 14:00 before performance and correctness test

/cc @mborsz