### PR TITLE
reduce control plane count for ec2 jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -96,6 +96,7 @@ def build_test(cloud='aws',
                storage_e2e_cred=False,
                alert_email=None,
                alert_num_failures=None,
+               job_queue_name=None,
                extra_refs=None):
     # pylint: disable=too-many-statements,too-many-arguments
     if kops_version is None:
@@ -237,6 +238,7 @@ def build_test(cloud='aws',
         storage_e2e_cred=storage_e2e_cred,
         instance_groups_overrides=instance_groups_overrides,
         extra_refs=extra_refs,
+        job_queue_name=job_queue_name,
     )
 
     spec = {
@@ -325,6 +327,7 @@ def presubmit_test(branch='master',
                    alert_email=None,
                    alert_num_failures=None,
                    instance_groups_overrides=None,
+                   job_queue_name=None,
                    extra_refs=None):
     # pylint: disable=too-many-statements,too-many-arguments
     kops_image = None
@@ -424,6 +427,7 @@ def presubmit_test(branch='master',
         cluster_name=cluster_name,
         instance_groups_overrides=instance_groups_overrides,
         extra_refs=extra_refs,
+        job_queue_name=job_queue_name,
     )
 
     spec = {
@@ -1644,7 +1648,7 @@ def generate_upgrades():
 def generate_presubmits_scale():
     results = [
         presubmit_test(
-            name='presubmit-kops-aws-scale-amazonvpc-using-cl2',
+            name='pull-kops-ec2-master-scale-performance-5000',
             scenario='scalability',
             build_cluster='eks-prow-build-cluster',
             # only helps with setting the right anotation test.kops.k8s.io/networking
@@ -1652,6 +1656,7 @@ def generate_presubmits_scale():
             always_run=False,
             optional=True,
             test_timeout_minutes=450,
+            job_queue_name="5k-aws-scale-test",
             use_preset_for_account_creds='preset-aws-credential-boskos-scale-001-kops',
             env={
                 'CNI_PLUGIN': "amazonvpc",
@@ -1660,8 +1665,8 @@ def generate_presubmits_scale():
                 'CL2_DELETE_TEST_THROUGHPUT': "50",
                 'CL2_RATE_LIMIT_POD_CREATION': "false",
                 'NODE_MODE': "master",
-                'CONTROL_PLANE_COUNT': "3",
-                'CONTROL_PLANE_SIZE': "c8a.24xlarge",
+                'CONTROL_PLANE_COUNT': "1",
+                'CONTROL_PLANE_SIZE': "c8i.24xlarge",
                 'PROMETHEUS_SCRAPE_KUBE_PROXY': "true",
                 'CL2_ENABLE_DNS_PROGRAMMING': "true",
                 'CL2_ENABLE_API_AVAILABILITY_MEASUREMENT': "true",
@@ -1678,7 +1683,7 @@ def generate_presubmits_scale():
             }
         ),
         presubmit_test(
-            name='presubmit-kops-aws-small-scale-amazonvpc-using-cl2',
+            name='pull-kops-ec2-master-scale-performance-100',
             scenario='scalability',
             build_cluster="eks-prow-build-cluster",
             # only helps with setting the right anotation test.kops.k8s.io/networking
@@ -1688,10 +1693,10 @@ def generate_presubmits_scale():
             use_preset_for_account_creds='preset-aws-credential-boskos-scale-001-kops',
             env={
                 'CNI_PLUGIN': "amazonvpc",
-                'KUBE_NODE_COUNT': "500",
+                'KUBE_NODE_COUNT': "100",
                 'CL2_SCHEDULER_THROUGHPUT_THRESHOLD': "20",
-                'CONTROL_PLANE_COUNT': "3",
-                'CONTROL_PLANE_SIZE': "c8a.8xlarge",
+                'CONTROL_PLANE_COUNT': "1",
+                'CONTROL_PLANE_SIZE': "c8i.8xlarge",
                 'CL2_LOAD_TEST_THROUGHPUT': "50",
                 'CL2_DELETE_TEST_THROUGHPUT': "50",
                 'CL2_RATE_LIMIT_POD_CREATION': "false",
@@ -1710,12 +1715,13 @@ def generate_presubmits_scale():
             }
         ),
         presubmit_test(
-            name='presubmit-kops-gce-scale-ipalias-using-cl2',
+            name='pull-kops-gce-master-scale-performance-5000',
             scenario='scalability',
             # only helps with setting the right anotation test.kops.k8s.io/networking
             networking='gce',
             cloud="gce",
             always_run=False,
+            job_queue_name="5k-gce-scale-test",
             test_timeout_minutes=450,
             env={
                 'CNI_PLUGIN': "gce",
@@ -1744,7 +1750,7 @@ def generate_presubmits_scale():
             }
         ),
         presubmit_test(
-            name='presubmit-kops-gce-small-scale-ipalias-using-cl2',
+            name='pull-kops-gce-master-scale-performance-100',
             scenario='scalability',
             # only helps with setting the right anotation test.kops.k8s.io/networking
             networking='gce',
@@ -1754,11 +1760,11 @@ def generate_presubmits_scale():
             test_timeout_minutes=450,
             env={
                 'CNI_PLUGIN': "gce",
-                'KUBE_NODE_COUNT': "500",
+                'KUBE_NODE_COUNT': "100",
                 'CL2_SCHEDULER_THROUGHPUT_THRESHOLD': "20",
                 'CONTROL_PLANE_COUNT': "1",
                 'KUBE_PROXY_MODE': 'nftables',
-                'CONTROL_PLANE_SIZE': "c4-standard-48",
+                'CONTROL_PLANE_SIZE': "c4-standard-32",
                 'CL2_LOAD_TEST_THROUGHPUT': "50",
                 'CL2_DELETE_TEST_THROUGHPUT': "50",
                 'CL2_RATE_LIMIT_POD_CREATION': "false",
@@ -1778,7 +1784,7 @@ def generate_presubmits_scale():
             }
         ),
         presubmit_test(
-            name='presubmit-kops-gce-small-scale-kindnet-using-cl2',
+            name='pull-kops-gce-master-scale-kindnet-performance-100',
             scenario='scalability',
             # only helps with setting the right anotation test.kops.k8s.io/networking
             networking='gce',

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -4,10 +4,11 @@ presubmits:
   kubernetes/kops:
 
   # {"cloud": "aws", "distro": "u2404", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
-  - name: presubmit-kops-aws-scale-amazonvpc-using-cl2
+  - name: pull-kops-ec2-master-scale-performance-5000
     cluster: eks-prow-build-cluster
     branches:
     - master
+    job_queue_name: '5k-aws-scale-test'
     always_run: false
     optional: true
     skip_report: false
@@ -55,9 +56,9 @@ presubmits:
         - name: NODE_MODE
           value: "master"
         - name: CONTROL_PLANE_COUNT
-          value: "3"
+          value: "1"
         - name: CONTROL_PLANE_SIZE
-          value: "c8a.24xlarge"
+          value: "c8i.24xlarge"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
@@ -103,10 +104,10 @@ presubmits:
       test.kops.k8s.io/networking: amazonvpc
       testgrid-dashboards: kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
-      testgrid-tab-name: presubmit-kops-aws-scale-amazonvpc-using-cl2
+      testgrid-tab-name: pull-kops-ec2-master-scale-performance-5000
 
   # {"cloud": "aws", "distro": "u2404", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
-  - name: presubmit-kops-aws-small-scale-amazonvpc-using-cl2
+  - name: pull-kops-ec2-master-scale-performance-100
     cluster: eks-prow-build-cluster
     branches:
     - master
@@ -147,13 +148,13 @@ presubmits:
         - name: CNI_PLUGIN
           value: "amazonvpc"
         - name: KUBE_NODE_COUNT
-          value: "500"
+          value: "100"
         - name: CL2_SCHEDULER_THROUGHPUT_THRESHOLD
           value: "20"
         - name: CONTROL_PLANE_COUNT
-          value: "3"
+          value: "1"
         - name: CONTROL_PLANE_SIZE
-          value: "c8a.8xlarge"
+          value: "c8i.8xlarge"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT
@@ -203,14 +204,14 @@ presubmits:
       test.kops.k8s.io/networking: amazonvpc
       testgrid-dashboards: kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
-      testgrid-tab-name: presubmit-kops-aws-small-scale-amazonvpc-using-cl2
+      testgrid-tab-name: pull-kops-ec2-master-scale-performance-100
 
   # {"cloud": "gce", "distro": "u2404", "k8s_version": "stable", "kops_channel": "alpha", "networking": "gce"}
-  - name: presubmit-kops-gce-scale-ipalias-using-cl2
+  - name: pull-kops-gce-master-scale-performance-5000
     cluster: k8s-infra-prow-build
     branches:
     - master
-    job_queue_name: "5k-gce-scale-test"
+    job_queue_name: '5k-gce-scale-test'
     always_run: false
     optional: false
     skip_report: false
@@ -307,15 +308,14 @@ presubmits:
       test.kops.k8s.io/networking: gce
       testgrid-dashboards: kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
-      testgrid-tab-name: presubmit-kops-gce-scale-ipalias-using-cl2
+      testgrid-tab-name: pull-kops-gce-master-scale-performance-5000
 
   # {"cloud": "gce", "distro": "u2404", "k8s_version": "stable", "kops_channel": "alpha", "networking": "gce"}
-  - name: presubmit-kops-gce-small-scale-ipalias-using-cl2
+  - name: pull-kops-gce-master-scale-performance-100
     cluster: k8s-infra-prow-build
     branches:
     - master
     run_if_changed: '^tests\/e2e\/scenarios\/scalability\/run-test.sh'
-    job_queue_name: "5k-gce-scale-test"
     always_run: false
     optional: false
     skip_report: false
@@ -352,7 +352,7 @@ presubmits:
         - name: CNI_PLUGIN
           value: "gce"
         - name: KUBE_NODE_COUNT
-          value: "500"
+          value: "100"
         - name: CL2_SCHEDULER_THROUGHPUT_THRESHOLD
           value: "20"
         - name: CONTROL_PLANE_COUNT
@@ -360,7 +360,7 @@ presubmits:
         - name: KUBE_PROXY_MODE
           value: "nftables"
         - name: CONTROL_PLANE_SIZE
-          value: "c4-standard-48"
+          value: "c4-standard-32"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT
@@ -410,14 +410,13 @@ presubmits:
       test.kops.k8s.io/networking: gce
       testgrid-dashboards: kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
-      testgrid-tab-name: presubmit-kops-gce-small-scale-ipalias-using-cl2
+      testgrid-tab-name: pull-kops-gce-master-scale-performance-100
 
   # {"cloud": "gce", "distro": "u2404", "k8s_version": "stable", "kops_channel": "alpha", "networking": "gce"}
-  - name: presubmit-kops-gce-small-scale-kindnet-using-cl2
+  - name: pull-kops-gce-master-scale-kindnet-performance-100
     cluster: k8s-infra-prow-build
     branches:
     - master
-    job_queue_name: "5k-gce-scale-test"
     always_run: false
     optional: false
     skip_report: false
@@ -510,4 +509,4 @@ presubmits:
       test.kops.k8s.io/networking: gce
       testgrid-dashboards: kops-presubmits, presubmits-kops, sig-cluster-lifecycle-kops
       testgrid-days-of-results: '90'
-      testgrid-tab-name: presubmit-kops-gce-small-scale-kindnet-using-cl2
+      testgrid-tab-name: pull-kops-gce-master-scale-kindnet-performance-100

--- a/config/jobs/kubernetes/kops/templates/presubmit-scenario.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit-scenario.yaml.jinja
@@ -6,8 +6,8 @@
     {%- if run_if_changed %}
     run_if_changed: '{{run_if_changed}}'
     {%- endif %}
-    {%- if cloud == "gce" and scenario == "scalability" %}
-    job_queue_name: "5k-gce-scale-test"
+    {%- if job_queue_name %}
+    job_queue_name: '{{job_queue_name}}'
     {%- endif %}
     always_run: {{always_run}}
     optional: {{optional}}

--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -396,7 +396,7 @@ periodics:
         - name: CONTROL_PLANE_COUNT
           value: "1"
         - name: CONTROL_PLANE_SIZE
-          value: "c4-standard-48"
+          value: "c4-standard-32"
         - name: KUBE_PROXY_MODE
           value: "nftables"
         - name: ENABLE_PROMETHEUS_SERVER

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -45,6 +45,7 @@ periodics:
     preset-aws-credential-boskos-scale-001-kops: "true"
     preset-dind-enabled: "true"
   decorate: true
+  job_queue_name: '5k-aws-scale-test'
   decoration_config:
     timeout: 480m
   extra_refs:
@@ -100,9 +101,9 @@ periodics:
       - name: NODE_MODE
         value: "master"
       - name: CONTROL_PLANE_COUNT
-        value: "3"
+        value: "1"
       - name: CONTROL_PLANE_SIZE
-        value: "c8a.24xlarge"
+        value: "c8i.24xlarge"
       - name: PROMETHEUS_SCRAPE_KUBE_PROXY
         value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
@@ -202,7 +203,7 @@ periodics:
       - name: NODE_MODE
         value: "master"
       - name: CONTROL_PLANE_COUNT
-        value: "3"
+        value: "1"
       - name: CONTROL_PLANE_SIZE
         value: "c8a.8xlarge"
       - name: PROMETHEUS_SCRAPE_KUBE_PROXY

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -149,7 +149,7 @@ presubmits:
         - name: CONTROL_PLANE_COUNT
           value: "1"
         - name: CONTROL_PLANE_SIZE
-          value: "c4-standard-48"
+          value: "c4-standard-32"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
@@ -881,9 +881,9 @@ presubmits:
         - name: NODE_MODE
           value: "master"
         - name: CONTROL_PLANE_COUNT
-          value: "3"
+          value: "1"
         - name: CONTROL_PLANE_SIZE
-          value: "c5.9xlarge"
+          value: "c8i.8xlarge"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
@@ -964,9 +964,9 @@ presubmits:
         - name: NODE_MODE
           value: "master"
         - name: CONTROL_PLANE_COUNT
-          value: "3"
+          value: "1"
         - name: CONTROL_PLANE_SIZE
-          value: "c8a.12xlarge"
+          value: "c8i.12xlarge"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
@@ -1048,7 +1048,7 @@ presubmits:
         - name: NODE_MODE
           value: "master"
         - name: CONTROL_PLANE_COUNT
-          value: "3"
+          value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c8a.24xlarge"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
@@ -1136,7 +1136,7 @@ presubmits:
         - name: CONTROL_PLANE_COUNT
           value: "1"
         - name: CONTROL_PLANE_SIZE
-          value: "c4-standard-48"
+          value: "c4-standard-32"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -246,7 +246,7 @@ periodics:
       - name: CONTROL_PLANE_COUNT
         value: "1"
       - name: CONTROL_PLANE_SIZE
-        value: "c4-standard-48"
+        value: "c4-standard-32"
       - name: PROMETHEUS_SCRAPE_KUBE_PROXY
         value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -13,6 +13,8 @@ plank:
     'test-infra-staging-image-push': 1
     # limits concurrency for 5k GCE jobs
     '5k-gce-scale-test': 4
+    # limits concurrency for 5k AWS jobs
+    '5k-aws-scale-test': 1
   default_decoration_config_entries:
   - config:
       timeout: 2h


### PR DESCRIPTION
ec2 jobs have a very high event count, which is caused by having highly-available control plane, we don't run GCE scale jobs like that so let's turn it off.

https://kubernetes.slack.com/archives/C09QZTRH7/p1770197978537249?thread_ts=1767977126.452879&cid=C09QZTRH7

/cc @ronaldngounou @mengqiy 

Also, fixed some jobs names