### PR TITLE
Update golang version in benchmarkjunit image

### DIFF
--- a/pkg/benchmarkjunit/Dockerfile
+++ b/pkg/benchmarkjunit/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13-alpine
+FROM golang:1.25-alpine
 
 COPY benchmarkjunit /benchmarkjunit
 

--- a/pkg/benchmarkjunit/cloudbuild.yaml
+++ b/pkg/benchmarkjunit/cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
     - ./pkg/benchmarkjunit
 substitutions:
   _GIT_TAG: '12345'
-  _GO_VERSION: 1.18-alpine
+  _GO_VERSION: 1.25-alpine
 images:
   - 'gcr.io/$PROJECT_ID/benchmarkjunit:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/benchmarkjunit:latest'


### PR DESCRIPTION
Update the golang version to 1.25 in the benchmarkjunit image so that tests using this image can make use of newer golang features.

Test currently failing because it requires a Go 1.23 feature: https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-structured-merge-diff-benchmark