### PR TITLE
Fix ppc64le integration job names

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -43,7 +43,7 @@ periodics:
               cpu: 6
               memory: "28Gi"
 
-  - name: ci-kubernetes-integration-master-ppc64le
+  - name: ci-kubernetes-integration-ppc64le-master
     interval: 1h
     cluster: k8s-infra-ppc64le-prow-build
     decorate: true
@@ -56,7 +56,7 @@ periodics:
       fork-per-release: "true"
       fork-per-release-cron: 0 0/2 * * *, 0 1/6 * * *, 0 2 * * *
       testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics
-      testgrid-tab-name: ci-kubernetes-integration-master-ppc64le
+      testgrid-tab-name: ci-kubernetes-integration-ppc64le-master
       testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '2'
       description: "Ends up running: make test-integration"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -844,7 +844,7 @@ periodics:
     testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
     testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics
     testgrid-num-failures-to-alert: "2"
-    testgrid-tab-name: ci-kubernetes-integration-1.33-ppc64le
+    testgrid-tab-name: ci-kubernetes-integration-ppc64le-1.33
   cluster: k8s-infra-ppc64le-prow-build
   decorate: true
   extra_refs:
@@ -853,7 +853,7 @@ periodics:
     path_alias: k8s.io/kubernetes
     repo: kubernetes
   cron: 0 2 * * *
-  name: ci-kubernetes-integration-master-ppc64le-1-33
+  name: ci-kubernetes-integration-ppc64le-1-33
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1122,7 +1122,7 @@ periodics:
     testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
     testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics
     testgrid-num-failures-to-alert: "2"
-    testgrid-tab-name: ci-kubernetes-integration-1.34-ppc64le
+    testgrid-tab-name: ci-kubernetes-integration-ppc64le-1.34
   cluster: k8s-infra-ppc64le-prow-build
   decorate: true
   extra_refs:
@@ -1131,7 +1131,7 @@ periodics:
     path_alias: k8s.io/kubernetes
     repo: kubernetes
   cron: 0 1/6 * * *
-  name: ci-kubernetes-integration-master-ppc64le-1-34
+  name: ci-kubernetes-integration-ppc64le-1-34
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -1240,7 +1240,7 @@ periodics:
     testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
     testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics
     testgrid-num-failures-to-alert: "2"
-    testgrid-tab-name: ci-kubernetes-integration-1.35-ppc64le
+    testgrid-tab-name: ci-kubernetes-integration-ppc64le-1.35
   cluster: k8s-infra-ppc64le-prow-build
   decorate: true
   extra_refs:
@@ -1249,7 +1249,7 @@ periodics:
     path_alias: k8s.io/kubernetes
     repo: kubernetes
   cron: 0 0/2 * * *
-  name: ci-kubernetes-integration-master-ppc64le-1-35
+  name: ci-kubernetes-integration-ppc64le-1-35
   spec:
     containers:
     - args:


### PR DESCRIPTION
### What the pull request does

The pull request corrects the names of the PPC64LE integration release branch jobs that were added in pull request #[36067](https://github.com/kubernetes/test-infra/pull/36067/).

The changes are
- Rename wrongly named jobs added in #[36067](https://github.com/kubernetes/test-infra/pull/36067/).by removing master from every affected job name.
- Updated integration release branch 1.33, 1.34, and 1.35 jobs to `ci-kubernetes-integration-ppc64le-1-XX`
- For each of the three jobs the value of `testgrid-tab-name` has been set equal to the new job name.

No other jobs and no periodic jobs, have been touched.

### Verification

- Every job name plus its matching `testgrid-tab-name` were checked by hand.
- The config forker tool will append the release suffix for version 1.35 as expected.

/cc @RajalakshmiGirish