### PR TITLE
CNTRLPLANE-2123: openshift/hypershift: add 4.22 release jobs and remove 4.14 release jobs

### DIFF
--- a/config/testgrids/openshift/hypershift.yaml
+++ b/config/testgrids/openshift/hypershift.yaml
@@ -1,4 +1,32 @@
 test_groups:
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-powervs
+  name: 4.22-powervs
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-kubevirt-conformance
+  name: 4.22-kubevirt-conformance
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-ovn-proxy-conformance
+  name: 4.22-aws-ovn-proxy-conformance
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-ovn-conformance-serial
+  name: 4.22-aws-ovn-conformance-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-ovn-conformance
+  name: 4.22-aws-ovn-conformance
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-ovn
+  name: 4.22-aws-ovn
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-multi
+  name: 4.22-aws-multi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-upgrade
+  name: 4.22-aws-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aks
+  name: 4.22-aks
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-azure-aks-ovn-conformance
+  name: 4.22-aks-ovn-conformance
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-openstack-aws
+  name: 4.22-openstack-aws
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-openstack-aws-conformance
+  name: 4.22-openstack-aws-conformance
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-openstack-aws-csi-cinder
+  name: 4.22-openstack-aws-csi-cinder
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-openstack-aws-csi-manila
+  name: 4.22-openstack-aws-csi-manila
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-powervs
   name: 4.21-powervs
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-kubevirt-conformance
@@ -151,22 +179,94 @@ test_groups:
   name: 4.15-aws-ovn-conformance
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn
   name: 4.15-aws-ovn
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-powervs
-  name: 4.14-powervs
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-kubevirt-conformance
-  name: 4.14-kubevirt-conformance
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn-proxy-conformance
-  name: 4.14-aws-ovn-proxy-conformance
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn-conformance-serial
-  name: 4.14-aws-ovn-conformance-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn-conformance
-  name: 4.14-aws-ovn-conformance
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn
-  name: 4.14-aws-ovn
 
 dashboards:
 - name: redhat-hypershift
   dashboard_tab:
+  - name: 4.22-powervs
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-powervs
+  - name: 4.22-kubevirt-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-kubevirt-conformance
+  - name: 4.22-aws-ovn-proxy-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-aws-ovn-proxy-conformance
+  - name: 4.22-aws-ovn-conformance-serial
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-aws-ovn-conformance-serial
+  - name: 4.22-aws-ovn-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-aws-ovn-conformance
+  - name: 4.22-aws-ovn
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-aws-ovn
+  - name: 4.22-aws-multi
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-aws-multi
+  - name: 4.22-aws-upgrade
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-aws-upgrade
+  - name: 4.22-aks
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-aks
+  - name: 4.22-aks-ovn-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-aks-ovn-conformance
+  - name: 4.22-openstack-aws
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-openstack-aws
+  - name: 4.22-openstack-aws-conformance
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-openstack-aws-conformance
+  - name: 4.22-openstack-aws-csi-cinder
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-openstack-aws-csi-cinder
+  - name: 4.22-openstack-aws-csi-manila
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: 4.22-openstack-aws-csi-manila
   - name: 4.21-powervs
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
@@ -623,39 +723,3 @@ dashboards:
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: 4.15-aws-ovn
-  - name: 4.14-powervs
-    open_test_template:
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.14-powervs
-  - name: 4.14-kubevirt-conformance
-    open_test_template:
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.14-kubevirt-conformance
-  - name: 4.14-aws-ovn-proxy-conformance
-    open_test_template:
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.14-aws-ovn-proxy-conformance
-  - name: 4.14-aws-ovn-conformance-serial
-    open_test_template:
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.14-aws-ovn-conformance-serial
-  - name: 4.14-aws-ovn-conformance
-    open_test_template:
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.14-aws-ovn-conformance
-  - name: 4.14-aws-ovn
-    open_test_template:
-      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: 4.14-aws-ovn


### PR DESCRIPTION
## Summary
This PR adds CI/CD test infrastructure for HyperShift 4.22 release while removing obsolete 4.14 release jobs to maintain current testing scope.

## Changes
- ✅ **Added 4.22 release jobs** - 14 new test configurations
- ✅ **Removed 4.14 release jobs** - cleanup of obsolete test configurations  
- ✅ **Updated testgrid configuration** - both test groups and dashboard tabs

## Reference
- 4.21 bump PR for review reference: https://github.com/kubernetes/test-infra/pull/35535

## Test Coverage
Following the same pattern as previous version bumps, this includes:
- PowerVS tests
- KubeVirt conformance tests  
- AWS OVN proxy conformance
- AWS OVN conformance (serial and standard)
- AWS multi-cluster tests
- AWS upgrade tests
- AKS tests
- OpenStack AWS tests
- CSI tests for both Cinder and Manila

🤖 Generated with [Claude Code](https://claude.com/claude-code)