### PR TITLE
Kops - Update cilium presubmit to Ubuntu 24.04

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1476,8 +1476,6 @@ def generate_network_plugins():
             extra_flags = ['--node-size=t3.large']
             if plugin in ['kuberouter']:
                 k8s_version = 'ci'
-            if plugin in ['cilium-eni']:
-                distro = 'u2204' # pinned to 22.04 because of network issues with 24.04 and these CNIs
             if plugin in ['amazon-vpc']:
                 extra_flags += [
                     "--set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true",

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -572,7 +572,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium-etcd
 
-# {"cloud": "aws", "distro": "u2204", "extra_flags": "--node-size=t3.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+# {"cloud": "aws", "distro": "u2404", "extra_flags": "--node-size=t3.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-aws-cni-cilium-eni
   cron: '13 5-23/8 * * *'
   labels:
@@ -602,7 +602,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20251212' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20251212' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -626,13 +626,13 @@ periodics:
           memory: 6Gi
   annotations:
     test.kops.k8s.io/cloud: aws
-    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/distro: u2404
     test.kops.k8s.io/extra_flags: --node-size=t3.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
     test.kops.k8s.io/networking: cilium-eni
-    testgrid-dashboards: kops-distro-u2204, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
+    testgrid-dashboards: kops-distro-u2404, kops-k8s-stable, kops-latest, kops-network-plugins, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium-eni
 


### PR DESCRIPTION
With network hotplug disabled (https://github.com/kubernetes/kops/pull/17882) this presubmit should work with 24.04

/cc @hakman