### PR TITLE
[sig-autoscaling] bump hpa-cpu-alpha-beta job parallelism to 10

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -658,12 +658,13 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-central1-b
       - --gcp-node-image=gci
+      - --gcp-node-size=e2-highcpu-8
       - --extract=ci/latest
       - --timeout=240m
       - --env=KUBE_FEATURE_GATES=HPAConfigurableTolerance=true
       - --test_args=--ginkgo.focus=\[Feature:HPAConfigurableTolerance\]
         --minStartupPods=8
-      - --ginkgo-parallel=1
+      - --ginkgo-parallel=10
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260108-6ef4f0b08f-master
       resources:
         limits:


### PR DESCRIPTION
Related to: https://github.com/kubernetes/kubernetes/issues/135026

Bumps ginkgo parallelism of the hpa-cpu job to 10. To accomodate this, each worker node will be the e2-highcpu-8 instances type. These have 8 CPU and 8 GiB of memory each: https://gcloud-compute.com/e2-highcpu-8.html.

Previously this was done for the regular HPA CPU test: https://github.com/kubernetes/test-infra/pull/36015 but now this must also be done from Alpha and Beta feature flagged HPA cpu tests.