### PR TITLE
shutdown the development scale jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-gce.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-gce.yaml
@@ -93,215 +93,11 @@ periodics:
         value: "scalability-project"
       resources:
         requests:
-          cpu: "7"
-          memory: "28Gi"
+          cpu: "5"
+          memory: "16Gi"
         limits:
-          cpu: "7"
-          memory: "28Gi"
-
-- name: ci-kubernetes-e2e-kops-gce-3000-ipalias-using-cl2
-  tags:
-  - "perfDashPrefix: gcp-3000Nodes"
-  - "perfDashBuildsCount: 270"
-  - "perfDashJobType: performance"
-  cluster: k8s-infra-prow-build
-  cron: '0 2,14 * * *' # Run twice a day at 02:00 and 14:00 UTC
-  labels:
-    preset-k8s-ssh: "true"
-    preset-dind-enabled: "true"
-  decorate: true
-  decoration_config:
-    timeout: 480m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  - org: kubernetes
-    repo: perf-tests
-    base_ref: master
-    path_alias: k8s.io/perf-tests
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    path_alias: k8s.io/kops
-    workdir: true
-  annotations:
-    test.kops.k8s.io/cloud: gce
-    test.kops.k8s.io/distro: u2404
-    test.kops.k8s.io/k8s_version: stable
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/networking: ipalias
-    testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-gce
-    testgrid-tab-name: gce-master-scale-performance-3000
-    # testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, eks-scalability@amazon.com, release-team@kubernetes.io
-  spec:
-    serviceAccountName: prow-build
-    containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251209-72d275a594-master
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - ./tests/e2e/scenarios/scalability/run-test.sh
-      securityContext:
-        privileged: true
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/ssh-key-secret/ssh-private
-      - name: KUBE_SSH_USER
-        value: prow
-      - name: GOPATH
-        value: /home/prow/go
-      - name: ARTIFACTS
-        value: $(ARTIFACTS)
-      - name: CNI_PLUGIN
-        value: gce
-      - name: KUBE_NODE_COUNT
-        value: "3000"
-      - name: KUBE_PROXY_MODE
-        value: "nftables"
-      - name: CL2_LOAD_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_DELETE_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_RATE_LIMIT_POD_CREATION
-        value: "false"
-      - name: NODE_MODE
-        value: "master"
-      - name: CONTROL_PLANE_COUNT
-        value: "1"
-      - name: CONTROL_PLANE_SIZE
-        value: "c4-standard-96"
-      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-        value: "true"
-      - name: CL2_ENABLE_DNS_PROGRAMMING
-        value: "true"
-      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-        value: "true"
-      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-        value: "99.5"
-      - name: CL2_ALLOWED_SLOW_API_CALLS
-        value: "1"
-      - name: ENABLE_PROMETHEUS_SERVER
-        value: "true"
-      - name: PROMETHEUS_PVC_STORAGE_CLASS
-        value: "ssd-csi"
-      - name: CLOUD_PROVIDER
-        value: "gce"
-      - name: GCP_PROJECT
-        value: "k8s-infra-e2e-boskos-scale-28"
-      # - name: BOSKOS_RESOURCE_TYPE
-      #   value: "scalability-scale-project"
-      resources:
-        requests:
-          cpu: "7"
-          memory: "28Gi"
-        limits:
-          cpu: "7"
-          memory: "28Gi"
-
-- name: ci-kubernetes-e2e-kops-gce-4000-ipalias-using-cl2
-  tags:
-  - "perfDashPrefix: gcp-4000Nodes"
-  - "perfDashBuildsCount: 270"
-  - "perfDashJobType: performance"
-  cluster: k8s-infra-prow-build
-  cron: '0 6,18 * * *' # Run twice a day at 06:00 and 18:00 UTC
-  labels:
-    preset-k8s-ssh: "true"
-    preset-dind-enabled: "true"
-  decorate: true
-  decoration_config:
-    timeout: 480m
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  - org: kubernetes
-    repo: perf-tests
-    base_ref: master
-    path_alias: k8s.io/perf-tests
-  - org: kubernetes
-    repo: kops
-    base_ref: master
-    path_alias: k8s.io/kops
-    workdir: true
-  annotations:
-    test.kops.k8s.io/cloud: gce
-    test.kops.k8s.io/distro: u2404
-    test.kops.k8s.io/k8s_version: stable
-    test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/networking: ipalias
-    testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-gce
-    testgrid-tab-name: gce-master-scale-performance-4000
-    # testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, eks-scalability@amazon.com, release-team@kubernetes.io
-  spec:
-    serviceAccountName: prow-build
-    containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251209-72d275a594-master
-      imagePullPolicy: Always
-      command:
-      - runner.sh
-      args:
-      - ./tests/e2e/scenarios/scalability/run-test.sh
-      securityContext:
-        privileged: true
-      env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/ssh-key-secret/ssh-private
-      - name: KUBE_SSH_USER
-        value: prow
-      - name: GOPATH
-        value: /home/prow/go
-      - name: ARTIFACTS
-        value: $(ARTIFACTS)
-      - name: CNI_PLUGIN
-        value: gce
-      - name: KUBE_NODE_COUNT
-        value: "4000"
-      - name: CL2_LOAD_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_DELETE_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_RATE_LIMIT_POD_CREATION
-        value: "false"
-      - name: NODE_MODE
-        value: "master"
-      - name: KUBE_PROXY_MODE
-        value: "nftables"
-      - name: CONTROL_PLANE_COUNT
-        value: "1"
-      - name: CONTROL_PLANE_SIZE
-        value: "c4-standard-96"
-      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-        value: "true"
-      - name: CL2_ENABLE_DNS_PROGRAMMING
-        value: "true"
-      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-        value: "true"
-      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-        value: "99.5"
-      - name: CL2_ALLOWED_SLOW_API_CALLS
-        value: "1"
-      - name: ENABLE_PROMETHEUS_SERVER
-        value: "true"
-      - name: PROMETHEUS_PVC_STORAGE_CLASS
-        value: "ssd-csi"
-      - name: CLOUD_PROVIDER
-        value: "gce"
-      - name: GCP_PROJECT
-        value: "k8s-infra-e2e-boskos-scale-29"
-      # - name: BOSKOS_RESOURCE_TYPE
-      #   value: "scalability-scale-project"
-      resources:
-        requests:
-          cpu: "7"
-          memory: "28Gi"
-        limits:
-          cpu: "7"
-          memory: "28Gi"
+          cpu: "5"
+          memory: "16Gi"
 
 - name: ci-kubernetes-e2e-kops-gce-5000-ipalias-using-cl2
   tags:
@@ -309,11 +105,12 @@ periodics:
   - "perfDashBuildsCount: 270"
   - "perfDashJobType: performance"
   cluster: k8s-infra-prow-build
-  cron: '0 10,22 * * *' # Run twice a day at 10:00 and 22:00 UTC
+  cron: '1 7 2-31/2 * *' # Run on even days at 07:01 UTC
   labels:
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
   decorate: true
+  job_queue_name: "5k-gce-scale-test" # DON'T REMOVE THIS
   decoration_config:
     timeout: 480m
   extra_refs:
@@ -393,14 +190,12 @@ periodics:
         value: "ssd-csi"
       - name: CLOUD_PROVIDER
         value: "gce"
-      - name: GCP_PROJECT
-        value: "k8s-infra-e2e-boskos-scale-30"
-      # - name: BOSKOS_RESOURCE_TYPE
-      #   value: "scalability-scale-project"
+      - name: BOSKOS_RESOURCE_TYPE
+        value: "scalability-scale-project"
       resources:
         requests:
           cpu: "7"
-          memory: "28Gi"
+          memory: "25Gi"
         limits:
           cpu: "7"
-          memory: "28Gi"
+          memory: "25Gi"

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -12,7 +12,7 @@ plank:
     # limits concurrency for k8s-test-infra-staging project
     'test-infra-staging-image-push': 1
     # limits concurrency for 5k GCE jobs
-    '5k-gce-scale-test': 1
+    '5k-gce-scale-test': 4
   default_decoration_config_entries:
   - config:
       timeout: 2h


### PR DESCRIPTION
It's the end of the year, and these jobs have run successfully. They will be replacing the main 5k and 100-node jobs in a separate PR.

/hold I'll merge it on the 31st of Dec