### PR TITLE
Bump go version 1.25.6/1.24.12 for kubekins-e2e-v2/krte

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -12,25 +12,25 @@ variants:
     DOCKER_VERSION: 5:28.*
   '1.35':
     CONFIG: '1.35'
-    GO_VERSION: 1.25.5
+    GO_VERSION: 1.25.6
     K8S_RELEASE: latest-1.35
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
   '1.34':
     CONFIG: '1.34'
-    GO_VERSION: 1.24.11
+    GO_VERSION: 1.24.12
     K8S_RELEASE: latest-1.34
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
   '1.33':
     CONFIG: '1.33'
-    GO_VERSION: 1.24.11
+    GO_VERSION: 1.24.12
     K8S_RELEASE: latest-1.33
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
   '1.32':
     CONFIG: '1.32'
-    GO_VERSION: 1.24.11
+    GO_VERSION: 1.24.12
     K8S_RELEASE: latest-1.32
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*


### PR DESCRIPTION
Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>

Bump go version 1.25.6/1.24.12 for kubekins-e2e-v2/krte

xref: https://github.com/kubernetes/release/issues/4237

/assign @dims @BenTheElder @Verolop @cpanato 
cc: @kubernetes/release-managers
