### PR TITLE
Standardize minikube prow job naming conventions

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-minikube.yaml
+++ b/config/jobs/image-pushing/k8s-staging-minikube.yaml
@@ -1,6 +1,6 @@
 postsubmits:
   kubernetes/minikube:
-    - name: post-kubernetes-bootcamp-image
+    - name: post-minikube-kubernetes-bootcamp-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: minikube-images, sig-k8s-infra-gcb
@@ -46,7 +46,7 @@ postsubmits:
             env:
               - name: LOG_TO_STDOUT
                 value: "y"
-    - name: post-kubernetes-registry-proxy-image
+    - name: post-minikube-kubernetes-registry-proxy-image
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: minikube-images, sig-k8s-infra-gcb

--- a/config/jobs/kubernetes/minikube/minikube-periodics.yaml
+++ b/config/jobs/kubernetes/minikube/minikube-periodics.yaml
@@ -33,7 +33,7 @@ periodics:
       securityContext:
         privileged: true
 # name convention: integration-<driver>-<container-runtime>-<OS>-<arch>
-- name: kvm-docker-linux-x86
+- name: ci-minikube-kvm-docker-linux-x86
   cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
@@ -67,7 +67,7 @@ periodics:
         limits:
           memory: 20Gi
           cpu: 7
-- name: docker-docker-linux-arm
+- name: ci-minikube-docker-docker-linux-arm
   cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
@@ -102,7 +102,7 @@ periodics:
         limits:
           memory: 20Gi
           cpu: 7
-- name: docker-containerd-linux-arm
+- name: ci-minikube-docker-containerd-linux-arm
   cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
@@ -137,7 +137,7 @@ periodics:
         limits:
           memory: 20Gi
           cpu: 7
-- name: kvm-containerd-linux-x86
+- name: ci-minikube-kvm-containerd-linux-x86
   cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
@@ -171,7 +171,7 @@ periodics:
         limits:
           memory: 20Gi
           cpu: 7
-- name: kvm-crio-linux-x86
+- name: ci-minikube-kvm-crio-linux-x86
   cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
@@ -205,7 +205,7 @@ periodics:
         limits:
           memory: 20Gi
           cpu: 7
-- name: docker-docker-linux-x86
+- name: ci-minikube-docker-docker-linux-x86
   cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
@@ -239,7 +239,7 @@ periodics:
         limits:
           memory: 20Gi
           cpu: 7
-- name: docker-containerd-linux-x86
+- name: ci-minikube-docker-containerd-linux-x86
   cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
@@ -273,7 +273,7 @@ periodics:
         limits:
           memory: 20Gi
           cpu: 7
-- name: docker-crio-linux-x86
+- name: ci-minikube-docker-crio-linux-x86
   cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
@@ -307,7 +307,7 @@ periodics:
         limits:
           memory: 20Gi
           cpu: 7
-- name: none-containerd-linux-x86
+- name: ci-minikube-none-containerd-linux-x86
   cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true
@@ -341,7 +341,7 @@ periodics:
         limits:
           memory: 20Gi
           cpu: 7
-- name: none-docker-linux-x86
+- name: ci-minikube-none-docker-linux-x86
   cluster: k8s-infra-prow-build
   interval: 4h
   decorate: true

--- a/config/jobs/kubernetes/minikube/minikube-presubmits.yaml
+++ b/config/jobs/kubernetes/minikube/minikube-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
             memory: "2000Mi"
             cpu: 2
   # name convention: integration-<driver>-<container-runtime>-<OS>-<arch>
-  - name: integration-kvm-docker-linux-x86
+  - name: pull-minikube-kvm-docker-linux-x86
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
@@ -58,7 +58,7 @@ presubmits:
           limits:
             memory: 20Gi
             cpu: 7
-  - name: integration-docker-docker-linux-arm
+  - name: pull-minikube-docker-docker-linux-arm
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
@@ -88,7 +88,7 @@ presubmits:
           limits:
             memory: 20Gi
             cpu: 7
-  - name: integration-docker-containerd-linux-arm
+  - name: pull-minikube-docker-containerd-linux-arm
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
@@ -119,7 +119,7 @@ presubmits:
           limits:
             memory: 20Gi
             cpu: 7
-  - name: integration-kvm-containerd-linux-x86
+  - name: pull-minikube-kvm-containerd-linux-x86
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
@@ -148,7 +148,7 @@ presubmits:
           limits:
             memory: 20Gi
             cpu: 7
-  - name: integration-kvm-crio-linux-x86
+  - name: pull-minikube-kvm-crio-linux-x86
     cluster: k8s-infra-prow-build
     optional: true
     decorate: true
@@ -178,7 +178,7 @@ presubmits:
           limits:
             memory: 20Gi
             cpu: 7
-  - name: integration-docker-docker-linux-x86
+  - name: pull-minikube-docker-docker-linux-x86
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
@@ -207,7 +207,7 @@ presubmits:
           limits:
             memory: 20Gi
             cpu: 7
-  - name: integration-docker-containerd-linux-x86
+  - name: pull-minikube-docker-containerd-linux-x86
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
@@ -236,7 +236,7 @@ presubmits:
           limits:
             memory: 20Gi
             cpu: 7
-  - name: integration-docker-crio-linux-x86
+  - name: pull-minikube-docker-crio-linux-x86
     cluster: k8s-infra-prow-build
     optional: true
     decorate: true
@@ -266,7 +266,7 @@ presubmits:
           limits:
             memory: 20Gi
             cpu: 7
-  - name: integration-none-containerd-linux-x86
+  - name: pull-minikube-none-containerd-linux-x86
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
@@ -296,7 +296,7 @@ presubmits:
           limits:
             memory: 20Gi
             cpu: 7
-  - name: integration-none-docker-linux-x86
+  - name: pull-minikube-none-docker-linux-x86
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
@@ -325,7 +325,7 @@ presubmits:
           limits:
             memory: 20Gi
             cpu: 7
-  - name: integration-vfkit-docker-macos-arm
+  - name: pull-minikube-vfkit-docker-macos-arm
     cluster: k8s-infra-prow-build
     optional: true # macos machine is precious, so only run when matainers explicitly trigger with /test <job_name>
     decorate: true


### PR DESCRIPTION
Apply consistent naming prefixes to minikube CI jobs:
- Presubmits: pull-minikube-* (11 jobs renamed)
- Periodics: ci-minikube-* (10 jobs renamed)
- Postsubmits: post-minikube-* (2 jobs renamed)

This aligns with the standard prow job naming convention where job names indicate their type (pull/ci/post) followed by the project name.