### PR TITLE
Drop kube-proxy daemonset from alpha jobs

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -21,7 +21,6 @@ periodics:
       - --gcp-node-image=gci
       - --extract=ci/latest-1.35
       - --timeout=180m
-      - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -237,7 +236,6 @@ periodics:
       - --gcp-node-image=gci
       - --extract=ci/latest-1.34
       - --timeout=180m
-      - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -441,7 +439,6 @@ periodics:
       - --gcp-node-image=gci
       - --extract=ci/latest-1.33
       - --timeout=180m
-      - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -645,7 +642,6 @@ periodics:
       - --gcp-node-image=gci
       - --extract=ci/latest-1.32
       - --timeout=180m
-      - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -849,7 +845,6 @@ periodics:
       - --gcp-node-image=gci
       - --extract=ci/latest-1.31
       - --timeout=180m
-      - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -116,7 +116,6 @@ periodics:
       - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-      - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/fast/latest-fast
       - --gcp-node-image=gci
@@ -160,7 +159,6 @@ periodics:
       - --check-leaked-resources
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-      - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/fast/latest-fast
       - --gcp-node-image=gci
@@ -1141,7 +1139,6 @@ presubmits:
         - --build=quick
         - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-        - --env=KUBE_PROXY_DAEMONSET=true
         - --env=ENABLE_POD_PRIORITY=true
         - --env=ENABLE_APISERVER_TRACING=true
         - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
@@ -1442,7 +1439,6 @@ presubmits:
         - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
         - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
-        - --env=KUBE_PROXY_DAEMONSET=true
         - --env=ENABLE_POD_PRIORITY=true
         - --gcp-node-image=gci
         - --gcp-region=us-central1

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -254,7 +254,6 @@ testSuites:
   alphafeatures:
     args:
     - --timeout=180m
-    - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
     - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true
     # Panic if anything mutates a shared informer cache
@@ -267,7 +266,6 @@ testSuites:
   alphafeatures-eventedpleg:
     args:
     - --timeout=180m
-    - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
     - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
     # Panic if anything mutates a shared informer cache
@@ -280,7 +278,6 @@ testSuites:
   alphafeatures-no-ccm:
     args:
     - --timeout=180m
-    - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
     - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,InTreePluginGCEUnregister=false,DisableCloudProviders=false,DisableKubeletCloudCredentialProviders=false
     # Panic if anything mutates a shared informer cache


### PR DESCRIPTION
Converge alpha jobs to match normal gce e2e deployment

xref https://github.com/kubernetes/kubernetes/pull/136571

/kind cleanup
/sig testing
