### PR TITLE
Allow UnifiedCgroup annotation for CRI-O tests

### DIFF
--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
+          "source": "data:;base64,H4sIAAAAAAAC/7SQMY/UQAyF+/kVVq6+bI+0BYKG6pCA6hRFk4mTmJvYke3ZuxXiv6PZLCBAh6C4KorH33vP7z4pSUtrnLELRjNHL4r9JpnSGY7QHNDToS4d9ln72YSbEHZQCzut2IUsc5/xhLkyIw5lbsKosvXEk8Y+ucIRppgNw4hTLNn7K1uBpOUPze9fa+trF66//RZ9uQQrpodMAz7hNeCusgqTi/5tT3itN9zAx7u3d69giSfiGXxBqBJgZUizStlgUIwPBr6QQZKcMTkJg+IqJ9zHjwsy+BIdyGCiJxx/HBiZxWMlDI7wBRot3Eqi1s7muI6tleHi09ScDXwNN/A6Z3mET0wT4fhmT/FTByZReP/hHay4ip5hUzQriuBobiFWGMffjO8bkvahDKiMfqmTbqX9xaLpni1fC6d/Kb/u/U/5z/nVS26XyGNGfQnfbwEAAP//k9RVKvECAAA="
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_canary.ign
+++ b/jobs/e2e_node/crio/crio_canary.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
+          "source": "data:;base64,H4sIAAAAAAAC/7SQMY/UQAyF+/kVVq6+bI+0BYKG6pCA6hRFk4mTmJvYke3ZuxXiv6PZLCBAh6C4KorH33vP7z4pSUtrnLELRjNHL4r9JpnSGY7QHNDToS4d9ln72YSbEHZQCzut2IUsc5/xhLkyIw5lbsKosvXEk8Y+ucIRppgNw4hTLNn7K1uBpOUPze9fa+trF66//RZ9uQQrpodMAz7hNeCusgqTi/5tT3itN9zAx7u3d69giSfiGXxBqBJgZUizStlgUIwPBr6QQZKcMTkJg+IqJ9zHjwsy+BIdyGCiJxx/HBiZxWMlDI7wBRot3Eqi1s7muI6tleHi09ScDXwNN/A6Z3mET0wT4fhmT/FTByZReP/hHay4ip5hUzQriuBobiFWGMffjO8bkvahDKiMfqmTbqX9xaLpni1fC6d/Kb/u/U/5z/nVS26XyGNGfQnfbwEAAP//k9RVKvECAAA="
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_drop_infra_ctr.ign
+++ b/jobs/e2e_node/crio/crio_drop_infra_ctr.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
+          "source": "data:;base64,H4sIAAAAAAAC/7SQMY/UQAyF+/kVVq6+bI+0BYKG6pCA6hRFk4mTmJvYke3ZuxXiv6PZLCBAh6C4KorH33vP7z4pSUtrnLELRjNHL4r9JpnSGY7QHNDToS4d9ln72YSbEHZQCzut2IUsc5/xhLkyIw5lbsKosvXEk8Y+ucIRppgNw4hTLNn7K1uBpOUPze9fa+trF66//RZ9uQQrpodMAz7hNeCusgqTi/5tT3itN9zAx7u3d69giSfiGXxBqBJgZUizStlgUIwPBr6QQZKcMTkJg+IqJ9zHjwsy+BIdyGCiJxx/HBiZxWMlDI7wBRot3Eqi1s7muI6tleHi09ScDXwNN/A6Z3mET0wT4fhmT/FTByZReP/hHay4ip5hUzQriuBobiFWGMffjO8bkvahDKiMfqmTbqX9xaLpni1fC6d/Kb/u/U/5z/nVS26XyGNGfQnfbwEAAP//k9RVKvECAAA="
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_eventedpleg.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
+          "source": "data:;base64,H4sIAAAAAAAC/7SQMY/UQAyF+/kVVq6+bI+0BYKG6pCA6hRFk4mTmJvYke3ZuxXiv6PZLCBAh6C4KorH33vP7z4pSUtrnLELRjNHL4r9JpnSGY7QHNDToS4d9ln72YSbEHZQCzut2IUsc5/xhLkyIw5lbsKosvXEk8Y+ucIRppgNw4hTLNn7K1uBpOUPze9fa+trF66//RZ9uQQrpodMAz7hNeCusgqTi/5tT3itN9zAx7u3d69giSfiGXxBqBJgZUizStlgUIwPBr6QQZKcMTkJg+IqJ9zHjwsy+BIdyGCiJxx/HBiZxWMlDI7wBRot3Eqi1s7muI6tleHi09ScDXwNN/A6Z3mET0wT4fhmT/FTByZReP/hHay4ip5hUzQriuBobiFWGMffjO8bkvahDKiMfqmTbqX9xaLpni1fC6d/Kb/u/U/5z/nVS26XyGNGfQnfbwEAAP//k9RVKvECAAA="
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_hugepages.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
+          "source": "data:;base64,H4sIAAAAAAAC/7SQMY/UQAyF+/kVVq6+bI+0BYKG6pCA6hRFk4mTmJvYke3ZuxXiv6PZLCBAh6C4KorH33vP7z4pSUtrnLELRjNHL4r9JpnSGY7QHNDToS4d9ln72YSbEHZQCzut2IUsc5/xhLkyIw5lbsKosvXEk8Y+ucIRppgNw4hTLNn7K1uBpOUPze9fa+trF66//RZ9uQQrpodMAz7hNeCusgqTi/5tT3itN9zAx7u3d69giSfiGXxBqBJgZUizStlgUIwPBr6QQZKcMTkJg+IqJ9zHjwsy+BIdyGCiJxx/HBiZxWMlDI7wBRot3Eqi1s7muI6tleHi09ScDXwNN/A6Z3mET0wT4fhmT/FTByZReP/hHay4ip5hUzQriuBobiFWGMffjO8bkvahDKiMfqmTbqX9xaLpni1fC6d/Kb/u/U/5z/nVS26XyGNGfQnfbwEAAP//k9RVKvECAAA="
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_imagefs.ign
+++ b/jobs/e2e_node/crio/crio_imagefs.ign
@@ -47,7 +47,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
+          "source": "data:;base64,H4sIAAAAAAAC/7SQMY/UQAyF+/kVVq6+bI+0BYKG6pCA6hRFk4mTmJvYke3ZuxXiv6PZLCBAh6C4KorH33vP7z4pSUtrnLELRjNHL4r9JpnSGY7QHNDToS4d9ln72YSbEHZQCzut2IUsc5/xhLkyIw5lbsKosvXEk8Y+ucIRppgNw4hTLNn7K1uBpOUPze9fa+trF66//RZ9uQQrpodMAz7hNeCusgqTi/5tT3itN9zAx7u3d69giSfiGXxBqBJgZUizStlgUIwPBr6QQZKcMTkJg+IqJ9zHjwsy+BIdyGCiJxx/HBiZxWMlDI7wBRot3Eqi1s7muI6tleHi09ScDXwNN/A6Z3mET0wT4fhmT/FTByZReP/hHay4ip5hUzQriuBobiFWGMffjO8bkvahDKiMfqmTbqX9xaLpni1fC6d/Kb/u/U/5z/nVS26XyGNGfQnfbwEAAP//k9RVKvECAAA="
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_splitfs.ign
+++ b/jobs/e2e_node/crio/crio_splitfs.ign
@@ -47,7 +47,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
+          "source": "data:;base64,H4sIAAAAAAAC/7SQMY/UQAyF+/kVVq6+bI+0BYKG6pCA6hRFk4mTmJvYke3ZuxXiv6PZLCBAh6C4KorH33vP7z4pSUtrnLELRjNHL4r9JpnSGY7QHNDToS4d9ln72YSbEHZQCzut2IUsc5/xhLkyIw5lbsKosvXEk8Y+ucIRppgNw4hTLNn7K1uBpOUPze9fa+trF66//RZ9uQQrpodMAz7hNeCusgqTi/5tT3itN9zAx7u3d69giSfiGXxBqBJgZUizStlgUIwPBr6QQZKcMTkJg+IqJ9zHjwsy+BIdyGCiJxx/HBiZxWMlDI7wBRot3Eqi1s7muI6tleHi09ScDXwNN/A6Z3mET0wT4fhmT/FTByZReP/hHay4ip5hUzQriuBobiFWGMffjO8bkvahDKiMfqmTbqX9xaLpni1fC6d/Kb/u/U/5z/nVS26XyGNGfQnfbwEAAP//k9RVKvECAAA="
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -29,7 +29,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
+          "source": "data:;base64,H4sIAAAAAAAC/7SQMY/UQAyF+/kVVq6+bI+0BYKG6pCA6hRFk4mTmJvYke3ZuxXiv6PZLCBAh6C4KorH33vP7z4pSUtrnLELRjNHL4r9JpnSGY7QHNDToS4d9ln72YSbEHZQCzut2IUsc5/xhLkyIw5lbsKosvXEk8Y+ucIRppgNw4hTLNn7K1uBpOUPze9fa+trF66//RZ9uQQrpodMAz7hNeCusgqTi/5tT3itN9zAx7u3d69giSfiGXxBqBJgZUizStlgUIwPBr6QQZKcMTkJg+IqJ9zHjwsy+BIdyGCiJxx/HBiZxWMlDI7wBRot3Eqi1s7muI6tleHi09ScDXwNN/A6Z3mET0wT4fhmT/FTByZReP/hHay4ip5hUzQriuBobiFWGMffjO8bkvahDKiMfqmTbqX9xaLpni1fC6d/Kb/u/U/5z/nVS26XyGNGfQnfbwEAAP//k9RVKvECAAA="
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_userns.ign
+++ b/jobs/e2e_node/crio/crio_userns.ign
@@ -39,7 +39,7 @@
         "path": "/etc/crio/crio.conf.d/20-crio.conf",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7RQPU/zQAze8yusvPOb7Ejd2LuwoSq6XJzEcLEj21daIf47uqawoCIYmE5nP19+HqOSNLSECQ+V0cTBs2K3SqJ4hh3ULXpsC6jdZs2TCddVtRE1s9OChyrJ1CU8YiqcAfs81dWgsnbEo4YuusIOxpAMqwHHkJN3V24hRM1fND9ea8r2UF2/3Rp8vgTLpm2iHk94DbipLMLkot/hhJdywz942N/v72AOR+IJfEYoEmC5j5NKXqFXDM8GPpNBlJQwOgmD4iJH3MYvMzL4HBzIYKQTDp8HBmbxUBgGO3iFWjM3EqmxszkuQ2O5v/jUJWcNbzcb0MzxJw0U3G8auOXnaP5/Djwk1L/wfQ8AAP//ee9iEHYCAAA="
+          "source": "data:;base64,H4sIAAAAAAAC/7SQMY/UQAyF+/kVVq6+bI+0BYKG6pCA6hRFk4mTmJvYke3ZuxXiv6PZLCBAh6C4KorH33vP7z4pSUtrnLELRjNHL4r9JpnSGY7QHNDToS4d9ln72YSbEHZQCzut2IUsc5/xhLkyIw5lbsKosvXEk8Y+ucIRppgNw4hTLNn7K1uBpOUPze9fa+trF66//RZ9uQQrpodMAz7hNeCusgqTi/5tT3itN9zAx7u3d69giSfiGXxBqBJgZUizStlgUIwPBr6QQZKcMTkJg+IqJ9zHjwsy+BIdyGCiJxx/HBiZxWMlDI7wBRot3Eqi1s7muI6tleHi09ScDXwNN/A6Z3mET0wT4fhmT/FTByZReP/hHay4ip5hUzQriuBobiFWGMffjO8bkvahDKiMfqmTbqX9xaLpni1fC6d/Kb/u/U/5z/nVS26XyGNGfQnfbwEAAP//k9RVKvECAAA="
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/templates/base/20-crio.conf
+++ b/jobs/e2e_node/crio/templates/base/20-crio.conf
@@ -11,6 +11,8 @@ runtime_path = "/usr/libexec/crio/crun"
 monitor_path = "/usr/libexec/crio/conmon"
 # TODO: having the crun subcgroup breaks this collection remove this when that is fixed
 default_annotations = { "run.oci.systemd.subgroup" = "" }
+# Allow UnifiedCgroup annotation for PSI memory pressure tests
+allowed_annotations = ["io.kubernetes.cri-o.UnifiedCgroup"]
 
 [crio.runtime.runtimes.runc]
 runtime_path = "/usr/libexec/crio/runc"


### PR DESCRIPTION
Enable io.kubernetes.cri-o.UnifiedCgroup annotation for the crun runtime to support setting memory.high for PSI memory pressure tests.

This is required for the memory PSI test which needs memory.high to generate sustained pressure metrics without triggering OOM kills.

Refers to https://github.com/kubernetes/kubernetes/pull/136191

@kubernetes/sig-node-cri-o-test-maintainers PTAL