### PR TITLE
Revert the windows master test to use 1.35 temporarily

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -110,7 +110,7 @@ periodics:
         command:
           - "runner.sh"
           - "env"
-          - "KUBERNETES_VERSION=latest" # fork-per-release-replacements only updates args / tags and not env vars so specify k8s-version here!
+          - "KUBERNETES_VERSION=latest-1.35" # fork-per-release-replacements only updates args / tags and not env vars so specify k8s-version here!
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
@@ -164,7 +164,7 @@ periodics:
         command:
           - "runner.sh"
           - "env"
-          - "KUBERNETES_VERSION=latest" # fork-per-release-replacements only updates args / tags and not env vars so specify k8s-version here!
+          - "KUBERNETES_VERSION=latest-1.35" # fork-per-release-replacements only updates args / tags and not env vars so specify k8s-version here!
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
@@ -217,7 +217,7 @@ periodics:
         command:
           - "runner.sh"
           - "env"
-          - "KUBERNETES_VERSION=latest"
+          - "KUBERNETES_VERSION=latest-1.35"
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
@@ -327,7 +327,7 @@ periodics:
         command:
           - "runner.sh"
           - "env"
-          - "KUBERNETES_VERSION=latest"
+          - "KUBERNETES_VERSION=latest-1.35"
           - "./capz/run-capz-e2e.sh"
         env:
           - name: WINDOWS_CONTAINERD_URL
@@ -379,7 +379,7 @@ periodics:
         command:
           - "runner.sh"
           - "env"
-          - "KUBERNETES_VERSION=latest"
+          - "KUBERNETES_VERSION=latest-1.35"
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
@@ -440,7 +440,7 @@ periodics:
         command:
           - "runner.sh"
           - "env"
-          - "KUBERNETES_VERSION=latest"
+          - "KUBERNETES_VERSION=latest-1.35"
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true
@@ -498,7 +498,7 @@ periodics:
         command:
           - "runner.sh"
           - "env"
-          - "KUBERNETES_VERSION=latest" # fork-per-release-replacements only updates args / tags and not env vars so specify k8s-version here!
+          - "KUBERNETES_VERSION=latest-1.35" # fork-per-release-replacements only updates args / tags and not env vars so specify k8s-version here!
           - "./capz/run-capz-e2e.sh"
         securityContext:
           privileged: true


### PR DESCRIPTION
the test grid is failed because of the: https://github.com/kubernetes-sigs/cluster-api/pull/13177. While we are waiting for a release from cluster api, temp revert the master test grid back to use k8s 1.35