### PR TITLE
Enable dind in cluster-autoscaler E2E periodic tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -485,6 +485,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 450m


### PR DESCRIPTION
Lack of dind caused tests to fail:
```
Building and pushing image...
GOOS=linux docker buildx build --pull --platform linux/amd64 \
	--build-arg "GOARCH=amd64" \
	-t gcr.io/k8s-infra-e2e-boskos-027/cluster-autoscaler-amd64:dev-d3df28b24-1770201141 \
	-f Dockerfile .
ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

Relates to kubernetes/autoscaler#9023