### PR TITLE
fix the aks heartbeat jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -15,7 +15,7 @@ periodics:
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     spec:
       containers:
-        - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+        - image: alpine:latest
           command:
             - "echo"
           args:
@@ -66,7 +66,6 @@ periodics:
     cluster: k8s-infra-aks-prow-build
     name: ci-kubernetes-verify-master-canary
     labels:
-      preset-service-account: "true"
       preset-dind-enabled: "true"
     annotations:
       testgrid-dashboards: sig-k8s-infra-canaries

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-prow.yaml
@@ -59,7 +59,7 @@ periodics:
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, k8s-infra-prow-oncall@kubernetes.io
   spec:
     containers:
-    - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+    - image: alpine:latest
       command:
       - "echo"
       args:


### PR DESCRIPTION
AKS doesn't taint the arm64 nodepools with `kubernetes.io/arch=arm64:NoSchedule`, so any pod will get scheduled, including those without an arm64 image. I'll taint the nodepools and mutate the pods when the nodeselector arch=arm64 is selected.


