### PR TITLE
peribolos: update container image in the ci jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
@@ -21,7 +21,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251209-72d275a594-master
         command:
         - ./admin/update.sh
         args:
@@ -61,7 +61,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: public.ecr.aws/docker/library/golang:1.24
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20251209-72d275a594-master
       command:
       - ./admin/update.sh
       args:


### PR DESCRIPTION
to fix failing job https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-org-peribolos/2009152073567834112

```
go: sigs.k8s.io/prow/cmd/peribolos@main: sigs.k8s.io/prow@v0.0.0-20260107131339-b51ff4a6e825 requires go >= 1.25 (running go 1.24.11; GOTOOLCHAIN=local)
make: *** [Makefile:84: /home/prow/go/src/github.com/kubernetes/org/_output/bin/peribolos] Error 1 
```
