### PR TITLE
Add inference-perf prow

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-inference-perf.yaml
+++ b/config/jobs/image-pushing/k8s-staging-inference-perf.yaml
@@ -6,7 +6,7 @@ postsubmits:
         testgrid-dashboards: sig-k8s-infra-gcb
       decorate: true
       branches:
-        - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -14,7 +14,7 @@ postsubmits:
             command:
               - /run.sh
             args:
-              - --project=k8s-staging-inference-perf
-              - --scratch-bucket=gs://k8s-staging-inference-perf-gcb
+              - --project=k8s-staging-images
+              - --scratch-bucket=gs://k8s-staging-images-gcb
               - --env-passthrough=PULL_BASE_REF
               - .


### PR DESCRIPTION
Adds prow config to push images for inference-perf. cloudbuild.yaml added in https://github.com/kubernetes-sigs/inference-perf/pull/306