### PR TITLE
Change emulated version tests back to using downloaded kubelet images

### DIFF
--- a/experiment/compatibility-versions/common.sh
+++ b/experiment/compatibility-versions/common.sh
@@ -218,7 +218,7 @@ download_release_version_bins() {
     echo "failed to download previous version ${version} binaries"
     return 1
   fi
-  tar -xvf kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz 
+  tar -xf kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz 
   mkdir -p _output/bin
   mv kubernetes/test/bin/* _output/bin
   export PATH="${PWD}/_output/bin:$PATH"
@@ -231,7 +231,7 @@ download_current_version_bins() {
     echo "failed to download current version binaries"
     return 1
   fi
-  tar -xvf kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz
+  tar -xf kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz
   mkdir -p _output/bin
   mv kubernetes/test/bin/* _output/bin
   return 0

--- a/experiment/compatibility-versions/kind-upgrade.sh
+++ b/experiment/compatibility-versions/kind-upgrade.sh
@@ -32,8 +32,6 @@ CONTROL_PLANE_COMPONENTS="kube-apiserver kube-controller-manager kube-scheduler"
 KUBE_ROOT="."
 # KUBE_ROOT="$(go env GOPATH)/src/k8s.io/kubernetes"
 source "${KUBE_ROOT}/hack/lib/version.sh"
-source "${KUBE_ROOT}/hack/lib/logging.sh"
-source "${KUBE_ROOT}/hack/lib/util.sh"
 
 DOCKER_TAG=${LATEST_VERSION/+/_}
 DOCKER_REGISTRY=${KUBE_DOCKER_REGISTRY:-registry.k8s.io}
@@ -70,7 +68,7 @@ parse_args $*
 
 download_images(){
   curl -L 'https://dl.k8s.io/ci/'${LATEST_VERSION}'/kubernetes-server-linux-amd64.tar.gz' > kubernetes-server-linux-amd64.tar.gz
-  tar -xvf kubernetes-server-linux-amd64.tar.gz
+  tar -xf kubernetes-server-linux-amd64.tar.gz
 }
 
 update_kubelet() {
@@ -120,7 +118,7 @@ pushd $TMP_DIR
 download_images
 popd
 IMAGES_PATH="${TMP_DIR}/kubernetes/server/bin"
-KUBELET_BINARY=$(kube::util::find-binary kubelet)
+KUBELET_BINARY=$(find ${TMP_DIR}/kubernetes/server/bin/ -type f -name kubelet)
 
 if [[ "$UPDATE_CONTROL_PLANE" == "true" ]]; then
   update_control_plane "true"


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/35948 accidentally had a conflict with downloading kubelet images. Revert that portion. Also reduce the verbosity of untar to make logs more readable.