### PR TITLE
Fix kubelet startup failure in kind-audit-e2e.sh

### DIFF
--- a/experiment/kind-audit-e2e.sh
+++ b/experiment/kind-audit-e2e.sh
@@ -192,11 +192,6 @@ kubeadmConfigPatches:
         value: "10"
       - name: "container-log-max-size"
         value: "100Mi"
-  ---
-  kind: KubeletConfiguration
-  apiVersion: kubelet.config.k8s.io/v1beta1
-  enableSystemLogHandler: true
-  enableSystemLogQuery: true
 # v1beta3 for v1.23.0 ... ?
 - |
   kind: ClusterConfiguration
@@ -240,11 +235,6 @@ kubeadmConfigPatches:
       "v": "${KIND_CLUSTER_LOG_LEVEL}"
       "container-log-max-files": "10"
       "container-log-max-size": "100Mi"
-  ---
-  kind: KubeletConfiguration
-  apiVersion: kubelet.config.k8s.io/v1beta1
-  enableSystemLogHandler: true
-  enableSystemLogQuery: true
 EOF
   # NOTE: must match the number of workers above
   NUM_NODES=2


### PR DESCRIPTION
Remove KubeletConfiguration blocks that set enableSystemLogQuery: true, which requires the NodeLogQuery feature gate to be enabled. This feature gate is still Beta (since v1.30) and defaults to false, causing the kubelet to fail validation and not start.

These settings were not needed for the audit logging functionality.