### PR TITLE
Fix depstat diff failure due to uncommitted changes

### DIFF
--- a/experiment/dependencies/update-dependencies-and-run-tests.sh
+++ b/experiment/dependencies/update-dependencies-and-run-tests.sh
@@ -90,6 +90,10 @@ hack/update-vendor.sh
 # gather stats for comparison after running update-vendor
 depstat stats -m "${MAIN_MODULES}" -v > "${WORKDIR}/stats-after.txt"
 
+# Commit the dependency changes so depstat diff can checkout the base ref
+git add -A
+git commit -m "dependency updates" --allow-empty || true
+
 # Generate dependency diff with visualization
 echo ""
 echo "=== Dependency Changes ==="


### PR DESCRIPTION
The depstat diff command runs `git checkout` to compare dependency graphs between refs. When the script modifies go.mod/go.sum without committing, git checkout fails with:

  error: Your local changes to the following files would be overwritten
  by checkout: go.mod go.sum

Fix by committing the dependency changes before running depstat diff.

References:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-dependencies/2019376599148793856
- https://testgrid.k8s.io/sig-arch-code-organization#kind-master-dependencies&width=20