### PR TITLE
SIG testing: increase timeout for pull-kubernetes-e2e-kind-alpha-beta-features-audit

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -583,7 +583,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
     decoration_config:
-      timeout: 60m
+      timeout: 2h
       grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:


### PR DESCRIPTION
Audit logging makes the apiserver slower such that the previous 1h limit was reached.

/assign @dims 