### PR TITLE
kubespray: add tide config from-branch-protection

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -878,6 +878,8 @@ tide:
             from-branch-protection: true
           cluster-api-provider-vsphere:
             from-branch-protection: true
+          kubespray:
+            from-branch-protection: true
   batch_size_limit:
     "kubernetes/kubernetes": 15
   priority:


### PR DESCRIPTION
We recently had PRs (backports) merged without CI after rapid lgtm and approval.
kubernetes-sigs/kubespray#12913
kubernetes-sigs/kubespray#12914
kubernetes-sigs/kubespray#12915
@tico88612

I'm not sure why, AFAICT the branch-protection config should have made Github prevent that, but let's have tide
respect it on its own as well.

ref: https://kubernetes.slack.com/archives/C09QZ4DQB/p1769526526012219
