### PR TITLE
Align the release blocking test with resource size test to validate 1.5GB resource

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -123,6 +123,24 @@ periodics:
       securityContext:
         privileged: true
       env:
+      - name: CL2_ENABLE_INFORMER_LATENCY_TEST
+        value: "true"
+      - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
+        value: "21474836480"
+      - name: CL2_EXECSERVICE_CPU_REQUESTS
+        value: "4"
+      - name: CL2_EXECSERVICE_MEMORY_REQUESTS
+        value: "8Gi"
+      # Override for 1.5GB pod resource size
+      - name: CL2_DAEMONSET_POD_PAYLOAD_SIZE
+        value: "6000"
+      - name: CL2_DEPLOYMENT_POD_PAYLOAD_SIZE
+        value: "6000"
+      - name: CL2_STATEFULSET_POD_PAYLOAD_SIZE
+        value: "6000"
+      - name: CL2_JOB_POD_PAYLOAD_SIZE
+        value: "6000"
+      #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
       - name: KUBE_SSH_USER
@@ -170,10 +188,10 @@ periodics:
       resources:
         requests:
           cpu: 7
-          memory: 25Gi
+          memory: "32Gi"
         limits:
           cpu: 7
-          memory: 25Gi
+          memory: "32Gi"
 
 - name: ci-kubernetes-e2e-gce-scale-performance-100
   tags:


### PR DESCRIPTION
Want to propose to snapshot  snapshot the results of large resource size and agree on 1.5GB as milestone for 1.36.

The resource size test had 8 successful runs with resource size 1.5GB and additional informers. 

<img width="1607" height="473" alt="image" src="https://github.com/user-attachments/assets/1e96f3d5-09a2-4574-ac13-4790d221665f" />

The LIST latency 99%ile has been pretty stable around 28s. https://perf-dash.k8s.io/#/?jobname=gce-5000Nodes-1.5GB-pods&metriccategoryname=APIServer&metricname=LoadResponsiveness_PrometheusSimple&Resource=pods&Scope=cluster&Subresource=&Verb=LIST

<img width="2037" height="1215" alt="image" src="https://github.com/user-attachments/assets/bf9bfe0f-bc09-4ccb-9b2b-218069d4854b" />

There was one test where LIST latency spiked to 32s, but after we moved Prometheus and other addons to dedicated node as it was in kube-up.

We also expect much better test stability when https://github.com/kubernetes/kops/issues/18070 aligns configuration of kops to what we run in kube-up.

/cc @mborsz @wojtek-t @marseel 