### PR TITLE
Add integration job for 1.35 ppc64le and also use config-forker/rotator

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -51,6 +51,8 @@ periodics:
       base_ref: master
       path_alias: k8s.io/kubernetes
     annotations:
+      fork-per-release: "true"
+      fork-per-release-cron: 0 0/2 * * *, 0 1/6 * * *, 0 2 * * *
       testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics
       testgrid-tab-name: ci-kubernetes-integration-master-ppc64le
       testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
@@ -76,79 +78,6 @@ periodics:
           requests:
             cpu: 6
             memory: 20Gi
-
-  - name: ci-kubernetes-integration-1-34-ppc64le
-    cron: "0 0-18/6 * * *" # every 6h starting at 00:00 UTC
-    cluster: k8s-infra-ppc64le-prow-build
-    decorate: true
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: release-1.34
-      path_alias: k8s.io/kubernetes
-    annotations:
-      testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics
-      testgrid-tab-name: ci-kubernetes-integration-1-34-ppc64le
-      testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '2'
-      description: "Ends up running: make test-integration"
-    spec:
-      containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251209-855adc2699-master
-        command:
-        - runner.sh
-        args:
-        - ./hack/jenkins/test-integration-dockerized.sh
-        env:
-        - name: SHORT
-          value: --short=false
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 4
-            memory: 20Gi
-          requests:
-            cpu: 4
-            memory: 20Gi
-
-  - name: ci-kubernetes-integration-1-33-ppc64le
-    cron: "0 1 * * *" # every 24h starting at 01:00 UTC
-    cluster: k8s-infra-ppc64le-prow-build
-    decorate: true
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: release-1.33
-      path_alias: k8s.io/kubernetes
-    annotations:
-      testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics
-      testgrid-tab-name: ci-kubernetes-integration-1-33-ppc64le
-      testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '2'
-      description: "Ends up running: make test-integration"
-    spec:
-      containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251209-855adc2699-master
-        command:
-        - runner.sh
-        args:
-        - ./hack/jenkins/test-integration-dockerized.sh
-        env:
-        - name: SHORT
-          value: --short=false
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 4
-            memory: 20Gi
-          requests:
-            cpu: 4
-            memory: 20Gi
-
 
   - name: ci-kubernetes-ppc64le-conformance-latest-kubetest2
     cron: "0 2-23/3 * * *" # every 3h starting at 02:00 UTC

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -834,6 +834,41 @@ periodics:
           memory: 9Gi
       securityContext:
         privileged: true
+- annotations:
+    fork-per-release-cron: ""
+    testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
+    testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-integration-1.33-ppc64le
+  cluster: k8s-infra-ppc64le-prow-build
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.33
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  cron: 0 2 * * *
+  name: ci-kubernetes-integration-master-ppc64le-1-33
+  spec:
+    containers:
+    - args:
+      - ./hack/jenkins/test-integration-dockerized.sh
+      command:
+      - runner.sh
+      env:
+      - name: SHORT
+        value: --short=false
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251209-855adc2699-1.33
+      name: ""
+      resources:
+        limits:
+          cpu: "6"
+          memory: 20Gi
+        requests:
+          cpu: "6"
+          memory: 20Gi
+      securityContext:
+        privileged: true
 postsubmits: {}
 presubmits:
   kubernetes/kubernetes:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1112,6 +1112,41 @@ periodics:
           memory: 24Gi
       securityContext:
         privileged: true
+- annotations:
+    fork-per-release-cron: 0 2 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
+    testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-integration-1.34-ppc64le
+  cluster: k8s-infra-ppc64le-prow-build
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.34
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  cron: 0 1/6 * * *
+  name: ci-kubernetes-integration-master-ppc64le-1-34
+  spec:
+    containers:
+    - args:
+      - ./hack/jenkins/test-integration-dockerized.sh
+      command:
+      - runner.sh
+      env:
+      - name: SHORT
+        value: --short=false
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251209-855adc2699-1.34
+      name: ""
+      resources:
+        limits:
+          cpu: "6"
+          memory: 20Gi
+        requests:
+          cpu: "6"
+          memory: 20Gi
+      securityContext:
+        privileged: true
 postsubmits: {}
 presubmits:
   kubernetes/kubernetes:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -1235,6 +1235,41 @@ periodics:
           memory: 24Gi
       securityContext:
         privileged: true
+- annotations:
+    fork-per-release-cron: 0 1/6 * * *, 0 2 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
+    testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-integration-1.35-ppc64le
+  cluster: k8s-infra-ppc64le-prow-build
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.35
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  cron: 0 0/2 * * *
+  name: ci-kubernetes-integration-master-ppc64le-1-35
+  spec:
+    containers:
+    - args:
+      - ./hack/jenkins/test-integration-dockerized.sh
+      command:
+      - runner.sh
+      env:
+      - name: SHORT
+        value: --short=false
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251209-855adc2699-1.35
+      name: ""
+      resources:
+        limits:
+          cpu: "6"
+          memory: 20Gi
+        requests:
+          cpu: "6"
+          memory: 20Gi
+      securityContext:
+        privileged: true
 postsubmits: {}
 presubmits:
   kubernetes/kubernetes:


### PR DESCRIPTION
- Adding k8s integration job for 1.35 branch for ppc64le provider
- Also, making changes so that release branch job creations will be automatic using config-forker/config rotator next time onwards