### PR TITLE
alpha/beta race detection: enable explicitly

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -604,6 +604,8 @@ presubmits:
           value: "Feature: isSubsetOf { OffByDefault, DataRace } && !Deprecated && !Slow && !Disruptive && !Flaky"
         - name: PARALLEL
           value: "true"
+        - name: KUBE_E2E_TEST_ARGS
+          value: "-logcheck-data-races"
         # -race gets injected into the build of dynamically linked binaries during "kind build node-image".
         - name: KUBE_RACE
           value: -race


### PR DESCRIPTION
The indirect enablement through a sentinel test didn't work because it's not possible to determine before a run which tests are enabled. Now an explicit parameter is used.

Support for KUBE_E2E_TEST_ARGS in Kubernetes still needs to be reviewed and merged. This job update is meant to verify that it works.