### PR TITLE
switch to current go for testing enhancements repo

### DIFF
--- a/config/jobs/kubernetes/enhancements/enhancements-presubmit.yaml
+++ b/config/jobs/kubernetes/enhancements/enhancements-presubmit.yaml
@@ -6,7 +6,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.17
+          - image: public.ecr.aws/docker/library/golang:1.25
             command:
               - sh
               - "-c"
@@ -24,7 +24,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.17
+          - image: public.ecr.aws/docker/library/golang:1.25
             command:
               - make
               - test


### PR DESCRIPTION
GOTOOLCHAIN support in go 1.21+ will make bumping this in the future merely an optimization