### PR TITLE
Increase testgrid-num-failures-to-alert for k8s-infra canary jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -15,7 +15,7 @@ periodics:
     testgrid-dashboards: sig-k8s-infra-canaries, sig-k8s-infra-registry
     testgrid-days-of-results: '7'
     testgrid-tab-name: registry-sandbox-e2e-gcp
-    testgrid-num-failures-to-alert: '1'
+    testgrid-num-failures-to-alert: '3'
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io
   spec:
     containers:
@@ -48,7 +48,7 @@ periodics:
     testgrid-dashboards: sig-k8s-infra-canaries, sig-k8s-infra-registry
     testgrid-days-of-results: '7'
     testgrid-tab-name: registry-sandbox-e2e-aws
-    testgrid-num-failures-to-alert: '1'
+    testgrid-num-failures-to-alert: '3'
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io
   spec:
     containers:
@@ -82,7 +82,7 @@ periodics:
     testgrid-dashboards: sig-k8s-infra-canaries, sig-k8s-infra-registry
     testgrid-days-of-results: '7'
     testgrid-tab-name: registry-sandbox-e2e-ibm
-    testgrid-num-failures-to-alert: '1'
+    testgrid-num-failures-to-alert: '3'
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io
   spec:
     containers:


### PR DESCRIPTION
As the title says, increase `testgrid-num-failures-to-alert` for jobs defined in `config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml` (`registry-sandbox-e2e-gcp`, `registry-sandbox-e2e-aws`, `registry-sandbox-e2e-ibm`).

These jobs run every 10 min to 1 hour, from time to time, they flake, but the next run is always green. However, every flake triggers an email notification, but such notifications are not actionable and the issue is resolved by itself on the next run. Hence, let's increase the notification threshold to 3. Because these jobs run very frequently, we would still know if something is wrong very fast.

/assign @upodroid 