### PR TITLE
pull-kubernetes-scheduler-perf: use -benchtime=1x

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -755,10 +755,9 @@ periodics:
         value: "y"
       - name: TEST_PREFIX
         value: BenchmarkPerfScheduling
-      # Set the benchtime to a very low value so every test is ran at most once
-      # even on very powerful machines
+      # Run benchmark once
       - name: BENCHTIME
-        value: 1ns
+        value: 1x
       # We distinguish which test cases to run with --short, and we want to run longer test cases in this job.
       # We have to explicitly disable --short flag because the script enables by default.
       - name: SHORT

--- a/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
+++ b/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
@@ -80,7 +80,7 @@ presubmits:
         args:
         - /bin/sh
         - -c
-        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} make test-integration WHAT=./test/integration/scheduler_perf/... KUBE_CACHE_MUTATION_DETECTOR=false KUBE_TIMEOUT=--timeout=3h55m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1ns -bench=BenchmarkPerfScheduling -data-items-dir=${ARTIFACTS}" SHORT='--short=false' KUBE_PRUNE_JUNIT_TESTS=false
+        - ./hack/install-etcd.sh && PATH=${PWD}/third_party/etcd:${PATH} make test-integration WHAT=./test/integration/scheduler_perf/... KUBE_CACHE_MUTATION_DETECTOR=false KUBE_TIMEOUT=--timeout=3h55m ETCD_LOGLEVEL=warn KUBE_TEST_ARGS="-run=nothing-because-no-test-has-this-name -benchtime=1x -bench=BenchmarkPerfScheduling -data-items-dir=${ARTIFACTS}" SHORT='--short=false' KUBE_PRUNE_JUNIT_TESTS=false
         # We need to constraint compute resources so all the tests
         # finish approximately at the same time. More compute power
         # can increase scheduling throughput and make consequent results


### PR DESCRIPTION
Update scheduler benchmark parameters to use
-benchtime=1x instead of -benchtime=1ns to explicitly run benchmarks one time.

This is a follow-up PR requested in [this k/k PR](https://github.com/kubernetes/kubernetes/pull/136197#pullrequestreview-3660749013)

/cc @pohly 