### PR TITLE
Switch local-e2e jobs to eks-prow-build-cluster

### DIFF
--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
       timeout: 240m
@@ -59,7 +59,7 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
-  cluster: k8s-infra-prow-build
+  cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
     timeout: 240m


### PR DESCRIPTION
Move both pull-kubernetes-local-e2e and ci-kubernetes-local-e2e jobs from k8s-infra-prow-build to eks-prow-build-cluster to investigate intermittent networking failures in docker-in-docker setup.

- https://prow.k8s.io/?job=ci-kubernetes-local-e2e
- https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-local-e2e

Let's see if switching environments helps.