### PR TITLE
failing-test: setting fail-fast for cloud provider azure dual stack t…

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -191,6 +191,8 @@ presubmits:
           value: "1"
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest"
+        - name: FAIL_FAST
+          value: "true"
         - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
           value: "Standard"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
@@ -518,6 +520,8 @@ presubmits:
           value: "1"
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest"
+        - name: FAIL_FAST
+          value: "true"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE  # CAPZ config
@@ -958,6 +962,8 @@ periodics:
         value: "1"
       - name: KUBERNETES_VERSION  # CAPZ config
         value: "latest"
+      - name: FAIL_FAST
+        value: "true"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
       - name: CLUSTER_TEMPLATE  # CAPZ config
@@ -1020,6 +1026,8 @@ periodics:
         value: "1"
       - name: KUBERNETES_VERSION  # CAPZ config
         value: "latest"
+      - name: FAIL_FAST
+        value: "true"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
       - name: CLUSTER_TEMPLATE  # CAPZ config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.31.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.31.yaml
@@ -490,6 +490,8 @@ presubmits:
           value: "1"
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.31"
+        - name: FAIL_FAST
+          value: "true"
         - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
           value: "Standard"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
@@ -612,6 +614,8 @@ presubmits:
           value: "1"
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.31"
+        - name: FAIL_FAST
+          value: "true"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE  # CAPZ config
@@ -796,6 +800,8 @@ periodics:
         value: "1"
       - name: KUBERNETES_VERSION  # CAPZ config
         value: "latest-1.31"
+      - name: FAIL_FAST
+        value: "true"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
       - name: CLUSTER_TEMPLATE  # CAPZ config
@@ -857,6 +863,8 @@ periodics:
         value: "1"
       - name: KUBERNETES_VERSION  # CAPZ config
         value: "latest-1.31"
+      - name: FAIL_FAST
+        value: "true"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
       - name: CLUSTER_TEMPLATE  # CAPZ config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.32.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.32.yaml
@@ -490,6 +490,8 @@ presubmits:
           value: "1"
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.32"
+        - name: FAIL_FAST
+          value: "true"
         - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
           value: "Standard"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
@@ -612,6 +614,8 @@ presubmits:
           value: "1"
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.32"
+        - name: FAIL_FAST
+          value: "true"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE  # CAPZ config
@@ -796,6 +800,8 @@ periodics:
         value: "1"
       - name: KUBERNETES_VERSION  # CAPZ config
         value: "latest-1.32"
+      - name: FAIL_FAST
+        value: "true"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
       - name: CLUSTER_TEMPLATE  # CAPZ config
@@ -857,6 +863,8 @@ periodics:
         value: "1"
       - name: KUBERNETES_VERSION  # CAPZ config
         value: "latest-1.32"
+      - name: FAIL_FAST
+        value: "true"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
       - name: CLUSTER_TEMPLATE  # CAPZ config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.33.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.33.yaml
@@ -490,6 +490,8 @@ presubmits:
           value: "1"
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.33"
+        - name: FAIL_FAST
+          value: "true"
         - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
           value: "Standard"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
@@ -612,6 +614,8 @@ presubmits:
           value: "1"
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.33"
+        - name: FAIL_FAST
+          value: "true"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE  # CAPZ config
@@ -796,6 +800,8 @@ periodics:
         value: "1"
       - name: KUBERNETES_VERSION  # CAPZ config
         value: "latest-1.33"
+      - name: FAIL_FAST
+        value: "true"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
       - name: CLUSTER_TEMPLATE  # CAPZ config
@@ -857,6 +863,8 @@ periodics:
         value: "1"
       - name: KUBERNETES_VERSION  # CAPZ config
         value: "latest-1.33"
+      - name: FAIL_FAST
+        value: "true"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
       - name: CLUSTER_TEMPLATE  # CAPZ config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.34.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.34.yaml
@@ -490,6 +490,8 @@ presubmits:
           value: "1"
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.34"
+        - name: FAIL_FAST
+          value: "true"
         - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
           value: "Standard"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
@@ -612,6 +614,8 @@ presubmits:
           value: "1"
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "latest-1.34"
+        - name: FAIL_FAST
+          value: "true"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
         - name: CLUSTER_TEMPLATE  # CAPZ config
@@ -796,6 +800,8 @@ periodics:
         value: "1"
       - name: KUBERNETES_VERSION  # CAPZ config
         value: "latest-1.34"
+      - name: FAIL_FAST
+        value: "true"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
       - name: CLUSTER_TEMPLATE  # CAPZ config
@@ -857,6 +863,8 @@ periodics:
         value: "1"
       - name: KUBERNETES_VERSION  # CAPZ config
         value: "latest-1.34"
+      - name: FAIL_FAST
+        value: "true"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
         value: "capz"
       - name: CLUSTER_TEMPLATE  # CAPZ config


### PR DESCRIPTION
…ests for better debugging

dualstack tests are flaky, but logs cannot be seen as tests are timed out and there is no time for log uploading. set fail-fast here for better debugging.

/area provider/azure
/kind failing-test
/sig cloud-provider
/priority important-soon