### PR TITLE
Increase the resource-size prow job memory to 32GB

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1281,7 +1281,7 @@ periodics:
       resources:
         requests:
           cpu: 6
-          memory: "16Gi"
+          memory: "32Gi"
         limits:
           cpu: 6
-          memory: "16Gi"
+          memory: "32Gi"


### PR DESCRIPTION
Forgot to upsize job size for https://github.com/kubernetes/test-infra/pull/35998