### PR TITLE
Update containerd to v2.1.5 and runc to v1.3.4 for COS CI jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -112,8 +112,8 @@ periodics:
     containers:
     - args:
       - --check-leaked-resources
-      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
-      - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
+      - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.1.5
+      - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.3.4
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -1435,8 +1435,8 @@ presubmits:
       - args:
         - --build=quick
         - --check-leaked-resources
-        - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.0
-        - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
+        - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.1.5
+        - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.3.4
         - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
         - --env=ENABLE_POD_PRIORITY=true

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -43,8 +43,8 @@ presubmits:
         - --cluster=
         - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
         - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0 --profiling --contention-profiling
-        - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.0.5
-        - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.2.1
+        - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.1.5
+        - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.3.4
         - --flush-mem-after-build=true
         - --gcp-node-image=gci
         - --gcp-nodes=100


### PR DESCRIPTION
Update KUBE_COS_INSTALL_CONTAINERD_VERSION and KUBE_COS_INSTALL_RUNC_VERSION for kubernetes/kubernetes CI jobs that do not target a specific release branch:

- pull-kubernetes-e2e-gce-100-performance
- ci-kubernetes-e2e-gci-gce-alpha-enabled-default
- pull-e2e-gci-gce-alpha-enabled-default

Will help avoid problems like we see like this:

<img width="1175" height="391" alt="image" src="https://github.com/user-attachments/assets/2994a425-5703-4508-a72d-aafa1d233c75" />
