### PR TITLE
chore: CAPA maintainer & reviewer changes

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
@@ -1,23 +1,20 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- luthermonson
-- cnmcavoy
-- nrb
-- faiq
-- fiunchinho
-- damdo
+  - faiq
+  - fiunchinho
 approvers:
-- richardcase
-- Ankitasw
-- dlipovetsky
-- nrb
-- AndiDog
+  - richardcase
+  - dlipovetsky
+  - nrb
+  - AndiDog
+  - damdo
 emeritus_approvers:
-- chuckha
-- detiber
-- ncdc
-- randomvariable
-- rudoi
-- Skarlso
-- vincepri
+  - Ankitasw
+  - chuckha
+  - detiber
+  - ncdc
+  - randomvariable
+  - rudoi
+  - Skarlso
+  - vincepri


### PR DESCRIPTION
Changes to the reviewers and maintainers for CAPA.

Relates: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5760