### PR TITLE
Bump go version 1.25.6 for kubekins-e2e/kubekins-e2e-v2/krte

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,12 +1,12 @@
 variants:
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.25.5
+    GO_VERSION: 1.25.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   master:
     CONFIG: master
-    GO_VERSION: 1.25.5
+    GO_VERSION: 1.25.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*


### PR DESCRIPTION
- Bump go version 1.25.5/1.24.11 for kubekins-e2e/kubekins-e2e-v2/krte


xref: https://github.com/kubernetes/release/issues/4237


go update for main k/k merged in https://github.com/kubernetes/kubernetes/pull/136465


/assign @dims @saschagrunert @Verolop 
cc @kubernetes/release-managers 