### PR TITLE
Rename jessie-dnsutils to glibc-dns-testing image job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
@@ -20,8 +20,8 @@ readonly IMAGES=(
     agnhost
     apparmor-loader
     busybox
+    glibc-dns-testing
     ipc-utils
-    jessie-dnsutils
     kitten
     nautilus
     nginx

--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -128,6 +128,48 @@ postsubmits:
               # We override that with the busybox image.
               - name: WHAT
                 value: "busybox"
+    - name: post-kubernetes-push-e2e-glibc-dns-testing-test-images
+      rerun_auth_config:
+        github_team_slugs:
+          - org: kubernetes
+            slug: release-managers
+          - org: kubernetes
+            slug: test-infra-admins
+        github_users:
+          - aojea
+          - chewong
+          - claudiubelu
+          - mkumatag
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
+      decorate: true
+      # we only need to run if the test images have been changed.
+      run_if_changed: '^.go-version$|^test/images/[^/]+$|^test\/images\/glibc-dns-testing\/'
+      branches:
+        # TODO(releng): Remove once repo default branch has been renamed
+        - ^master$
+        - ^main$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20251215-d7853fe2a6
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-e2e-test-images
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA,WHAT
+              - --build-dir=.
+              - test/images
+            env:
+              # By default, the E2E test image's WHAT is all-conformance.
+              # We override that with the glibc-dns-testing image.
+              - name: WHAT
+                value: "glibc-dns-testing"
     - name: post-kubernetes-push-e2e-ipc-utils-test-images
       rerun_auth_config:
         github_team_slugs:
@@ -170,48 +212,6 @@ postsubmits:
               # We override that with the ipc-utils image.
               - name: WHAT
                 value: "ipc-utils"
-    - name: post-kubernetes-push-e2e-jessie-dnsutils-test-images
-      rerun_auth_config:
-        github_team_slugs:
-          - org: kubernetes
-            slug: release-managers
-          - org: kubernetes
-            slug: test-infra-admins
-        github_users:
-          - aojea
-          - chewong
-          - claudiubelu
-          - mkumatag
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: sig-testing-images, sig-k8s-infra-gcb
-      decorate: true
-      # we only need to run if the test images have been changed.
-      run_if_changed: '^.go-version$|^test/images/[^/]+$|^test\/images\/jessie-dnsutils\/'
-      branches:
-        # TODO(releng): Remove once repo default branch has been renamed
-        - ^master$
-        - ^main$
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/image-builder:v20251215-d7853fe2a6
-            command:
-              - /run.sh
-            args:
-              # this is the project GCB will run in, which is the same as the GCR
-              # images are pushed to.
-              - --project=k8s-staging-e2e-test-images
-              # This is the same as above, but with -gcb appended.
-              - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
-              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA,WHAT
-              - --build-dir=.
-              - test/images
-            env:
-              # By default, the E2E test image's WHAT is all-conformance.
-              # We override that with the jessie-dnsutils image.
-              - name: WHAT
-                value: "jessie-dnsutils"
     - name: post-kubernetes-push-e2e-kitten-test-images
       rerun_auth_config:
         github_team_slugs:


### PR DESCRIPTION
The jessie-dnsutils image was renamed to glibc-dns-testing in kubernetes/kubernetes#136358 to better reflect its purpose: testing glibc-based DNS resolution behavior.