### PR TITLE
Exclude kubernetes/dashboard from triage robot close/rotten jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -195,6 +195,7 @@ periodics:
         -repo:kubernetes/kubectl
         -repo:kubernetes/steering
         -repo:kubernetes-sigs/ingate
+        -repo:kubernetes/dashboard
         -label:lifecycle/frozen
         -label:"help wanted"
         -label:"good first issue"
@@ -339,6 +340,7 @@ periodics:
         -repo:kubernetes/ingress-nginx
         -repo:kubernetes/steering
         -repo:kubernetes-sigs/ingate
+        -repo:kubernetes/dashboard
         -label:lifecycle/frozen
         -label:lifecycle/rotten
         -label:"help wanted"


### PR DESCRIPTION
see failures in:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-k8s-triage-robot-close-issues/2016294048192532480
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-k8s-triage-robot-rotten-issues/2016298578376396800

The kubernetes/dashboard repository has been archived and should not be processed by the triage robot. This excludes it from:
- ci-k8s-triage-robot-close-issues
- ci-k8s-triage-robot-rotten-issues

Job history:
- https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-k8s-triage-robot-close-issues
- https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-k8s-triage-robot-rotten-issues