### PR TITLE
alpha/beta race detection: enable kubelet log query

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -592,8 +592,12 @@ presubmits:
         command:
         - wrapper.sh
         - bash
+        # The modified e2e-k8s.sh enables the log query feature in the kubelet config (off by default for security reasons).
         - -c
-        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" &&
+          curl -sSL https://github.com/kubernetes/test-infra/raw/master/experiment/kind-race-e2e-k8s.sh >$(which e2e-k8s.sh) &&
+          chmod u+x $(which e2e-k8s.sh) &&
+          e2e-k8s.sh
         env:
         # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
         - name: FEATURE_GATES

--- a/experiment/kind-race-e2e-k8s.sh
+++ b/experiment/kind-race-e2e-k8s.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2018 The Kubernetes Authors.
+# Copyright 2026 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -154,6 +154,11 @@ kubeadmConfigPatches:
         value: "10"
       - name: "container-log-max-size"
         value: "100Mi"
+  ---
+  kind: KubeletConfiguration
+  apiVersion: kubelet.config.k8s.io/v1beta1
+    enableSystemLogHandler: true
+    enableSystemLogQuery: true
 # v1beta3 for v1.23.0 ... ?
 - |
   kind: ClusterConfiguration
@@ -187,6 +192,11 @@ kubeadmConfigPatches:
       # Most CI jobs should not need them, but some CI jobs might.
       "container-log-max-files": "10"
       "container-log-max-size": "100Mi"
+  ---
+  kind: KubeletConfiguration
+  apiVersion: kubelet.config.k8s.io/v1beta1
+    enableSystemLogHandler: true
+    enableSystemLogQuery: true
 EOF
   # NOTE: must match the number of workers above
   NUM_NODES=2


### PR DESCRIPTION
The feature gate is already enabled via AllBeta, but the kubelet config also needs to be modified. The e2e-k8s.sh script is meant to be forked for such advanced config changes.

The changes to the upstream e2e-k8s.sh can be seen in the second commit.


