### PR TITLE
image-pushing: add agentic-networking quickstart images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-agentic-net.yaml
+++ b/config/jobs/image-pushing/k8s-staging-agentic-net.yaml
@@ -1,6 +1,6 @@
 postsubmits:
   kubernetes-sigs/kube-agentic-networking:
-  - name: post-agentic-net-push-images
+  - name: post-agentic-net-push-controller-image
     cluster: k8s-infra-prow-build-trusted
     annotations:
       testgrid-dashboards: sig-network-kube-agentic-networking, sig-k8s-infra-gcb
@@ -22,3 +22,49 @@ postsubmits:
         - --build-dir=.
         - --with-git-dir
         - .
+  - name: post-agentic-net-push-adk-agent-image
+    cluster: k8s-infra-prow-build-trusted
+    annotations:
+      testgrid-dashboards: sig-network-kube-agentic-networking, sig-k8s-infra-gcb
+    decorate: true
+    run_if_changed: '^quickstart\/adk-agent\/'
+    skip_branches:
+    # do not run on dependabot branches, these exist prior to merge
+    # only merged code should trigger these jobs
+    - '^dependabot'
+    spec:
+      serviceAccountName: gcb-builder
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20251215-d7853fe2a6
+        command:
+        - /run.sh
+        args:
+        - --project=k8s-staging-images
+        - --scratch-bucket=gs://k8s-staging-images-gcb
+        - --env-passthrough=PULL_BASE_REF
+        - --build-dir=.
+        - --with-git-dir
+        - quickstart/adk-agent
+  - name: post-agentic-net-push-everything-mcp-image
+    cluster: k8s-infra-prow-build-trusted
+    annotations:
+      testgrid-dashboards: sig-network-kube-agentic-networking, sig-k8s-infra-gcb
+    decorate: true
+    run_if_changed: '^quickstart\/mcpserver\/'
+    skip_branches:
+    # do not run on dependabot branches, these exist prior to merge
+    # only merged code should trigger these jobs
+    - '^dependabot'
+    spec:
+      serviceAccountName: gcb-builder
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20251215-d7853fe2a6
+        command:
+        - /run.sh
+        args:
+        - --project=k8s-staging-images
+        - --scratch-bucket=gs://k8s-staging-images-gcb
+        - --env-passthrough=PULL_BASE_REF
+        - --build-dir=.
+        - --with-git-dir
+        - quickstart/mcpserver


### PR DESCRIPTION
Adds Prow postsubmit jobs to build and push staging images for the `adk-agent` and `mcpserver` quickstart components. 

This job will trigger the execution of the cloudbuild.yaml files added in https://github.com/kubernetes-sigs/kube-agentic-networking/pull/60 