### PR TITLE
Add gke-gcloud-auth-plugin to kubekins-e2e-v2 image round 2

### DIFF
--- a/images/gcb-docker-gcloud/cloudbuild.yaml
+++ b/images/gcb-docker-gcloud/cloudbuild.yaml
@@ -36,3 +36,5 @@ substitutions:
   _GIT_TAG: '12345'
   _DOCKER_VERSION: '28' # Docker v29+ doesn't work in GCP Cloud Build because its stuck on 20.10.x
   _GO_VERSION: '1.25.5'
+tags:
+  - gcb-docker-gcloud

--- a/images/krte/cloudbuild.yaml
+++ b/images/krte/cloudbuild.yaml
@@ -30,3 +30,6 @@ options:
 images:
   - 'gcr.io/$PROJECT_ID/krte:$_GIT_TAG-$_CONFIG'
   - 'gcr.io/$PROJECT_ID/krte:latest-$_CONFIG'
+tags:
+  - krte
+  - $_CONFIG

--- a/images/kubekins-e2e-v2/Dockerfile
+++ b/images/kubekins-e2e-v2/Dockerfile
@@ -14,7 +14,7 @@
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
 
-FROM debian:bookworm-20251208
+FROM debian:bookworm-20260112
 ARG TARGETARCH
 
 WORKDIR /workspace
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     graphviz \
     bc \
     && rm -rf /var/lib/apt/lists/* \
-    && python3 -m pip install --no-cache-dir --break-system-packages --upgrade pip setuptools wheel
+    && python3 -m pip install --no-cache-dir --break-system-packages --upgrade pip uv setuptools wheel
 
 # Install gcloud
 ARG GCLOUD_SDK_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz
@@ -71,9 +71,9 @@ RUN wget -O google-cloud-sdk.tar.gz -q $GCLOUD_SDK_URL && \
     --disable-installation-options \
     --bash-completion=false \
     --path-update=false \
-    --usage-reporting=false; \
+    --usage-reporting=false \
+    --additional-components alpha beta gke-gcloud-auth-plugin; \
     fi && \
-    gcloud components install alpha beta && \
     gcloud info | tee /workspace/gcloud-info.txt
 
 

--- a/images/kubekins-e2e-v2/cloudbuild.yaml
+++ b/images/kubekins-e2e-v2/cloudbuild.yaml
@@ -32,10 +32,13 @@ substitutions:
   _K8S_RELEASE: stable
   _KIND_VERSION: '0.31.0'
   _KUBETEST2_VERSION: 'master'
-  _YQ_VERSION: v4.47.2
+  _YQ_VERSION: v4.49.2
   _DOCKER_VERSION: 5:29.*
 timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
   # this is a large and critical CI image, builds are slow on the default 1 core
   machineType: E2_HIGHCPU_32
+tags:
+  - kubekins-e2e-v2
+  - $_CONFIG

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -54,3 +54,6 @@ options:
 images:
   - 'gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG'
   - 'gcr.io/$PROJECT_ID/kubekins-e2e:latest-$_CONFIG'
+tags:
+  - kubekins-e2e
+  - $_CONFIG


### PR DESCRIPTION
This time it should work. I tested it by running `gcloud builds submit --project k8s-infra-e2e-node-e2e-project`

Also, I added tags to some of the jobs so we can filter them in Cloud Build