### PR TITLE
Modify ci-kubernetes-e2e-gci-gce-autoscaling to use tests from autoscaler repo 

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -488,6 +488,12 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 450m
+  extra_refs:
+  - org: kubernetes
+    repo: autoscaler
+    base_ref: master
+    path_alias: k8s.io/autoscaler
+    workdir: true
   spec:
     containers:
     - command:
@@ -509,7 +515,8 @@ periodics:
       - --gcp-zone=us-central1-b
       - --provider=gce
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
-      - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
+      - --test=false
+      - --test-cmd=../cluster-autoscaler/hack/run-e2e.sh
       - --timeout=400m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260108-6ef4f0b08f-master
       resources:


### PR DESCRIPTION
This PR changes cluster-autoscaler E2E runner to use tests from autoscaler repo. 
