### PR TITLE
SIG windows: use the same pull-kubernetes-e2e-capz-windows name for all releases

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows-presubmits.yaml
@@ -10,7 +10,7 @@ presets:
     value: "Standard_D4s_v3"
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-capz-windows-master
+  - name: pull-kubernetes-e2e-capz-windows
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:


### PR DESCRIPTION
pull-kubernetes-e2e-capz-windows-master = pull-kubernetes-e2e-capz-windows-1-35 = pull-kubernetes-e2e-capz-windows-1-34 ...  is the only presubmit which gets renamed when forking for a release. This is unnecessary (the right job gets picked depending on the branches field) and potentially confusing (for example, in a `/test` command one has to remember which branch one wants to test.

This only gets changed for current master and future releases. Existing forked jobs still have the release suffix.
