### PR TITLE
Add explicit Serial skip to kind e2e jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -142,6 +142,8 @@ periodics:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
         value: "true"
+      - name: "SKIP"
+        value: \[Serial\]
       command:
         - wrapper.sh
         - bash
@@ -190,6 +192,8 @@ periodics:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
         value: "true"
+      - name: "SKIP"
+        value: \[Serial\]
       command:
         - wrapper.sh
         - bash

--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -32,7 +32,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: Alpha|Beta|Disruptive|Flaky|Networking-IPv6|LoadBalancer|SCTPConnectivity
+          value: \[Serial\]|Alpha|Beta|Disruptive|Flaky|Networking-IPv6|LoadBalancer|SCTPConnectivity
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|IPv6DualStack|SCTPConnectivity
+          value: \[Serial\]|Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|IPv6DualStack|SCTPConnectivity
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -197,7 +197,7 @@ presubmits:
               value: \[sig-network\]|\[Conformance\]
             # FIXME: AdmissionWebhooks flakes https://issues.k8s.io/128230
             - name: SKIP
-              value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|IPv6DualStack|AdmissionWebhook|SCTPConnectivity
+              value: \[Serial\]|Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|IPv6DualStack|AdmissionWebhook|SCTPConnectivity
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true
@@ -394,7 +394,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|SCTPConnectivity
+        value: \[Serial\]|Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|SCTPConnectivity
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -443,7 +443,7 @@ periodics:
         value: \[sig-network\]|\[Conformance\]
       # FIXME: AdmissionWebhooks flakes https://issues.k8s.io/128230
       - name: SKIP
-        value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|IPv6DualStack|AdmissionWebhook|SCTPConnectivity
+        value: \[Serial\]|Alpha|Beta|LoadBalancer|Disruptive|Flaky|Networking-IPv6|IPv6DualStack|AdmissionWebhook|SCTPConnectivity
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -491,7 +491,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv6|Internet.connection|SCTPConnectivity
+        value: \[Serial\]|Alpha|Beta|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv6|Internet.connection|SCTPConnectivity
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -544,7 +544,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: Alpha|Beta|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv4|Internet.connection|SCTPConnectivity
+        value: \[Serial\]|Alpha|Beta|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv4|Internet.connection|SCTPConnectivity
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -598,7 +598,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: Alpha|Beta|NetworkPolicy|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv6|Internet.connection|SCTPConnectivity
+        value: \[Serial\]|Alpha|Beta|NetworkPolicy|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv6|Internet.connection|SCTPConnectivity
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -639,7 +639,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: Alpha|Beta|NetworkPolicy|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv6|Internet.connection|SCTPConnectivity
+        value: \[Serial\]|Alpha|Beta|NetworkPolicy|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv6|Internet.connection|SCTPConnectivity
       command:
         - wrapper.sh
         - bash
@@ -690,7 +690,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: Alpha|Beta|NetworkPolicy|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv4|Internet.connection|SCTPConnectivity
+        value: \[Serial\]|Alpha|Beta|NetworkPolicy|LoadBalancer|Disruptive|Flaky|IPv6DualStack|Networking-IPv4|Internet.connection|SCTPConnectivity
       command:
         - wrapper.sh
         - bash
@@ -948,7 +948,7 @@ periodics:
       - name: RUNTIME_CONFIG
         value: '{"api/all":"true"}'
       - name: LABEL_FILTER
-        value: "(Conformance || sig-network ) && !Feature: containsAny {Networking-IPv6, LoadBalancer, IPv6DualStack} && !Disruptive && !Flaky"
+        value: "(Conformance || sig-network ) && !Feature: containsAny {Networking-IPv6, LoadBalancer, IPv6DualStack} && !Disruptive && !Flaky && !Serial"
       - name: SKIP
         value: SCTPConnectivity
       - name: PARALLEL

--- a/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
@@ -197,7 +197,7 @@ presubmits:
         - name: FOCUS
           value: \[Feature:VolumeAttributesClass\]
         - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]
+          value: \[Serial\]|\[Slow\]|\[Disruptive\]|\[Flaky\]
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -241,7 +241,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
         - name: LABEL_FILTER
-          value: "FeatureGate:VolumeAttributesClass && Slow"
+          value: "FeatureGate:VolumeAttributesClass && Slow && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -337,7 +337,7 @@ periodics:
         - name: FOCUS
           value: \[Feature:VolumeAttributesClass\]
         - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]
+          value: \[Serial\]|\[Slow\]|\[Disruptive\]|\[Flaky\]
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -30,7 +30,7 @@ periodics:
       - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       - name: LABEL_FILTER
-        value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+        value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -83,7 +83,7 @@ periodics:
       - name: IP_FAMILY
         value: "ipv6"
       - name: LABEL_FILTER
-        value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+        value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -133,7 +133,7 @@ periodics:
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       - name: LABEL_FILTER
-        value: "Feature: isSubsetOf OffByDefault && !Alpha && !Deprecated && !Slow && !Disruptive && !Flaky"
+        value: "Feature: isSubsetOf OffByDefault && !Alpha && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -182,7 +182,7 @@ periodics:
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       - name: LABEL_FILTER
-        value: "Feature: isEmpty && !Alpha && !Deprecated && !Slow && !Disruptive && !Flaky"
+        value: "Feature: isEmpty && !Alpha && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -231,7 +231,7 @@ periodics:
       - name: RUNTIME_CONFIG
         value: '{"api/beta":"true", "api/ga":"true"}'
       - name: LABEL_FILTER
-        value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky"
+        value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -281,7 +281,7 @@ periodics:
       - name: RUNTIME_CONFIG
         value: '{"api/all":"true"}'
       - name: LABEL_FILTER
-        value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
+        value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -387,7 +387,7 @@ periodics:
       - name: RUNTIME_CONFIG
         value: '{"api/all":"true"}'
       - name: LABEL_FILTER
-        value: "Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky"
+        value: "Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -437,7 +437,7 @@ periodics:
       - name: RUNTIME_CONFIG
         value: '{"api/all":"true"}'
       - name: LABEL_FILTER
-        value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky"
+        value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker
@@ -548,7 +548,7 @@ periodics:
       - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-arm64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       - name: LABEL_FILTER
-        value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+        value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
       - name: PARALLEL
         value: "true"
       # we need privileged mode in order to do docker in docker

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -70,7 +70,7 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -112,7 +112,7 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # enable IPV6 in bootstrap image
@@ -162,7 +162,7 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # enable IPV6 in bootstrap image
@@ -257,6 +257,8 @@ presubmits:
           value: '{"api/alpha":"false", "api/beta":"false"}'
         - name: PARALLEL
           value: "true"
+        - name: SKIP
+          value: \[Serial\]
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -306,7 +308,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/beta":"true", "api/ga":"true"}'
         - name: LABEL_FILTER
-          value: "Feature: isSubsetOf OffByDefault && !Alpha && !Deprecated && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isSubsetOf OffByDefault && !Alpha && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -356,7 +358,7 @@ presubmits:
         - name: SKIP
           value: ""
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -406,7 +408,7 @@ presubmits:
         - name: SKIP
           value: ""
         - name: LABEL_FILTER
-          value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky"
+          value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -453,7 +455,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/all":"true"}'
         - name: LABEL_FILTER
-          value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -504,7 +506,7 @@ presubmits:
         - name: SKIP
           value: ""
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -555,7 +557,7 @@ presubmits:
         - name: SKIP
           value: ""
         - name: LABEL_FILTER
-          value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky"
+          value: "Conformance && !Deprecated && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker
@@ -656,7 +658,7 @@ presubmits:
         - name: RUNTIME_CONFIG
           value: '{"api/alpha":"true", "api/ga":"true"}'
         - name: LABEL_FILTER
-          value: "Feature: isSubsetOf EventedPLEG && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isSubsetOf EventedPLEG && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
We should not be hiding the fact that we are skipping serial in a script!

Prepare for kubernetes-sigs/kind#4095 which removes the automatic addition of [Serial] to SKIP when PARALLEL=true. Ginkgo v2 natively handles Serial specs, but to preserve current behavior (skipping Serial tests in parallel jobs), we need to explicitly configure it.

For jobs using LABEL_FILTER, added "&& !Serial"
For jobs using SKIP, added "\[Serial\]" to the pattern