### PR TITLE
replace ahg-g with kannon92 for kueue test infra approvals

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/OWNERS
+++ b/config/jobs/kubernetes-sigs/kueue/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ahg-g
 - mimowo
 - tenzen-y
+- kannon92
 reviewers:
-- ahg-g
 - mimowo
 - tenzen-y
+- kannon92


### PR DESCRIPTION
I am already an approver for test-infra in sig-node / JobSet.

I am a reviewer for Kueue also. https://github.com/kubernetes-sigs/kueue/blob/main/OWNERS_ALIASES#L6

https://github.com/kubernetes/test-infra/pulls?q=is%3Apr+is%3Aclosed+author%3Akannon92

ahg-g is an emertius approver in the kueue owners aliase so I think it makes sense to remove.