### PR TITLE
kOps: fix incorrect boskos flag

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -2472,7 +2472,7 @@ presubmits:
             --up --build --down \
             --cloud-provider=aws \
             --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20251126' --channel=alpha --networking=cilium --master-size=c8g.xlarge" \
-            --boskos-resource-type=aws-account \
+            --boskos-aws-resource-type=aws-account \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \

--- a/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
@@ -59,8 +59,11 @@
             {%- if kubernetes_feature_gates %}
             --kubernetes-feature-gates={{ kubernetes_feature_gates }} \
             {%- endif %}
-            {%- if boskos_resource_type %}
-            --boskos-resource-type={{boskos_resource_type}} \
+            {%- if boskos_resource_type and cloud == "aws" %}
+            --boskos-aws-resource-type={{boskos_resource_type}} \
+            {%- endif %}
+            {%- if boskos_resource_type and cloud == "gce" %}
+            --boskos-gcp-resource-type={{boskos_resource_type}} \
             {%- endif %}
             --kubernetes-version={{k8s_deploy_url}} \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \


### PR DESCRIPTION
`boskos-resource-type` is removed in favor of `boskos-aws-resource-type` and `boskos-gcp-resource-type`