### PR TITLE
Switch Ubuntu e2e jobs to ubuntu-os-cloud for cgroupv2 support

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -673,8 +673,8 @@ presubmits:
         - --gcp-node-image=ubuntu
         - --gcp-region=us-central1
         - --ginkgo-parallel=30
-        - --image-family=pipeline-1-34-amd64
-        - --image-project=ubuntu-os-gke-cloud
+        - --image-family=ubuntu-2404-lts-amd64
+        - --image-project=ubuntu-os-cloud
         - --provider=gce
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -472,8 +472,8 @@ periodics:
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-central1-b
       - --ginkgo-parallel=30
-      - --image-family=pipeline-1-34-amd64
-      - --image-project=ubuntu-os-gke-cloud
+      - --image-family=ubuntu-2404-lts-amd64
+      - --image-project=ubuntu-os-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m


### PR DESCRIPTION
The ubuntu-os-gke-cloud project's pipeline-1-34-amd64 image family defaults to cgroupsv1 images, which are no longer supported in Kubernetes 1.36. The kubelet fails with:

  "kubelet is configured to not run on a host using cgroup v1.
   cgroup v1 support is unsupported and will be removed in a
   future release"

- https://prow.k8s.io/?job=ci-cos-containerd-e2e-ubuntu-gce
- https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-cos-containerd-e2e-ubuntu-gce

Switch to ubuntu-os-cloud's ubuntu-2404-lts-amd64 family which provides cgroupv2 images (Ubuntu 24.04's default).

Affected jobs:
- ci-cos-containerd-e2e-ubuntu-gce
- pull-cos-containerd-e2e-ubuntu-gce