### PR TITLE
Disable periodic enhancements sync for v1.36

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -1,8 +1,8 @@
 periodics:
 - name: periodic-sync-enhancements-github-project-1-36
   # temporarily disable job by with an impossible cron date instead of deleting it
-  #cron: '0 0 31 2 *'
-  interval: 6h
+  cron: '0 0 31 2 *'
+  #interval: 6h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   annotations:


### PR DESCRIPTION
Disable the syncing of lead-opted-in KEPs to the https://github.com/orgs/kubernetes/projects/241.

Opening this PR early to get approvals. We can remove the hold once PRR Freeze is in effect (Wednesday 4th February 2026 (AoE) / Thursday 5th February 2026, 12:00 UTC). 

cc. @rytswd @katcosgrove @fsmunoz 

/hold