### PR TITLE
Cleanup K8S v1.29 dashboards for Gardener

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -77,21 +77,6 @@ dashboards:
     - name: Gardener, v1.30 Alibaba Cloud
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
       test_group_name: ci-gardener-e2e-conformance-alicloud-v1.30
-    - name: Gardener, v1.29 AWS
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
-      test_group_name: ci-gardener-e2e-conformance-aws-v1.29
-    - name: Gardener, v1.29 GCE
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
-      test_group_name: ci-gardener-e2e-conformance-gce-v1.29
-    - name: Gardener, v1.29 OpenStack
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
-      test_group_name: ci-gardener-e2e-conformance-openstack-v1.29
-    - name: Gardener, v1.29 Azure
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
-      test_group_name: ci-gardener-e2e-conformance-azure-v1.29
-    - name: Gardener, v1.29 Alibaba Cloud
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
-      test_group_name: ci-gardener-e2e-conformance-alicloud-v1.29
 
 - name: conformance-apisnoop
 - name: conformance-ec2
@@ -203,31 +188,6 @@ dashboards:
     - name: Gardener, v1.30 Alibaba Cloud
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
       test_group_name: ci-gardener-e2e-conformance-alicloud-v1.30
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.29 AWS
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
-      test_group_name: ci-gardener-e2e-conformance-aws-v1.29
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.29 GCE
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)"
-      test_group_name: ci-gardener-e2e-conformance-gce-v1.29
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.29 OpenStack
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack"
-      test_group_name: ci-gardener-e2e-conformance-openstack-v1.29
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.29 Azure
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure"
-      test_group_name: ci-gardener-e2e-conformance-azure-v1.29
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.29 Alibaba Cloud
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
-      test_group_name: ci-gardener-e2e-conformance-alicloud-v1.29
       alert_options:
         alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
@@ -378,31 +338,6 @@ test_groups:
   disable_prowjob_analysis: true
 - name: ci-gardener-e2e-conformance-alicloud-v1.30
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-alicloud-v1.30
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-aws-v1.29
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.29
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-gce-v1.29
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-gce-v1.29
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-openstack-v1.29
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-openstack-v1.29
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-azure-v1.29
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-azure-v1.29
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-alicloud-v1.29
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-alicloud-v1.29
   alert_stale_results_hours: 168
   num_failures_to_alert: 1
   disable_prowjob_analysis: true


### PR DESCRIPTION
/kind cleanup

Gardener no longer supports Kubernetes v1.29.
This PR cleans up Gardener related dashboards for Kubernetes v1.29.

/cc @ialidzhikov