### PR TITLE
Add kueue performance test job with TAS

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -154,6 +154,44 @@ periodics:
               cpu: "6"
               memory: "9Gi"
   - interval: 12h
+    name: periodic-kueue-test-tas-scheduling-perf-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-tas-scheduling-perf-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue test-tas-scheduling-perf"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.25
+          command:
+            - make
+          args:
+            - test-tas-performance-scheduler
+          env:
+            - name: GOMAXPROCS
+              value: "6"
+          resources:
+            requests:
+              cpu: "6"
+              memory: "9Gi"
+            limits:
+              cpu: "6"
+              memory: "9Gi"
+  - interval: 12h
     name: periodic-kueue-test-e2e-main-1-32
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-15.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-15.yaml
@@ -154,6 +154,44 @@ periodics:
               cpu: "6"
               memory: "9Gi"
   - interval: 12h
+    name: periodic-kueue-test-tas-scheduling-perf-release-0-15
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-tas-scheduling-perf-release-0-15
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue test-tas-scheduling-perf"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.15
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.25
+          command:
+            - make
+          args:
+            - test-tas-performance-scheduler
+          env:
+            - name: GOMAXPROCS
+              value: "6"
+          resources:
+            requests:
+              cpu: "6"
+              memory: "9Gi"
+            limits:
+              cpu: "6"
+              memory: "9Gi"
+  - interval: 12h
     name: periodic-kueue-test-e2e-release-0-15-1-32
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
@@ -154,6 +154,44 @@ periodics:
               cpu: "6"
               memory: "9Gi"
   - interval: 12h
+    name: periodic-kueue-test-tas-scheduling-perf-release-0-16
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-tas-scheduling-perf-release-0-16
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue test-tas-scheduling-perf"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.16
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.25
+          command:
+            - make
+          args:
+            - test-tas-performance-scheduler
+          env:
+            - name: GOMAXPROCS
+              value: "6"
+          resources:
+            requests:
+              cpu: "6"
+              memory: "9Gi"
+            limits:
+              cpu: "6"
+              memory: "9Gi"
+  - interval: 12h
     name: periodic-kueue-test-e2e-release-0-16-1-32
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -669,6 +669,34 @@ presubmits:
           limits:
             cpu: "6"
             memory: "9Gi"
+  - name: pull-kueue-test-tas-scheduling-perf-main
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^main
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+    decorate: true
+    path_alias: sigs.k8s.io/kueue
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-kueue-test-tas-scheduling-perf-main
+      description: "Run kueue test-tas-scheduling-perf"
+    spec:
+      containers:
+      - image: public.ecr.aws/docker/library/golang:1.25
+        command:
+        - make
+        args:
+        - test-tas-performance-scheduler
+        env:
+        - name: GOMAXPROCS
+          value: "6"
+        resources:
+          requests:
+            cpu: "6"
+            memory: "9Gi"
+          limits:
+            cpu: "6"
+            memory: "9Gi"
   - name: pull-kueue-populator-verify-main
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-15.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-15.yaml
@@ -631,6 +631,34 @@ presubmits:
               limits:
                 cpu: "6"
                 memory: "9Gi"
+    - name: pull-kueue-test-tas-scheduling-perf-release-0-15
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.15
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-tas-scheduling-perf-release-0-15
+        description: "Run kueue test-tas-scheduling-perf"
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.25
+            command:
+              - make
+            args:
+              - test-tas-performance-scheduler
+            env:
+              - name: GOMAXPROCS
+                value: "6"
+            resources:
+              requests:
+                cpu: "6"
+                memory: "9Gi"
+              limits:
+                cpu: "6"
+                memory: "9Gi"
     - name: pull-kueue-populator-verify-release-0-15
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
@@ -669,6 +669,34 @@ presubmits:
               limits:
                 cpu: "6"
                 memory: "9Gi"
+    - name: pull-kueue-test-tas-scheduling-perf-release-0-16
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.16
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-tas-scheduling-perf-release-0-16
+        description: "Run kueue test-tas-scheduling-perf"
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.25
+            command:
+              - make
+            args:
+              - test-tas-performance-scheduler
+            env:
+              - name: GOMAXPROCS
+                value: "6"
+            resources:
+              requests:
+                cpu: "6"
+                memory: "9Gi"
+              limits:
+                cpu: "6"
+                memory: "9Gi"
     - name: pull-kueue-populator-verify-release-0-16
       cluster: eks-prow-build-cluster
       branches:


### PR DESCRIPTION
MR adds new performance test jobs with TopologyAwareScheduling:
- pull-kueue-test-tas-scheduling-perf-main
- pull-kueue-test-tas-scheduling-perf-release-0-15
- pull-kueue-test-tas-scheduling-perf-release-0-16
- periodic-kueue-test-tas-scheduling-perf-main
- periodic-kueue-test-tas-scheduling-perf-release-0-15
- periodic-kueue-test-tas-scheduling-perf-release-0-16

Don't merge before https://github.com/kubernetes-sigs/kueue/pull/8917 is merged (and cherry-picked to 0.15, 0.16).