### PR TITLE
Increase memory limits for ci-kubernetes-e2e-prow-canary

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -23,11 +23,11 @@ periodics:
       - --timeout=65m
       resources:
         limits:
-          cpu: 2
-          memory: 4Gi
+          cpu: 4
+          memory: 14Gi
         requests:
-          cpu: 2
-          memory: 4Gi
+          cpu: 4
+          memory: 14Gi
   annotations:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: prow


### PR DESCRIPTION
The ci-kubernetes-e2e-prow-canary job has been consistently failing since November 1, 2025 due to OOMKilled errors. The job runs 25 parallel Ginkgo processes but only had 4Gi memory limit.

- pull-kubernetes-e2e-gce-network-policies: 6Gi memory, 4 CPU
- pull-kubernetes-e2e-gci-gce-ipvs: 6Gi memory, 2 CPU
- pull-kubernetes-e2e-gce (release-1.35): 14Gi memory, 4 CPU
- pull-kubernetes-e2e-gce-cos-canary (release-1.35): 14Gi memory, 4 CPU

This change increases memory from 4Gi to 14Gi and CPU from 2 to 4 to match the resource allocation of similar jobs.

Details:
- https://testgrid.k8s.io/sig-testing-canaries#prow&width=20
- https://storage.googleapis.com/k8s-triage/index.html?job=ci-kubernetes-e2e-prow-canary&xjob=azure%7Ckops%7Ccrio%7Cautoscaling%7Ccapz%7Cci-kubernetes-verify%7Ccluster-api%7C-cos-%7Cfedora%7Cwindows%7Clocal-e2e%7Calpha-enabled-default&xtest=should%20run%20without%20error#29575e0af2b04fc93060
- https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-prow-canary