### PR TITLE
fix description about base image

### DIFF
--- a/images/gcb-docker-gcloud/README.md
+++ b/images/gcb-docker-gcloud/README.md
@@ -6,7 +6,7 @@ combination of `docker`, `gcloud`, and `go` all in the same build step
 ## contents
 
 - base:
-  - golang:1.24.3-alpine
+  - golang:1.25.5-alpine3.22
 - languages:
   - `go`
 - tools:


### PR DESCRIPTION
The version which gcb-docker-gcloud uses is Go1.25.5.