### PR TITLE
Fix ci-kubernetes-e2e-kind-audit cluster creation failure

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
@@ -190,9 +190,8 @@ periodics:
                   mountPath: /var/log/kubernetes\
                   readOnly: false' e2e-k8s.sh
 
-            # Also add the extraMounts to copy audit policy into the node
-            sed -i '/nodes:/a\
-            - role: control-plane\
+            # Add extraMounts to the existing control-plane node to mount audit policy
+            sed -i '/- role: control-plane$/a\
               extraMounts:\
               - hostPath: '"${ARTIFACTS}"'/audit\
                 containerPath: /audit' e2e-k8s.sh


### PR DESCRIPTION
The sed command was adding a new control-plane node instead of adding extraMounts to the existing one. This created a cluster with 2 control-plane nodes where only the first had extraMounts for the audit policy file, causing the second control-plane to fail joining the cluster.

Fixed by changing the sed pattern from '/nodes:/a\' to '/- role: control-plane$/a\' which appends extraMounts after the existing control-plane node instead of creating a new one.