### PR TITLE
Fix ci-aws-ec2-janitor: remove unsupported --sweep-count flag

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -924,7 +924,6 @@ periodics:
         - --ttl=6h
         - --path=s3://provider-aws-test-infra/objs.json
         - --region=us-east-1
-        - --sweep-count=2
         image: gcr.io/k8s-staging-boskos/aws-janitor:v20260107-c2c6f43
         resources:
           requests:


### PR DESCRIPTION
This is a partial revert of a33a0f1cb9 which accidentally added the --sweep-count=2 flag to the ci-aws-ec2-janitor job.

The aws-janitor image (gcr.io/k8s-staging-boskos/aws-janitor) does not support the --sweep-count flag. This flag only exists in the separate aws-janitor-boskos binary (cmd/aws-janitor-boskos), not in the aws-janitor binary (cmd/aws-janitor) that this job uses.

Job: https://prow.k8s.io/?job=ci-aws-ec2-janitor
History: https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-aws-ec2-janitor