### PR TITLE
upgrade the capz version

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.32-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.32-windows.yaml
@@ -9,7 +9,7 @@ periodics:
   decoration_config:
     timeout: 4h0m0s
   extra_refs:
-  - base_ref: release-1.21
+  - base_ref: main
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -65,7 +65,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.21
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-1.33
     decorate: true
     extra_refs:
-    - base_ref: release-1.21
+    - base_ref: main
       org: kubernetes-sigs
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.33-windows.yaml
@@ -9,7 +9,7 @@ periodics:
   decoration_config:
     timeout: 4h0m0s
   extra_refs:
-  - base_ref: release-1.21
+  - base_ref: main
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -65,7 +65,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.21
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-1.34
     decorate: true
     extra_refs:
-    - base_ref: release-1.21
+    - base_ref: main
       org: kubernetes-sigs
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.34-windows.yaml
@@ -9,7 +9,7 @@ periodics:
   decoration_config:
     timeout: 4h0m0s
   extra_refs:
-  - base_ref: release-1.21
+  - base_ref: main
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -65,7 +65,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.21
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.35-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.35-windows-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-1.35
     decorate: true
     extra_refs:
-    - base_ref: release-1.21
+    - base_ref: main
       org: kubernetes-sigs
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       repo: cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.35-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.35-windows.yaml
@@ -9,7 +9,7 @@ periodics:
   decoration_config:
     timeout: 4h0m0s
   extra_refs:
-  - base_ref: release-1.21
+  - base_ref: main
     org: kubernetes-sigs
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     repo: cluster-api-provider-azure
@@ -65,7 +65,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: release-1.21
+    base_ref: main
     path_alias: sigs.k8s.io/cluster-api-provider-azure
     workdir: false
   - org: kubernetes-sigs


### PR DESCRIPTION
With the upgrade of CAPI version in sig windows testing https://github.com/kubernetes-sigs/windows-testing/commit/f846def9f25978a799e7ffc3344cc724a503bd9f, the clusterctl from capz will need to be upgraded as well otherwise it will cause log collection related issues. this is to fix it