### PR TITLE
Upsize the resource-size tests to run 3GB pods by increasing pod size to 15KB

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1218,6 +1218,18 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
+      # Override MASTER_SIZE to get additional memory to fit larger resource size.
+      - --env=MASTER_SIZE=n2-standard-64 # 64 vCPUs, 256GB memory
+      - --env=ETCD_QUOTA_BACKEND_BYTES=21474836480 # 20GB
+      # Ensure exec-service is not scheduled on normal node of size e2-medium (2vCPUs, 4GB memory)
+      - --env=CL2_EXECSERVICE_CPU_REQUESTS=2
+      - --env=CL2_EXECSERVICE_MEMORY_REQUESTS=4Gi
+      # Override for pod large resource size
+      - --env=CL2_DAEMONSET_POD_PAYLOAD_SIZE=15360 # 15KB
+      - --env=CL2_DEPLOYMENT_POD_PAYLOAD_SIZE=15360 # 15KB
+      - --env=CL2_STATEFULSET_POD_PAYLOAD_SIZE=15360 # 15KB
+      - --env=CL2_JOB_POD_PAYLOAD_SIZE=15360 # 15KB
+      #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance
       - --cluster=gce-scale-cluster
       - --env=HEAPSTER_MACHINE_TYPE=e2-standard-32
       # TODO(mborsz): Adjust or remove this change once we understand coredns
@@ -1246,12 +1258,6 @@ periodics:
       - --env=APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0
       - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true
       - --env=CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD=99.5
-      # Override MASTER_SIZE to get additional memory to fit larger resource size.
-      - --env=MASTER_SIZE=n2-standard-64
-      - --env=CL2_DAEMONSET_POD_PAYLOAD_SIZE=5120
-      - --env=CL2_DEPLOYMENT_POD_PAYLOAD_SIZE=5120
-      - --env=CL2_STATEFULSET_POD_PAYLOAD_SIZE=5120
-      - --env=CL2_JOB_POD_PAYLOAD_SIZE=5120
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2


### PR DESCRIPTION
Got succesfull run for 3GB pods after the following improvements:
* Increase etcd quota to 20GB
* Requesting resources in execservice to avoid OOMs

Reordered the config to make it clearer

/assign @mborsz