### PR TITLE
Updated E2E presubmits to run on newer versions (1.34, 1.35)

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -53,68 +53,6 @@ presubmits:
           requests:
             cpu: 3
             memory: 10Gi
-  - name: pull-lws-test-e2e-main-1-33
-    cluster: eks-prow-build-cluster
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/lws
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: pull-lws-test-e2e-main-1-33
-      description: "Run lws end to end tests for Kubernetes 1.33"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.33.1
-          command:
-            - runner.sh
-          args:
-            - make
-            - test-e2e
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 3
-              memory: 10Gi
-            requests:
-              cpu: 3
-              memory: 10Gi
-  - name: pull-lws-test-e2e-main-1-31
-    cluster: eks-prow-build-cluster
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/lws
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: pull-lws-test-e2e-main-1-31
-      description: "Run lws end to end tests for Kubernetes 1.31"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.31.0
-          command:
-            - runner.sh
-          args:
-            - make
-            - test-e2e
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 3
-              memory: 10Gi
-            requests:
-              cpu: 3
-              memory: 10Gi
   - name: pull-lws-test-e2e-main-1-32
     cluster: eks-prow-build-cluster
     always_run: true
@@ -131,7 +69,100 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.0
+              value: kindest/node:v1.32.11
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+  - name: pull-lws-test-e2e-main-1-33
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/lws
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: pull-lws-test-e2e-main-1-33
+      description: "Run lws end to end tests for Kubernetes 1.33"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.33.7
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+  - name: pull-lws-test-e2e-main-1-34
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/lws
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: pull-lws-test-e2e-main-1-34
+      description: "Run lws end to end tests for Kubernetes 1.34"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.34.3
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+  - name: pull-lws-test-e2e-main-1-35
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/lws
+    annotations:
+      testgrid-dashboards: sig-apps
+      testgrid-tab-name: pull-lws-test-e2e-main-1-35
+      description: "Run lws end to end tests for Kubernetes 1.35"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.35.0
           command:
             - runner.sh
           args:
@@ -162,7 +193,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.0
+              value: kindest/node:v1.35.0
           command:
             - runner.sh
           args:
@@ -193,7 +224,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.0
+              value: kindest/node:v1.35.0
           command:
             - runner.sh
           args:


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/lws/issues/745

-Replaced 1.31 E2E presubmits with 1.34, 1.35
-Now E2E presubmits run for v1.32, v1.33, v1.34, v1.35
-`cert-manager` and `gang-scheduling` test now runs on v1.35.0