### PR TITLE
set rebase as default method for kubernetes-sigs/kro

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -843,6 +843,7 @@ tide:
     kubernetes-sigs/kjob: squash
     kubernetes-sigs/krew-index: squash
     kubernetes-sigs/krew: squash
+    kubernetes-sigs/kro: rebase
     kubernetes-sigs/kubespray: squash
     kubernetes-sigs/kueue: squash
     kubernetes-sigs/kui: rebase


### PR DESCRIPTION
Configure tide to use rebase merge method for kubernetes-sigs/kro to maintain linear git history.