### PR TITLE
config/jobs: exclude resource manager tests from cri-o serial job

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -185,7 +185,9 @@ periodics:
           - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-serial.yaml
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=1 --timeout=5h --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:OffByDefault\]"
+          # *Manager jobs are skipped because they have corresponding test lanes with the right image
+          # These jobs in serial get partially skipped and are long jobs.
+          - --test_args=--nodes=1 --timeout=5h --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:OffByDefault\]"
           - --timeout=300m
       env:
       - name: GOPATH


### PR DESCRIPTION
Exclude [Feature:CPUManager], [Feature:MemoryManager], and [Feature:TopologyManager] from ci-kubernetes-node-kubelet-serial-cri-o to match the pattern used by the containerd serial job: https://github.com/kubernetes/test-infra/blob/62729a4aadc83658aab0445771d501271478bad9/config/jobs/kubernetes/sig-node/node-kubelet.yaml#L86

These tests experience flakes when run on basic e2-standard-4 machines without proper NUMA/resource topology configuration. They are already properly tested in dedicated jobs with appropriate infrastructure:
- ci-crio-node-e2e-resource-managers (CRI-O, 4h interval)
- ci-kubernetes-node-kubelet-serial-topology-manager (Containerd, 24h)
- ci-kubernetes-node-kubelet-containerd-resource-managers (Containerd, 24h)

Example flakes:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-kubelet-serial-cri-o/2013013835769712640 https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-kubelet-serial-cri-o/2012832639953670144