### PR TITLE
Add DRA GPU presubmit for EC2

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -310,6 +310,74 @@ presubmits:
             requests:
               cpu: 7
               memory: 10Gi
+  - name: pull-kubernetes-e2e-ec2-dra-gpu
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: presubmits-ec2
+      description: Runs DRA GPU tests using kubetest2-ec2 against kubernetes master on EC2 with NVIDIA T4 GPUs
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    path_alias: k8s.io/kubernetes
+    always_run: false
+    optional: true
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: provider-aws-test-infra
+        base_ref: main
+        path_alias: sigs.k8s.io/provider-aws-test-infra
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+              AMI_ID=$(aws ssm get-parameters --names \
+                     /aws/service/eks/optimized-ami/1.34/amazon-linux-2023/x86_64/nvidia/recommended/image_id \
+                     --query 'Parameters[0].[Value]' --output text)
+              kubetest2 ec2 \
+               --build \
+               --worker-instance-type=g4dn.12xlarge \
+               --dra-nvidia true \
+               --worker-image="$AMI_ID" \
+               --region us-east-1 \
+               --target-build-arch linux/amd64 \
+               --stage provider-aws-test-infra \
+               --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
+               --up \
+               --down \
+               --test=ginkgo \
+               -- \
+               --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
+               --focus-regex="\[Feature:DynamicResourceAllocation\].*GPU" \
+               --use-built-binaries true \
+               --parallel=1
+          env:
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 7
+              memory: 10Gi
+            requests:
+              cpu: 7
+              memory: 10Gi
   kubernetes-sigs/provider-aws-test-infra:
   - name: pull-kubernetes-e2e-ec2-quick
     skip_branches:


### PR DESCRIPTION
Add pull-kubernetes-e2e-ec2-dra-gpu presubmit job that tests Dynamic Resource Allocation (DRA) based GPU allocation on EC2 with NVIDIA T4 GPUs (g4dn.12xlarge).

This is similar to pull-kubernetes-e2e-ec2-device-plugin-gpu but uses the new DRA API instead of the device plugin approach:
- Uses --dra-nvidia flag instead of --device-plugin-nvidia
- Runs [Feature:DynamicResourceAllocation].*GPU tests
- Uses serial execution (parallel=1) since GPU tests share resources