### PR TITLE
api-machinery: make pull-kubernetes-e2e-gce-network-proxy-http-connect optional

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -79,6 +79,7 @@ presubmits:
   - name: pull-kubernetes-e2e-gce-network-proxy-http-connect
     cluster: k8s-infra-prow-build
     always_run: false
+    optional: true
     run_if_changed: '^(cluster/gce/manifests/konnectivity-server.yaml$|cluster/gce/addons/konnectivity-agent)'
     labels:
       preset-service-account: "true"

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -53,9 +53,6 @@ dashboards:
   - name: pull-kubernetes-dependencies
     test_group_name: pull-kubernetes-dependencies
     base_options: width=10
-  - name: pull-kubernetes-e2e-gce-network-proxy-http-connect
-    test_group_name: pull-kubernetes-e2e-gce-network-proxy-http-connect
-    base_options: width=10
   - name: pull-kubernetes-conformance-kind-ga-only-parallel
     test_group_name: pull-kubernetes-conformance-kind-ga-only-parallel
     base_options: width=10


### PR DESCRIPTION
It doesn't always run, so it might regress and then other changes cannot be merged when it gets triggered.

Discussed in https://github.com/kubernetes/test-infra/pull/33958#discussion_r2736094654.

/assign @BenTheElder 