### PR TITLE
alpha/beta race detection: increase memory limits

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -617,10 +617,10 @@ presubmits:
         resources:
           limits:
             cpu: 7
-            memory: 9000Mi
+            memory: 26Gi
           requests:
             cpu: 7
-            memory: 9000Mi
+            memory: 26Gi
 
   - name: pull-kubernetes-e2e-kind-evented-pleg
     cluster: k8s-infra-prow-build


### PR DESCRIPTION
Race detection needs more memory than normal runs, causing OOM killing of Ginkgo workers. The "large"  config from
https://github.com/kubernetes/test-infra/issues/34139#issuecomment-2764561619 is "7 cores and 32GB of memory", but on Slack 26 GB was recommended instead.

/assign @upodroid 
