### PR TITLE
metrics: Add failures dashboard HTML viewer

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -58,6 +58,32 @@ postsubmits:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: Compiles and updates testgrid config on test-infra pushes
+  - name: post-test-infra-upload-metrics-dashboards
+    cluster: k8s-infra-prow-build-trusted
+    branches:
+    - ^master$
+    max_concurrency: 1
+    run_if_changed: '^metrics/web/.*\.html$'
+    decorate: true
+    spec:
+      serviceAccountName: k8s-metrics
+      containers:
+      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+        command:
+        - make
+        args:
+        - -C
+        - ./metrics/web/
+        - push-static
+        resources:
+          requests:
+            memory: "256Mi"
+    annotations:
+      testgrid-dashboards: sig-testing-misc, sig-k8s-infra-prow
+      testgrid-tab-name: metrics-dashboards-update
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: Updates the HTML dashboards for k8s-metrics bucket.
 
 
 periodics:

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -57,6 +57,37 @@ jqfilter: |
     - [Config](configs/weekly-consistency-config.yaml)
     - [weekly-consistency-latest.json](http://storage.googleapis.com/k8s-metrics/weekly-consistency-latest.json)
 
+## Web Dashboards
+
+Interactive HTML dashboards are available in the [web/](web/) directory for visualizing metrics data:
+
+* [failures-latest.html](web/failures-latest.html) - Jobs failing for consecutive days
+* [flakes-latest.html](web/flakes-latest.html) - Weekly flake data with test-level details
+* [flakes-daily-latest.html](web/flakes-daily-latest.html) - Daily flake data
+* [job-health-latest.html](web/job-health-latest.html) - Daily job health with failure rates and durations
+* [presubmit-health-latest.html](web/presubmit-health-latest.html) - Presubmit job health with PR failure rates
+* [index.html](web/index.html) - Landing page linking all dashboards
+
+### Local Testing
+
+To test the dashboards locally:
+
+```bash
+cd metrics/web
+
+# Download latest data from GCS
+gsutil cp gs://k8s-metrics/failures-latest.json .
+gsutil cp gs://k8s-metrics/flakes-latest.json .
+gsutil cp gs://k8s-metrics/flakes-daily-latest.json .
+gsutil cp gs://k8s-metrics/job-health-latest.json .
+gsutil cp gs://k8s-metrics/presubmit-health-latest.json .
+
+# Serve locally
+python3 -m http.server 8080
+
+# Open http://localhost:8080/
+```
+
 ## Adding a new metric
 
 To add a new metric, create a PR that adds a new yaml config file

--- a/metrics/web/Makefile
+++ b/metrics/web/Makefile
@@ -1,0 +1,24 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+STATIC_FILES = index.html \
+	failures-latest.html \
+	flakes-latest.html \
+	flakes-daily-latest.html \
+	job-health-latest.html \
+	presubmit-health-latest.html
+
+.PHONY: push-static
+push-static:
+	gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp $(STATIC_FILES) gs://k8s-metrics/

--- a/metrics/web/failures-latest.html
+++ b/metrics/web/failures-latest.html
@@ -1,0 +1,707 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kubernetes CI Failures Dashboard</title>
+    <style>
+        :root {
+            --critical: #dc2626;
+            --severe: #ea580c;
+            --warning: #d97706;
+            --moderate: #ca8a04;
+            --low: #65a30d;
+            --bg-dark: #1e293b;
+            --bg-card: #334155;
+            --text-primary: #f1f5f9;
+            --text-secondary: #94a3b8;
+            --border: #475569;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--bg-dark);
+            color: var(--text-primary);
+            line-height: 1.6;
+            padding: 20px;
+        }
+
+        .container {
+            max-width: 1800px;
+            margin: 0 auto;
+        }
+
+        header {
+            display: flex;
+            align-items: baseline;
+            gap: 16px;
+            margin-bottom: 16px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        h1 {
+            font-size: 1.4rem;
+            font-weight: 600;
+            margin: 0;
+        }
+
+        .subtitle {
+            color: var(--text-secondary);
+            font-size: 0.8rem;
+        }
+
+        .subtitle a {
+            color: var(--text-secondary);
+        }
+
+        .nav-links {
+            margin-left: auto;
+            display: flex;
+            gap: 16px;
+        }
+
+        .nav-links a {
+            color: #60a5fa;
+            text-decoration: none;
+            font-size: 0.85rem;
+        }
+
+        .nav-links a:hover {
+            text-decoration: underline;
+        }
+
+        .stats-grid {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 16px;
+            flex-wrap: wrap;
+        }
+
+        .stat-card {
+            background: var(--bg-card);
+            border-radius: 8px;
+            padding: 8px 16px;
+            text-align: center;
+            border: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .stat-value {
+            font-size: 1.2rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--text-secondary);
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+        }
+
+        .controls {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 12px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        .search-box {
+            flex: 1;
+            min-width: 200px;
+            max-width: 350px;
+        }
+
+        .search-box input {
+            width: 100%;
+            padding: 8px 12px;
+            border-radius: 6px;
+            border: 1px solid var(--border);
+            background: var(--bg-card);
+            color: var(--text-primary);
+            font-size: 0.85rem;
+        }
+
+        .search-box input::placeholder {
+            color: var(--text-secondary);
+        }
+
+        .search-box input:focus {
+            outline: none;
+            border-color: #3b82f6;
+        }
+
+        .filter-group {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+
+        .filter-btn {
+            padding: 5px 12px;
+            border-radius: 14px;
+            border: 1px solid var(--border);
+            background: var(--bg-card);
+            color: var(--text-primary);
+            cursor: pointer;
+            font-size: 0.75rem;
+            transition: all 0.2s;
+        }
+
+        .filter-btn:hover {
+            background: var(--border);
+        }
+
+        .filter-btn.active {
+            background: #3b82f6;
+            border-color: #3b82f6;
+        }
+
+        .table-container {
+            background: var(--bg-card);
+            border-radius: 12px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        th, td {
+            padding: 8px 12px;
+            text-align: left;
+        }
+
+        th {
+            background: rgba(0,0,0,0.2);
+            font-weight: 600;
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            user-select: none;
+            position: sticky;
+            top: 0;
+        }
+
+        th:hover {
+            background: rgba(0,0,0,0.3);
+        }
+
+        th .sort-icon {
+            margin-left: 8px;
+            opacity: 0.5;
+        }
+
+        th.sorted .sort-icon {
+            opacity: 1;
+        }
+
+        tr {
+            border-bottom: 1px solid var(--border);
+        }
+
+        tr:last-child {
+            border-bottom: none;
+        }
+
+        tr:hover {
+            background: rgba(255,255,255,0.03);
+        }
+
+        .job-name {
+            font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+            font-size: 0.9rem;
+            word-break: break-all;
+        }
+
+        .job-link {
+            color: #60a5fa;
+            text-decoration: none;
+        }
+
+        .job-link:hover {
+            text-decoration: underline;
+        }
+
+        .code-link {
+            margin-left: 6px;
+            text-decoration: none;
+            opacity: 0.5;
+            font-size: 0.85em;
+        }
+
+        .code-link:hover {
+            opacity: 1;
+        }
+
+        .days-cell {
+            text-align: right;
+            font-weight: 600;
+            font-variant-numeric: tabular-nums;
+        }
+
+        .severity-badge {
+            display: inline-block;
+            padding: 4px 12px;
+            border-radius: 12px;
+            font-size: 0.8rem;
+            font-weight: 500;
+        }
+
+        .severity-critical { background: var(--critical); }
+        .severity-severe { background: var(--severe); }
+        .severity-warning { background: var(--warning); }
+        .severity-moderate { background: var(--moderate); }
+        .severity-low { background: var(--low); }
+
+        .bar-cell {
+            width: 200px;
+        }
+
+        .bar-container {
+            height: 8px;
+            background: rgba(255,255,255,0.1);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+
+        .bar-fill {
+            height: 100%;
+            border-radius: 4px;
+            transition: width 0.3s ease;
+        }
+
+        .count-display {
+            text-align: center;
+            padding: 20px;
+            color: var(--text-secondary);
+        }
+
+        .legend {
+            display: flex;
+            gap: 12px;
+            justify-content: flex-start;
+            margin-bottom: 12px;
+            flex-wrap: wrap;
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            font-size: 0.7rem;
+            color: var(--text-secondary);
+        }
+
+        .legend-color {
+            width: 10px;
+            height: 10px;
+            border-radius: 2px;
+        }
+
+        .loading {
+            text-align: center;
+            padding: 60px 20px;
+            color: var(--text-secondary);
+        }
+
+        .loading-spinner {
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            border: 3px solid var(--border);
+            border-top-color: #3b82f6;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            margin-bottom: 12px;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        .error {
+            text-align: center;
+            padding: 40px 20px;
+            color: var(--critical);
+        }
+
+        .hidden {
+            display: none;
+        }
+
+        @media (max-width: 768px) {
+            .bar-cell {
+                display: none;
+            }
+
+            th, td {
+                padding: 10px 12px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Kubernetes CI Failures Dashboard</h1>
+            <p class="subtitle">Data from <a href="failures-latest.json" style="color: var(--text-secondary)">failures-latest.json</a></p>
+            <div class="nav-links">
+                <a href="index.html">Index</a>
+                <a href="flakes-latest.html">Flakes (Weekly)</a>
+                <a href="flakes-daily-latest.html">Flakes (Daily)</a>
+            </div>
+        </header>
+
+        <div class="stats-grid" id="stats-grid">
+            <!-- Stats will be populated by JS -->
+        </div>
+
+        <div class="legend">
+            <div class="legend-item"><div class="legend-color" style="background: var(--critical)"></div>Critical (365+ days)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--severe)"></div>Severe (180-364 days)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--warning)"></div>Warning (90-179 days)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--moderate)"></div>Moderate (30-89 days)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--low)"></div>Low (1-29 days)</div>
+        </div>
+
+        <div class="controls">
+            <div class="search-box">
+                <input type="text" id="include" placeholder="Include regex (e.g., kops|gce)">
+            </div>
+            <div class="search-box">
+                <input type="text" id="exclude" placeholder="Exclude regex (e.g., upgrade|scale)">
+            </div>
+            <div class="filter-group">
+                <button class="filter-btn active" data-filter="all">All</button>
+                <button class="filter-btn" data-filter="critical">Critical</button>
+                <button class="filter-btn" data-filter="severe">Severe</button>
+                <button class="filter-btn" data-filter="warning">Warning</button>
+                <button class="filter-btn" data-filter="moderate">Moderate</button>
+                <button class="filter-btn" data-filter="low">Low</button>
+            </div>
+        </div>
+
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th data-sort="name">Job Name <span class="sort-icon">↕</span></th>
+                        <th data-sort="days" class="sorted">Failing Days <span class="sort-icon">↓</span></th>
+                        <th data-sort="severity">Severity <span class="sort-icon">↕</span></th>
+                        <th class="bar-cell">Relative</th>
+                    </tr>
+                </thead>
+                <tbody id="table-body">
+                    <tr>
+                        <td colspan="5">
+                            <div class="loading">
+                                <div class="loading-spinner"></div>
+                                <div>Loading failures data...</div>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="count-display" id="count-display"></div>
+    </div>
+
+    <script>
+        // Data loaded from JSON file
+        let jobs = [];
+        let maxDays = 0;
+
+        function getSeverity(days) {
+            if (days >= 365) return 'critical';
+            if (days >= 180) return 'severe';
+            if (days >= 90) return 'warning';
+            if (days >= 30) return 'moderate';
+            return 'low';
+        }
+
+        function getSeverityLabel(days) {
+            if (days >= 365) return 'Critical';
+            if (days >= 180) return 'Severe';
+            if (days >= 90) return 'Warning';
+            if (days >= 30) return 'Moderate';
+            return 'Low';
+        }
+
+        function getSeverityRank(days) {
+            if (days >= 365) return 5;
+            if (days >= 180) return 4;
+            if (days >= 90) return 3;
+            if (days >= 30) return 2;
+            return 1;
+        }
+
+        function getBarColor(days) {
+            if (days >= 365) return 'var(--critical)';
+            if (days >= 180) return 'var(--severe)';
+            if (days >= 90) return 'var(--warning)';
+            if (days >= 30) return 'var(--moderate)';
+            return 'var(--low)';
+        }
+
+        function getJobUrl(name) {
+            if (name.startsWith('pr:')) {
+                const jobName = name.substring(3);
+                return `https://prow.k8s.io/?job=${encodeURIComponent(jobName)}`;
+            }
+            return `https://prow.k8s.io/?job=${encodeURIComponent(name)}`;
+        }
+
+        function getCodeSearchUrl(name) {
+            const jobName = name.startsWith('pr:') ? name.substring(3) : name;
+            return `https://cs.k8s.io/?q=${encodeURIComponent(jobName)}&i=nope&literal=nope&files=&excludeFiles=&repos=kubernetes/test-infra`;
+        }
+
+        function updateStats(filteredJobs) {
+            const stats = {
+                total: filteredJobs.length,
+                critical: filteredJobs.filter(j => j.days >= 365).length,
+                severe: filteredJobs.filter(j => j.days >= 180 && j.days < 365).length,
+                warning: filteredJobs.filter(j => j.days >= 90 && j.days < 180).length,
+                moderate: filteredJobs.filter(j => j.days >= 30 && j.days < 90).length,
+                low: filteredJobs.filter(j => j.days < 30).length,
+                avgDays: filteredJobs.length > 0 ? Math.round(filteredJobs.reduce((s, j) => s + j.days, 0) / filteredJobs.length) : 0
+            };
+
+            document.getElementById('stats-grid').innerHTML = `
+                <div class="stat-card">
+                    <div class="stat-value">${stats.total.toLocaleString()}</div>
+                    <div class="stat-label">Total Failing Jobs</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--critical)">${stats.critical}</div>
+                    <div class="stat-label">Critical (365+ days)</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--severe)">${stats.severe}</div>
+                    <div class="stat-label">Severe (180-364)</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--warning)">${stats.warning}</div>
+                    <div class="stat-label">Warning (90-179)</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--moderate)">${stats.moderate}</div>
+                    <div class="stat-label">Moderate (30-89)</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value">${stats.avgDays}</div>
+                    <div class="stat-label">Avg Failing Days</div>
+                </div>
+            `;
+        }
+
+        // State
+        let currentSort = { field: 'days', asc: false };
+        let currentFilter = 'all';
+        let includePattern = '';
+        let excludePattern = '';
+
+        function updateUrl() {
+            const params = new URLSearchParams();
+            if (includePattern) params.set('include', includePattern);
+            if (excludePattern) params.set('exclude', excludePattern);
+            if (currentFilter !== 'all') params.set('filter', currentFilter);
+            params.set('sort', currentSort.field);
+            params.set('asc', currentSort.asc ? '1' : '0');
+            const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+            window.history.replaceState({}, '', newUrl);
+        }
+
+        function loadFromUrl() {
+            const params = new URLSearchParams(window.location.search);
+            includePattern = params.get('include') || '';
+            excludePattern = params.get('exclude') || '';
+            currentFilter = params.get('filter') || 'all';
+            currentSort.field = params.get('sort') || 'days';
+            currentSort.asc = params.get('asc') === '1';
+
+            document.getElementById('include').value = includePattern;
+            document.getElementById('exclude').value = excludePattern;
+            document.querySelectorAll('.filter-btn').forEach(b => {
+                b.classList.toggle('active', b.dataset.filter === currentFilter);
+            });
+            document.querySelectorAll('th[data-sort]').forEach(th => {
+                const isActive = th.dataset.sort === currentSort.field;
+                th.classList.toggle('sorted', isActive);
+                th.querySelector('.sort-icon').textContent = isActive ? (currentSort.asc ? '↑' : '↓') : '↕';
+            });
+        }
+
+        function tryRegex(pattern, text) {
+            if (!pattern) return null;
+            try {
+                return new RegExp(pattern, 'i').test(text);
+            } catch (e) {
+                return null;
+            }
+        }
+
+        function filterAndSort() {
+            let filtered = [...jobs];
+
+            if (includePattern) {
+                filtered = filtered.filter(j => {
+                    const result = tryRegex(includePattern, j.name);
+                    return result === null ? true : result;
+                });
+            }
+
+            if (excludePattern) {
+                filtered = filtered.filter(j => {
+                    const result = tryRegex(excludePattern, j.name);
+                    return result === null ? true : !result;
+                });
+            }
+
+            if (currentFilter !== 'all') {
+                filtered = filtered.filter(j => getSeverity(j.days) === currentFilter);
+            }
+
+            filtered.sort((a, b) => {
+                let cmp;
+                if (currentSort.field === 'name') {
+                    cmp = a.name.localeCompare(b.name);
+                } else if (currentSort.field === 'severity') {
+                    cmp = getSeverityRank(a.days) - getSeverityRank(b.days);
+                    if (cmp === 0) cmp = a.days - b.days;
+                } else {
+                    cmp = a.days - b.days;
+                }
+                return currentSort.asc ? cmp : -cmp;
+            });
+
+            return filtered;
+        }
+
+        function render() {
+            const filtered = filterAndSort();
+            updateStats(filtered);
+
+            const tbody = document.getElementById('table-body');
+            tbody.innerHTML = filtered.map((job, idx) => `
+                <tr>
+                    <td>${idx + 1}</td>
+                    <td class="job-name">
+                        <a href="${getJobUrl(job.name)}" target="_blank" class="job-link">${job.name}</a>
+                        <a href="${getCodeSearchUrl(job.name)}" target="_blank" class="code-link" title="Search in test-infra">&#128269;</a>
+                    </td>
+                    <td class="days-cell">${job.days.toLocaleString()}</td>
+                    <td>
+                        <span class="severity-badge severity-${getSeverity(job.days)}">
+                            ${getSeverityLabel(job.days)}
+                        </span>
+                    </td>
+                    <td class="bar-cell">
+                        <div class="bar-container">
+                            <div class="bar-fill" style="width: ${(job.days / maxDays * 100).toFixed(1)}%; background: ${getBarColor(job.days)}"></div>
+                        </div>
+                    </td>
+                </tr>
+            `).join('');
+
+            document.getElementById('count-display').textContent =
+                `Showing ${filtered.length} of ${jobs.length} jobs`;
+        }
+
+        function showError(message) {
+            document.getElementById('table-body').innerHTML = `
+                <tr>
+                    <td colspan="5">
+                        <div class="error">${message}</div>
+                    </td>
+                </tr>
+            `;
+        }
+
+        // Event handlers
+        document.getElementById('include').addEventListener('input', (e) => {
+            includePattern = e.target.value;
+            updateUrl();
+            render();
+        });
+
+        document.getElementById('exclude').addEventListener('input', (e) => {
+            excludePattern = e.target.value;
+            updateUrl();
+            render();
+        });
+
+        document.querySelectorAll('.filter-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                currentFilter = btn.dataset.filter;
+                updateUrl();
+                render();
+            });
+        });
+
+        document.querySelectorAll('th[data-sort]').forEach(th => {
+            th.addEventListener('click', () => {
+                const field = th.dataset.sort;
+                if (currentSort.field === field) {
+                    currentSort.asc = !currentSort.asc;
+                } else {
+                    currentSort.field = field;
+                    currentSort.asc = field === 'name';
+                }
+
+                document.querySelectorAll('th[data-sort]').forEach(t => {
+                    t.classList.remove('sorted');
+                    t.querySelector('.sort-icon').textContent = '↕';
+                });
+                th.classList.add('sorted');
+                th.querySelector('.sort-icon').textContent = currentSort.asc ? '↑' : '↓';
+
+                updateUrl();
+                render();
+            });
+        });
+
+        // Load data and initialize
+        async function init() {
+            try {
+                const response = await fetch('failures-latest.json');
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                }
+                const data = await response.json();
+
+                jobs = Object.entries(data).map(([name, info]) => ({
+                    name,
+                    days: info.failing_days
+                }));
+
+                maxDays = Math.max(...jobs.map(j => j.days));
+
+                loadFromUrl();
+                render();
+            } catch (err) {
+                showError(`Failed to load data: ${err.message}<br><small>Make sure failures-latest.json is in the same directory</small>`);
+            }
+        }
+
+        init();
+    </script>
+</body>
+</html>

--- a/metrics/web/flakes-daily-latest.html
+++ b/metrics/web/flakes-daily-latest.html
@@ -1,0 +1,743 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kubernetes CI Daily Flakes Dashboard</title>
+    <style>
+        :root {
+            --critical: #dc2626;
+            --severe: #ea580c;
+            --warning: #d97706;
+            --moderate: #ca8a04;
+            --low: #65a30d;
+            --bg-dark: #1e293b;
+            --bg-card: #334155;
+            --text-primary: #f1f5f9;
+            --text-secondary: #94a3b8;
+            --border: #475569;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--bg-dark);
+            color: var(--text-primary);
+            line-height: 1.6;
+            padding: 20px;
+        }
+
+        .container {
+            max-width: 1800px;
+            margin: 0 auto;
+        }
+
+        header {
+            display: flex;
+            align-items: baseline;
+            gap: 16px;
+            margin-bottom: 16px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        h1 {
+            font-size: 1.4rem;
+            font-weight: 600;
+            margin: 0;
+        }
+
+        .subtitle {
+            color: var(--text-secondary);
+            font-size: 0.8rem;
+        }
+
+        .subtitle a {
+            color: var(--text-secondary);
+        }
+
+        .nav-links {
+            margin-left: auto;
+            display: flex;
+            gap: 16px;
+        }
+
+        .nav-links a {
+            color: #60a5fa;
+            text-decoration: none;
+            font-size: 0.85rem;
+        }
+
+        .nav-links a:hover {
+            text-decoration: underline;
+        }
+
+        .stats-grid {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 16px;
+            flex-wrap: wrap;
+        }
+
+        .stat-card {
+            background: var(--bg-card);
+            border-radius: 8px;
+            padding: 8px 16px;
+            text-align: center;
+            border: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .stat-value {
+            font-size: 1.2rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--text-secondary);
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+        }
+
+        .controls {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 12px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        .search-box {
+            flex: 1;
+            min-width: 200px;
+            max-width: 350px;
+        }
+
+        .search-box input {
+            width: 100%;
+            padding: 8px 12px;
+            border-radius: 6px;
+            border: 1px solid var(--border);
+            background: var(--bg-card);
+            color: var(--text-primary);
+            font-size: 0.85rem;
+        }
+
+        .search-box input::placeholder {
+            color: var(--text-secondary);
+        }
+
+        .search-box input:focus {
+            outline: none;
+            border-color: #3b82f6;
+        }
+
+        .filter-group {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+
+        .filter-btn {
+            padding: 5px 12px;
+            border-radius: 14px;
+            border: 1px solid var(--border);
+            background: var(--bg-card);
+            color: var(--text-primary);
+            cursor: pointer;
+            font-size: 0.75rem;
+            transition: all 0.2s;
+        }
+
+        .filter-btn:hover {
+            background: var(--border);
+        }
+
+        .filter-btn.active {
+            background: #3b82f6;
+            border-color: #3b82f6;
+        }
+
+        .table-container {
+            background: var(--bg-card);
+            border-radius: 12px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        th, td {
+            padding: 8px 12px;
+            text-align: left;
+        }
+
+        th {
+            background: rgba(0,0,0,0.2);
+            font-weight: 600;
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            user-select: none;
+            position: sticky;
+            top: 0;
+        }
+
+        th:hover {
+            background: rgba(0,0,0,0.3);
+        }
+
+        th .sort-icon {
+            margin-left: 8px;
+            opacity: 0.5;
+        }
+
+        th.sorted .sort-icon {
+            opacity: 1;
+        }
+
+        tr {
+            border-bottom: 1px solid var(--border);
+        }
+
+        tr:last-child {
+            border-bottom: none;
+        }
+
+        tr:hover {
+            background: rgba(255,255,255,0.03);
+        }
+
+        .job-name {
+            font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+            font-size: 0.9rem;
+            word-break: break-all;
+        }
+
+        .job-link {
+            color: #60a5fa;
+            text-decoration: none;
+        }
+
+        .job-link:hover {
+            text-decoration: underline;
+        }
+
+        .code-link {
+            margin-left: 6px;
+            text-decoration: none;
+            opacity: 0.5;
+            font-size: 0.85em;
+        }
+
+        .code-link:hover {
+            opacity: 1;
+        }
+
+        .num-cell {
+            text-align: right;
+            font-weight: 600;
+            font-variant-numeric: tabular-nums;
+        }
+
+        .consistency-badge {
+            display: inline-block;
+            padding: 4px 12px;
+            border-radius: 12px;
+            font-size: 0.8rem;
+            font-weight: 500;
+        }
+
+        .consistency-critical { background: var(--critical); }
+        .consistency-severe { background: var(--severe); }
+        .consistency-warning { background: var(--warning); }
+        .consistency-moderate { background: var(--moderate); }
+        .consistency-good { background: var(--low); }
+
+        .bar-cell {
+            width: 150px;
+        }
+
+        .bar-container {
+            height: 8px;
+            background: rgba(255,255,255,0.1);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+
+        .bar-fill {
+            height: 100%;
+            border-radius: 4px;
+            transition: width 0.3s ease;
+        }
+
+        .test-flakes {
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+            max-width: 400px;
+        }
+
+        .test-flakes-toggle {
+            cursor: pointer;
+            color: #60a5fa;
+            font-size: 0.75rem;
+        }
+
+        .test-flakes-list {
+            display: none;
+            margin-top: 4px;
+            padding-left: 12px;
+            border-left: 2px solid var(--border);
+        }
+
+        .test-flakes-list.expanded {
+            display: block;
+        }
+
+        .test-flake-item {
+            margin: 2px 0;
+            font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+            font-size: 0.7rem;
+        }
+
+        .count-display {
+            text-align: center;
+            padding: 20px;
+            color: var(--text-secondary);
+        }
+
+        .legend {
+            display: flex;
+            gap: 12px;
+            justify-content: flex-start;
+            margin-bottom: 12px;
+            flex-wrap: wrap;
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            font-size: 0.7rem;
+            color: var(--text-secondary);
+        }
+
+        .legend-color {
+            width: 10px;
+            height: 10px;
+            border-radius: 2px;
+        }
+
+        .loading {
+            text-align: center;
+            padding: 60px 20px;
+            color: var(--text-secondary);
+        }
+
+        .loading-spinner {
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            border: 3px solid var(--border);
+            border-top-color: #3b82f6;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            margin-bottom: 12px;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        .error {
+            text-align: center;
+            padding: 40px 20px;
+            color: var(--critical);
+        }
+
+        @media (max-width: 768px) {
+            .bar-cell, .test-flakes {
+                display: none;
+            }
+
+            th, td {
+                padding: 10px 12px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Kubernetes CI Daily Flakes Dashboard</h1>
+            <p class="subtitle">Data from <a href="flakes-daily-latest.json">flakes-daily-latest.json</a></p>
+            <div class="nav-links">
+                <a href="index.html">Index</a>
+                <a href="failures-latest.html">Failures</a>
+                <a href="flakes-latest.html">Flakes (Weekly)</a>
+            </div>
+        </header>
+
+        <div class="stats-grid" id="stats-grid"></div>
+
+        <div class="legend">
+            <div class="legend-item"><div class="legend-color" style="background: var(--critical)"></div>Critical (&lt;50%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--severe)"></div>Severe (50-69%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--warning)"></div>Warning (70-84%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--moderate)"></div>Moderate (85-94%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--low)"></div>Good (95%+)</div>
+        </div>
+
+        <div class="controls">
+            <div class="search-box">
+                <input type="text" id="include" placeholder="Include regex (e.g., pull-kubernetes|ci-)">
+            </div>
+            <div class="search-box">
+                <input type="text" id="exclude" placeholder="Exclude regex (e.g., azure|aws)">
+            </div>
+            <div class="filter-group">
+                <button class="filter-btn active" data-filter="all">All</button>
+                <button class="filter-btn" data-filter="critical">Critical</button>
+                <button class="filter-btn" data-filter="severe">Severe</button>
+                <button class="filter-btn" data-filter="warning">Warning</button>
+                <button class="filter-btn" data-filter="moderate">Moderate</button>
+                <button class="filter-btn" data-filter="good">Good</button>
+            </div>
+        </div>
+
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th data-sort="name">Job Name <span class="sort-icon">↕</span></th>
+                        <th data-sort="consistency">Consistency <span class="sort-icon">↕</span></th>
+                        <th data-sort="flakes" class="sorted">Flakes <span class="sort-icon">↓</span></th>
+                        <th class="bar-cell">Consistency</th>
+                        <th>Test Flakes</th>
+                    </tr>
+                </thead>
+                <tbody id="table-body">
+                    <tr>
+                        <td colspan="6">
+                            <div class="loading">
+                                <div class="loading-spinner"></div>
+                                <div>Loading flakes data...</div>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="count-display" id="count-display"></div>
+    </div>
+
+    <script>
+        let jobs = [];
+        let maxFlakes = 0;
+
+        function getConsistencyLevel(consistency) {
+            if (consistency < 0.5) return 'critical';
+            if (consistency < 0.7) return 'severe';
+            if (consistency < 0.85) return 'warning';
+            if (consistency < 0.95) return 'moderate';
+            return 'good';
+        }
+
+        function getConsistencyLabel(consistency) {
+            if (consistency < 0.5) return 'Critical';
+            if (consistency < 0.7) return 'Severe';
+            if (consistency < 0.85) return 'Warning';
+            if (consistency < 0.95) return 'Moderate';
+            return 'Good';
+        }
+
+        function getConsistencyRank(consistency) {
+            if (consistency < 0.5) return 5;
+            if (consistency < 0.7) return 4;
+            if (consistency < 0.85) return 3;
+            if (consistency < 0.95) return 2;
+            return 1;
+        }
+
+        function getBarColor(consistency) {
+            if (consistency < 0.5) return 'var(--critical)';
+            if (consistency < 0.7) return 'var(--severe)';
+            if (consistency < 0.85) return 'var(--warning)';
+            if (consistency < 0.95) return 'var(--moderate)';
+            return 'var(--low)';
+        }
+
+        function getJobUrl(name) {
+            if (name.startsWith('pr:')) {
+                return `https://prow.k8s.io/?job=${encodeURIComponent(name.substring(3))}`;
+            }
+            return `https://prow.k8s.io/?job=${encodeURIComponent(name)}`;
+        }
+
+        function getCodeSearchUrl(name) {
+            const jobName = name.startsWith('pr:') ? name.substring(3) : name;
+            return `https://cs.k8s.io/?q=${encodeURIComponent(jobName)}&i=nope&literal=nope&files=&excludeFiles=&repos=kubernetes/test-infra`;
+        }
+
+        function updateStats(filteredJobs) {
+            const stats = {
+                total: filteredJobs.length,
+                critical: filteredJobs.filter(j => j.consistency < 0.5).length,
+                severe: filteredJobs.filter(j => j.consistency >= 0.5 && j.consistency < 0.7).length,
+                warning: filteredJobs.filter(j => j.consistency >= 0.7 && j.consistency < 0.85).length,
+                moderate: filteredJobs.filter(j => j.consistency >= 0.85 && j.consistency < 0.95).length,
+                good: filteredJobs.filter(j => j.consistency >= 0.95).length,
+                totalFlakes: filteredJobs.reduce((s, j) => s + j.flakes, 0)
+            };
+
+            document.getElementById('stats-grid').innerHTML = `
+                <div class="stat-card">
+                    <div class="stat-value">${stats.total.toLocaleString()}</div>
+                    <div class="stat-label">Total Jobs</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value">${stats.totalFlakes.toLocaleString()}</div>
+                    <div class="stat-label">Total Flakes</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--critical)">${stats.critical}</div>
+                    <div class="stat-label">Critical (&lt;50%)</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--severe)">${stats.severe}</div>
+                    <div class="stat-label">Severe (50-69%)</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--warning)">${stats.warning}</div>
+                    <div class="stat-label">Warning (70-84%)</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--low)">${stats.good}</div>
+                    <div class="stat-label">Good (95%+)</div>
+                </div>
+            `;
+        }
+
+        let currentSort = { field: 'flakes', asc: false };
+        let currentFilter = 'all';
+        let includePattern = '';
+        let excludePattern = '';
+
+        function updateUrl() {
+            const params = new URLSearchParams();
+            if (includePattern) params.set('include', includePattern);
+            if (excludePattern) params.set('exclude', excludePattern);
+            if (currentFilter !== 'all') params.set('filter', currentFilter);
+            params.set('sort', currentSort.field);
+            params.set('asc', currentSort.asc ? '1' : '0');
+            const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+            window.history.replaceState({}, '', newUrl);
+        }
+
+        function loadFromUrl() {
+            const params = new URLSearchParams(window.location.search);
+            includePattern = params.get('include') || '';
+            excludePattern = params.get('exclude') || '';
+            currentFilter = params.get('filter') || 'all';
+            currentSort.field = params.get('sort') || 'flakes';
+            currentSort.asc = params.get('asc') === '1';
+
+            document.getElementById('include').value = includePattern;
+            document.getElementById('exclude').value = excludePattern;
+            document.querySelectorAll('.filter-btn').forEach(b => {
+                b.classList.toggle('active', b.dataset.filter === currentFilter);
+            });
+            document.querySelectorAll('th[data-sort]').forEach(th => {
+                const isActive = th.dataset.sort === currentSort.field;
+                th.classList.toggle('sorted', isActive);
+                th.querySelector('.sort-icon').textContent = isActive ? (currentSort.asc ? '↑' : '↓') : '↕';
+            });
+        }
+
+        function tryRegex(pattern, text) {
+            if (!pattern) return null;
+            try {
+                return new RegExp(pattern, 'i').test(text);
+            } catch (e) {
+                return null;
+            }
+        }
+
+        function filterAndSort() {
+            let filtered = [...jobs];
+
+            if (includePattern) {
+                filtered = filtered.filter(j => {
+                    const result = tryRegex(includePattern, j.name);
+                    return result === null ? true : result;
+                });
+            }
+
+            if (excludePattern) {
+                filtered = filtered.filter(j => {
+                    const result = tryRegex(excludePattern, j.name);
+                    return result === null ? true : !result;
+                });
+            }
+
+            if (currentFilter !== 'all') {
+                filtered = filtered.filter(j => getConsistencyLevel(j.consistency) === currentFilter);
+            }
+
+            filtered.sort((a, b) => {
+                let cmp;
+                if (currentSort.field === 'name') {
+                    cmp = a.name.localeCompare(b.name);
+                } else if (currentSort.field === 'consistency') {
+                    cmp = a.consistency - b.consistency;
+                } else {
+                    cmp = a.flakes - b.flakes;
+                }
+                return currentSort.asc ? cmp : -cmp;
+            });
+
+            return filtered;
+        }
+
+        function renderTestFlakes(testFlakes, idx) {
+            if (!testFlakes || Object.keys(testFlakes).length === 0) {
+                return '<span style="color: var(--text-secondary)">—</span>';
+            }
+            const entries = Object.entries(testFlakes).sort((a, b) => b[1] - a[1]);
+            const count = entries.length;
+            const listItems = entries.map(([test, cnt]) =>
+                `<div class="test-flake-item">${cnt}× ${test}</div>`
+            ).join('');
+
+            return `
+                <span class="test-flakes-toggle" onclick="toggleTestFlakes(${idx})">${count} test${count > 1 ? 's' : ''} ▼</span>
+                <div class="test-flakes-list" id="test-flakes-${idx}">${listItems}</div>
+            `;
+        }
+
+        window.toggleTestFlakes = function(idx) {
+            const list = document.getElementById(`test-flakes-${idx}`);
+            list.classList.toggle('expanded');
+        };
+
+        function render() {
+            const filtered = filterAndSort();
+            updateStats(filtered);
+
+            const tbody = document.getElementById('table-body');
+            tbody.innerHTML = filtered.map((job, idx) => `
+                <tr>
+                    <td>${idx + 1}</td>
+                    <td class="job-name">
+                        <a href="${getJobUrl(job.name)}" target="_blank" class="job-link">${job.name}</a>
+                        <a href="${getCodeSearchUrl(job.name)}" target="_blank" class="code-link" title="Search in test-infra">&#128269;</a>
+                    </td>
+                    <td class="num-cell">
+                        <span class="consistency-badge consistency-${getConsistencyLevel(job.consistency)}">
+                            ${(job.consistency * 100).toFixed(1)}%
+                        </span>
+                    </td>
+                    <td class="num-cell">${job.flakes}</td>
+                    <td class="bar-cell">
+                        <div class="bar-container">
+                            <div class="bar-fill" style="width: ${(job.consistency * 100).toFixed(1)}%; background: ${getBarColor(job.consistency)}"></div>
+                        </div>
+                    </td>
+                    <td class="test-flakes">${renderTestFlakes(job.testFlakes, idx)}</td>
+                </tr>
+            `).join('');
+
+            document.getElementById('count-display').textContent =
+                `Showing ${filtered.length} of ${jobs.length} jobs`;
+        }
+
+        function showError(message) {
+            document.getElementById('table-body').innerHTML = `
+                <tr><td colspan="6"><div class="error">${message}</div></td></tr>
+            `;
+        }
+
+        document.getElementById('include').addEventListener('input', (e) => {
+            includePattern = e.target.value;
+            updateUrl();
+            render();
+        });
+
+        document.getElementById('exclude').addEventListener('input', (e) => {
+            excludePattern = e.target.value;
+            updateUrl();
+            render();
+        });
+
+        document.querySelectorAll('.filter-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                currentFilter = btn.dataset.filter;
+                updateUrl();
+                render();
+            });
+        });
+
+        document.querySelectorAll('th[data-sort]').forEach(th => {
+            th.addEventListener('click', () => {
+                const field = th.dataset.sort;
+                if (currentSort.field === field) {
+                    currentSort.asc = !currentSort.asc;
+                } else {
+                    currentSort.field = field;
+                    currentSort.asc = field === 'name';
+                }
+
+                document.querySelectorAll('th[data-sort]').forEach(t => {
+                    t.classList.remove('sorted');
+                    t.querySelector('.sort-icon').textContent = '↕';
+                });
+                th.classList.add('sorted');
+                th.querySelector('.sort-icon').textContent = currentSort.asc ? '↑' : '↓';
+
+                updateUrl();
+                render();
+            });
+        });
+
+        async function init() {
+            try {
+                const response = await fetch('flakes-daily-latest.json');
+                if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                const data = await response.json();
+
+                jobs = Object.entries(data).map(([name, info]) => ({
+                    name,
+                    consistency: info.consistency,
+                    flakes: info.flakes,
+                    testFlakes: info.test_flakes
+                }));
+
+                maxFlakes = Math.max(...jobs.map(j => j.flakes));
+
+                loadFromUrl();
+                render();
+            } catch (err) {
+                showError(`Failed to load data: ${err.message}<br><small>Make sure flakes-daily-latest.json is in the same directory</small>`);
+            }
+        }
+
+        init();
+    </script>
+</body>
+</html>

--- a/metrics/web/flakes-latest.html
+++ b/metrics/web/flakes-latest.html
@@ -1,0 +1,743 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kubernetes CI Weekly Flakes Dashboard</title>
+    <style>
+        :root {
+            --critical: #dc2626;
+            --severe: #ea580c;
+            --warning: #d97706;
+            --moderate: #ca8a04;
+            --low: #65a30d;
+            --bg-dark: #1e293b;
+            --bg-card: #334155;
+            --text-primary: #f1f5f9;
+            --text-secondary: #94a3b8;
+            --border: #475569;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--bg-dark);
+            color: var(--text-primary);
+            line-height: 1.6;
+            padding: 20px;
+        }
+
+        .container {
+            max-width: 1800px;
+            margin: 0 auto;
+        }
+
+        header {
+            display: flex;
+            align-items: baseline;
+            gap: 16px;
+            margin-bottom: 16px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        h1 {
+            font-size: 1.4rem;
+            font-weight: 600;
+            margin: 0;
+        }
+
+        .subtitle {
+            color: var(--text-secondary);
+            font-size: 0.8rem;
+        }
+
+        .subtitle a {
+            color: var(--text-secondary);
+        }
+
+        .nav-links {
+            margin-left: auto;
+            display: flex;
+            gap: 16px;
+        }
+
+        .nav-links a {
+            color: #60a5fa;
+            text-decoration: none;
+            font-size: 0.85rem;
+        }
+
+        .nav-links a:hover {
+            text-decoration: underline;
+        }
+
+        .stats-grid {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 16px;
+            flex-wrap: wrap;
+        }
+
+        .stat-card {
+            background: var(--bg-card);
+            border-radius: 8px;
+            padding: 8px 16px;
+            text-align: center;
+            border: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .stat-value {
+            font-size: 1.2rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--text-secondary);
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+        }
+
+        .controls {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 12px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        .search-box {
+            flex: 1;
+            min-width: 200px;
+            max-width: 350px;
+        }
+
+        .search-box input {
+            width: 100%;
+            padding: 8px 12px;
+            border-radius: 6px;
+            border: 1px solid var(--border);
+            background: var(--bg-card);
+            color: var(--text-primary);
+            font-size: 0.85rem;
+        }
+
+        .search-box input::placeholder {
+            color: var(--text-secondary);
+        }
+
+        .search-box input:focus {
+            outline: none;
+            border-color: #3b82f6;
+        }
+
+        .filter-group {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+
+        .filter-btn {
+            padding: 5px 12px;
+            border-radius: 14px;
+            border: 1px solid var(--border);
+            background: var(--bg-card);
+            color: var(--text-primary);
+            cursor: pointer;
+            font-size: 0.75rem;
+            transition: all 0.2s;
+        }
+
+        .filter-btn:hover {
+            background: var(--border);
+        }
+
+        .filter-btn.active {
+            background: #3b82f6;
+            border-color: #3b82f6;
+        }
+
+        .table-container {
+            background: var(--bg-card);
+            border-radius: 12px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        th, td {
+            padding: 8px 12px;
+            text-align: left;
+        }
+
+        th {
+            background: rgba(0,0,0,0.2);
+            font-weight: 600;
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            user-select: none;
+            position: sticky;
+            top: 0;
+        }
+
+        th:hover {
+            background: rgba(0,0,0,0.3);
+        }
+
+        th .sort-icon {
+            margin-left: 8px;
+            opacity: 0.5;
+        }
+
+        th.sorted .sort-icon {
+            opacity: 1;
+        }
+
+        tr {
+            border-bottom: 1px solid var(--border);
+        }
+
+        tr:last-child {
+            border-bottom: none;
+        }
+
+        tr:hover {
+            background: rgba(255,255,255,0.03);
+        }
+
+        .job-name {
+            font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+            font-size: 0.9rem;
+            word-break: break-all;
+        }
+
+        .job-link {
+            color: #60a5fa;
+            text-decoration: none;
+        }
+
+        .job-link:hover {
+            text-decoration: underline;
+        }
+
+        .code-link {
+            margin-left: 6px;
+            text-decoration: none;
+            opacity: 0.5;
+            font-size: 0.85em;
+        }
+
+        .code-link:hover {
+            opacity: 1;
+        }
+
+        .num-cell {
+            text-align: right;
+            font-weight: 600;
+            font-variant-numeric: tabular-nums;
+        }
+
+        .consistency-badge {
+            display: inline-block;
+            padding: 4px 12px;
+            border-radius: 12px;
+            font-size: 0.8rem;
+            font-weight: 500;
+        }
+
+        .consistency-critical { background: var(--critical); }
+        .consistency-severe { background: var(--severe); }
+        .consistency-warning { background: var(--warning); }
+        .consistency-moderate { background: var(--moderate); }
+        .consistency-good { background: var(--low); }
+
+        .bar-cell {
+            width: 150px;
+        }
+
+        .bar-container {
+            height: 8px;
+            background: rgba(255,255,255,0.1);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+
+        .bar-fill {
+            height: 100%;
+            border-radius: 4px;
+            transition: width 0.3s ease;
+        }
+
+        .test-flakes {
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+            max-width: 400px;
+        }
+
+        .test-flakes-toggle {
+            cursor: pointer;
+            color: #60a5fa;
+            font-size: 0.75rem;
+        }
+
+        .test-flakes-list {
+            display: none;
+            margin-top: 4px;
+            padding-left: 12px;
+            border-left: 2px solid var(--border);
+        }
+
+        .test-flakes-list.expanded {
+            display: block;
+        }
+
+        .test-flake-item {
+            margin: 2px 0;
+            font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+            font-size: 0.7rem;
+        }
+
+        .count-display {
+            text-align: center;
+            padding: 20px;
+            color: var(--text-secondary);
+        }
+
+        .legend {
+            display: flex;
+            gap: 12px;
+            justify-content: flex-start;
+            margin-bottom: 12px;
+            flex-wrap: wrap;
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            font-size: 0.7rem;
+            color: var(--text-secondary);
+        }
+
+        .legend-color {
+            width: 10px;
+            height: 10px;
+            border-radius: 2px;
+        }
+
+        .loading {
+            text-align: center;
+            padding: 60px 20px;
+            color: var(--text-secondary);
+        }
+
+        .loading-spinner {
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            border: 3px solid var(--border);
+            border-top-color: #3b82f6;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            margin-bottom: 12px;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        .error {
+            text-align: center;
+            padding: 40px 20px;
+            color: var(--critical);
+        }
+
+        @media (max-width: 768px) {
+            .bar-cell, .test-flakes {
+                display: none;
+            }
+
+            th, td {
+                padding: 10px 12px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Kubernetes CI Weekly Flakes Dashboard</h1>
+            <p class="subtitle">Data from <a href="flakes-latest.json">flakes-latest.json</a></p>
+            <div class="nav-links">
+                <a href="index.html">Index</a>
+                <a href="failures-latest.html">Failures</a>
+                <a href="flakes-daily-latest.html">Flakes (Daily)</a>
+            </div>
+        </header>
+
+        <div class="stats-grid" id="stats-grid"></div>
+
+        <div class="legend">
+            <div class="legend-item"><div class="legend-color" style="background: var(--critical)"></div>Critical (&lt;50%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--severe)"></div>Severe (50-69%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--warning)"></div>Warning (70-84%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--moderate)"></div>Moderate (85-94%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--low)"></div>Good (95%+)</div>
+        </div>
+
+        <div class="controls">
+            <div class="search-box">
+                <input type="text" id="include" placeholder="Include regex (e.g., pull-kubernetes|ci-)">
+            </div>
+            <div class="search-box">
+                <input type="text" id="exclude" placeholder="Exclude regex (e.g., azure|aws)">
+            </div>
+            <div class="filter-group">
+                <button class="filter-btn active" data-filter="all">All</button>
+                <button class="filter-btn" data-filter="critical">Critical</button>
+                <button class="filter-btn" data-filter="severe">Severe</button>
+                <button class="filter-btn" data-filter="warning">Warning</button>
+                <button class="filter-btn" data-filter="moderate">Moderate</button>
+                <button class="filter-btn" data-filter="good">Good</button>
+            </div>
+        </div>
+
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th data-sort="name">Job Name <span class="sort-icon">↕</span></th>
+                        <th data-sort="consistency">Consistency <span class="sort-icon">↕</span></th>
+                        <th data-sort="flakes" class="sorted">Flakes <span class="sort-icon">↓</span></th>
+                        <th class="bar-cell">Consistency</th>
+                        <th>Test Flakes</th>
+                    </tr>
+                </thead>
+                <tbody id="table-body">
+                    <tr>
+                        <td colspan="6">
+                            <div class="loading">
+                                <div class="loading-spinner"></div>
+                                <div>Loading flakes data...</div>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="count-display" id="count-display"></div>
+    </div>
+
+    <script>
+        let jobs = [];
+        let maxFlakes = 0;
+
+        function getConsistencyLevel(consistency) {
+            if (consistency < 0.5) return 'critical';
+            if (consistency < 0.7) return 'severe';
+            if (consistency < 0.85) return 'warning';
+            if (consistency < 0.95) return 'moderate';
+            return 'good';
+        }
+
+        function getConsistencyLabel(consistency) {
+            if (consistency < 0.5) return 'Critical';
+            if (consistency < 0.7) return 'Severe';
+            if (consistency < 0.85) return 'Warning';
+            if (consistency < 0.95) return 'Moderate';
+            return 'Good';
+        }
+
+        function getConsistencyRank(consistency) {
+            if (consistency < 0.5) return 5;
+            if (consistency < 0.7) return 4;
+            if (consistency < 0.85) return 3;
+            if (consistency < 0.95) return 2;
+            return 1;
+        }
+
+        function getBarColor(consistency) {
+            if (consistency < 0.5) return 'var(--critical)';
+            if (consistency < 0.7) return 'var(--severe)';
+            if (consistency < 0.85) return 'var(--warning)';
+            if (consistency < 0.95) return 'var(--moderate)';
+            return 'var(--low)';
+        }
+
+        function getJobUrl(name) {
+            if (name.startsWith('pr:')) {
+                return `https://prow.k8s.io/?job=${encodeURIComponent(name.substring(3))}`;
+            }
+            return `https://prow.k8s.io/?job=${encodeURIComponent(name)}`;
+        }
+
+        function getCodeSearchUrl(name) {
+            const jobName = name.startsWith('pr:') ? name.substring(3) : name;
+            return `https://cs.k8s.io/?q=${encodeURIComponent(jobName)}&i=nope&literal=nope&files=&excludeFiles=&repos=kubernetes/test-infra`;
+        }
+
+        function updateStats(filteredJobs) {
+            const stats = {
+                total: filteredJobs.length,
+                critical: filteredJobs.filter(j => j.consistency < 0.5).length,
+                severe: filteredJobs.filter(j => j.consistency >= 0.5 && j.consistency < 0.7).length,
+                warning: filteredJobs.filter(j => j.consistency >= 0.7 && j.consistency < 0.85).length,
+                moderate: filteredJobs.filter(j => j.consistency >= 0.85 && j.consistency < 0.95).length,
+                good: filteredJobs.filter(j => j.consistency >= 0.95).length,
+                totalFlakes: filteredJobs.reduce((s, j) => s + j.flakes, 0)
+            };
+
+            document.getElementById('stats-grid').innerHTML = `
+                <div class="stat-card">
+                    <div class="stat-value">${stats.total.toLocaleString()}</div>
+                    <div class="stat-label">Total Jobs</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value">${stats.totalFlakes.toLocaleString()}</div>
+                    <div class="stat-label">Total Flakes</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--critical)">${stats.critical}</div>
+                    <div class="stat-label">Critical (&lt;50%)</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--severe)">${stats.severe}</div>
+                    <div class="stat-label">Severe (50-69%)</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--warning)">${stats.warning}</div>
+                    <div class="stat-label">Warning (70-84%)</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value" style="color: var(--low)">${stats.good}</div>
+                    <div class="stat-label">Good (95%+)</div>
+                </div>
+            `;
+        }
+
+        let currentSort = { field: 'flakes', asc: false };
+        let currentFilter = 'all';
+        let includePattern = '';
+        let excludePattern = '';
+
+        function updateUrl() {
+            const params = new URLSearchParams();
+            if (includePattern) params.set('include', includePattern);
+            if (excludePattern) params.set('exclude', excludePattern);
+            if (currentFilter !== 'all') params.set('filter', currentFilter);
+            params.set('sort', currentSort.field);
+            params.set('asc', currentSort.asc ? '1' : '0');
+            const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+            window.history.replaceState({}, '', newUrl);
+        }
+
+        function loadFromUrl() {
+            const params = new URLSearchParams(window.location.search);
+            includePattern = params.get('include') || '';
+            excludePattern = params.get('exclude') || '';
+            currentFilter = params.get('filter') || 'all';
+            currentSort.field = params.get('sort') || 'flakes';
+            currentSort.asc = params.get('asc') === '1';
+
+            document.getElementById('include').value = includePattern;
+            document.getElementById('exclude').value = excludePattern;
+            document.querySelectorAll('.filter-btn').forEach(b => {
+                b.classList.toggle('active', b.dataset.filter === currentFilter);
+            });
+            document.querySelectorAll('th[data-sort]').forEach(th => {
+                const isActive = th.dataset.sort === currentSort.field;
+                th.classList.toggle('sorted', isActive);
+                th.querySelector('.sort-icon').textContent = isActive ? (currentSort.asc ? '↑' : '↓') : '↕';
+            });
+        }
+
+        function tryRegex(pattern, text) {
+            if (!pattern) return null;
+            try {
+                return new RegExp(pattern, 'i').test(text);
+            } catch (e) {
+                return null;
+            }
+        }
+
+        function filterAndSort() {
+            let filtered = [...jobs];
+
+            if (includePattern) {
+                filtered = filtered.filter(j => {
+                    const result = tryRegex(includePattern, j.name);
+                    return result === null ? true : result;
+                });
+            }
+
+            if (excludePattern) {
+                filtered = filtered.filter(j => {
+                    const result = tryRegex(excludePattern, j.name);
+                    return result === null ? true : !result;
+                });
+            }
+
+            if (currentFilter !== 'all') {
+                filtered = filtered.filter(j => getConsistencyLevel(j.consistency) === currentFilter);
+            }
+
+            filtered.sort((a, b) => {
+                let cmp;
+                if (currentSort.field === 'name') {
+                    cmp = a.name.localeCompare(b.name);
+                } else if (currentSort.field === 'consistency') {
+                    cmp = a.consistency - b.consistency;
+                } else {
+                    cmp = a.flakes - b.flakes;
+                }
+                return currentSort.asc ? cmp : -cmp;
+            });
+
+            return filtered;
+        }
+
+        function renderTestFlakes(testFlakes, idx) {
+            if (!testFlakes || Object.keys(testFlakes).length === 0) {
+                return '<span style="color: var(--text-secondary)">—</span>';
+            }
+            const entries = Object.entries(testFlakes).sort((a, b) => b[1] - a[1]);
+            const count = entries.length;
+            const listItems = entries.map(([test, cnt]) =>
+                `<div class="test-flake-item">${cnt}× ${test}</div>`
+            ).join('');
+
+            return `
+                <span class="test-flakes-toggle" onclick="toggleTestFlakes(${idx})">${count} test${count > 1 ? 's' : ''} ▼</span>
+                <div class="test-flakes-list" id="test-flakes-${idx}">${listItems}</div>
+            `;
+        }
+
+        window.toggleTestFlakes = function(idx) {
+            const list = document.getElementById(`test-flakes-${idx}`);
+            list.classList.toggle('expanded');
+        };
+
+        function render() {
+            const filtered = filterAndSort();
+            updateStats(filtered);
+
+            const tbody = document.getElementById('table-body');
+            tbody.innerHTML = filtered.map((job, idx) => `
+                <tr>
+                    <td>${idx + 1}</td>
+                    <td class="job-name">
+                        <a href="${getJobUrl(job.name)}" target="_blank" class="job-link">${job.name}</a>
+                        <a href="${getCodeSearchUrl(job.name)}" target="_blank" class="code-link" title="Search in test-infra">&#128269;</a>
+                    </td>
+                    <td class="num-cell">
+                        <span class="consistency-badge consistency-${getConsistencyLevel(job.consistency)}">
+                            ${(job.consistency * 100).toFixed(1)}%
+                        </span>
+                    </td>
+                    <td class="num-cell">${job.flakes}</td>
+                    <td class="bar-cell">
+                        <div class="bar-container">
+                            <div class="bar-fill" style="width: ${(job.consistency * 100).toFixed(1)}%; background: ${getBarColor(job.consistency)}"></div>
+                        </div>
+                    </td>
+                    <td class="test-flakes">${renderTestFlakes(job.testFlakes, idx)}</td>
+                </tr>
+            `).join('');
+
+            document.getElementById('count-display').textContent =
+                `Showing ${filtered.length} of ${jobs.length} jobs`;
+        }
+
+        function showError(message) {
+            document.getElementById('table-body').innerHTML = `
+                <tr><td colspan="6"><div class="error">${message}</div></td></tr>
+            `;
+        }
+
+        document.getElementById('include').addEventListener('input', (e) => {
+            includePattern = e.target.value;
+            updateUrl();
+            render();
+        });
+
+        document.getElementById('exclude').addEventListener('input', (e) => {
+            excludePattern = e.target.value;
+            updateUrl();
+            render();
+        });
+
+        document.querySelectorAll('.filter-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                currentFilter = btn.dataset.filter;
+                updateUrl();
+                render();
+            });
+        });
+
+        document.querySelectorAll('th[data-sort]').forEach(th => {
+            th.addEventListener('click', () => {
+                const field = th.dataset.sort;
+                if (currentSort.field === field) {
+                    currentSort.asc = !currentSort.asc;
+                } else {
+                    currentSort.field = field;
+                    currentSort.asc = field === 'name';
+                }
+
+                document.querySelectorAll('th[data-sort]').forEach(t => {
+                    t.classList.remove('sorted');
+                    t.querySelector('.sort-icon').textContent = '↕';
+                });
+                th.classList.add('sorted');
+                th.querySelector('.sort-icon').textContent = currentSort.asc ? '↑' : '↓';
+
+                updateUrl();
+                render();
+            });
+        });
+
+        async function init() {
+            try {
+                const response = await fetch('flakes-latest.json');
+                if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                const data = await response.json();
+
+                jobs = Object.entries(data).map(([name, info]) => ({
+                    name,
+                    consistency: info.consistency,
+                    flakes: info.flakes,
+                    testFlakes: info.test_flakes
+                }));
+
+                maxFlakes = Math.max(...jobs.map(j => j.flakes));
+
+                loadFromUrl();
+                render();
+            } catch (err) {
+                showError(`Failed to load data: ${err.message}<br><small>Make sure flakes-latest.json is in the same directory</small>`);
+            }
+        }
+
+        init();
+    </script>
+</body>
+</html>

--- a/metrics/web/index.html
+++ b/metrics/web/index.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kubernetes CI Metrics Dashboards</title>
+    <style>
+        :root {
+            --bg-dark: #1e293b;
+            --bg-card: #334155;
+            --text-primary: #f1f5f9;
+            --text-secondary: #94a3b8;
+            --border: #475569;
+            --link: #60a5fa;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--bg-dark);
+            color: var(--text-primary);
+            line-height: 1.6;
+            padding: 40px 20px;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            font-size: 1.8rem;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+
+        .subtitle {
+            color: var(--text-secondary);
+            font-size: 0.9rem;
+            margin-bottom: 32px;
+        }
+
+        .subtitle a {
+            color: var(--link);
+            text-decoration: none;
+        }
+
+        .subtitle a:hover {
+            text-decoration: underline;
+        }
+
+        h2 {
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: var(--text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 16px;
+            margin-top: 32px;
+        }
+
+        h2:first-of-type {
+            margin-top: 0;
+        }
+
+        .card-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 16px;
+        }
+
+        .card {
+            background: var(--bg-card);
+            border-radius: 12px;
+            padding: 20px;
+            border: 1px solid var(--border);
+            text-decoration: none;
+            color: var(--text-primary);
+            transition: all 0.2s;
+        }
+
+        .card:hover {
+            border-color: var(--link);
+            transform: translateY(-2px);
+        }
+
+        .card-title {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin-bottom: 8px;
+            color: var(--link);
+        }
+
+        .card-desc {
+            font-size: 0.85rem;
+            color: var(--text-secondary);
+        }
+
+        .json-list {
+            list-style: none;
+        }
+
+        .json-list li {
+            margin: 8px 0;
+        }
+
+        .json-list a {
+            color: var(--link);
+            text-decoration: none;
+            font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+            font-size: 0.9rem;
+        }
+
+        .json-list a:hover {
+            text-decoration: underline;
+        }
+
+        .json-desc {
+            color: var(--text-secondary);
+            font-size: 0.8rem;
+            margin-left: 8px;
+        }
+
+        .section {
+            background: var(--bg-card);
+            border-radius: 12px;
+            padding: 20px;
+            border: 1px solid var(--border);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Kubernetes CI Metrics Dashboards</h1>
+        <p class="subtitle">
+            Interactive dashboards for CI job health data from
+            <a href="https://console.cloud.google.com/storage/browser/k8s-metrics" target="_blank">gs://k8s-metrics</a>
+        </p>
+
+        <h2>Dashboards</h2>
+        <div class="card-grid">
+            <a href="failures-latest.html" class="card">
+                <div class="card-title">Failures Dashboard</div>
+                <div class="card-desc">
+                    Jobs that have been consistently failing, sorted by number of consecutive failing days.
+                    Helps identify long-standing broken jobs that need attention.
+                </div>
+            </a>
+            <a href="flakes-latest.html" class="card">
+                <div class="card-title">Weekly Flakes Dashboard</div>
+                <div class="card-desc">
+                    Jobs with flaky test results over the past week. Shows consistency percentage
+                    and individual flaky tests within each job.
+                </div>
+            </a>
+            <a href="flakes-daily-latest.html" class="card">
+                <div class="card-title">Daily Flakes Dashboard</div>
+                <div class="card-desc">
+                    Jobs with flaky test results from the past day. Useful for catching
+                    newly introduced flakiness before it becomes chronic.
+                </div>
+            </a>
+            <a href="job-health-latest.html" class="card">
+                <div class="card-title">Job Health Dashboard</div>
+                <div class="card-desc">
+                    Daily snapshot of all CI jobs showing run counts, failure rates,
+                    test counts, and duration percentiles (p50, p75, p99).
+                </div>
+            </a>
+            <a href="presubmit-health-latest.html" class="card">
+                <div class="card-title">Presubmit Health Dashboard</div>
+                <div class="card-desc">
+                    Presubmit job health metrics showing PR failure rates, run counts,
+                    and average run times to help identify problematic presubmits.
+                </div>
+            </a>
+        </div>
+
+        <h2>Raw Data (JSON)</h2>
+        <div class="section">
+            <ul class="json-list">
+                <li>
+                    <a href="failures-latest.json">failures-latest.json</a>
+                    <span class="json-desc">— Jobs failing for consecutive days</span>
+                </li>
+                <li>
+                    <a href="flakes-latest.json">flakes-latest.json</a>
+                    <span class="json-desc">— Weekly flake data with test-level details</span>
+                </li>
+                <li>
+                    <a href="flakes-daily-latest.json">flakes-daily-latest.json</a>
+                    <span class="json-desc">— Daily flake data with test-level details</span>
+                </li>
+                <li>
+                    <a href="job-health-latest.json">job-health-latest.json</a>
+                    <span class="json-desc">— Daily job health with failure rates and durations</span>
+                </li>
+                <li>
+                    <a href="presubmit-health-latest.json">presubmit-health-latest.json</a>
+                    <span class="json-desc">— Presubmit job health with PR failure rates</span>
+                </li>
+            </ul>
+        </div>
+    </div>
+</body>
+</html>

--- a/metrics/web/job-health-latest.html
+++ b/metrics/web/job-health-latest.html
@@ -1,0 +1,440 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kubernetes CI Job Health Dashboard</title>
+    <style>
+        :root {
+            --critical: #dc2626;
+            --severe: #ea580c;
+            --warning: #d97706;
+            --moderate: #ca8a04;
+            --low: #65a30d;
+            --bg-dark: #1e293b;
+            --bg-card: #334155;
+            --text-primary: #f1f5f9;
+            --text-secondary: #94a3b8;
+            --border: #475569;
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--bg-dark);
+            color: var(--text-primary);
+            line-height: 1.6;
+            padding: 20px;
+        }
+
+        .container { max-width: 1800px; margin: 0 auto; }
+
+        header {
+            display: flex;
+            align-items: baseline;
+            gap: 16px;
+            margin-bottom: 16px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        h1 { font-size: 1.4rem; font-weight: 600; margin: 0; }
+
+        .subtitle { color: var(--text-secondary); font-size: 0.8rem; }
+        .subtitle a { color: var(--text-secondary); }
+
+        .nav-links { margin-left: auto; display: flex; gap: 16px; }
+        .nav-links a { color: #60a5fa; text-decoration: none; font-size: 0.85rem; }
+        .nav-links a:hover { text-decoration: underline; }
+
+        .stats-grid { display: flex; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; }
+
+        .stat-card {
+            background: var(--bg-card);
+            border-radius: 8px;
+            padding: 8px 16px;
+            border: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .stat-value { font-size: 1.2rem; font-weight: 700; }
+        .stat-label { color: var(--text-secondary); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.3px; }
+
+        .controls { display: flex; gap: 12px; margin-bottom: 12px; flex-wrap: wrap; align-items: center; }
+
+        .search-box { flex: 1; min-width: 200px; max-width: 350px; }
+        .search-box input {
+            width: 100%;
+            padding: 8px 12px;
+            border-radius: 6px;
+            border: 1px solid var(--border);
+            background: var(--bg-card);
+            color: var(--text-primary);
+            font-size: 0.85rem;
+        }
+        .search-box input::placeholder { color: var(--text-secondary); }
+        .search-box input:focus { outline: none; border-color: #3b82f6; }
+
+        .filter-group { display: flex; gap: 8px; flex-wrap: wrap; }
+        .filter-btn {
+            padding: 5px 12px;
+            border-radius: 14px;
+            border: 1px solid var(--border);
+            background: var(--bg-card);
+            color: var(--text-primary);
+            cursor: pointer;
+            font-size: 0.75rem;
+            transition: all 0.2s;
+        }
+        .filter-btn:hover { background: var(--border); }
+        .filter-btn.active { background: #3b82f6; border-color: #3b82f6; }
+
+        .table-container {
+            background: var(--bg-card);
+            border-radius: 12px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+        }
+
+        table { width: 100%; border-collapse: collapse; }
+        th, td { padding: 8px 12px; text-align: left; }
+
+        th {
+            background: rgba(0,0,0,0.2);
+            font-weight: 600;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            user-select: none;
+            position: sticky;
+            top: 0;
+        }
+        th:hover { background: rgba(0,0,0,0.3); }
+        th .sort-icon { margin-left: 8px; opacity: 0.5; }
+        th.sorted .sort-icon { opacity: 1; }
+
+        tr { border-bottom: 1px solid var(--border); }
+        tr:last-child { border-bottom: none; }
+        tr:hover { background: rgba(255,255,255,0.03); }
+
+        .job-name { font-family: 'SF Mono', Monaco, 'Courier New', monospace; font-size: 0.85rem; word-break: break-all; }
+        .job-link { color: #60a5fa; text-decoration: none; }
+        .job-link:hover { text-decoration: underline; }
+        .code-link { margin-left: 6px; text-decoration: none; opacity: 0.5; font-size: 0.85em; }
+        .code-link:hover { opacity: 1; }
+
+        .num-cell { text-align: right; font-weight: 600; font-variant-numeric: tabular-nums; font-size: 0.85rem; }
+
+        .rate-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 0.75rem;
+            font-weight: 500;
+        }
+        .rate-good { background: var(--low); }
+        .rate-moderate { background: var(--moderate); }
+        .rate-warning { background: var(--warning); }
+        .rate-severe { background: var(--severe); }
+        .rate-critical { background: var(--critical); }
+
+        .duration-cell { font-size: 0.8rem; color: var(--text-secondary); }
+
+        .count-display { text-align: center; padding: 20px; color: var(--text-secondary); }
+
+        .legend { display: flex; gap: 12px; justify-content: flex-start; margin-bottom: 12px; flex-wrap: wrap; }
+        .legend-item { display: flex; align-items: center; gap: 4px; font-size: 0.7rem; color: var(--text-secondary); }
+        .legend-color { width: 10px; height: 10px; border-radius: 2px; }
+
+        .loading { text-align: center; padding: 60px 20px; color: var(--text-secondary); }
+        .loading-spinner {
+            display: inline-block;
+            width: 24px; height: 24px;
+            border: 3px solid var(--border);
+            border-top-color: #3b82f6;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            margin-bottom: 12px;
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+
+        .error { text-align: center; padding: 40px 20px; color: var(--critical); }
+
+        @media (max-width: 1200px) {
+            .duration-cell { display: none; }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Kubernetes CI Job Health Dashboard</h1>
+            <p class="subtitle">Data from <a href="job-health-latest.json">job-health-latest.json</a></p>
+            <div class="nav-links">
+                <a href="index.html">Index</a>
+                <a href="failures-latest.html">Failures</a>
+                <a href="flakes-latest.html">Flakes</a>
+                <a href="presubmit-health-latest.html">Presubmit Health</a>
+            </div>
+        </header>
+
+        <div class="stats-grid" id="stats-grid"></div>
+
+        <div class="legend">
+            <div class="legend-item"><div class="legend-color" style="background: var(--low)"></div>Good (0%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--moderate)"></div>Moderate (1-10%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--warning)"></div>Warning (11-25%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--severe)"></div>Severe (26-50%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--critical)"></div>Critical (&gt;50%)</div>
+        </div>
+
+        <div class="controls">
+            <div class="search-box">
+                <input type="text" id="include" placeholder="Include regex (e.g., kubernetes|e2e)">
+            </div>
+            <div class="search-box">
+                <input type="text" id="exclude" placeholder="Exclude regex (e.g., azure|aws)">
+            </div>
+            <div class="filter-group">
+                <button class="filter-btn active" data-filter="all">All</button>
+                <button class="filter-btn" data-filter="critical">Critical</button>
+                <button class="filter-btn" data-filter="severe">Severe</button>
+                <button class="filter-btn" data-filter="warning">Warning</button>
+                <button class="filter-btn" data-filter="moderate">Moderate</button>
+                <button class="filter-btn" data-filter="good">Good</button>
+            </div>
+        </div>
+
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th data-sort="name">Job Name <span class="sort-icon">↕</span></th>
+                        <th data-sort="runs">Runs <span class="sort-icon">↕</span></th>
+                        <th data-sort="failure_rate" class="sorted">Fail Rate <span class="sort-icon">↓</span></th>
+                        <th data-sort="tests">Tests <span class="sort-icon">↕</span></th>
+                        <th data-sort="test_failure_rate">Test Fail <span class="sort-icon">↕</span></th>
+                        <th class="duration-cell">p50</th>
+                        <th class="duration-cell">p75</th>
+                        <th class="duration-cell">p99</th>
+                    </tr>
+                </thead>
+                <tbody id="table-body">
+                    <tr><td colspan="9"><div class="loading"><div class="loading-spinner"></div><div>Loading job health data...</div></div></td></tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="count-display" id="count-display"></div>
+    </div>
+
+    <script>
+        let jobs = [];
+
+        function getHealthLevel(rate) {
+            if (rate === 0) return 'good';
+            if (rate <= 0.1) return 'moderate';
+            if (rate <= 0.25) return 'warning';
+            if (rate <= 0.5) return 'severe';
+            return 'critical';
+        }
+
+        function getHealthRank(rate) {
+            if (rate === 0) return 1;
+            if (rate <= 0.1) return 2;
+            if (rate <= 0.25) return 3;
+            if (rate <= 0.5) return 4;
+            return 5;
+        }
+
+        function formatDuration(minutes) {
+            if (minutes < 1) return `${(minutes * 60).toFixed(0)}s`;
+            if (minutes < 60) return `${minutes.toFixed(1)}m`;
+            return `${(minutes / 60).toFixed(1)}h`;
+        }
+
+        function getJobUrl(name) {
+            const jobName = name.startsWith('pr:') ? name.substring(3) : name;
+            return `https://prow.k8s.io/?job=${encodeURIComponent(jobName)}`;
+        }
+
+        function getCodeSearchUrl(name) {
+            const jobName = name.startsWith('pr:') ? name.substring(3) : name;
+            return `https://cs.k8s.io/?q=${encodeURIComponent(jobName)}&i=nope&literal=nope&files=&excludeFiles=&repos=kubernetes/test-infra`;
+        }
+
+        function updateStats(filteredJobs) {
+            const stats = {
+                total: filteredJobs.length,
+                totalRuns: filteredJobs.reduce((s, j) => s + j.runs, 0),
+                critical: filteredJobs.filter(j => j.failure_rate > 0.5).length,
+                severe: filteredJobs.filter(j => j.failure_rate > 0.25 && j.failure_rate <= 0.5).length,
+                warning: filteredJobs.filter(j => j.failure_rate > 0.1 && j.failure_rate <= 0.25).length,
+                good: filteredJobs.filter(j => j.failure_rate === 0).length
+            };
+
+            document.getElementById('stats-grid').innerHTML = `
+                <div class="stat-card"><div class="stat-value">${stats.total.toLocaleString()}</div><div class="stat-label">Total Jobs</div></div>
+                <div class="stat-card"><div class="stat-value">${stats.totalRuns.toLocaleString()}</div><div class="stat-label">Total Runs</div></div>
+                <div class="stat-card"><div class="stat-value" style="color: var(--critical)">${stats.critical}</div><div class="stat-label">Critical (&gt;50%)</div></div>
+                <div class="stat-card"><div class="stat-value" style="color: var(--severe)">${stats.severe}</div><div class="stat-label">Severe (26-50%)</div></div>
+                <div class="stat-card"><div class="stat-value" style="color: var(--warning)">${stats.warning}</div><div class="stat-label">Warning (11-25%)</div></div>
+                <div class="stat-card"><div class="stat-value" style="color: var(--low)">${stats.good}</div><div class="stat-label">Good (0%)</div></div>
+            `;
+        }
+
+        let currentSort = { field: 'failure_rate', asc: false };
+        let currentFilter = 'all';
+        let includePattern = '';
+        let excludePattern = '';
+
+        function updateUrl() {
+            const params = new URLSearchParams();
+            if (includePattern) params.set('include', includePattern);
+            if (excludePattern) params.set('exclude', excludePattern);
+            if (currentFilter !== 'all') params.set('filter', currentFilter);
+            params.set('sort', currentSort.field);
+            params.set('asc', currentSort.asc ? '1' : '0');
+            window.history.replaceState({}, '', window.location.pathname + (params.toString() ? '?' + params.toString() : ''));
+        }
+
+        function loadFromUrl() {
+            const params = new URLSearchParams(window.location.search);
+            includePattern = params.get('include') || '';
+            excludePattern = params.get('exclude') || '';
+            currentFilter = params.get('filter') || 'all';
+            currentSort.field = params.get('sort') || 'failure_rate';
+            currentSort.asc = params.get('asc') === '1';
+
+            document.getElementById('include').value = includePattern;
+            document.getElementById('exclude').value = excludePattern;
+            document.querySelectorAll('.filter-btn').forEach(b => b.classList.toggle('active', b.dataset.filter === currentFilter));
+            document.querySelectorAll('th[data-sort]').forEach(th => {
+                const isActive = th.dataset.sort === currentSort.field;
+                th.classList.toggle('sorted', isActive);
+                th.querySelector('.sort-icon').textContent = isActive ? (currentSort.asc ? '↑' : '↓') : '↕';
+            });
+        }
+
+        function tryRegex(pattern, text) {
+            if (!pattern) return null;
+            try { return new RegExp(pattern, 'i').test(text); } catch (e) { return null; }
+        }
+
+        function filterAndSort() {
+            let filtered = [...jobs];
+
+            if (includePattern) {
+                filtered = filtered.filter(j => { const r = tryRegex(includePattern, j.name); return r === null ? true : r; });
+            }
+            if (excludePattern) {
+                filtered = filtered.filter(j => { const r = tryRegex(excludePattern, j.name); return r === null ? true : !r; });
+            }
+            if (currentFilter !== 'all') {
+                filtered = filtered.filter(j => getHealthLevel(j.failure_rate) === currentFilter);
+            }
+
+            filtered.sort((a, b) => {
+                let cmp;
+                if (currentSort.field === 'name') cmp = a.name.localeCompare(b.name);
+                else cmp = a[currentSort.field] - b[currentSort.field];
+                return currentSort.asc ? cmp : -cmp;
+            });
+
+            return filtered;
+        }
+
+        function render() {
+            const filtered = filterAndSort();
+            updateStats(filtered);
+
+            const tbody = document.getElementById('table-body');
+            tbody.innerHTML = filtered.map((job, idx) => `
+                <tr>
+                    <td>${idx + 1}</td>
+                    <td class="job-name">
+                        <a href="${getJobUrl(job.name)}" target="_blank" class="job-link">${job.name}</a>
+                        <a href="${getCodeSearchUrl(job.name)}" target="_blank" class="code-link" title="Search in test-infra">&#128269;</a>
+                    </td>
+                    <td class="num-cell">${job.runs}</td>
+                    <td class="num-cell">
+                        <span class="rate-badge rate-${getHealthLevel(job.failure_rate)}">${(job.failure_rate * 100).toFixed(1)}%</span>
+                    </td>
+                    <td class="num-cell">${job.tests || '—'}</td>
+                    <td class="num-cell">${job.test_failure_rate ? `${(job.test_failure_rate * 100).toFixed(1)}%` : '—'}</td>
+                    <td class="duration-cell">${formatDuration(job.p50_duration)}</td>
+                    <td class="duration-cell">${formatDuration(job.p75_duration)}</td>
+                    <td class="duration-cell">${formatDuration(job.p99_duration)}</td>
+                </tr>
+            `).join('');
+
+            document.getElementById('count-display').textContent = `Showing ${filtered.length} of ${jobs.length} jobs`;
+        }
+
+        function showError(message) {
+            document.getElementById('table-body').innerHTML = `<tr><td colspan="9"><div class="error">${message}</div></td></tr>`;
+        }
+
+        document.getElementById('include').addEventListener('input', (e) => { includePattern = e.target.value; updateUrl(); render(); });
+        document.getElementById('exclude').addEventListener('input', (e) => { excludePattern = e.target.value; updateUrl(); render(); });
+
+        document.querySelectorAll('.filter-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                currentFilter = btn.dataset.filter;
+                updateUrl();
+                render();
+            });
+        });
+
+        document.querySelectorAll('th[data-sort]').forEach(th => {
+            th.addEventListener('click', () => {
+                const field = th.dataset.sort;
+                if (currentSort.field === field) currentSort.asc = !currentSort.asc;
+                else { currentSort.field = field; currentSort.asc = field === 'name'; }
+
+                document.querySelectorAll('th[data-sort]').forEach(t => {
+                    t.classList.remove('sorted');
+                    t.querySelector('.sort-icon').textContent = '↕';
+                });
+                th.classList.add('sorted');
+                th.querySelector('.sort-icon').textContent = currentSort.asc ? '↑' : '↓';
+                updateUrl();
+                render();
+            });
+        });
+
+        async function init() {
+            try {
+                const response = await fetch('job-health-latest.json');
+                if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                const data = await response.json();
+
+                jobs = data.map(j => ({
+                    name: j.job,
+                    runs: j.runs,
+                    failure_rate: j.failure_rate,
+                    tests: j.tests,
+                    test_failure_rate: j.test_failure_rate,
+                    p50_duration: j.p50_duration,
+                    p75_duration: j.p75_duration,
+                    p99_duration: j.p99_duration
+                }));
+
+                loadFromUrl();
+                render();
+            } catch (err) {
+                showError(`Failed to load data: ${err.message}<br><small>Make sure job-health-latest.json is in the same directory</small>`);
+            }
+        }
+
+        init();
+    </script>
+</body>
+</html>

--- a/metrics/web/presubmit-health-latest.html
+++ b/metrics/web/presubmit-health-latest.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kubernetes CI Presubmit Health Dashboard</title>
+    <style>
+        :root {
+            --critical: #dc2626;
+            --severe: #ea580c;
+            --warning: #d97706;
+            --moderate: #ca8a04;
+            --low: #65a30d;
+            --bg-dark: #1e293b;
+            --bg-card: #334155;
+            --text-primary: #f1f5f9;
+            --text-secondary: #94a3b8;
+            --border: #475569;
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--bg-dark);
+            color: var(--text-primary);
+            line-height: 1.6;
+            padding: 20px;
+        }
+
+        .container { max-width: 1800px; margin: 0 auto; }
+
+        header {
+            display: flex;
+            align-items: baseline;
+            gap: 16px;
+            margin-bottom: 16px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        h1 { font-size: 1.4rem; font-weight: 600; margin: 0; }
+
+        .subtitle { color: var(--text-secondary); font-size: 0.8rem; }
+        .subtitle a { color: var(--text-secondary); }
+
+        .nav-links { margin-left: auto; display: flex; gap: 16px; }
+        .nav-links a { color: #60a5fa; text-decoration: none; font-size: 0.85rem; }
+        .nav-links a:hover { text-decoration: underline; }
+
+        .stats-grid { display: flex; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; }
+
+        .stat-card {
+            background: var(--bg-card);
+            border-radius: 8px;
+            padding: 8px 16px;
+            border: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .stat-value { font-size: 1.2rem; font-weight: 700; }
+        .stat-label { color: var(--text-secondary); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.3px; }
+
+        .controls { display: flex; gap: 12px; margin-bottom: 12px; flex-wrap: wrap; align-items: center; }
+
+        .search-box { flex: 1; min-width: 200px; max-width: 350px; }
+        .search-box input {
+            width: 100%;
+            padding: 8px 12px;
+            border-radius: 6px;
+            border: 1px solid var(--border);
+            background: var(--bg-card);
+            color: var(--text-primary);
+            font-size: 0.85rem;
+        }
+        .search-box input::placeholder { color: var(--text-secondary); }
+        .search-box input:focus { outline: none; border-color: #3b82f6; }
+
+        .filter-group { display: flex; gap: 8px; flex-wrap: wrap; }
+        .filter-btn {
+            padding: 5px 12px;
+            border-radius: 14px;
+            border: 1px solid var(--border);
+            background: var(--bg-card);
+            color: var(--text-primary);
+            cursor: pointer;
+            font-size: 0.75rem;
+            transition: all 0.2s;
+        }
+        .filter-btn:hover { background: var(--border); }
+        .filter-btn.active { background: #3b82f6; border-color: #3b82f6; }
+
+        .table-container {
+            background: var(--bg-card);
+            border-radius: 12px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+        }
+
+        table { width: 100%; border-collapse: collapse; }
+        th, td { padding: 8px 12px; text-align: left; }
+
+        th {
+            background: rgba(0,0,0,0.2);
+            font-weight: 600;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            user-select: none;
+            position: sticky;
+            top: 0;
+        }
+        th:hover { background: rgba(0,0,0,0.3); }
+        th .sort-icon { margin-left: 8px; opacity: 0.5; }
+        th.sorted .sort-icon { opacity: 1; }
+
+        tr { border-bottom: 1px solid var(--border); }
+        tr:last-child { border-bottom: none; }
+        tr:hover { background: rgba(255,255,255,0.03); }
+
+        .job-name { font-family: 'SF Mono', Monaco, 'Courier New', monospace; font-size: 0.85rem; word-break: break-all; }
+        .job-link { color: #60a5fa; text-decoration: none; }
+        .job-link:hover { text-decoration: underline; }
+        .code-link { margin-left: 6px; text-decoration: none; opacity: 0.5; font-size: 0.85em; }
+        .code-link:hover { opacity: 1; }
+
+        .num-cell { text-align: right; font-weight: 600; font-variant-numeric: tabular-nums; font-size: 0.85rem; }
+
+        .rate-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 0.75rem;
+            font-weight: 500;
+        }
+        .rate-good { background: var(--low); }
+        .rate-moderate { background: var(--moderate); }
+        .rate-warning { background: var(--warning); }
+        .rate-severe { background: var(--severe); }
+        .rate-critical { background: var(--critical); }
+
+        .time-cell { font-size: 0.8rem; color: var(--text-secondary); }
+
+        .count-display { text-align: center; padding: 20px; color: var(--text-secondary); }
+
+        .legend { display: flex; gap: 12px; justify-content: flex-start; margin-bottom: 12px; flex-wrap: wrap; }
+        .legend-item { display: flex; align-items: center; gap: 4px; font-size: 0.7rem; color: var(--text-secondary); }
+        .legend-color { width: 10px; height: 10px; border-radius: 2px; }
+
+        .loading { text-align: center; padding: 60px 20px; color: var(--text-secondary); }
+        .loading-spinner {
+            display: inline-block;
+            width: 24px; height: 24px;
+            border: 3px solid var(--border);
+            border-top-color: #3b82f6;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            margin-bottom: 12px;
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+
+        .error { text-align: center; padding: 40px 20px; color: var(--critical); }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Kubernetes CI Presubmit Health Dashboard</h1>
+            <p class="subtitle">Data from <a href="presubmit-health-latest.json">presubmit-health-latest.json</a></p>
+            <div class="nav-links">
+                <a href="index.html">Index</a>
+                <a href="failures-latest.html">Failures</a>
+                <a href="flakes-latest.html">Flakes</a>
+                <a href="job-health-latest.html">Job Health</a>
+            </div>
+        </header>
+
+        <div class="stats-grid" id="stats-grid"></div>
+
+        <div class="legend">
+            <div class="legend-item"><div class="legend-color" style="background: var(--low)"></div>Good (0%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--moderate)"></div>Moderate (1-25%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--warning)"></div>Warning (26-50%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--severe)"></div>Severe (51-75%)</div>
+            <div class="legend-item"><div class="legend-color" style="background: var(--critical)"></div>Critical (&gt;75%)</div>
+        </div>
+
+        <div class="controls">
+            <div class="search-box">
+                <input type="text" id="include" placeholder="Include regex (e.g., kubernetes|e2e)">
+            </div>
+            <div class="search-box">
+                <input type="text" id="exclude" placeholder="Exclude regex (e.g., azure|aws)">
+            </div>
+            <div class="filter-group">
+                <button class="filter-btn active" data-filter="all">All</button>
+                <button class="filter-btn" data-filter="critical">Critical</button>
+                <button class="filter-btn" data-filter="severe">Severe</button>
+                <button class="filter-btn" data-filter="warning">Warning</button>
+                <button class="filter-btn" data-filter="moderate">Moderate</button>
+                <button class="filter-btn" data-filter="good">Good</button>
+            </div>
+        </div>
+
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th data-sort="name">Job Name <span class="sort-icon">↕</span></th>
+                        <th data-sort="pr_failure_perc" class="sorted">PR Fail % <span class="sort-icon">↓</span></th>
+                        <th data-sort="prs">PRs <span class="sort-icon">↕</span></th>
+                        <th data-sort="prs_failed">Failed <span class="sort-icon">↕</span></th>
+                        <th data-sort="total_runs">Runs <span class="sort-icon">↕</span></th>
+                        <th data-sort="avg_run_time_minutes">Avg Time <span class="sort-icon">↕</span></th>
+                        <th data-sort="avg_pass_time_minutes">Pass Time <span class="sort-icon">↕</span></th>
+                    </tr>
+                </thead>
+                <tbody id="table-body">
+                    <tr><td colspan="8"><div class="loading"><div class="loading-spinner"></div><div>Loading presubmit health data...</div></div></td></tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="count-display" id="count-display"></div>
+    </div>
+
+    <script>
+        let jobs = [];
+
+        function getHealthLevel(rate) {
+            if (rate === 0) return 'good';
+            if (rate <= 25) return 'moderate';
+            if (rate <= 50) return 'warning';
+            if (rate <= 75) return 'severe';
+            return 'critical';
+        }
+
+        function formatTime(minutes) {
+            if (!minutes || minutes === 0) return '—';
+            if (minutes < 1) return `${(minutes * 60).toFixed(0)}s`;
+            if (minutes < 60) return `${minutes.toFixed(1)}m`;
+            return `${(minutes / 60).toFixed(1)}h`;
+        }
+
+        function getJobUrl(name) {
+            const jobName = name.startsWith('pr:') ? name.substring(3) : name;
+            return `https://prow.k8s.io/?job=${encodeURIComponent(jobName)}`;
+        }
+
+        function getCodeSearchUrl(name) {
+            const jobName = name.startsWith('pr:') ? name.substring(3) : name;
+            return `https://cs.k8s.io/?q=${encodeURIComponent(jobName)}&i=nope&literal=nope&files=&excludeFiles=&repos=kubernetes/test-infra`;
+        }
+
+        function updateStats(filteredJobs) {
+            const stats = {
+                total: filteredJobs.length,
+                totalPRs: filteredJobs.reduce((s, j) => s + j.prs, 0),
+                totalRuns: filteredJobs.reduce((s, j) => s + j.total_runs, 0),
+                critical: filteredJobs.filter(j => j.pr_failure_perc > 75).length,
+                severe: filteredJobs.filter(j => j.pr_failure_perc > 50 && j.pr_failure_perc <= 75).length,
+                warning: filteredJobs.filter(j => j.pr_failure_perc > 25 && j.pr_failure_perc <= 50).length,
+                good: filteredJobs.filter(j => j.pr_failure_perc === 0).length
+            };
+
+            document.getElementById('stats-grid').innerHTML = `
+                <div class="stat-card"><div class="stat-value">${stats.total.toLocaleString()}</div><div class="stat-label">Total Jobs</div></div>
+                <div class="stat-card"><div class="stat-value">${stats.totalPRs.toLocaleString()}</div><div class="stat-label">Total PRs</div></div>
+                <div class="stat-card"><div class="stat-value">${stats.totalRuns.toLocaleString()}</div><div class="stat-label">Total Runs</div></div>
+                <div class="stat-card"><div class="stat-value" style="color: var(--critical)">${stats.critical}</div><div class="stat-label">Critical (&gt;75%)</div></div>
+                <div class="stat-card"><div class="stat-value" style="color: var(--severe)">${stats.severe}</div><div class="stat-label">Severe (51-75%)</div></div>
+                <div class="stat-card"><div class="stat-value" style="color: var(--low)">${stats.good}</div><div class="stat-label">Good (0%)</div></div>
+            `;
+        }
+
+        let currentSort = { field: 'pr_failure_perc', asc: false };
+        let currentFilter = 'all';
+        let includePattern = '';
+        let excludePattern = '';
+
+        function updateUrl() {
+            const params = new URLSearchParams();
+            if (includePattern) params.set('include', includePattern);
+            if (excludePattern) params.set('exclude', excludePattern);
+            if (currentFilter !== 'all') params.set('filter', currentFilter);
+            params.set('sort', currentSort.field);
+            params.set('asc', currentSort.asc ? '1' : '0');
+            window.history.replaceState({}, '', window.location.pathname + (params.toString() ? '?' + params.toString() : ''));
+        }
+
+        function loadFromUrl() {
+            const params = new URLSearchParams(window.location.search);
+            includePattern = params.get('include') || '';
+            excludePattern = params.get('exclude') || '';
+            currentFilter = params.get('filter') || 'all';
+            currentSort.field = params.get('sort') || 'pr_failure_perc';
+            currentSort.asc = params.get('asc') === '1';
+
+            document.getElementById('include').value = includePattern;
+            document.getElementById('exclude').value = excludePattern;
+            document.querySelectorAll('.filter-btn').forEach(b => b.classList.toggle('active', b.dataset.filter === currentFilter));
+            document.querySelectorAll('th[data-sort]').forEach(th => {
+                const isActive = th.dataset.sort === currentSort.field;
+                th.classList.toggle('sorted', isActive);
+                th.querySelector('.sort-icon').textContent = isActive ? (currentSort.asc ? '↑' : '↓') : '↕';
+            });
+        }
+
+        function tryRegex(pattern, text) {
+            if (!pattern) return null;
+            try { return new RegExp(pattern, 'i').test(text); } catch (e) { return null; }
+        }
+
+        function filterAndSort() {
+            let filtered = [...jobs];
+
+            if (includePattern) {
+                filtered = filtered.filter(j => { const r = tryRegex(includePattern, j.name); return r === null ? true : r; });
+            }
+            if (excludePattern) {
+                filtered = filtered.filter(j => { const r = tryRegex(excludePattern, j.name); return r === null ? true : !r; });
+            }
+            if (currentFilter !== 'all') {
+                filtered = filtered.filter(j => getHealthLevel(j.pr_failure_perc) === currentFilter);
+            }
+
+            filtered.sort((a, b) => {
+                let cmp;
+                if (currentSort.field === 'name') cmp = a.name.localeCompare(b.name);
+                else cmp = a[currentSort.field] - b[currentSort.field];
+                return currentSort.asc ? cmp : -cmp;
+            });
+
+            return filtered;
+        }
+
+        function render() {
+            const filtered = filterAndSort();
+            updateStats(filtered);
+
+            const tbody = document.getElementById('table-body');
+            tbody.innerHTML = filtered.map((job, idx) => `
+                <tr>
+                    <td>${idx + 1}</td>
+                    <td class="job-name">
+                        <a href="${getJobUrl(job.name)}" target="_blank" class="job-link">${job.name.replace('pr:', '')}</a>
+                        <a href="${getCodeSearchUrl(job.name)}" target="_blank" class="code-link" title="Search in test-infra">&#128269;</a>
+                    </td>
+                    <td class="num-cell">
+                        <span class="rate-badge rate-${getHealthLevel(job.pr_failure_perc)}">${job.pr_failure_perc.toFixed(0)}%</span>
+                    </td>
+                    <td class="num-cell">${job.prs}</td>
+                    <td class="num-cell">${job.prs_failed}</td>
+                    <td class="num-cell">${job.total_runs}</td>
+                    <td class="time-cell">${formatTime(job.avg_run_time_minutes)}</td>
+                    <td class="time-cell">${formatTime(job.avg_pass_time_minutes)}</td>
+                </tr>
+            `).join('');
+
+            document.getElementById('count-display').textContent = `Showing ${filtered.length} of ${jobs.length} jobs`;
+        }
+
+        function showError(message) {
+            document.getElementById('table-body').innerHTML = `<tr><td colspan="8"><div class="error">${message}</div></td></tr>`;
+        }
+
+        document.getElementById('include').addEventListener('input', (e) => { includePattern = e.target.value; updateUrl(); render(); });
+        document.getElementById('exclude').addEventListener('input', (e) => { excludePattern = e.target.value; updateUrl(); render(); });
+
+        document.querySelectorAll('.filter-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                currentFilter = btn.dataset.filter;
+                updateUrl();
+                render();
+            });
+        });
+
+        document.querySelectorAll('th[data-sort]').forEach(th => {
+            th.addEventListener('click', () => {
+                const field = th.dataset.sort;
+                if (currentSort.field === field) currentSort.asc = !currentSort.asc;
+                else { currentSort.field = field; currentSort.asc = field === 'name'; }
+
+                document.querySelectorAll('th[data-sort]').forEach(t => {
+                    t.classList.remove('sorted');
+                    t.querySelector('.sort-icon').textContent = '↕';
+                });
+                th.classList.add('sorted');
+                th.querySelector('.sort-icon').textContent = currentSort.asc ? '↑' : '↓';
+                updateUrl();
+                render();
+            });
+        });
+
+        async function init() {
+            try {
+                const response = await fetch('presubmit-health-latest.json');
+                if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                const data = await response.json();
+
+                jobs = data.map(j => ({
+                    name: j.job,
+                    pr_failure_perc: j.pr_failure_perc,
+                    prs: j.prs,
+                    prs_failed: j.prs_failed,
+                    total_runs: j.total_runs,
+                    avg_run_time_minutes: j.avg_run_time_minutes,
+                    avg_pass_time_minutes: j.avg_pass_time_minutes
+                }));
+
+                loadFromUrl();
+                render();
+            } catch (err) {
+                showError(`Failed to load data: ${err.message}<br><small>Make sure presubmit-health-latest.json is in the same directory</small>`);
+            }
+        }
+
+        init();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add a standalone HTML dashboard for visualizing CI job failures from the k8s-metrics GCS bucket (gs://k8s-metrics/failures-latest.json).

Features:
- Sortable columns (job name, failing days, severity)
- Include/exclude regex filters with URL state persistence
- Severity categorization (Critical: 365+ days, Severe: 180-364, Warning: 90-179, Moderate: 30-89, Low: 1-29)
- Direct links to Prow job pages and cs.k8s.io code search

The dashboard fetches failures-latest.json from the same directory, so both files need to be served together.

To test locally:
```
  gsutil cp gs://k8s-metrics/failures-latest.json metrics/web/
  cd metrics/web && python3 -m http.server 8080
  # Open http://localhost:8080/failures-latest.html
  ```