### PR TITLE
Enable privileged mode for CA periodic E2E tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -523,6 +523,9 @@ periodics:
         requests:
           cpu: 2
           memory: 6Gi
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
     testgrid-tab-name: gci-gce-autoscaling


### PR DESCRIPTION
After enabling dind preset E2E tests keep failing with: ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?

Based on other job configs, dind needs privileged mode to work. It should have been added together with dind preset.