### PR TITLE
Revert "add 1.35 kind tests for Kueue"

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -292,52 +292,6 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-main-1-35
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-main-1-35
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue end to end tests for Kubernetes 1.35"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: main
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260108-6ef4f0b08f-master
-          env:
-            - name: E2E_K8S_VERSION
-              value: "1.35"
-            - name: BASE_BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "7"
-              memory: "10Gi"
-            limits:
-              cpu: "7"
-              memory: "10Gi"
-  - interval: 12h
     name: periodic-kueue-test-e2e-multikueue-main
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-14.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-14.yaml
@@ -292,52 +292,6 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-release-0-14-1-35
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-release-0-14-1-35
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue end to end tests for Kubernetes 1.35"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: release-0.14
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260108-6ef4f0b08f-master
-          env:
-            - name: E2E_K8S_VERSION
-              value: "1.35"
-            - name: BASE_BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "7"
-              memory: "10Gi"
-            limits:
-              cpu: "7"
-              memory: "10Gi"
-  - interval: 12h
     name: periodic-kueue-test-e2e-multikueue-release-0-14
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-15.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-15.yaml
@@ -292,52 +292,6 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-release-0-15-1-35
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-release-0-15-1-35
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue end to end tests for Kubernetes 1.35"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: release-0.15
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260108-6ef4f0b08f-master
-          env:
-            - name: E2E_K8S_VERSION
-              value: "1.35"
-            - name: BASE_BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "7"
-              memory: "10Gi"
-            limits:
-              cpu: "7"
-              memory: "10Gi"
-  - interval: 12h
     name: periodic-kueue-test-e2e-multikueue-release-0-15
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -228,44 +228,6 @@ presubmits:
             limits:
               cpu: "7"
               memory: "10Gi"
-  - name: pull-kueue-test-e2e-main-1-35
-    cluster: eks-prow-build-cluster
-    branches:
-      - ^main
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-main-1-35
-      description: "Run kueue end to end tests for Kubernetes 1.35"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260108-6ef4f0b08f-master
-          env:
-            - name: E2E_K8S_VERSION
-              value: "1.35"
-            - name: BASE_BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "7"
-              memory: "10Gi"
-            limits:
-              cpu: "7"
-              memory: "10Gi"
   - name: pull-kueue-test-e2e-multikueue-main
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-14.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-14.yaml
@@ -228,44 +228,6 @@ presubmits:
             limits:
               cpu: "7"
               memory: "10Gi"
-  - name: pull-kueue-test-e2e-release-0-14-1-35
-    cluster: eks-prow-build-cluster
-    branches:
-      - ^release-0.14
-    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
-    decorate: true
-    path_alias: sigs.k8s.io/kueue
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-kueue-test-e2e-release-0-14-1-35
-      description: "Run kueue end to end tests for Kubernetes 1.35"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260108-6ef4f0b08f-master
-          env:
-            - name: E2E_K8S_VERSION
-              value: "1.35"
-            - name: BASE_BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-e2e
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "7"
-              memory: "10Gi"
-            limits:
-              cpu: "7"
-              memory: "10Gi"
   - name: pull-kueue-test-e2e-multikueue-release-0-14
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-15.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-15.yaml
@@ -228,44 +228,6 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-release-0-15-1-35
-      cluster: eks-prow-build-cluster
-      branches:
-        - ^release-0.15
-      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
-      decorate: true
-      path_alias: sigs.k8s.io/kueue
-      annotations:
-        testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-release-0-15-1-35
-        description: "Run kueue end to end tests for Kubernetes 1.35"
-      labels:
-        preset-dind-enabled: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260108-6ef4f0b08f-master
-            env:
-              - name: E2E_K8S_VERSION
-                value: "1.35"
-              - name: BASE_BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang
-            command:
-              # generic runner script, handles DIND, bazelrc for caching, etc.
-              - runner.sh
-            args:
-              - make
-              - kind-image-build
-              - test-e2e
-            # docker-in-docker needs privileged mode
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                cpu: "7"
-                memory: "10Gi"
-              limits:
-                cpu: "7"
-                memory: "10Gi"
     - name: pull-kueue-test-e2e-multikueue-release-0-15
       cluster: eks-prow-build-cluster
       branches:


### PR DESCRIPTION
Reverts kubernetes/test-infra#36188

https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-35

Seems that this is failing and blocking merges.