### PR TITLE
Bump memory limit for ci-prow-continuous-test-verify job

### DIFF
--- a/config/jobs/kubernetes-sigs/prow/prow-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-periodics.yaml
@@ -25,10 +25,10 @@ periodics:
       resources:
         limits:
           cpu: 2
-          memory: 4Gi
+          memory: 6Gi
         requests:
           cpu: 2
-          memory: 4Gi
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-testing-prow-repo
     testgrid-tab-name: continuous-test-verify


### PR DESCRIPTION
The test https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-prow-continuous-test-verify is currently failing because the linter in this job is getting OOM killed. It requires around 4.5 GB of memory. Bumping the memory requests and limits to 6Gi should be sufficient to make it work again.