### PR TITLE
Bump go version 1.25.5/1.24.11 for kubekins-e2e/kubekins-e2e-v2/krte

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,31 +1,31 @@
 variants:
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.25.4
+    GO_VERSION: 1.25.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   master:
     CONFIG: master
-    GO_VERSION: 1.25.4
+    GO_VERSION: 1.25.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   '1.35':
     CONFIG: '1.35'
-    GO_VERSION: 1.25.4
+    GO_VERSION: 1.25.5
     K8S_RELEASE: latest-1.35
     BAZEL_VERSION: 3.4.1
   '1.34':
     CONFIG: '1.34'
-    GO_VERSION: 1.24.10
+    GO_VERSION: 1.24.11
     K8S_RELEASE: latest-1.34
     BAZEL_VERSION: 3.4.1
   '1.33':
     CONFIG: '1.33'
-    GO_VERSION: 1.24.10
+    GO_VERSION: 1.24.11
     K8S_RELEASE: latest-1.33
     BAZEL_VERSION: 3.4.1
   '1.32':
     CONFIG: '1.32'
-    GO_VERSION: 1.24.10
+    GO_VERSION: 1.24.11
     K8S_RELEASE: latest-1.32
     BAZEL_VERSION: 3.4.1


### PR DESCRIPTION
- Bump go version 1.25.5/1.24.11 for kubekins-e2e/kubekins-e2e-v2/krte


xref: https://github.com/kubernetes/release/issues/4205


/assign @dims @saschagrunert @Verolop 
cc @kubernetes/release-managers 