### PR TITLE
Fix ci-kubernetes-e2e-kind-audit to run all tests like gci-gce

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
@@ -219,7 +219,10 @@ periodics:
       env:
       - name: BUILD_TYPE
         value: docker
-      # Match ci-kubernetes-e2e-gci-gce skip pattern exactly
+      # Match ci-kubernetes-e2e-gci-gce test coverage exactly
+      # FOCUS="" overrides the default [Conformance] focus to run all tests
+      - name: FOCUS
+        value: ""
       # Skip: Driver:gcepd (GCE-specific), Slow, Serial, Disruptive, Flaky, Feature tests
       - name: SKIP
         value: "\\[Driver:.gcepd\\]|\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"


### PR DESCRIPTION
The kind e2e-k8s.sh script defaults to FOCUS=\[Conformance\] when FOCUS is not set, causing the job to only run ~413 conformance tests instead of ~1225 tests like ci-kubernetes-e2e-gci-gce.

Add FOCUS="" to explicitly override this default and run all tests matching the skip pattern.

Need a change in kind as well to work:
xref: https://github.com/kubernetes-sigs/kind/pull/4094