### PR TITLE
DRA canary: increase memory for DATA RACE detection

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -176,12 +176,13 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          # With DATA RACE detection enabled, more memory is needed.
           limits:
             cpu: 2
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: 2
-            memory: 6Gi
+            memory: 12Gi
 
   - name: pull-kubernetes-kind-dra-all-slow-canary
     cluster: eks-prow-build-cluster
@@ -271,12 +272,13 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          # With DATA RACE detection enabled, more memory is needed.
           limits:
             cpu: 2
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: 2
-            memory: 6Gi
+            memory: 12Gi
 
   - name: pull-kubernetes-kind-dra-n-1-canary
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -279,10 +279,20 @@ presubmits:
           privileged: true
         {%- endif %}
         resources:
+          {%- if job_type == "e2e" and all_features and canary %}
+          # With DATA RACE detection enabled, more memory is needed.
+          limits:
+            cpu: 2
+            memory: 12Gi
+          requests:
+            cpu: 2
+            memory: 12Gi
+          {%- else %}
           limits:
             cpu: 2
             memory: 6Gi
           requests:
             cpu: 2
             memory: 6Gi
+          {%- endif %}
 


### PR DESCRIPTION
https://monitoring-eks.prow.k8s.io/d/96Q8oOOZk/builds?var-org=kubernetes&var-repo=kubernetes&var-job=pull-kubernetes-kind-dra-all-canary&orgId=1&refresh=30s shows that 6GiB was not enough - the job didn't finish and must have been killed.

