### PR TITLE
images/kubekins*: apply default Docker daemon.json

### DIFF
--- a/images/kubekins-e2e-v2/runner.sh
+++ b/images/kubekins-e2e-v2/runner.sh
@@ -48,6 +48,22 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     # Fix ulimit issue
     sed -i 's|ulimit -Hn|ulimit -n|' /etc/init.d/docker || true
 
+    # Use the overlay2 storage driver and disable the containerd snapshotter
+    DAEMON_JSON=/etc/docker/daemon.json
+    echo "Applying Docker config."
+
+    mkdir -p /etc/docker
+    cat ${DAEMON_JSON} > /dev/null <<EOF
+{
+    "storage-driver": "overlay2",
+    "features": {
+        "containerd-snapshotter": false
+    }
+}
+EOF
+
+    cat ${DAEMON_JSON}
+
     # start the docker daemon
     service docker start
     # the service can be started but the docker socket not ready, wait for ready


### PR DESCRIPTION
- Use the overlay2 storage driver
- Disable the containerd snapshotter.

Without this config we are hitting bugs when doing 'docker pull', 'docker save' from kubekins and then trying to 'ctr import' the resulted tar files

xref 
- https://github.com/kubernetes/kubernetes/issues/135652
- https://github.com/kubernetes/kubeadm/issues/3265


slack
https://kubernetes.slack.com/archives/CN0K3TE2C/p1765057601502659
