### PR TITLE
[sig-autoscaling] bump hpa-cpu job parallelism to 10

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -611,12 +611,12 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-central1-b
       - --gcp-node-image=gci
-      - --gcp-node-size=e2-standard-4
+      - --gcp-node-size=e2-highcpu-8
       - --extract=ci/latest
       - --timeout=240m
       - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Alpha\]|\[Beta\]
         --minStartupPods=8
-      - --ginkgo-parallel=3
+      - --ginkgo-parallel=10
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251209-13d7d11b0f-master
       resources:
         limits:


### PR DESCRIPTION
Related to: https://github.com/kubernetes/kubernetes/issues/135026

Bumps ginkgo parallelism of the hpa-cpu job to 10. To accomodate this, each worker node will be the e2-highcpu-8 instances type. These have 8 CPU and 8 GiB of memory each: https://gcloud-compute.com/e2-highcpu-8.html.