### PR TITLE
DRA: promote data race detection

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -175,19 +175,28 @@ periodics:
           }
           trap atexit EXIT
 
-          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
+        env:
+        # -race gets injected into the build of dynamically linked binaries during "kind build node-image" and "make e2e.test".
+        - name: KUBE_RACE
+          value: -race
+        # Normally control plane components are linked statically, which does not work with -race (needs CGO).
+        # We need to override the default for components of interest.
+        - name: KUBE_CGO_OVERRIDES
+          value: kube-apiserver kube-controller-manager kube-scheduler
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
+          # With DATA RACE detection enabled, more memory is needed.
           limits:
             cpu: 2
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: 2
-            memory: 6Gi
+            memory: 12Gi
 
   - name: ci-kind-dra-n-1
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -165,19 +165,28 @@ presubmits:
           }
           trap atexit EXIT
 
-          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
+        env:
+        # -race gets injected into the build of dynamically linked binaries during "kind build node-image" and "make e2e.test".
+        - name: KUBE_RACE
+          value: -race
+        # Normally control plane components are linked statically, which does not work with -race (needs CGO).
+        # We need to override the default for components of interest.
+        - name: KUBE_CGO_OVERRIDES
+          value: kube-apiserver kube-controller-manager kube-scheduler
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
+          # With DATA RACE detection enabled, more memory is needed.
           limits:
             cpu: 2
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: 2
-            memory: 6Gi
+            memory: 12Gi
 
   - name: pull-kubernetes-kind-dra-all-slow
     cluster: eks-prow-build-cluster
@@ -253,19 +262,28 @@ presubmits:
           }
           trap atexit EXIT
 
-          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
+        env:
+        # -race gets injected into the build of dynamically linked binaries during "kind build node-image" and "make e2e.test".
+        - name: KUBE_RACE
+          value: -race
+        # Normally control plane components are linked statically, which does not work with -race (needs CGO).
+        # We need to override the default for components of interest.
+        - name: KUBE_CGO_OVERRIDES
+          value: kube-apiserver kube-controller-manager kube-scheduler
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
+          # With DATA RACE detection enabled, more memory is needed.
           limits:
             cpu: 2
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: 2
-            memory: 6Gi
+            memory: 12Gi
 
   - name: pull-kubernetes-kind-dra-n-1
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -259,10 +259,10 @@ presubmits:
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
           {%- endif %}
 
-          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus {%- if kubelet_skew|int > 0 %}$kubelet_label_filter{%- endif %} {%- if not all_features %} && !Alpha {%- endif %} && !Flaky {%- if not ci and not allow_slow %} && !Slow {%- endif %}" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit {%- if all_features and canary %} -logcheck-data-races{%endif%} &
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus {%- if kubelet_skew|int > 0 %}$kubelet_label_filter{%- endif %} {%- if not all_features %} && !Alpha {%- endif %} && !Flaky {%- if not ci and not allow_slow %} && !Slow {%- endif %}" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit {%- if all_features %} -logcheck-data-races{%endif%} &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
-        {%- if all_features and canary %}
+        {%- if all_features %}
         env:
         # -race gets injected into the build of dynamically linked binaries during "kind build node-image" and "make e2e.test".
         - name: KUBE_RACE
@@ -279,7 +279,7 @@ presubmits:
           privileged: true
         {%- endif %}
         resources:
-          {%- if job_type == "e2e" and all_features and canary %}
+          {%- if job_type == "e2e" and all_features %}
           # With DATA RACE detection enabled, more memory is needed.
           limits:
             cpu: 2


### PR DESCRIPTION
This was previously tested as a canary, now data race detection gets enabled for periodic and normal dra-all jobs. The rationale for doing it there instead of a separate job is that dra-all a) runs all DRA tests and b) is experimental because of alpha tests, so occasional flakes (should they occur) because of data races are okay.

/assign @bart0sh 