### PR TITLE
pin docker engine to v28

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "/images/"
+    directory: "/images/**"
     schedule:
       interval: "daily"
     labels:

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -103,7 +103,7 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # Trying to remount these makes for a very noisy error block in the beginning of
 # the pod logs, so we just comment out the call to it... :shrug:
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin && \
+    apt-get install -y --no-install-recommends docker-ce=5:28.* docker-buildx-plugin && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
     && update-alternatives --set iptables /usr/sbin/iptables-legacy \

--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.25.4
-
-FROM multiarch/qemu-user-static:7.2.0-1 AS qemu-image
-
+ARG GO_VERSION=1.25.5
+# Docker v29+ doesn't work in GCP Cloud Build because its stuck on 20.10.x
+ARG DOCKER_VERSION=28
 # Includes bash, docker, and gcloud
-FROM golang:${GO_VERSION}-alpine
+FROM golang:${GO_VERSION}-alpine3.22
 
 # add env we can debug with the image name:tag
 ARG IMAGE_ARG
@@ -30,7 +29,10 @@ ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
 WORKDIR /workspace
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/latest-stable/community >> /etc/apk/repositories && \
-    apk --no-cache add curl python3 py-crcmod bash libc6-compat openssh-client git gnupg docker-cli make
+    apk --no-cache add curl python3 py-crcmod bash \
+    libc6-compat openssh-client git gnupg \
+    docker-cli-buildx \
+    docker-cli~${DOCKER_VERSION} make
 
 RUN curl -fsSLO https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz
 RUN tar xzf google-cloud-sdk.tar.gz -C /
@@ -54,8 +56,5 @@ COPY --from=qemu-image /register /register
 ADD ./buildx-entrypoint.sh /buildx-entrypoint
 
 RUN apk add qemu
-
-# Install buildx system-wide for fast docker builds
-COPY --from=docker/buildx-bin:0.29.1 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 ENTRYPOINT ["/bin/bash"]

--- a/images/kubekins-e2e-v2/Dockerfile
+++ b/images/kubekins-e2e-v2/Dockerfile
@@ -107,7 +107,7 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # Trying to remount these makes for a very noisy error block in the beginning of
 # the pod logs, so we just comment out the call to it... :shrug:
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin && \
+    apt-get install -y --no-install-recommends docker-ce=5:28.* docker-buildx-plugin && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
     && update-alternatives --set iptables /usr/sbin/iptables-legacy \

--- a/images/kubekins-e2e-v2/README.md
+++ b/images/kubekins-e2e-v2/README.md
@@ -10,3 +10,6 @@ Features:
 - gcloud
 - DinD
 - runner.sh wrapper
+
+Its available at `us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:latest-master`.
+If you are using it in a prowjob, please use a versioned tag(e.g. `v20251205-d1700a27d1-master` ) that will be autobumped.

--- a/images/kubekins-e2e/README.md
+++ b/images/kubekins-e2e/README.md
@@ -5,3 +5,5 @@ This image is deprecated in favour of kubekins-e2e-v2 image. Please use that ima
 - kubetest1
 - scenarios/*
 - various unmaintained tools such as logexporter, etc
+
+Its available at `gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master`. If you are using it in a prowjob, please use a versioned tag(eg: `v20251205-d1700a27d1-master` ) that will be autobumped.


### PR DESCRIPTION
Docker Engine v29 has a few breaking changes so I'm pinning it to v28