### PR TITLE
image-builder: bump to 90m for building Azure VHDs

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     run_if_changed: 'images/capi/(Makefile|ansible\.cfg)|images/capi/ansible/.*|images/capi/scripts/ci-azure-e2e\.sh|images/capi/packer/(config|goss|azure)/.*|images/capi/hack/ensure-(ansible|packer|jq|azure-cli|goss).*'
     decoration_config:
-      timeout: 1h
+      timeout: 90m
     max_concurrency: 5
     path_alias: sigs.k8s.io/image-builder
     spec:


### PR DESCRIPTION
We've had several CI failures recently on the pull-azure-vhds job that are timeouts after 60 minutes. This bumps the job time to 90 minutes, which is the same as the pull-azure-sigs job.