### PR TITLE
Add kind-image-build to e2e-k8s-main-was periodic job

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -636,6 +636,7 @@ periodics:
             - runner.sh
           args:
             - make
+            - kind-image-build
             - test-e2e-k8s-main-was
           securityContext:
             privileged: true


### PR DESCRIPTION
The `periodic-kueue-test-e2e-k8s-main-was` job is missing `kind-image-build` in its make targets, so the Kueue manager image is never built before loading into Kind.

Fixes kubernetes-sigs/kueue#9006