### PR TITLE
Add ci-kubernetes-e2e-kind-audit job (was ci-kubernetes-e2e-kind-alpha-beta-audit)

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
@@ -117,13 +117,11 @@ periodics:
     testgrid-num-failures-to-alert: '1'
     description: 'Uses patched ci-kubernetes-kind-conformance job to generate ARTIFACT/audit/audit.log'
 
-# Full e2e test against kubernetes master branch with `kind` and audit logs enabled.
-# This job provides maximum API endpoint coverage for APISnoop by:
-# - Enabling all alpha/beta feature gates and APIs
-# - Running broad e2e tests (not just conformance)
-# - Generating audit logs for all API calls
+# E2E tests against kubernetes master branch with `kind` and audit logs enabled.
+# This job mirrors ci-kubernetes-e2e-gci-gce test coverage but runs on KIND with audit logging.
+# Uses the standard kind e2e-k8s.sh script with audit logging injected via wrapper.
 - interval: 3h
-  name: ci-kubernetes-e2e-kind-alpha-beta-audit
+  name: ci-kubernetes-e2e-kind-audit
   cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
@@ -148,25 +146,84 @@ periodics:
         - wrapper.sh
         - bash
         - -c
-        -
+        - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+
+            # Install kind
             curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/"
-            && curl -sO https://raw.githubusercontent.com/ii/kind/ci-audit-logging/hack/ci/e2e-k8s.sh
-            && bash e2e-k8s.sh
-            && apt-get update && apt-get install -y --no-install-recommends python3-pip && pip3 install --no-cache-dir --break-system-packages pyyaml
-            && python3 ./../test-infra/experiment/audit/audit_log_parser.py --audit-logs ${ARTIFACTS}/audit/audit*.log --output "${ARTIFACTS}/audit/audit-endpoints.txt" --audit-operations-json "${ARTIFACTS}/audit/audit-operations.json" --swagger-url "file://$PWD/api/openapi-spec/swagger.json"
+
+            # Create audit policy for capturing API calls
+            mkdir -p "${ARTIFACTS}/audit"
+            cat > "${ARTIFACTS}/audit/policy.yaml" << 'AUDIT_POLICY'
+            apiVersion: audit.k8s.io/v1
+            kind: Policy
+            rules:
+              - level: Metadata
+                stages:
+                  - ResponseComplete
+            AUDIT_POLICY
+
+            # Download standard kind e2e script
+            curl -sSLo e2e-k8s.sh https://raw.githubusercontent.com/kubernetes-sigs/kind/main/hack/ci/e2e-k8s.sh
+
+            # Patch the script to inject audit logging into the kind config
+            # This adds audit policy and log path to the API server configuration
+            sed -i '/kubeadmConfigPatches:/a\
+            - |\
+              kind: ClusterConfiguration\
+              apiServer:\
+                extraArgs:\
+                  audit-policy-file: /etc/kubernetes/audit/policy.yaml\
+                  audit-log-path: /var/log/kubernetes/audit.log\
+                  audit-log-maxage: "0"\
+                  audit-log-maxbackup: "0"\
+                  audit-log-maxsize: "2000000000"\
+                extraVolumes:\
+                - name: audit-policy\
+                  hostPath: /audit/policy.yaml\
+                  mountPath: /etc/kubernetes/audit/policy.yaml\
+                  readOnly: true\
+                - name: audit-logs\
+                  hostPath: /audit\
+                  mountPath: /var/log/kubernetes\
+                  readOnly: false' e2e-k8s.sh
+
+            # Also add the extraMounts to copy audit policy into the node
+            sed -i '/nodes:/a\
+            - role: control-plane\
+              extraMounts:\
+              - hostPath: '"${ARTIFACTS}"'/audit\
+                containerPath: /audit' e2e-k8s.sh
+
+            # Run the e2e tests
+            chmod +x e2e-k8s.sh
+            ./e2e-k8s.sh
+
+            # Copy audit logs from kind node to artifacts
+            docker cp kind-control-plane:/var/log/kubernetes/audit.log "${ARTIFACTS}/audit/" || true
+
+            # Parse audit logs
+            apt-get update && apt-get install -y --no-install-recommends python3-pip
+            pip3 install --no-cache-dir --break-system-packages pyyaml
+            python3 ./../test-infra/experiment/audit/audit_log_parser.py \
+              --audit-logs "${ARTIFACTS}/audit/audit.log" \
+              --output "${ARTIFACTS}/audit/audit-endpoints.txt" \
+              --audit-operations-json "${ARTIFACTS}/audit/audit-operations.json" \
+              --swagger-url "file://$PWD/api/openapi-spec/swagger.json" \
+              --ineligible-endpoints-url "file://$PWD/test/conformance/testdata/ineligible_endpoints.yaml" \
+              --pending-eligible-endpoints-url "file://$PWD/test/conformance/testdata/pending_eligible_endpoints.yaml"
+            python3 ./../test-infra/experiment/audit/kubernetes_api_analysis.py \
+              --pull-audit-endpoints "${ARTIFACTS}/audit/audit-endpoints.txt" \
+              --swagger-url "file://$PWD/api/openapi-spec/swagger.json"
       env:
       - name: BUILD_TYPE
         value: docker
-      # Enable all alpha and beta feature gates for maximum API coverage
-      - name: FEATURE_GATES
-        value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
-      # Enable all API groups including alpha/beta
-      - name: RUNTIME_CONFIG
-        value: '{"api/all":"true"}'
-      # Run broad e2e tests - only skip Serial (requires single-node), Deprecated, and Flaky
-      # This provides much broader coverage than conformance-only tests
-      - name: LABEL_FILTER
-        value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Flaky && !Serial"
+      # Match ci-kubernetes-e2e-gci-gce skip pattern exactly
+      # Skip: Driver:gcepd (GCE-specific), Slow, Serial, Disruptive, Flaky, Feature tests
+      - name: SKIP
+        value: "\\[Driver:.gcepd\\]|\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -181,7 +238,7 @@ periodics:
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-arch-conformance, sig-testing-kind
-    testgrid-tab-name: kind-e2e-alpha-beta-audit
+    testgrid-tab-name: kind-e2e-audit
     testgrid-alert-email: kubernetes-sig-arch-conformance-test-failures@googlegroups.com
     testgrid-num-failures-to-alert: '3'
-    description: 'Runs full e2e tests with all alpha/beta features enabled and audit logging for maximum API coverage'
+    description: 'Mirrors ci-kubernetes-e2e-gci-gce test coverage on KIND with audit logging for API coverage analysis'


### PR DESCRIPTION
Add a new periodic job that mirrors ci-kubernetes-e2e-gci-gce test coverage but runs on KIND with audit logging enabled. This provides API endpoint coverage data for APISnoop without requiring GCE.

The job:
- Uses the standard kind e2e-k8s.sh script with audit logging injected
- Matches ci-kubernetes-e2e-gci-gce skip pattern: `[Driver:.gcepd]|[Slow]|[Serial]|[Disruptive]|[Flaky]|[Feature:.+]`
- Runs tests in parallel
- Parses audit logs with ineligible/pending endpoint filtering
- Runs kubernetes_api_analysis.py for additional coverage analysis