### PR TITLE
rightsize various kubernetes unit/typecheck  jobs

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
@@ -79,11 +79,11 @@ presubmits:
         - unit
         resources:
           limits:
-            cpu: 7.2
-            memory: "43Gi"
+            cpu: 7
+            memory: 16Gi
           requests:
-            cpu: 7.2
-            memory: "43Gi"
+            cpu: 7
+            memory: 16Gi
     annotations:
       testgrid-dashboards: sig-arch-code-organization
       testgrid-tab-name: pull-unit-master-dependencies
@@ -174,11 +174,11 @@ presubmits:
           value: "devel"
         resources:
           limits:
-            cpu: 7.2
-            memory: "43Gi"
+            cpu: 7
+            memory: 16Gi
           requests:
-            cpu: 7.2
-            memory: "43Gi"
+            cpu: 7
+            memory: 16Gi
     annotations:
       testgrid-dashboards: sig-arch-code-organization
       testgrid-tab-name: pull-unit-master-golang-tip
@@ -271,11 +271,11 @@ periodics:
       - unit
       resources:
         limits:
-          cpu: 7.2
-          memory: "43Gi"
+          cpu: 7
+          memory: 16Gi
         requests:
-          cpu: 7.2
-          memory: "43Gi"
+          cpu: 7
+          memory: 16Gi
 
 - interval: 4h
   cluster: k8s-infra-prow-build
@@ -365,11 +365,11 @@ periodics:
         value: "devel"
       resources:
         limits:
-          cpu: 7.2
-          memory: "43Gi"
+          cpu: 7
+          memory: 16Gi
         requests:
-          cpu: 7.2
-          memory: "43Gi"
+          cpu: 7
+          memory: 16Gi
 
 - interval: 4h
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -23,11 +23,11 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 7300m
-            memory: "41Gi"
+            cpu: 7
+            memory: "25Gi"
           requests:
-            cpu: 7300m
-            memory: "41Gi"
+            cpu: 7
+            memory: "25Gi"
     annotations:
       testgrid-create-test-group: 'true'
 

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -404,11 +404,11 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: "4"
-          memory: 36Gi
+          cpu: 7
+          memory: 16Gi
         requests:
-          cpu: "4"
-          memory: 36Gi
+          cpu: 7
+          memory: 16Gi
       securityContext:
         allowPrivilegeEscalation: false
     securityContext:
@@ -2148,10 +2148,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 32Gi
+            memory: 12Gi
           requests:
             cpu: "5"
-            memory: 32Gi
+            memory: 12Gi
   - always_run: false
     branches:
     - release-1.32

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -686,11 +686,11 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: 7200m
-          memory: 43Gi
+          cpu: 7
+          memory: 16Gi
         requests:
-          cpu: 7200m
-          memory: 43Gi
+          cpu: 7
+          memory: 16Gi
       securityContext:
         allowPrivilegeEscalation: false
     securityContext:
@@ -2750,10 +2750,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 32Gi
+            memory: 12Gi
           requests:
             cpu: "5"
-            memory: 32Gi
+            memory: 12Gi
   - always_run: false
     branches:
     - release-1.33

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1057,11 +1057,11 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: 7200m
-          memory: 43Gi
+          cpu: 7
+          memory: 16Gi
         requests:
-          cpu: 7200m
-          memory: 43Gi
+          cpu: 7
+          memory: 16Gi
       securityContext:
         allowPrivilegeEscalation: false
     securityContext:
@@ -3593,10 +3593,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 32Gi
+            memory: 12Gi
           requests:
             cpu: "5"
-            memory: 32Gi
+            memory: 12Gi
   - always_run: false
     branches:
     - release-1.34

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -3932,10 +3932,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 32Gi
+            memory: 12Gi
           requests:
             cpu: "5"
-            memory: 32Gi
+            memory: 12Gi
   - always_run: false
     branches:
     - release-1.35

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -29,11 +29,11 @@ presubmits:
             - test
           resources:
             limits:
-              cpu: 7.2
-              memory: "43Gi"
+              cpu: 7
+              memory: "16Gi"
             requests:
-              cpu: 7.2
-              memory: "43Gi"
+              cpu: 7
+              memory: "16Gi"
   - name: pull-kubernetes-unit-canary
     annotations:
       fork-per-release: "false"
@@ -73,11 +73,11 @@ presubmits:
             value: "5"
           resources:
             limits:
-              cpu: 7.2
-              memory: "43Gi"
+              cpu: 7
+              memory: 16Gi
             requests:
-              cpu: 7.2
-              memory: "43Gi"
+              cpu: 7
+              memory: 16Gi
   - name: pull-kubernetes-unit-go-compatibility
     annotations:
       fork-per-release: "true"
@@ -186,11 +186,10 @@ periodics:
           command:
             - make
             - test
-          # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:
-              cpu: 7.2
-              memory: "43Gi"
+              cpu: 7
+              memory: 16Gi
             requests:
-              cpu: 7.2
-              memory: "43Gi"
+              cpu: 7
+              memory: 16Gi

--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -23,10 +23,10 @@ presubmits:
         resources:
           limits:
             cpu: 5
-            memory: 32Gi
+            memory: 12Gi
           requests:
             cpu: 5
-            memory: 32Gi
+            memory: 12Gi
         args:
         - verify
         env:


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/36121, we want to enforce a max memory of 27GB and 7 cores for prowjobs, and some jobs exceeding it have been highlighted in that PR.

I looked at the resource usage of the jobs and observed the following:
- unit tests don't exceed 9/10GB of RAM. So I reduced it to 16 instead of 43, ref: https://monitoring-gke.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&refresh=30s&var-org=kubernetes&var-repo=kubernetes&var-job=pull-kubernetes-unit&var-build=All&from=now-24h&to=now
- pull-kubernetes-typecheck doesn't exceed 8GB either, its now reduced to 12GB, ref: https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&var-org=kubernetes&var-repo=kubernetes&var-job=pull-kubernetes-typecheck&var-build=All&from=now-12h&to=now&refresh=30s

@pohly @dims