### PR TITLE
Add Gardener test results for Kubernetes v1.34

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -31,6 +31,7 @@ dashboards:
       test_group_name: ci-gardener-e2e-conformance-azure-v1.34
     - name: Gardener, v1.34 Alibaba Cloud
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud"
+      test_group_name: ci-gardener-e2e-conformance-alicloud-v1.34
     - name: Gardener, v1.33 AWS
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)"
       test_group_name: ci-gardener-e2e-conformance-aws-v1.33


### PR DESCRIPTION
Adds Gardener test results for Kubernetes `v1.34` to testgrid.