### PR TITLE
pull-kubernetes-e2e-gci-gce: add missing settings for a presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -548,8 +548,16 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 2h20m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
     labels:
+      preset-dind-enabled: "true"
       preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
     # Keep the job in sync with ci-kubernetes-e2e-gci-gce.
     name: pull-kubernetes-e2e-gci-gce
@@ -583,6 +591,8 @@ presubmits:
           requests:
             cpu: "2"
             memory: 6Gi
+        securityContext:
+          privileged: true
   - always_run: false
     annotations:
       fork-per-release: "true"


### PR DESCRIPTION
The job is now almost identical to pull-kubernetes-e2e-gce-cos, except for using some settings from ci-kubernetes-e2e-gci-gce and of course the different name.

Here's a diff:

    $ diff /tmp/gci-gce /tmp/gce-cos
    2d1
    <     optional: true # Optional because it does not always run. ci-kubernetes-e2e-gci-gce is release blocking.
    4,5d2
    <       description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature)
    <         against a cluster created with cluster/kube-up.sh
    13c10
    <       timeout: 2h20m0s
    ---
    >       timeout: 1h45m0s
    25,26c22
    <     # Keep the job in sync with ci-kubernetes-e2e-gci-gce.
    <     name: pull-kubernetes-e2e-gci-gce
    ---
    >     name: pull-kubernetes-e2e-gce-cos
    33d28
    <         - --check-leaked-resources
    44c39
    <         - --timeout=120m
    ---
    >         - --timeout=80m
    52,53c47,48
    <             cpu: "2"
    <             memory: 6Gi
    ---
    >             cpu: "4"
    >             memory: 14Gi
    55,56c50,51
    <             cpu: "2"
    <             memory: 6Gi
    ---
    >             cpu: "4"
    >             memory: 14Gi

We might want to phase out pull-kubernetes-e2e-gce-cos in favor of pull-kubernetes-e2e-gci-gce.