### PR TITLE
Revert "Update Boskos as needed"

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -924,7 +924,7 @@ periodics:
         - --ttl=6h
         - --path=s3://provider-aws-test-infra/objs.json
         - --region=us-east-1
-        image: gcr.io/k8s-staging-boskos/aws-janitor:v20260107-c2c6f43
+        image: gcr.io/k8s-staging-boskos/aws-janitor:v20251218-e3340a3
         resources:
           requests:
             cpu: 1

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -19,7 +19,7 @@ periodics:
       args:
       - --ttl=12h
       - --path=s3://k8s-infra-kops-scale-tests/objs.json
-      image: gcr.io/k8s-staging-boskos/aws-janitor:v20260107-c2c6f43
+      image: gcr.io/k8s-staging-boskos/aws-janitor:v20251218-e3340a3
       resources:
         requests:
           cpu: 1

--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -21,7 +21,7 @@ periodics:
       - --path=s3://cloud-provider-aws-shared-e2e/objs.json
       - --exclude-tags=Shared=Ignore
       - --enable-target-group-clean=true
-      image: gcr.io/k8s-staging-boskos/aws-janitor:v20260107-c2c6f43
+      image: gcr.io/k8s-staging-boskos/aws-janitor:v20251218-e3340a3
       resources:
         requests:
           cpu: 1
@@ -55,7 +55,7 @@ periodics:
       - --ttl=2h30m
       - --path=s3://k8s-kops-prow/objs.json
       - --exclude-tags=Shared=Ignore
-      image: gcr.io/k8s-staging-boskos/aws-janitor:v20260107-c2c6f43
+      image: gcr.io/k8s-staging-boskos/aws-janitor:v20251218-e3340a3
   annotations:
     testgrid-dashboards: sig-testing-maintenance
     testgrid-tab-name: ci-aws-janitor


### PR DESCRIPTION
Reverts kubernetes/test-infra#36169

It appears we got all aws-project stuck in dirty state around the time this merged.

I suspect perhaps related to https://github.com/kubernetes-sigs/boskos/pull/235 but don't have time to dig further at the moment.

cc @dims @upodroid 

ref: 

https://kubernetes.slack.com/archives/C7J9RP96G/p1768416755760379?thread_ts=1742406545.163939&cid=C7J9RP96G

https://monitoring-eks.prow.k8s.io/d/wSrfvNxWz/boskos-resource-usage?orgId=1&from=now-30d&to=now