### PR TITLE
Make ci-kubernetes-e2e-gci-gce-autoscaling build new CA image

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -503,10 +503,6 @@ periodics:
       - --cluster=ca
       # Override GCE default for cluster size autoscaling purposes.
       - --env=ENABLE_CUSTOM_METRICS=true
-      - --env=KUBE_ENABLE_CLUSTER_AUTOSCALER=true
-      - --env=KUBE_AUTOSCALER_MIN_NODES=3
-      - --env=KUBE_AUTOSCALER_MAX_NODES=6
-      - --env=KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
       - --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,Priority
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/latest
@@ -516,7 +512,7 @@ periodics:
       - --provider=gce
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test=false
-      - --test-cmd=../cluster-autoscaler/hack/run-e2e.sh
+      - --test-cmd=../cluster-autoscaler/hack/e2e/run-e2e.sh
       - --timeout=400m
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
       resources:


### PR DESCRIPTION
This patch disables cluster autoscaler deployment by kubetest2 gce. Instead, Cluster Autoscaler run script was extended to build and deploy new CA image on every run.