### PR TITLE
cluster race detection: verbosity, feature

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -583,7 +583,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
     decoration_config:
-      timeout: 60m
+      timeout: 90m
       grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:


### PR DESCRIPTION
The revised log checking in https://github.com/kubernetes/kubernetes/pull/133844 should support more log output because it's now based on streaming. It'll use `Feature:DataRace` to determine whether checking is enabled.