### PR TITLE
Update cypress base to 24.13.0

### DIFF
--- a/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
@@ -102,7 +102,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: cypress/base:18.6.0
+      - image: cypress/base:24.13.0
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
PTAL @kubernetes/release-engineering 

Required for https://github.com/kubernetes-sigs/release-notes/pull/947