### PR TITLE
SIG testing: define test-infra job for local-up.sh

### DIFF
--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -52,6 +52,64 @@ presubmits:
       testgrid-dashboards: sig-testing-misc
       description: Runs single node conformance tests using kubetest with local-up-cluster
 
+  kubernetes/test-infra:
+  - name: pull-test-infra-local-e2e
+    branches:
+    - master
+    always_run: false
+    skip_report: false
+    max_concurrency: 8
+    optional: true
+    # Image bumps modify this YAML file and must not break jobs like pull-kubernetes-local-e2e.
+    run_if_changed: 'local-e2e.yaml'
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    cluster: k8s-infra-prow-build
+    decorate: true
+    decoration_config:
+      timeout: 240m
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20251205-d1700a27d1-master
+        env:
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
+        - name: CONTAINER_RUNTIME_ENDPOINT
+          value: "/var/run/docker/containerd/containerd.sock"
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --build=quick
+        - --deployment=local
+        - --ginkgo-parallel=1
+        - --provider=local
+        # Currently doesn't run any tests. Maybe it should run something very simple.
+        - --test_args=--ginkgo.focus=nothing-nada-niente-nichts --ginkgo.skip=.
+        - --timeout=180m
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: sig-testing-misc
+      description: Brings up a cluster using kubetest with local-up-cluster
+
 periodics:
 - name: ci-kubernetes-local-e2e
   interval: 3h


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/36028 broke https://testgrid.k8s.io/conformance-all#local-up-cluster,%20master%20(dev) and https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-dra-integration (both using local-up-cluster.sh).

Instead of merging an image bump blindly and hoping that it goes well, let's do at least some trial runs with jobs that will be affected by an image bump. The new pull-test-infra-local-e2e is such a job. It gets triggered by edits to the job file (like image bumps) and is optional (can be ignored if the normal job is unstable).

/assign @upodroid 