### PR TITLE
Add periodic job for DRA GPU tests on EC2

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -966,6 +966,73 @@ periodics:
           requests:
             cpu: 7
             memory: 10Gi
+- interval: 24h
+  cluster: eks-prow-build-cluster
+  name: ci-kubernetes-e2e-ec2-dra-gpu
+  annotations:
+    testgrid-dashboards: amazon-ec2
+    testgrid-tab-name: ec2-dra-gpu-master
+    description: Runs DRA GPU tests using kubetest2-ec2 against kubernetes master on EC2 with NVIDIA T4 GPUs
+  labels:
+    preset-e2e-containerd-ec2: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: provider-aws-test-infra
+      base_ref: main
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+  spec:
+    serviceAccountName: node-e2e-tests
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
+            AMI_ID=$(aws ssm get-parameters --names \
+                   /aws/service/eks/optimized-ami/1.34/amazon-linux-2023/x86_64/nvidia/recommended/image_id \
+                   --query 'Parameters[0].[Value]' --output text)
+            kubetest2 ec2 \
+             --build \
+             --worker-instance-type=g4dn.12xlarge \
+             --dra-nvidia true \
+             --worker-image="$AMI_ID" \
+             --region us-east-1 \
+             --target-build-arch linux/amd64 \
+             --stage provider-aws-test-infra \
+             --worker-user-data-file $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config/al2023.sh \
+             --up \
+             --down \
+             --test=ginkgo \
+             -- \
+             --test-args="--provider=aws --minStartupPods=8" \
+             --focus-regex="\[Feature:DynamicResourceAllocation\].*GPU" \
+             --use-built-binaries true \
+             --parallel=1
+        env:
+          - name: USE_DOCKERIZED_BUILD
+            value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 7
+            memory: 10Gi
+          requests:
+            cpu: 7
+            memory: 10Gi
 - interval: 1h
   cluster: eks-prow-build-cluster
   name: ci-aws-ec2-janitor


### PR DESCRIPTION
Add ci-kubernetes-e2e-ec2-dra-gpu periodic job that runs daily to test Dynamic Resource Allocation (DRA) with NVIDIA GPUs on EC2.

- Runs every 24h against kubernetes master
- Uses g4dn.12xlarge instances with NVIDIA T4 GPUs
- Installs NVIDIA DRA driver via helm
- Focuses on [Feature:DynamicResourceAllocation].*GPU tests

PS: the presubmit seems to be working! https://testgrid.k8s.io/presubmits-ec2#pull-kubernetes-e2e-ec2-dra-gpu 