### PR TITLE
Sync `config/jobs/kubernetes-sigs/jobset/OWNERS` to https://github.com/kubernetes-sigs/jobset/blob/main/OWNERS

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/OWNERS
+++ b/config/jobs/kubernetes-sigs/jobset/OWNERS
@@ -2,5 +2,8 @@
 
 approvers:
   - ahg-g
-  - danielvegamyhre
+  - andreyvelich
+  - GiuseppeTT
   - kannon92
+emeritus_approvers:
+  - danielvegamyhre  # 2026-01-16


### PR DESCRIPTION
Sync `config/jobs/kubernetes-sigs/jobset/OWNERS` to https://github.com/kubernetes-sigs/jobset/blob/main/OWNERS

In practice, this means:

- Add @andreyvelich to `approvers`
- Add @GiuseppeTT (myself) to `approvers`
- Move @danielvegamyhre to `emeritus_approvers`

This is a follow up to https://github.com/kubernetes-sigs/jobset/pull/1122 and https://github.com/kubernetes-sigs/jobset/pull/1123 . Let's wait for them to get merged first.

cc @ahg-g @kannon92 @andreyvelich @danielvegamyhre 