### PR TITLE
Enable cleanup of aws-ebs-csi-driver images in AWS CI accounts

### DIFF
--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -21,6 +21,7 @@ periodics:
       - --path=s3://cloud-provider-aws-shared-e2e/objs.json
       - --exclude-tags=Shared=Ignore
       - --enable-target-group-clean=true
+      - --clean-ecr-repositories=aws-ebs-csi-driver
       image: gcr.io/k8s-staging-boskos/aws-janitor:v20260428-2afb3ad
       resources:
         requests:
@@ -55,6 +56,7 @@ periodics:
       - --ttl=2h30m
       - --path=s3://k8s-kops-prow/objs.json
       - --exclude-tags=Shared=Ignore
+      - --clean-ecr-repositories=aws-ebs-csi-driver
       image: gcr.io/k8s-staging-boskos/aws-janitor:v20260428-2afb3ad
   annotations:
     testgrid-dashboards: sig-testing-maintenance


### PR DESCRIPTION
Enables the feature from https://github.com/kubernetes-sigs/boskos/pull/235 for the `aws-ebs-csi-driver` repo in the AWS Kubernetes CI accounts.

This will prevent the repos from hitting 10k images inside and blocking CI jobs by regularly cleaning them.