### PR TITLE
Add presubmit pull-perf-tests-ec2-master-scale-performance-100

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/presubmit-pull-perf-tests-ec2-master-scale-perfomance-100.yaml
+++ b/config/jobs/kubernetes/sig-scalability/presubmit-pull-perf-tests-ec2-master-scale-perfomance-100.yaml
@@ -1,0 +1,98 @@
+presubmits:
+  kubernetes/perf-tests:
+  - name: pull-perf-tests-ec2-master-scale-performance-100
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential-boskos-scale-001-kops: "true"
+      preset-dind-enabled: "true"
+    decorate: true
+    decoration_config:
+      timeout: 480m
+    path_alias: k8s.io/perf-tests
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    - org: kubernetes
+      repo: kops
+      base_ref: master
+      workdir: true
+      path_alias: k8s.io/kops
+    annotations:
+      test.kops.k8s.io/cloud: aws
+      test.kops.k8s.io/distro: u2204
+      test.kops.k8s.io/k8s_version: stable
+      test.kops.k8s.io/kops_channel: alpha
+      test.kops.k8s.io/networking: amazonvpc
+      testgrid-dashboards: presubmits-kubernetes-scalability
+      testgrid-tab-name: pull-perf-tests-ec2-master-scale-performance-100
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260108-6ef4f0b08f-master
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - ./tests/e2e/scenarios/scalability/run-test.sh
+        securityContext:
+          privileged: true
+        env:
+        - name: KUBE_SSH_KEY_PATH
+          value: /etc/aws-ssh/aws-ssh-private
+        - name: KUBE_SSH_USER
+          value: ubuntu
+        - name: GOPATH
+          value: /home/prow/go
+        - name: ARTIFACTS
+          value: $(ARTIFACTS)
+        - name: CNI_PLUGIN
+          value: "amazonvpc"
+        - name: KUBE_NODE_COUNT
+          value: "100"
+        - name: CL2_LOAD_TEST_THROUGHPUT
+          value: "50"
+        - name: CL2_DELETE_TEST_THROUGHPUT
+          value: "50"
+        - name: CL2_RATE_LIMIT_POD_CREATION
+          value: "false"
+        - name: NODE_MODE
+          value: "master"
+        - name: CONTROL_PLANE_COUNT
+          value: "3"
+        - name: CONTROL_PLANE_SIZE
+          value: "c5.9xlarge"
+        - name: KOPS_STATE_STORE
+          value: "s3://k8s-infra-kops-scale-tests"
+        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+          value: "true"
+        - name: CL2_ENABLE_DNS_PROGRAMMING
+          value: "true"
+        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+          value: "true"
+        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+          value: "99.5"
+        - name: CL2_ALLOWED_SLOW_API_CALLS
+          value: "1"
+        - name: ENABLE_PROMETHEUS_SERVER
+          value: "true"
+        - name: PROMETHEUS_PVC_STORAGE_CLASS
+          value: "gp2"
+        - name: CLOUD_PROVIDER
+          value: "aws"
+        - name: CLUSTER_NAME
+          value: "pull-perf-scale-100.presubmit.test-cncf-aws.k8s.io"
+        - name: KOPS_IRSA
+          value: "true"
+        resources:
+          requests:
+            cpu: 5
+            memory: 16Gi
+          limits:
+            cpu: 5
+            memory: 16Gi


### PR DESCRIPTION
## Context

After updating the latest prometheus-operator in PR: https://github.com/kubernetes/perf-tests/pull/3789, the logs were not helpful. This helps in order to have the kops job capture logs from the prometheus-operator.

The intention is to resolve the ec2-master-scale-performance test failures. 
<img width="2273" height="343" alt="image" src="https://github.com/user-attachments/assets/ade50e5b-8d15-4c96-9700-da0f3e6fa0ac" />


Kubernetes `sig-scalability slack thread:` https://kubernetes.slack.com/archives/C09QZTRH7/p1767977126452879

Related PR: [kubernetes/perf-tests] Bump prometheus-operator version to 0.88.0 to resolve ec2-master-scale-performance failures https://github.com/kubernetes/perf-tests/pull/3789

cc @upodroid 