### PR TITLE
Remove feature gates from kind config

### DIFF
--- a/experiment/kind-multizone-e2e.sh
+++ b/experiment/kind-multizone-e2e.sh
@@ -116,9 +116,6 @@ create_cluster() {
   cat <<EOF > "${ARTIFACTS}/kind-config.yaml"
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  TopologyAwareHints: true
-  ServiceTrafficDistribution: true
 nodes:
 - role: control-plane
 - role: worker


### PR DESCRIPTION
Removed feature gates for TopologyAwareHints and ServiceTrafficDistribution from the kind configuration since no longer exist and make the job to panic

https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20multizone

https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-kind-multizone/2011063587098857472/artifacts/logs/kind-control-plane/kubelet.log

https://github.com/kubernetes/kubernetes/pull/136112

/assign @danwinship 