### PR TITLE
bump typecheck memory

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -2153,10 +2153,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 12Gi
+            memory: 19Gi
           requests:
             cpu: "5"
-            memory: 12Gi
+            memory: 19Gi
   - always_run: false
     branches:
     - release-1.32

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -2755,10 +2755,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 12Gi
+            memory: 19Gi
           requests:
             cpu: "5"
-            memory: 12Gi
+            memory: 19Gi
   - always_run: false
     branches:
     - release-1.33

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -3598,10 +3598,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 12Gi
+            memory: 19Gi
           requests:
             cpu: "5"
-            memory: 12Gi
+            memory: 19Gi
   - always_run: false
     branches:
     - release-1.34

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -3932,10 +3932,10 @@ presubmits:
         resources:
           limits:
             cpu: "5"
-            memory: 12Gi
+            memory: 19Gi
           requests:
             cpu: "5"
-            memory: 12Gi
+            memory: 19Gi
   - always_run: false
     branches:
     - release-1.35

--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -23,10 +23,10 @@ presubmits:
         resources:
           limits:
             cpu: 5
-            memory: 12Gi
+            memory: 19Gi
           requests:
             cpu: 5
-            memory: 12Gi
+            memory: 19Gi
         args:
         - verify
         env:


### PR DESCRIPTION
this has been oomkilled endlessly while patching go on 1.34

cpu:memory ratio roughly based on https://github.com/kubernetes/test-infra/pull/36121

ref: https://github.com/kubernetes/kubernetes/pull/136467 / https://kubernetes.slack.com/archives/CJH2GBF7Y/p1769844192290279?thread_ts=1769712642.296219&cid=CJH2GBF7Y