### PR TITLE
enforce cpu/memory ceiling for prow jobs

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -53,9 +53,15 @@ var k8sProw = flag.Bool("k8s-prow", true, "If the config is for k8s prow cluster
 // Loaded at TestMain.
 var c *cfg.Config
 
-// TODO: (rjsadow) figure out a better way to incorporate all/any community clusters
-func isCritical(clusterName string) bool {
-	return clusterName == "k8s-infra-prow-build" || clusterName == "eks-prow-build-cluster"
+// These are a list of Build Clusters used by Prow
+var buildClusters = []string{
+	"k8s-infra-aks-prow-build",
+	"k8s-infra-kops-prow-build",
+	"k8s-infra-prow-build",
+	"k8s-infra-prow-build-trusted",
+	"eks-prow-build-cluster",
+	"k8s-infra-ppc64le-prow-build",
+	"k8s-infra-s390x-prow-build",
 }
 
 func matchesAnyRegex(job string, patterns []string) (bool, error) {
@@ -1139,19 +1145,23 @@ func verifyPodQOSGuaranteed(spec *coreapi.PodSpec, required bool) (errs []error)
 			if limit.Cmp(zero) == 0 {
 				errs = append(errs, fmt.Errorf("container '%v' resources.limits[%v] %v be non-zero", c.Name, r, should))
 			} else if limit.Cmp(request) != 0 {
-				errs = append(errs, fmt.Errorf("container '%v' resources.limits[%v] (%v) %v match request (%v)", c.Name, r, limit.String(), should, request.String()))
+				errs = append(errs, fmt.Errorf("resources.limits[%v] (%v) %v match resources.request[%v] (%v)", r, limit.String(), should, r, request.String()))
+			} else if r == coreapi.ResourceMemory {
+				// Enforce a maximum memory limit to allow jobs to fit in an 8 core, 30G Node
+				maxMem := resource.MustParse("27Gi")
+				if limit.Cmp(maxMem) > 0 {
+					errs = append(errs, fmt.Errorf("container '%v' resources.limits[%v] (%v) %v be at most %v", c.Name, r, limit.String(), should, maxMem.String()))
+				}
+			} else if r == coreapi.ResourceCPU {
+				// Enforce a maximum CPU limit to allow jobs to fit in an 8 core, 30G Node
+				maxCPU := resource.MustParse("7")
+				if limit.Cmp(maxCPU) > 0 {
+					errs = append(errs, fmt.Errorf("container '%v' resources.limits[%v] (%v) %v be at most %v", c.Name, r, limit.String(), should, maxCPU.String()))
+				}
 			}
 		}
 	}
 	return errs
-}
-
-// A job is merge-blocking if it:
-// - is not optional
-// - reports (aka does not skip reporting)
-// - always runs OR runs if some path changed
-func isMergeBlocking(job cfg.Presubmit) bool {
-	return !job.Optional && !job.SkipReport && (job.AlwaysRun || job.RunIfChanged != "" || job.SkipIfOnlyChanged != "")
 }
 
 func isKubernetesReleaseBlocking(job cfg.JobBase) bool {
@@ -1163,62 +1173,29 @@ func isKubernetesReleaseBlocking(job cfg.JobBase) bool {
 	return re.MatchString(dashboards)
 }
 
-func TestKubernetesMergeBlockingJobsCIPolicy(t *testing.T) {
-	jobsToFix := 0
-	repo := "kubernetes/kubernetes"
-	jobs := c.AllStaticPresubmits([]string{repo})
-	sort.Slice(jobs, func(i, j int) bool {
-		return jobs[i].Name < jobs[j].Name
-	})
-	for _, job := range jobs {
-		// Only consider Pods that are merge-blocking
-		if job.Spec == nil || !isMergeBlocking(job) {
-			continue
-		}
-		// job Pod must qualify for Guaranteed QoS
-		errs := verifyPodQOSGuaranteed(job.Spec, true)
-		if !isCritical(job.Cluster) {
-			errs = append(errs, fmt.Errorf("must run in cluster: k8s-infra-prow-build or eks-prow-build-cluster, found: %v", job.Cluster))
-		}
-		branches := job.Branches
-		if len(errs) > 0 {
-			jobsToFix++
-		}
-		for _, err := range errs {
-			t.Errorf("%v (%v): %v", job.Name, branches, err)
-		}
-	}
-	t.Logf("summary: %4d/%4d jobs fail to meet kubernetes/kubernetes merge-blocking CI policy", jobsToFix, len(jobs))
-}
-
 func TestClusterName(t *testing.T) {
 	jobsToFix := 0
 	jobs := allStaticJobs()
 	for _, job := range jobs {
 		// Useful for identifiying how many jobs are running a specific cluster by omitting from this list
-		validClusters := []string{"default", "test-infra-trusted", "k8s-infra-aks-prow-build", "k8s-infra-kops-prow-build", "k8s-infra-prow-build", "k8s-infra-prow-build-trusted", "eks-prow-build-cluster", "k8s-infra-ppc64le-prow-build", "k8s-infra-s390x-prow-build"}
-		if !slices.Contains(validClusters, job.Cluster) || job.Cluster == "" {
-			err := fmt.Errorf("must run in one of these clusters: %v, found: %v", validClusters, job.Cluster)
+		if !slices.Contains(buildClusters, job.Cluster) || job.Cluster == "" {
+			err := fmt.Errorf("must run in one of these clusters: %v, found: %v", buildClusters, job.Cluster)
 			t.Errorf("%v: %v", job.Name, err)
 			jobsToFix++
 		}
 
 	}
-	t.Logf("summary: %4d/%4d jobs fail to meet sig-k8s-infra cluster name policy", jobsToFix, len(jobs))
+	t.Logf("summary: %4d/%4d jobs failed to reference a valid build cluster", jobsToFix, len(jobs))
 }
 
 func TestKubernetesReleaseBlockingJobsCIPolicy(t *testing.T) {
 	jobsToFix := 0
 	numJobs := len(allStaticJobs())
+	var errs []error
 	for _, job := range c.AllPeriodics() {
 		// Only consider Pods that are release-blocking
 		if job.Spec == nil || !isKubernetesReleaseBlocking(job.JobBase) {
 			continue
-		}
-		// job Pod must qualify for Guaranteed QoS
-		errs := verifyPodQOSGuaranteed(job.Spec, true)
-		if !isCritical(job.Cluster) {
-			errs = append(errs, fmt.Errorf("must run in cluster: k8s-infra-prow-build or eks-prow-build-cluster, found: %v", job.Cluster))
 		}
 		// Allow some buffer over the 120m target in the release blocking job policy:
 		// "Have the average of 75% percentile duration of all runs for a week finishing in 120 minutes or less"
@@ -1260,12 +1237,6 @@ func TestKubernetesReleaseBlockingJobsCIPolicy(t *testing.T) {
 			if job.Spec == nil || !isKubernetesReleaseBlocking(job.JobBase) {
 				continue
 			}
-			// release blocking jobs must follow policy
-			// job Pod must qualify for Guaranteed QoS
-			errs := verifyPodQOSGuaranteed(job.Spec, true)
-			if !isCritical(job.Cluster) {
-				errs = append(errs, fmt.Errorf("must run in cluster: k8s-infra-prow-build or eks-prow-build-cluster, found: %v", job.Cluster))
-			}
 			// Allow some buffer over the 120m target in the release blocking job policy:
 			// "Have the average of 75% percentile duration of all runs for a week finishing in 120 minutes or less"
 			// "Run at least every 3 hours"
@@ -1298,7 +1269,8 @@ func TestK8sInfraProwBuildJobsCIPolicy(t *testing.T) {
 	jobsToFix := 0
 	jobs := allStaticJobs()
 	for _, job := range jobs {
-		if job.Spec == nil || !isCritical(job.Cluster) {
+		// We don't enforce CI policies for image build jobs in the trusted cluster yet
+		if job.Spec == nil || (job.Cluster == "k8s-infra-prow-build-trusted" && job.Spec.ServiceAccountName == "gcb-builder") {
 			continue
 		}
 		// job Pod must qualify for Guaranteed QoS


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/issues/34139
/hold for discussion

We don't use the same instance sizes between clouds. Right now, we use an 8core 64gb RAM instance on GCP (c4|c4a|c4d-highmem-8) and a 16core 128gb node on AWS(r5ad.4xlarge or r5ad.2xlarge).

The preferred node size we should adopt consistently between clouds is the latest 8 core 32GB instance that has local SSDs.

Our nodes are underutilised in memory, as you can see in Datadog.

While we determine how to inject small, medium, and large pod sizes via Kyverno (mutating webhooks), I'll enforce a new change that caps the pod size to 7 cores and 27 GB of RAM. The remaining half core and a 1G of RAM goes to any agents we run on the cluster.

c4(30GB) -> c4d(31GB) -> c4a(32GB)
<img width="1183" height="440" alt="image" src="https://github.com/user-attachments/assets/917e7799-37c0-4a14-befa-73673fa8e9b2" />


Less than 1% of prow jobs(54 out of 5874) request more than 28GB of RAM, and most of them don't need it.

```
 .venv  mahamed  Mac  ~  Desktop  Git  test-infra   enforce-cpu-memory-ceiling  3✎  1+  1⚑  USAGE  $  go test ./config/tests/jobs/ | grep "must be at most"
    jobs_test.go:1171: ci-k8sio-image-promo: container '' resources.limits[memory] (40Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-build: container '' resources.limits[memory] (34Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-build-1-31: container '' resources.limits[memory] (34Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-build-1-32: container '' resources.limits[memory] (34Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-build-1-33: container '' resources.limits[memory] (34Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-build-1-34: container '' resources.limits[memory] (34Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-build-1-35: container '' resources.limits[memory] (34Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-cross-canary: container '' resources.limits[memory] (41Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-e2e-gce-scale-correctness: container '' resources.limits[memory] (39Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-e2e-gce-scale-resource-size: container '' resources.limits[memory] (32Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-e2e-kops-aws-scale-amazonvpc-using-cl2: container '' resources.limits[memory] (48Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-e2e-kops-aws-small-scale-amazonvpc-using-cl2: container '' resources.limits[memory] (48Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-unit: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-unit-1-31: container '' resources.limits[memory] (36Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-unit-1-32: container '' resources.limits[memory] (36Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-unit-1-33: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-unit-1-34: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-unit-1-35: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-unit-dependencies: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: ci-kubernetes-unit-golang-tip: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: ci-test-infra-triage: container '' resources.limits[memory] (48Gi) must be at most 28Gi
    jobs_test.go:1171: post-k8sio-image-promo: container '' resources.limits[memory] (40Gi) must be at most 28Gi
    jobs_test.go:1171: pull-cluster-api-addon-provider-helm-capi-e2e: container '' resources.limits[memory] (32Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kops-build: container '' resources.limits[memory] (64Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kops-test: container '' resources.limits[memory] (64Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kops-verify-golangci-lint: container '' resources.limits[memory] (64Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kops-verify-govet: container '' resources.limits[memory] (64Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kops-verify-hashes: container '' resources.limits[memory] (64Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-cross: container '' resources.limits[memory] (41Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-e2e-unit-dependencies: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-e2e-unit-dependencies: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-e2e-unit-dependencies: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-e2e-unit-golang-tip: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-e2e-unit-golang-tip: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-e2e-unit-golang-tip: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-typecheck: container 'main' resources.limits[memory] (32Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-typecheck: container 'main' resources.limits[memory] (32Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-typecheck: container 'main' resources.limits[memory] (32Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-typecheck: container 'main' resources.limits[memory] (32Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-typecheck: container 'main' resources.limits[memory] (32Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-typecheck: container 'main' resources.limits[memory] (32Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit: container '' resources.limits[memory] (36Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit: container '' resources.limits[memory] (36Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit: container '' resources.limits[memory] (43Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit-go-canary: container '' resources.limits[memory] (36Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit-go-compatibility: container '' resources.limits[memory] (36Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit-go-compatibility: container '' resources.limits[memory] (36Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit-go-compatibility: container '' resources.limits[memory] (36Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit-go-compatibility: container '' resources.limits[memory] (36Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit-go-compatibility: container '' resources.limits[memory] (36Gi) must be at most 28Gi
    jobs_test.go:1171: pull-kubernetes-unit-go-compatibility: container '' resources.limits[memory] (36Gi) must be at most 28Gi
```

Examples of misconfigured sizings: 
1. https://monitoring-gke.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&refresh=30s&var-org=kubernetes&var-repo=kubernetes&var-job=ci-kubernetes-unit&var-build=All&from=now-24h&to=now Requested 43Gi but never exceeds 10Gi
2. https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&refresh=30s&var-org=kubernetes&var-repo=kubernetes&var-job=pull-kubernetes-typecheck&var-build=All&from=now-2d&to=now requested 32Gi but never exceeds 10Gi