### PR TITLE
Update EC2 prow jobs from AL2 to AL2023

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -278,7 +278,7 @@ presubmits:
             - |
               GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
               AMI_ID=$(aws ssm get-parameters --names \
-                     /aws/service/eks/optimized-ami/1.30/amazon-linux-2-gpu/recommended/image_id \
+                     /aws/service/eks/optimized-ami/1.34/amazon-linux-2023/x86_64/nvidia/recommended/image_id \
                      --query 'Parameters[0].[Value]' --output text)
               kubetest2 ec2 \
                --build \
@@ -288,7 +288,7 @@ presubmits:
                --region us-east-1 \
                --target-build-arch linux/amd64 \
                --stage provider-aws-test-infra \
-               --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \
+               --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
                --up \
                --down \
                --test=ginkgo \
@@ -635,7 +635,7 @@ presubmits:
             - |
               cd kubetest2-ec2 && GOPROXY=direct go install .
               AMI_ID=$(aws ssm get-parameters --names \
-                       /aws/service/eks/optimized-ami/1.28/amazon-linux-2/recommended/image_id \
+                       /aws/service/eks/optimized-ami/1.34/amazon-linux-2023/x86_64/standard/recommended/image_id \
                        --query 'Parameters[0].[Value]' --output text)
               kubetest2 ec2 \
                --build \
@@ -643,7 +643,7 @@ presubmits:
                --region us-east-1 \
                --target-build-arch linux/amd64 \
                --worker-image "$AMI_ID" \
-               --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \
+               --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
                --stage provider-aws-test-infra \
                --up \
                --down \

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -33,7 +33,7 @@ periodics:
           - |
             GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
             AMI_ID=$(aws ssm get-parameters --names \
-                     /aws/service/eks/optimized-ami/1.30/amazon-linux-2-gpu/recommended/image_id \
+                     /aws/service/eks/optimized-ami/1.34/amazon-linux-2023/x86_64/nvidia/recommended/image_id \
                      --query 'Parameters[0].[Value]' --output text)
             VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
             kubetest2 ec2 \
@@ -42,7 +42,7 @@ periodics:
              --worker-instance-type=g4dn.12xlarge \
              --device-plugin-nvidia true \
              --worker-image="$AMI_ID" \
-             --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2.sh \
+             --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
              --up \
              --down \
              --test=ginkgo \


### PR DESCRIPTION
Migrate GPU and EKS conformance jobs from Amazon Linux 2 to Amazon Linux 2023. AL2 is being deprecated and AWS recommends AL2023.

Changes:
- pull-kubernetes-e2e-ec2-device-plugin-gpu: Use AL2023 NVIDIA AMI
- ci-kubernetes-e2e-ec2-device-plugin-gpu: Use AL2023 NVIDIA AMI
- pull-kubernetes-e2e-ec2-eks-conformance-canary: Use AL2023 standard AMI

SSM path changes:
- GPU: amazon-linux-2-gpu -> amazon-linux-2023/x86_64/nvidia
- Standard: amazon-linux-2 -> amazon-linux-2023/x86_64/standard