### PR TITLE
update test config for v1.35

### DIFF
--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -168,38 +168,38 @@ jobs:
     releaseBlocking: true
     testSuite: alphafeatures-eventedpleg
 
-  # # stable4
-  # ci-kubernetes-e2e-gce-cos-k8sstable4-reboot:
-  #   interval: 24h
-  #   sigOwners: [sig-cloud-provider-gcp]
-  #   releaseBlocking: true
-  # ci-kubernetes-e2e-gce-cos-k8sstable4-ingress:
-  #   interval: 24h
-  #   sigOwners: [sig-cloud-provider-gcp]
-  #   releaseBlocking: true
-  # ci-kubernetes-e2e-gce-cos-k8sstable4-default:
-  #   interval: 24h
-  #   sigOwners: [sig-cloud-provider-gcp]
-  #   releaseBlocking: true
-  #   testgridNumFailuresToAlert: 6
-  # ci-kubernetes-e2e-gce-cos-k8sstable4-serial:
-  #   args:
-  #   - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\]
-  #     --minStartupPods=8
-  #   interval: 24h
-  #   sigOwners: [sig-cloud-provider-gcp]
-  #   releaseInforming: true
-  #   testgridNumFailuresToAlert: 6
-  # ci-kubernetes-e2e-gce-cos-k8sstable4-slow:
-  #   interval: 24h
-  #   sigOwners: [sig-cloud-provider-gcp]
-  #   releaseInforming: true
-  #   testgridNumFailuresToAlert: 6
-  # ci-kubernetes-e2e-gce-cos-k8sstable4-alphafeatures:
-  #   interval: 24h
-  #   sigOwners: [sig-cloud-provider-gcp]
-  #   releaseBlocking: true
-  #   testSuite: alphafeatures-eventedpleg
+  # stable4
+  ci-kubernetes-e2e-gce-cos-k8sstable4-reboot:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+  ci-kubernetes-e2e-gce-cos-k8sstable4-ingress:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+  ci-kubernetes-e2e-gce-cos-k8sstable4-default:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+    testgridNumFailuresToAlert: 6
+  ci-kubernetes-e2e-gce-cos-k8sstable4-serial:
+    args:
+    - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\]
+      --minStartupPods=8
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseInforming: true
+    testgridNumFailuresToAlert: 6
+  ci-kubernetes-e2e-gce-cos-k8sstable4-slow:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseInforming: true
+    testgridNumFailuresToAlert: 6
+  ci-kubernetes-e2e-gce-cos-k8sstable4-alphafeatures:
+    interval: 24h
+    sigOwners: [sig-cloud-provider-gcp]
+    releaseBlocking: true
+    testSuite: alphafeatures-eventedpleg
 
 # The following settings are used by cluster e2e tests.
 
@@ -265,10 +265,10 @@ k8sVersions:
     args:
     - --extract=ci/latest-1.32
     version: '1.32'
-  # stable4:
-  #   args:
-  #   - --extract=ci/latest-1.31
-  #   version: '1.31'
+  stable4:
+    args:
+    - --extract=ci/latest-1.31
+    version: '1.31'
 
 testSuites:
   alphafeatures:
@@ -465,10 +465,10 @@ nodeK8sVersions:
     args:
     - --repo=k8s.io/kubernetes=release-1.32
     prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251202-27e1f5f482-1.32
-  # stable4:
-  #   args:
-  #   - --repo=k8s.io/kubernetes=release-1.31
-  #   prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250714-70266d743a-1.31
+  stable4:
+    args:
+    - --repo=k8s.io/kubernetes=release-1.31
+    prowImage: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250714-70266d743a-1.31
 
 nodeTestSuites:
   default:


### PR DESCRIPTION
/hold

Update test configs for v1.35, using images built in https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-test-infra-push-kubekins-e2e/1995871630173147136

similar to https://github.com/kubernetes/test-infra/pull/35275

cc @kubernetes/release-managers @xmudrii 