### PR TITLE
Fix ginkgo not found in e2e-two-steps-upgrade test

### DIFF
--- a/experiment/compatibility-versions/common.sh
+++ b/experiment/compatibility-versions/common.sh
@@ -234,6 +234,7 @@ download_current_version_bins() {
   tar -xf kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz
   mkdir -p _output/bin
   mv kubernetes/test/bin/* _output/bin
+  export PATH="${PWD}/_output/bin:$PATH"
   return 0
 }
 


### PR DESCRIPTION
The `download_current_version_bins` function was missing the `PATH` export that `download_release_version_bins` has. This caused the second phase of the `two-steps-upgrade` test to fail with `"ginkgo: command not found"` because the downloaded binaries in `_output/bin` were not added to `PATH`.

Test that's currently failing because of this: https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-two-steps-upgrade-n-minus-1