### PR TITLE
Fix FOCUS variable handling in kind-audit-e2e.sh

### DIFF
--- a/experiment/kind-audit-e2e.sh
+++ b/experiment/kind-audit-e2e.sh
@@ -285,11 +285,14 @@ run_tests() {
   fi
 
   # ginkgo regexes and label filter
+  # Note: We check if FOCUS is unset (not just empty) to allow
+  # explicit FOCUS="" to mean "run all tests" (no focus filter)
   SKIP="${SKIP:-}"
-  FOCUS="${FOCUS:-}"
   LABEL_FILTER="${LABEL_FILTER:-}"
-  if [ -z "${FOCUS}" ] && [ -z "${LABEL_FILTER}" ]; then
+  if [ -z "${FOCUS+x}" ] && [ -z "${LABEL_FILTER}" ]; then
     FOCUS="\\[Conformance\\]"
+  else
+    FOCUS="${FOCUS:-}"
   fi
   # if we set PARALLEL=true, enable parallel testing
   # NOTE: Unlike other e2e scripts, we do NOT skip Serial tests here.


### PR DESCRIPTION
Fix FOCUS variable handling to distinguish between unset and empty. When FOCUS="" is explicitly set (to run all tests), the script was incorrectly overriding it to "[Conformance]" because -z "" is true. Now uses ${FOCUS+x} to check if the variable is set vs unset.