### PR TITLE
remove permafailing tests on ci-kubernetes-e2e-gci-gce-nftables

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
@@ -245,7 +245,7 @@ presubmits:
         - --gcp-master-image=gci
         - --gcp-node-image=gci
         - --ginkgo-parallel=30
-        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[sig-storage\]|\[Feature:.+\] --minStartupPods=8
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[sig-storage\]|\[Feature:.+\]|SupplementalGroups --minStartupPods=8
         - --timeout=80m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
         resources:
@@ -815,7 +815,7 @@ periodics:
       - --ginkgo-parallel=30
       - --provider=gce
       # skip ESIPP should work from pods #97081
-      - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\]|ESIPP|LoadBalancers --minStartupPods=8
+      - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\]|ESIPP|LoadBalancers|SupplementalGroups --minStartupPods=8
       - --timeout=150m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251029-79c2132152-master
       resources:


### PR DESCRIPTION
Tests COS images with nftables kube-proxy, have some new tests failing constantly

https://testgrid.k8s.io/sig-network-gce#periodic-network-nftables,%20google-gce

Asked in #sig-node slack https://kubernetes.slack.com/archives/C0BP8PW9G/p1764352424417739

