### PR TITLE
feat(ci): Add pull-prow-verify-codegen presubmit job

### DIFF
--- a/config/jobs/kubernetes-sigs/prow/prow-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/prow/prow-presubmits.yaml
@@ -149,3 +149,25 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-testing-prow-repo
       testgrid-tab-name: verify-test
+  - name: pull-prow-verify-codegen
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: '^site/'
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260108-6ef4f0b08f-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - verify-codegen
+        resources:
+          requests:
+            cpu: "7"
+            memory: "8Gi"
+          limits:
+            cpu: "7"
+            memory: "8Gi"
+    annotations:
+      testgrid-dashboards: sig-testing-prow-repo
+      testgrid-tab-name: verify-codegen


### PR DESCRIPTION
## Problem

Follow-up to kubernetes-sigs/prow#593 - the `make verify-codegen` target exists in the prow repo but is not executed as part of CI presubmit testing. This allowed a regression where `bindata.go` was not regenerated after HTML source changes.

## Solution

Add a new presubmit job `pull-prow-verify-codegen` that runs `make verify-codegen` on PRs to kubernetes-sigs/prow.

## Job Configuration

- **Name**: `pull-prow-verify-codegen`
- **Cluster**: `eks-prow-build-cluster`
- **Trigger**: Runs on PRs, skipped only when changes are limited to `site/` directory
- **Command**: `make verify-codegen`
- **TestGrid**: Reports to `sig-testing-prow-repo` dashboard under `verify-codegen` tab

## Testing

- `make verify-generated-jobs` passes ✅

/cc @smg247