### PR TITLE
Update milestone applier for k/website dev-1.36 release branch

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -609,7 +609,7 @@ milestone_applier:
   kubernetes-sigs/boskos:
     master: v1.23
   kubernetes/website:
-    dev-1.35: 1.35
+    dev-1.36: 1.36
   kubernetes-sigs/node-problem-detector:
     main: v1.36
     release-1.35: v1.35


### PR DESCRIPTION
Update the k/website milestone applier for the dev-1.36 branch to automatically apply the 1.36 milestone for PRs created against the dev-1.36 branch.

/hold for review from @kubernetes/sig-docs-leads