### PR TITLE
CAPG: increase memory and cpu for presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-11.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-11.yaml
@@ -15,11 +15,11 @@ presubmits:
         - "./scripts/ci-test.sh"
         resources:
           limits:
-            cpu: 4
-            memory: 4Gi
+            cpu: 7
+            memory: 16Gi
           requests:
-            cpu: 4
-            memory: 4Gi
+            cpu: 7
+            memory: 16Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-test-release-1-11
@@ -38,11 +38,11 @@ presubmits:
         - "./scripts/ci-build.sh"
         resources:
           limits:
-            cpu: 4
-            memory: 4Gi
+            cpu: 7
+            memory: 16Gi
           requests:
-            cpu: 4
-            memory: 4Gi
+            cpu: 7
+            memory: 16Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-build-release-1-11


### PR DESCRIPTION
# Description

These two jobs have been getting stuck and running for hours and, after investigating the contents of the artifacts, it looks like we had `OOMKilled` errors (see [podinfo.json](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-gcp/1594/pull-cluster-api-provider-gcp-test-release-1-11/2014786958324142080/podinfo.json)).

Comparing the jobs' definitions with their `main` equivalents shows that the memory and CPU allocated is lower.