### PR TITLE
Upgrade containerd in CI jobs for ImageVolume support

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
@@ -234,7 +234,7 @@ presubmits:
         - --build=quick
         - --env=ALLOW_PRIVILEGED=true
         - --env=KUBE_PROXY_MODE=nftables
-        - --env=KUBE_GCE_NODE_IMAGE=cos-113-18244-236-88
+        - --env=KUBE_GCE_NODE_IMAGE=cos-125-19216-104-117
         - --gcp-nodes=4
         - --gcp-zone=us-central1-b
         - --provider=gce
@@ -868,7 +868,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --env=KUBE_PROXY_MODE=nftables
-      - --env=KUBE_GCE_NODE_IMAGE=cos-113-18244-236-88
+      - --env=KUBE_GCE_NODE_IMAGE=cos-125-19216-104-117
       - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci


### PR DESCRIPTION
The nftables presubmit and periodic jobs were using cos-113 which bundles containerd 1.7.24. This causes ImageVolume tests to fail because ImageVolume requires containerd 2.x CRI extensions.

<img width="1080" height="343" alt="image" src="https://github.com/user-attachments/assets/85a42455-df99-4af7-963d-b9dd915a13d3" />


Here's the PR where containerd added support:
https://github.com/containerd/containerd/commit/1ec10d9ae7535ddd7b18e3c21b6cd8ff12a2f90d

Here's the support matrix:
https://github.com/containerd/containerd/blob/883ac7a263827ae7335dae20b0e4161390f75c6e/RELEASES.md#kubernetes-support

(if the test says `MinimumKubeletVersion:1.35` we definitely need containerd 2.x)

Upgrade from cos-113-18244-236-88 to cos-125-19216-104-117:
- containerd: 1.7.24 -> 2.1.5
- kernel: 6.1.112+ -> 6.12.55+