### PR TITLE
metrics: Reduce redundant "Dashboard" text in index.html

### DIFF
--- a/metrics/web/index.html
+++ b/metrics/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Kubernetes CI Metrics Dashboards</title>
+    <title>Kubernetes CI Metrics</title>
     <style>
         :root {
             --bg-dark: #1e293b;
@@ -136,44 +136,44 @@
 </head>
 <body>
     <div class="container">
-        <h1>Kubernetes CI Metrics Dashboards</h1>
+        <h1>Kubernetes CI Metrics</h1>
         <p class="subtitle">
-            Interactive dashboards for CI job health data from
+            Interactive views for CI job health data from
             <a href="https://console.cloud.google.com/storage/browser/k8s-metrics" target="_blank">gs://k8s-metrics</a>
         </p>
 
         <h2>Dashboards</h2>
         <div class="card-grid">
             <a href="failures-latest.html" class="card">
-                <div class="card-title">Failures Dashboard</div>
+                <div class="card-title">Failures</div>
                 <div class="card-desc">
                     Jobs that have been consistently failing, sorted by number of consecutive failing days.
                     Helps identify long-standing broken jobs that need attention.
                 </div>
             </a>
             <a href="flakes-latest.html" class="card">
-                <div class="card-title">Weekly Flakes Dashboard</div>
+                <div class="card-title">Weekly Flakes</div>
                 <div class="card-desc">
                     Jobs with flaky test results over the past week. Shows consistency percentage
                     and individual flaky tests within each job.
                 </div>
             </a>
             <a href="flakes-daily-latest.html" class="card">
-                <div class="card-title">Daily Flakes Dashboard</div>
+                <div class="card-title">Daily Flakes</div>
                 <div class="card-desc">
                     Jobs with flaky test results from the past day. Useful for catching
                     newly introduced flakiness before it becomes chronic.
                 </div>
             </a>
             <a href="job-health-latest.html" class="card">
-                <div class="card-title">Job Health Dashboard</div>
+                <div class="card-title">Job Health</div>
                 <div class="card-desc">
                     Daily snapshot of all CI jobs showing run counts, failure rates,
                     test counts, and duration percentiles (p50, p75, p99).
                 </div>
             </a>
             <a href="presubmit-health-latest.html" class="card">
-                <div class="card-title">Presubmit Health Dashboard</div>
+                <div class="card-title">Presubmit Health</div>
                 <div class="card-desc">
                     Presubmit job health metrics showing PR failure rates, run counts,
                     and average run times to help identify problematic presubmits.


### PR DESCRIPTION
Simplify the index page by removing repetitive "Dashboard" from title, heading, and card titles. The h2 section header provides sufficient context.

(using this to test if new `post-test-infra-upload-metrics-dashboards` job works fine)