### PR TITLE
Secret Store CSI Driver - fix permafailing upgrade periodics

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -1093,7 +1093,7 @@ periodics:
           - bash
           - -c
           - >-
-            make e2e-bootstrap e2e-mock-provider-container e2e-helm-deploy-release e2e-provider-deploy e2e-provider && make e2e-helm-upgrade e2e-provider
+            make e2e-bootstrap e2e-mock-provider-container e2e-helm-deploy-release e2e-provider-deploy && make e2e-helm-upgrade e2e-provider
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -1135,7 +1135,7 @@ periodics:
           - bash
           - -c
           - >-
-            INPLACE_UPGRADE_TEST=true make e2e-bootstrap e2e-mock-provider-container e2e-helm-deploy-release e2e-provider-deploy e2e-provider && INPLACE_UPGRADE_TEST=true make e2e-helm-upgrade e2e-provider
+            INPLACE_UPGRADE_TEST=true make e2e-bootstrap e2e-mock-provider-container e2e-helm-deploy-release e2e-provider-deploy && INPLACE_UPGRADE_TEST=true make e2e-helm-upgrade e2e-provider
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -1151,4 +1151,46 @@ periodics:
     testgrid-tab-name: secrets-store-csi-driver-inplace-upgrade-test-e2e-provider
     testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
     description: "Run driver in-place upgrade test with e2e provider for Secrets Store CSI driver."
+    testgrid-num-columns-recent: '30'
+- interval: 12h
+  name: periodic-secrets-store-csi-driver-test-e2e-provider
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 30m
+  labels:
+    # this is required because we want to run kind in docker
+    preset-dind-enabled: "true"
+    # this is required to make CNI installation to succeed for kind
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: secrets-store-csi-driver
+    base_ref: main
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260127-f10a7ebcce-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - >-
+            make e2e-bootstrap e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "4Gi"
+          limits:
+            cpu: "4"
+            memory: "4Gi"
+  annotations:
+    testgrid-dashboards: sig-auth-secrets-store-csi-driver, sig-auth-secrets-store-csi-driver-periodic
+    testgrid-tab-name: secrets-store-csi-driver-test-e2e-provider
+    testgrid-alert-email: kubernetes-secrets-store-csi-driver@googlegroups.com
+    description: "Run driver tests with e2e provider for Secrets Store CSI driver."
     testgrid-num-columns-recent: '30'


### PR DESCRIPTION
The tests would permanently fail as they attempt to run "main" test set that assume that a bug that fixes ':authority' gRPC header is correct, but the released version does not have those fixes yet.

Only run the current tests on the most current version. This commit also adds another test job to run the tests with the current driver install without a previous upgrade.

/cc aramase enj 