### PR TITLE
Enable periodic GH Bug Triage project board syncing for v1.36

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -26,7 +26,7 @@ periodics:
             secretKeyRef:
               name: k8s-release-enhancements-triage-github-token
               key: token
-- name: periodic-sync-bug-triage-github-project-beta-1-34
+- name: periodic-sync-bug-triage-github-project-beta-1-36
   interval: 3h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
@@ -47,7 +47,7 @@ periodics:
         - name: PROJECT_NUMBER
           value: "80"
         - name: MILESTONE
-          value: "v1.34"
+          value: "v1.36"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
- Enable periodic GH Bug Triage project board syncing for v1.36