### PR TITLE
add region, machine-type and worker-pool flags to image builder

### DIFF
--- a/images/builder/cloudbuild.yaml
+++ b/images/builder/cloudbuild.yaml
@@ -25,3 +25,5 @@ substitutions:
 images:
   - 'gcr.io/$PROJECT_ID/image-builder:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/image-builder:latest'
+tags:
+  - builder


### PR DESCRIPTION
Required for https://github.com/kubernetes/kubernetes/pull/136464

We have some builds that need to use a worker pool so we need to set them as extra flags. machine type and worker-pool can't be set at the same time.

Also, the image builder will warn you if you are using GCB to push a single arch image. We shouldn't be doing that anymore, as described here. https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md
