### PR TITLE
Update Kubebuilder OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -306,21 +306,6 @@ aliases:
     - justaugustus # subproject owner
     - mrbobbytables # subproject owner
 
-  # mostly copied from sigs.k8s.io/kubebuilder/OWNERS_ALIASES
-  kubebuilder-admins:
-  - camilamacedo86
-  - mengqiy
-  - estroz
-  - joelanford
-
-  kubebuilder-reviewers:
-  - alexeldeib
-
-  kubebuilder-emeritus-approvers:
-  - pwittrock
-
-  # end sigs.k8s.io/kubebuilder/OWNERS_ALIASES
-
   # copied from sigs.k8s.io/promo-tools/OWNERS_ALIASES
   promo-tools-approvers:
     - cpanato

--- a/config/jobs/kubernetes-sigs/kubebuilder/OWNERS
+++ b/config/jobs/kubernetes-sigs/kubebuilder/OWNERS
@@ -1,8 +1,7 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
 
 approvers:
-  - kubebuilder-admins
-  - kubebuilder-emeritus-approvers
+  - camilamacedo86
+  - varshaprasad96
 reviewers:
-  - kubebuilder-admins
-  - kubebuilder-reviewers
+  - vitorfloriano


### PR DESCRIPTION
The Kubebuilder OWNERS is now up-to-date with the current owners in the Kubebuilder repo.

We have also removed the Kubebuilder section from OWNER_ALIASES, as recommended, considering the OWNERS are being used in only one place in the repo.

Closes kubernetes-sigs/kubebuilder#5331