### PR TITLE
Bump go version 1.25.4/1.24.10 for kubekins-e2e/kubekins-e2e-v2/krte

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -24,8 +24,3 @@ variants:
     GO_VERSION: 1.24.10
     K8S_RELEASE: latest-1.32
     BAZEL_VERSION: 3.4.1
-  '1.31':
-    CONFIG: '1.31'
-    GO_VERSION: 1.24.10
-    K8S_RELEASE: latest-1.31
-    BAZEL_VERSION: 3.4.1


### PR DESCRIPTION
- Bump go version 1.25.4/1.24.10 for kubekins-e2e/kubekins-e2e-v2/krte
- drop 1.31 variant as it is EOL

xref: https://github.com/kubernetes/release/issues/4187


/assign @dims @saschagrunert @Verolop 
cc @kubernetes/release-managers 