### PR TITLE
build only oss tags for gcp cloud-provider repo

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cloud-provider-gcp.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cloud-provider-gcp.yaml
@@ -74,7 +74,8 @@ postsubmits:
         # trigger another image build. Images are only built for tags that follow
         # the repository specific format https://github.com/kubernetes/cloud-provider-gcp#tagging-for-new-cloud-controller-manager-versions
         # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
-        - v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+        # NOTE: this repo cuts additional tags not used by community, eg ccm/v1.0.0
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
Verified the regex at https://regex101.com/r/owmuyG/1

ref: https://github.com/kubernetes/cloud-provider-gcp/issues/929 

This repo will be cutting multiple tags concurrently:
- vX.Y.Z used by the community and will have a corresponding GitHub release
- ccm/vX.Y.Z used by downstream consumers which will not have a GitHub release

The job has been tweaked to run only if the community tags are cut.

/cc @aojea