### PR TITLE
SIG testing: add pull-kubernetes-e2e-kind-alpha-beta-features-audit

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -569,6 +569,57 @@ presubmits:
             cpu: 7
             memory: 9000Mi
 
+  - name: pull-kubernetes-e2e-kind-alpha-beta-features-audit
+    annotations:
+      description: Runs tests with no special requirements other than alpha or beta feature gates in a KinD cluster where alpha and beta feature gates and APIs are enabled together with audit logging.
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'
+    cluster: k8s-infra-prow-build
+    optional: true
+    decorate: true
+    skip_branches:
+    - release-\d+\.\d+ # per-release settings
+    labels:
+      preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20260127-f10a7ebcce-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        # kind-audit-e2e.sh enables audit logging.
+        - >
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" &&
+          curl -sSL https://github.com/kubernetes/test-infra/raw/master/experiment/kind-audit-e2e.sh >/tmp/kind-audit-e2e.sh &&
+          chmod u+x /tmp/kind-audit-e2e.sh &&
+          /tmp/kind-audit-e2e.sh
+        env:
+        # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/all":"true"}'
+        - name: LABEL_FILTER
+          value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 7
+            memory: 9000Mi
+          requests:
+            cpu: 7
+            memory: 9000Mi
+
   - name: pull-kubernetes-e2e-kind-alpha-beta-features-race
     annotations:
       description: Runs tests with no special requirements other than alpha or beta feature gates in a KinD cluster where alpha and beta feature gates and APIs are enabled and control plane components are built with race detection.

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -124,6 +124,9 @@ dashboards:
   - name: pull-kubernetes-e2e-kind-alpha-beta-enabled-conformance
     test_group_name: pull-kubernetes-e2e-kind-alpha-beta-enabled-conformance
     base_options: width=10
+  - name: pull-kubernetes-e2e-kind-alpha-beta-features-audit
+    test_group_name: pull-kubernetes-e2e-kind-alpha-beta-features-audit
+    base_options: width=10
   - name: pull-kubernetes-e2e-kind-alpha-beta-features-race
     test_group_name: pull-kubernetes-e2e-kind-alpha-beta-features-race
     base_options: width=10


### PR DESCRIPTION
It's an on-demand job which creates audit logs for as many tests as possible.