### PR TITLE
update cloudbuild docs and use a newer buildx multiarch approach

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.25.5
-FROM multiarch/qemu-user-static:7.2.0-1 AS qemu-image
+ARG GO_VERSION
 # Includes bash, docker, and gcloud
 FROM golang:${GO_VERSION}-alpine3.22
 # upstream go image sets GOTOOLCHAIN=local
@@ -53,14 +52,9 @@ RUN echo ${IMAGE_ARG} > /workspace/image-reference.txt
 # Default home for cloudbuild jobs is /builder/home
 RUN mkdir -p /builder/home
 
-# Copy qemu static binaries.
-COPY --from=qemu-image /usr/bin /qemu-bin
-RUN cp /qemu-bin/qemu-* /usr/bin/ && \
-    rm -rf /qemu-bin
-COPY --from=qemu-image /qemu-binfmt-conf.sh /qemu-binfmt-conf.sh
-COPY --from=qemu-image /register /register
 ADD ./buildx-entrypoint.sh /buildx-entrypoint
 
-RUN apk add qemu
+COPY ["runner.sh", \
+    "/usr/local/bin/"]
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/usr/local/bin/runner.sh"]

--- a/images/gcb-docker-gcloud/README.md
+++ b/images/gcb-docker-gcloud/README.md
@@ -11,5 +11,5 @@ combination of `docker`, `gcloud`, and `go` all in the same build step
   - `go`
 - tools:
   - `docker`
-  - `docker-buildx`, `qemu` binaries, `/buildx-entrypoint` for multi-arch support
+  - `docker-buildx` and `tonistiigi/binfmt` for multi-arch support
   - `gcloud` via rapid channel, with default components

--- a/images/gcb-docker-gcloud/buildx-entrypoint.sh
+++ b/images/gcb-docker-gcloud/buildx-entrypoint.sh
@@ -15,7 +15,7 @@
 
 set -eo pipefail
 
-/register --reset -p yes
+docker run --privileged --rm tonistiigi/binfmt:qemu-v10.0.4 --install all
 if [ -z "${BUILDX_NO_DEFAULT_ATTESTATIONS}" ]; then
     export BUILDX_NO_DEFAULT_ATTESTATIONS=1
 fi

--- a/images/gcb-docker-gcloud/cloudbuild.yaml
+++ b/images/gcb-docker-gcloud/cloudbuild.yaml
@@ -5,6 +5,7 @@ steps:
       - --tag=gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG
       - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG
       - --build-arg=DOCKER_VERSION=$_DOCKER_VERSION
+      - --build-arg=GO_VERSION=$_GO_VERSION
       - .
     dir: images/gcb-docker-gcloud/
   - name: gcr.io/cloud-builders/docker
@@ -12,9 +13,26 @@ steps:
     - tag
     - gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG
     - gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest
+  - name: gcr.io/cloud-builders/docker
+    args:
+    - push
+    - gcr.io/$PROJECT_ID/gcb-docker-gcloud
+    - -a
+  - name: gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest
+    args:
+      - docker 
+      - run 
+      - --platform 
+      - linux/riscv64 
+      - alpine 
+      - uname 
+      - -a
+  - name: gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest
+    entrypoint: /buildx-entrypoint
+    args:
+      - ls 
+      - --no-trunc 
 substitutions:
   _GIT_TAG: '12345'
   _DOCKER_VERSION: '28' # Docker v29+ doesn't work in GCP Cloud Build because its stuck on 20.10.x
-images:
-  - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG'
-  - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:latest'
+  _GO_VERSION: '1.25.5'

--- a/images/gcb-docker-gcloud/runner.sh
+++ b/images/gcb-docker-gcloud/runner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generic runner script
+
+early_exit_handler() {
+    if [ -n "${WRAPPED_COMMAND_PID:-}" ]; then
+        kill -TERM "$WRAPPED_COMMAND_PID" || true
+    fi
+}
+
+trap early_exit_handler INT TERM
+
+# disable error exit so we can run post-command cleanup
+set +o errexit
+
+# Handle initialising buildx multiarch
+if [ -z "${BUILDX_NO_DEFAULT_ATTESTATIONS}" ]; then
+    export BUILDX_NO_DEFAULT_ATTESTATIONS=1
+fi
+docker run --privileged --rm tonistiigi/binfmt:qemu-v10.0.4 --install all
+
+docker buildx create \
+    --name multiarch-multiplatform-builder \
+    --driver docker-container \
+    --bootstrap --use
+
+# actually start bootstrap and the job
+set -o xtrace
+"$@" &
+WRAPPED_COMMAND_PID=$!
+wait $WRAPPED_COMMAND_PID
+EXIT_VALUE=$?
+set +o xtrace
+
+# preserve exit value from job / bootstrap
+exit ${EXIT_VALUE}


### PR DESCRIPTION
`multiarch/qemu-user-static:7.2.0-1` is no longer maintained and the correct approach described at https://docs.docker.com/build/building/multi-platform/#install-qemu-manually is to run `docker run --privileged --rm tonistiigi/binfmt --install all`

Also, I updated our Cloud Build docs and removed the simple build example as it doesn't follow best practices.

Now, all you need to do is use our image with the default entrypoint and `docker build --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le -t foo/bar --push .` will work without any additional commands.
