### PR TITLE
revert: enable dependabot for images/

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "docker"
-    directories:
-      -  "/images/**"
-    schedule:
-      interval: "daily"
-    labels:
-    - "skip-review"


### PR DESCRIPTION
partially reverts https://github.com/kubernetes/test-infra/pull/35799

1. We do not need daily PRs for each of these images. We do not have bandwidth for this.
2. Patching these images comes at significant risk, we have already had multiple regressions to release blocking signal late in the release cycle
3. This change was not widely discussed but has far reaching impact.

We can revisit e.g. lower frequency, select images, etc in the future.

Today the latest is broken image builds in kind https://github.com/kubernetes-sigs/kind/pull/4056#issuecomment-3639085183, we're already strapped for bandwidth across SIG Testing. You can see other breakage in kubernetes slack and discussed on the original PR.

We need to be more pragmatic about updates and when updating images someone needs to be responsible for working on the breakages. We do not need new features from any of the tools in these images, and these images are generally not intended for use in secure contexts, or indeed for third party reuse at all.

cc @kubernetes/sig-testing-leads 