### PR TITLE
Add periodic job to verify archived dependencies are tracked

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
@@ -61,4 +61,5 @@ periodics:
     annotations:
       testgrid-create-test-group: "true"
       testgrid-dashboards: sig-arch-code-organization
+      testgrid-alert-email: davanum@gmail.com
       description: Generates comprehensive dependency statistics and graph for kubernetes master

--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -73,4 +73,5 @@ presubmits:
     annotations:
       testgrid-create-test-group: "true"
       testgrid-dashboards: sig-arch-code-organization
+      testgrid-alert-email: davanum@gmail.com
       description: Generates dependency diff with visualization showing added/removed dependencies

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-arch-code-organization.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-arch-code-organization.yaml
@@ -1,0 +1,51 @@
+periodics:
+- interval: 24h
+  name: check-dependency-archived-periodical
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  decoration_config:
+    timeout: 20m
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: golang
+      command:
+      - /bin/bash
+      args:
+      - -c
+      - |
+        set -euo pipefail
+        export PATH=$PATH:$GOPATH/bin
+
+        # Install jq (same pattern as other depstat jobs)
+        apt-get update -qq && apt-get install -y -qq jq > /dev/null 2>&1
+
+        ./experiment/dependencies/verify-archived-repos.sh ${GOPATH}/src/k8s.io/kubernetes
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github
+        readOnly: true
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
+    volumes:
+    - name: github
+      secret:
+        secretName: k8s-github-robot-github-token
+  annotations:
+    testgrid-create-test-group: "true"
+    testgrid-dashboards: sig-arch-code-organization
+    testgrid-tab-name: verify-archived-dependencies
+    testgrid-alert-email: davanum@gmail.com
+    description: Verifies that all archived Go dependencies are tracked in hack/unwanted-dependencies.json

--- a/experiment/dependencies/verify-archived-repos.sh
+++ b/experiment/dependencies/verify-archived-repos.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify all archived Go dependencies are tracked in hack/unwanted-dependencies.json.
+# Usage: ./verify.sh [path/to/kubernetes]
+
+set -euo pipefail
+
+K8S_DIR="${1:-.}"
+K8S_DIR="$(cd "$K8S_DIR" && pwd)"
+UNWANTED_FILE="${K8S_DIR}/hack/unwanted-dependencies.json"
+[[ -f "$UNWANTED_FILE" ]] || { echo "ERROR: ${UNWANTED_FILE} not found."; exit 1; }
+
+TOKEN_PATH="/etc/github/token"
+DEPSTAT_TOKEN_ARGS=()
+if [[ -f "$TOKEN_PATH" ]]; then
+  DEPSTAT_TOKEN_ARGS=(--github-token-path "$TOKEN_PATH")
+elif [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "ERROR: GitHub token required. Place at ${TOKEN_PATH} or set GITHUB_TOKEN."; exit 1
+fi
+
+go install github.com/kubernetes-sigs/depstat@latest
+JSON_OUTPUT=$(depstat archived --json --dir="$K8S_DIR" "${DEPSTAT_TOKEN_ARGS[@]}")
+
+FAILURES=0
+while IFS= read -r module; do
+  reason=$(jq -r --arg mod "$module" '.spec.unwantedModules[$mod] // empty' "$UNWANTED_FILE")
+  if [[ -z "$reason" ]]; then
+    repo_url=$(echo "$JSON_OUTPUT" | jq -r --arg mod "$module" '.archived[] | select(.module == $mod) | .repoUrl' | head -1)
+    version=$(echo "$JSON_OUTPUT" | jq -r --arg mod "$module" '.archived[] | select(.module == $mod) | .version' | head -1)
+    echo "FAIL: ${module} (${version}) archived at ${repo_url} — not in unwanted-dependencies.json"
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "OK:   ${module} (${reason})"
+  fi
+done < <(echo "$JSON_OUTPUT" | jq -r '.archived[].module')
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo "FAILED: ${FAILURES} archived dep(s) not tracked in unwanted-dependencies.json"
+  exit 1
+fi
+echo "PASSED: All archived dependencies are tracked."


### PR DESCRIPTION
Add check-dependency-archived-periodical, a daily periodic job that uses depstat archived to detect archived GitHub dependencies in kubernetes/kubernetes and cross-checks them against hack/unwanted-dependencies.json.

The job runs in the trusted cluster to access the GitHub API token via --github-token-path (no env var export needed).

xref: https://github.com/kubernetes/kubernetes/issues/120276
xref: https://github.com/kubernetes-sigs/depstat/pull/74