### PR TITLE
Add kind-audit-e2e.sh script and simplify audit job

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
@@ -119,7 +119,6 @@ periodics:
 
 # E2E tests against kubernetes master branch with `kind` and audit logs enabled.
 # This job mirrors ci-kubernetes-e2e-gci-gce test coverage but runs on KIND with audit logging.
-# Uses the standard kind e2e-k8s.sh script with audit logging injected via wrapper.
 #
 # Serial tests are included (not skipped) because Ginkgo v2 handles them automatically:
 # parallel specs run first, then Serial specs run on process #1 after all others complete.
@@ -159,66 +158,21 @@ periodics:
             # Install kind
             curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/"
 
-            # Create audit policy for capturing API calls
-            mkdir -p "${ARTIFACTS}/audit"
-            cat > "${ARTIFACTS}/audit/policy.yaml" << 'AUDIT_POLICY'
-            apiVersion: audit.k8s.io/v1
-            kind: Policy
-            rules:
-              - level: Metadata
-                stages:
-                  - ResponseComplete
-            AUDIT_POLICY
-
-            # Download standard kind e2e script
-            curl -sSLo e2e-k8s.sh https://raw.githubusercontent.com/kubernetes-sigs/kind/main/hack/ci/e2e-k8s.sh
-
-            # Patch the script to inject audit logging into the kind config
-            # This adds audit policy and log path to the API server configuration
-            sed -i '/kubeadmConfigPatches:/a\
-            - |\
-              kind: ClusterConfiguration\
-              apiServer:\
-                extraArgs:\
-                  audit-policy-file: /etc/kubernetes/audit/policy.yaml\
-                  audit-log-path: /var/log/kubernetes/audit.log\
-                  audit-log-maxage: "0"\
-                  audit-log-maxbackup: "0"\
-                  audit-log-maxsize: "2000000000"\
-                extraVolumes:\
-                - name: audit-policy\
-                  hostPath: /audit/policy.yaml\
-                  mountPath: /etc/kubernetes/audit/policy.yaml\
-                  readOnly: true\
-                - name: audit-logs\
-                  hostPath: /audit\
-                  mountPath: /var/log/kubernetes\
-                  readOnly: false' e2e-k8s.sh
-
-            # Add extraMounts to the existing control-plane node to mount audit policy
-            sed -i '/- role: control-plane$/a\
-              extraMounts:\
-              - hostPath: '"${ARTIFACTS}"'/audit\
-                containerPath: /audit' e2e-k8s.sh
-
-            # Run the e2e tests
-            chmod +x e2e-k8s.sh
-            ./e2e-k8s.sh
-
-            # Copy audit logs from kind node to artifacts
-            docker cp kind-control-plane:/var/log/kubernetes/audit.log "${ARTIFACTS}/audit/" || true
+            # Run the audit e2e script
+            cd ./../../k8s.io/kubernetes
+            $GOPATH/src/k8s.io/test-infra/experiment/kind-audit-e2e.sh
 
             # Parse audit logs
             apt-get update && apt-get install -y --no-install-recommends python3-pip
             pip3 install --no-cache-dir --break-system-packages pyyaml
-            python3 ./../test-infra/experiment/audit/audit_log_parser.py \
+            python3 $GOPATH/src/k8s.io/test-infra/experiment/audit/audit_log_parser.py \
               --audit-logs "${ARTIFACTS}/audit/audit.log" \
               --output "${ARTIFACTS}/audit/audit-endpoints.txt" \
               --audit-operations-json "${ARTIFACTS}/audit/audit-operations.json" \
               --swagger-url "file://$PWD/api/openapi-spec/swagger.json" \
               --ineligible-endpoints-url "file://$PWD/test/conformance/testdata/ineligible_endpoints.yaml" \
               --pending-eligible-endpoints-url "file://$PWD/test/conformance/testdata/pending_eligible_endpoints.yaml"
-            python3 ./../test-infra/experiment/audit/kubernetes_api_analysis.py \
+            python3 $GOPATH/src/k8s.io/test-infra/experiment/audit/kubernetes_api_analysis.py \
               --pull-audit-endpoints "${ARTIFACTS}/audit/audit-endpoints.txt" \
               --swagger-url "file://$PWD/api/openapi-spec/swagger.json"
       env:

--- a/experiment/kind-audit-e2e.sh
+++ b/experiment/kind-audit-e2e.sh
@@ -1,0 +1,363 @@
+#!/bin/sh
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# hack script for running kind e2e tests with audit logging enabled
+# must be run with a kubernetes checkout in $PWD (IE from the checkout)
+# Usage: SKIP="ginkgo skip regex" FOCUS="ginkgo focus regex" kind-audit-e2e.sh
+#
+# This script runs E2E tests with audit logging enabled for API coverage analysis.
+# Serial tests are NOT skipped - Ginkgo v2 runs them automatically after parallel
+# tests complete, providing better API coverage for auditing.
+
+set -o errexit -o nounset -o xtrace
+
+# Settings:
+# SKIP: ginkgo skip regex
+# FOCUS: ginkgo focus regex
+# LABEL_FILTER: ginkgo label query for selecting tests (see "Spec Labels" in https://onsi.github.io/ginkgo/#filtering-specs)
+#
+# The default is to focus on conformance tests.
+# Unlike other e2e scripts, Serial tests are NOT skipped when PARALLEL=true.
+# This is intentional for audit logging - we want maximum API coverage.
+#
+# FEATURE_GATES:
+#          JSON or YAML encoding of a string/bool map: {"FeatureGateA": true, "FeatureGateB": false}
+#          Enables or disables feature gates in the entire cluster.
+# RUNTIME_CONFIG:
+#          JSON or YAML encoding of a string/string (!) map: {"apia.example.com/v1alpha1": "true", "apib.example.com/v1beta1": "false"}
+#          Enables API groups in the apiserver via --runtime-config.
+
+# cleanup logic for cleanup on exit
+CLEANED_UP=false
+cleanup() {
+  if [ "$CLEANED_UP" = "true" ]; then
+    return
+  fi
+  # KIND_CREATE_ATTEMPTED is true once we: kind create
+  if [ "${KIND_CREATE_ATTEMPTED:-}" = true ]; then
+    # Copy audit logs from kind node before cleanup
+    echo "Copying audit logs from kind node..."
+    docker cp kind-control-plane:/var/log/kubernetes/audit.log "${ARTIFACTS}/audit/" 2>/dev/null || true
+
+    kind "export" logs "${ARTIFACTS}" || true
+    kind delete cluster || true
+  fi
+  rm -f _output/bin/e2e.test || true
+  # remove our tempdir, this needs to be last, or it will prevent kind delete
+  if [ -n "${TMP_DIR:-}" ]; then
+    rm -rf "${TMP_DIR:?}"
+  fi
+  CLEANED_UP=true
+}
+
+# setup signal handlers
+# shellcheck disable=SC2317 # this is not unreachable code
+signal_handler() {
+  if [ -n "${GINKGO_PID:-}" ]; then
+    kill -TERM "$GINKGO_PID" || true
+  fi
+  cleanup
+}
+trap signal_handler INT TERM
+
+# build kubernetes / node image, e2e binaries
+build() {
+  # build the node image w/ kubernetes
+  kind build node-image -v 1
+  # Ginkgo v1 is used by Kubernetes 1.24 and earlier, fallback if v2 is not available.
+  GINKGO_SRC_DIR="vendor/github.com/onsi/ginkgo/v2/ginkgo"
+  if [ ! -d "$GINKGO_SRC_DIR" ]; then
+      GINKGO_SRC_DIR="vendor/github.com/onsi/ginkgo/ginkgo"
+  fi
+  # make sure we have e2e requirements
+  make all WHAT="cmd/kubectl test/e2e/e2e.test ${GINKGO_SRC_DIR}"
+
+  # Ensure the built kubectl is used instead of system
+  export PATH="${PWD}/_output/bin:$PATH"
+}
+
+# up a cluster with kind
+create_cluster() {
+  # Default Log level for all components in test clusters
+  KIND_CLUSTER_LOG_LEVEL=${KIND_CLUSTER_LOG_LEVEL:-4}
+
+  # JSON or YAML map injected into featureGates config
+  feature_gates="${FEATURE_GATES:-{\}}"
+  # --runtime-config argument value passed to the API server, again as a map
+  runtime_config="${RUNTIME_CONFIG:-{\}}"
+
+  # Create audit policy directory
+  mkdir -p "${ARTIFACTS}/audit"
+
+  # Create audit policy file
+  cat > "${ARTIFACTS}/audit/policy.yaml" << 'AUDIT_POLICY'
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: Metadata
+    stages:
+      - ResponseComplete
+AUDIT_POLICY
+
+  # create the config file
+  cat <<EOF > "${ARTIFACTS}/kind-config.yaml"
+# config for 1 control plane node and 2 workers (necessary for conformance)
+# with audit logging enabled
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: ${IP_FAMILY:-ipv4}
+  kubeProxyMode: ${KUBE_PROXY_MODE:-iptables}
+  # don't pass through host search paths
+  dnsSearch: []
+nodes:
+- role: control-plane
+  extraMounts:
+  # Mount audit policy and log directory
+  - hostPath: ${ARTIFACTS}/audit
+    containerPath: /audit
+- role: worker
+- role: worker
+featureGates: ${feature_gates}
+runtimeConfig: ${runtime_config}
+kubeadmConfigPatches:
+# v1beta4 for the future (v1.35.0+ ?)
+# https://github.com/kubernetes-sigs/kind/issues/3847
+# TODO: drop v1beta3 when we no longer need versions that use it
+- |
+  kind: ClusterConfiguration
+  apiVersion: kubeadm.k8s.io/v1beta4
+  apiServer:
+    extraArgs:
+      - name: "v"
+        value: "${KIND_CLUSTER_LOG_LEVEL}"
+      - name: "audit-policy-file"
+        value: "/etc/kubernetes/audit/policy.yaml"
+      - name: "audit-log-path"
+        value: "/var/log/kubernetes/audit.log"
+      - name: "audit-log-maxage"
+        value: "0"
+      - name: "audit-log-maxbackup"
+        value: "0"
+      - name: "audit-log-maxsize"
+        value: "2000000000"
+    extraVolumes:
+      - name: audit-policy
+        hostPath: /audit/policy.yaml
+        mountPath: /etc/kubernetes/audit/policy.yaml
+        readOnly: true
+      - name: audit-logs
+        hostPath: /audit
+        mountPath: /var/log/kubernetes
+        readOnly: false
+  controllerManager:
+    extraArgs:
+      - name: "v"
+        value: "${KIND_CLUSTER_LOG_LEVEL}"
+  scheduler:
+    extraArgs:
+      - name: "v"
+        value: "${KIND_CLUSTER_LOG_LEVEL}"
+  ---
+  kind: InitConfiguration
+  apiVersion: kubeadm.k8s.io/v1beta4
+  nodeRegistration:
+    kubeletExtraArgs:
+      - name: "v"
+        value: "${KIND_CLUSTER_LOG_LEVEL}"
+      - name: "container-log-max-files"
+        value: "10"
+      - name: "container-log-max-size"
+        value: "100Mi"
+  ---
+  kind: JoinConfiguration
+  apiVersion: kubeadm.k8s.io/v1beta4
+  nodeRegistration:
+    kubeletExtraArgs:
+      - name: "v"
+        value: "${KIND_CLUSTER_LOG_LEVEL}"
+      - name: "container-log-max-files"
+        value: "10"
+      - name: "container-log-max-size"
+        value: "100Mi"
+  ---
+  kind: KubeletConfiguration
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  enableSystemLogHandler: true
+  enableSystemLogQuery: true
+# v1beta3 for v1.23.0 ... ?
+- |
+  kind: ClusterConfiguration
+  apiVersion: kubeadm.k8s.io/v1beta3
+  apiServer:
+    extraArgs:
+      "v": "${KIND_CLUSTER_LOG_LEVEL}"
+      "audit-policy-file": "/etc/kubernetes/audit/policy.yaml"
+      "audit-log-path": "/var/log/kubernetes/audit.log"
+      "audit-log-maxage": "0"
+      "audit-log-maxbackup": "0"
+      "audit-log-maxsize": "2000000000"
+    extraVolumes:
+      - name: audit-policy
+        hostPath: /audit/policy.yaml
+        mountPath: /etc/kubernetes/audit/policy.yaml
+        readOnly: true
+      - name: audit-logs
+        hostPath: /audit
+        mountPath: /var/log/kubernetes
+        readOnly: false
+  controllerManager:
+    extraArgs:
+      "v": "${KIND_CLUSTER_LOG_LEVEL}"
+  scheduler:
+    extraArgs:
+      "v": "${KIND_CLUSTER_LOG_LEVEL}"
+  ---
+  kind: InitConfiguration
+  apiVersion: kubeadm.k8s.io/v1beta3
+  nodeRegistration:
+    kubeletExtraArgs:
+      "v": "${KIND_CLUSTER_LOG_LEVEL}"
+      "container-log-max-files": "10"
+      "container-log-max-size": "100Mi"
+  ---
+  kind: JoinConfiguration
+  apiVersion: kubeadm.k8s.io/v1beta3
+  nodeRegistration:
+    kubeletExtraArgs:
+      "v": "${KIND_CLUSTER_LOG_LEVEL}"
+      "container-log-max-files": "10"
+      "container-log-max-size": "100Mi"
+  ---
+  kind: KubeletConfiguration
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  enableSystemLogHandler: true
+  enableSystemLogQuery: true
+EOF
+  # NOTE: must match the number of workers above
+  NUM_NODES=2
+  # actually create the cluster
+  KIND_CREATE_ATTEMPTED=true
+  kind create cluster \
+    --image=kindest/node:latest \
+    --retain \
+    --wait=1m \
+    -v=3 \
+    "--config=${ARTIFACTS}/kind-config.yaml"
+
+  # debug cluster version
+  kubectl version
+
+  # Patch kube-proxy to set the verbosity level
+  kubectl patch -n kube-system daemonset/kube-proxy \
+    --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--v='"${KIND_CLUSTER_LOG_LEVEL}"'" }]'
+}
+
+# run e2es with ginkgo-e2e.sh
+run_tests() {
+  # IPv6 clusters need some CoreDNS changes in order to work in k8s CI:
+  # 1. k8s CI doesn't offer IPv6 connectivity, so CoreDNS should be configured
+  # to work in an offline environment:
+  # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
+  # 2. k8s CI adds following domains to resolv.conf search field:
+  # c.k8s-prow-builds.internal google.internal.
+  # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
+  # otherwise pods stops trying to resolve the domain.
+  if [ "${IP_FAMILY:-ipv4}" = "ipv6" ]; then
+    # Get the current config
+    original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
+    echo "Original CoreDNS config:"
+    echo "${original_coredns}"
+    # Patch it
+    fixed_coredns=$(
+      printf '%s' "${original_coredns}" | sed \
+        -e 's/^.*kubernetes cluster\.local/& internal/' \
+        -e '/^.*upstream$/d' \
+        -e '/^.*fallthrough.*$/d' \
+        -e '/^.*forward . \/etc\/resolv.conf$/d' \
+        -e '/^.*loop$/d' \
+    )
+    echo "Patched CoreDNS config:"
+    echo "${fixed_coredns}"
+    printf '%s' "${fixed_coredns}" | kubectl apply -f -
+  fi
+
+  # ginkgo regexes and label filter
+  SKIP="${SKIP:-}"
+  FOCUS="${FOCUS:-}"
+  LABEL_FILTER="${LABEL_FILTER:-}"
+  if [ -z "${FOCUS}" ] && [ -z "${LABEL_FILTER}" ]; then
+    FOCUS="\\[Conformance\\]"
+  fi
+  # if we set PARALLEL=true, enable parallel testing
+  # NOTE: Unlike other e2e scripts, we do NOT skip Serial tests here.
+  # Ginkgo v2 handles Serial tests properly - they run after parallel tests complete.
+  # This gives us better API coverage for audit logging.
+  if [ "${PARALLEL:-false}" = "true" ]; then
+    export GINKGO_PARALLEL=y
+    # Serial tests are intentionally NOT skipped for audit coverage
+  fi
+
+  # setting this env prevents ginkgo e2e from trying to run provider setup
+  export KUBERNETES_CONFORMANCE_TEST='y'
+  # setting these is required to make RuntimeClass tests work ... :/
+  export KUBE_CONTAINER_RUNTIME=remote
+  export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
+  export KUBE_CONTAINER_RUNTIME_NAME=containerd
+  # ginkgo can take forever to exit, so we run it in the background and save the
+  # PID, bash will not run traps while waiting on a process, but it will while
+  # running a builtin like `wait`, saving the PID also allows us to forward the
+  # interrupt
+  ./hack/ginkgo-e2e.sh \
+    '--provider=skeleton' "--num-nodes=${NUM_NODES}" \
+    "--ginkgo.focus=${FOCUS}" "--ginkgo.skip=${SKIP}" "--ginkgo.label-filter=${LABEL_FILTER}" \
+    "--report-dir=${ARTIFACTS}" '--disable-log-dump=true' &
+  GINKGO_PID=$!
+  wait "$GINKGO_PID"
+}
+
+main() {
+  # create temp dir and setup cleanup
+  TMP_DIR=$(mktemp -d)
+
+  # ensure artifacts (results) directory exists when not in CI
+  export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
+  mkdir -p "${ARTIFACTS}"
+
+  # export the KUBECONFIG to a unique path for testing
+  KUBECONFIG="${HOME}/.kube/kind-test-config"
+  export KUBECONFIG
+  echo "exported KUBECONFIG=${KUBECONFIG}"
+
+  # debug kind version
+  kind version
+
+  # build kubernetes
+  build
+  # in CI attempt to release some memory after building
+  if [ -n "${KUBETEST_IN_DOCKER:-}" ]; then
+    sync || true
+    echo 1 > /proc/sys/vm/drop_caches || true
+  fi
+
+  # create the cluster and run tests
+  res=0
+  create_cluster || res=$?
+  run_tests || res=$?
+  cleanup || res=$?
+  exit $res
+}
+
+main


### PR DESCRIPTION
Add a new experiment/kind-audit-e2e.sh script that runs kind e2e tests with audit logging enabled. This follows the pattern of other experiment scripts like kind-race-e2e-k8s.sh.

- Self-contained audit logging configuration (both v1beta3 and v1beta4)
- Does NOT skip Serial tests when PARALLEL=true, allowing Ginkgo v2 to run them after parallel tests for better API coverage
- Copies audit logs from kind node to artifacts during cleanup