### PR TITLE
Increse memory limits for aws-ebs-csi-driver jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -22,10 +22,10 @@ periodics:
       resources:
         limits:
           cpu: "2"
-          memory: "4Gi"
+          memory: "8Gi"
         requests:
           cpu: "2"
-          memory: "4Gi"
+          memory: "8Gi"
   annotations:
     testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-periodics
     testgrid-tab-name: ci-unit-test
@@ -58,10 +58,10 @@ periodics:
       resources:
         limits:
           cpu: "2"
-          memory: "4Gi"
+          memory: "8Gi"
         requests:
           cpu: "2"
-          memory: "4Gi"
+          memory: "8Gi"
   annotations:
     testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-periodics
     testgrid-tab-name: ci-e2e-test-single-az
@@ -94,10 +94,10 @@ periodics:
       resources:
         limits:
           cpu: "2"
-          memory: "4Gi"
+          memory: "8Gi"
         requests:
           cpu: "2"
-          memory: "4Gi"
+          memory: "8Gi"
   annotations:
     testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-periodics
     testgrid-tab-name: ci-e2e-test-multi-az
@@ -130,10 +130,10 @@ periodics:
       resources:
         limits:
           cpu: "2"
-          memory: "4Gi"
+          memory: "8Gi"
         requests:
           cpu: "2"
-          memory: "4Gi"
+          memory: "8Gi"
   annotations:
     testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-periodics
     testgrid-tab-name: ci-external-test

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -24,10 +24,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
           requests:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: test-e2e-external-eks-windows
@@ -57,10 +57,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
           requests:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: test-e2e-external-eks-windows-fips
@@ -90,10 +90,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
           requests:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: test-helm-chart
@@ -180,10 +180,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
           requests:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-e2e-test-single-az
@@ -213,10 +213,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
           requests:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-e2e-test-multi-az
@@ -247,10 +247,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
           requests:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-e2e-test-disruptive
@@ -280,10 +280,10 @@ presubmits:
           resources:
             limits:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
             requests:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-external-test
@@ -313,10 +313,10 @@ presubmits:
           resources:
             limits:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
             requests:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-external-test-fips
@@ -342,10 +342,10 @@ presubmits:
           resources:
             limits:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
             requests:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-security
@@ -375,10 +375,10 @@ presubmits:
           resources:
             limits:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
             requests:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-ebs-external-test-eks-bottlerocket
@@ -408,10 +408,10 @@ presubmits:
           resources:
             limits:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
             requests:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-ebs-external-test-eks
@@ -441,10 +441,10 @@ presubmits:
           resources:
             limits:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
             requests:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-external-test-kustomize
@@ -474,10 +474,10 @@ presubmits:
           resources:
             limits:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
             requests:
               cpu: "2"
-              memory: "4Gi"
+              memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-external-test-arm64
@@ -507,10 +507,10 @@ presubmits:
         resources:
           requests:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
           limits:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
       testgrid-tab-name: pull-ebs-image-test


### PR DESCRIPTION
We're seeing jobs we think are stalled by memory limits from the new 1.35 k/k tests, for example: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/2836/pull-aws-ebs-csi-driver-external-test/2014791690627321856

Bumping the memory limits to see if it resolves the issue.