### PR TITLE
Kueue: Add periodic e2e test for k8s main with WAS

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -568,6 +568,47 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
+    name: periodic-kueue-test-e2e-k8s-main-was
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-k8s-main-was
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic e2e tests against k8s main with WAS enabled"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
+          env:
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-k8s-main-was
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
     name: periodic-kueue-test-e2e-kueueviz-main
     cluster: eks-prow-build-cluster
     annotations:


### PR DESCRIPTION
Add periodic job `periodic-kueue-test-e2e-k8s-main-was` to run Kueue e2e tests against Kubernetes main with WAS (Workload Aware Scheduling) feature gates enabled.

Related Kueue PR: https://github.com/kubernetes-sigs/kueue/pull/8935