### PR TITLE
Exit with test run's return code in ppc64le e2e-node job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -188,12 +188,13 @@ periodics:
               # Skipping test related to https://github.com/kubernetes/kubernetes/issues/124791
               kubetest2 tf --test=exec -- ssh -i /etc/secret-volume/ssh-privatekey root@$EXTERNAL_IP \
                 "export SKIP='\[Flaky\]|\[Slow\]|\[Serial\]|should.execute.readiness.probe.while.in.preStop' && /make-test-e2e-node.sh"; \
-                scp -r -i /etc/secret-volume/ssh-privatekey root@$EXTERNAL_IP:/tmp/_artifacts $ARTIFACTS
+                rc=$?; scp -r -i /etc/secret-volume/ssh-privatekey root@$EXTERNAL_IP:/tmp/_artifacts $ARTIFACTS
 
               kubetest2 tf \
                 --ignore-cluster-dir true \
                 --cluster-name $CLUSTER_NAME\
                 --down --auto-approve --ignore-destroy-errors
+              [ $rc != 0 ] && echo "ERROR: E2ENode Test suite exited with code:$rc"; exit $rc
 
   - name: ci-kubernetes-ppc64le-e2e-alpha-enabled-default
     cron: "30 4-22/6 * * *" # every 6h starting at 04:30 UTC


### PR DESCRIPTION
After the https://github.com/kubernetes/test-infra/pull/36208 change, the job [ci-kubernetes-ppc64le-e2e-node-latest-kubetest2](https://testgrid.k8s.io/ibm-ppc64le-node-e2e#ci-kubernetes-ppc64le-e2e-node-latest-kubetest2) has been not reporting failed state inspite of the tests failing!

For example, Job https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-ppc64le-e2e-node-latest-kubetest2/2019614669127290880 has the result shown as PASSED inspite of the test run failing!

Out of e2e jobs defined at https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml,  only [ci-kubernetes-ppc64le-e2e-node-latest-kubetest2](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml#L137) has multiple kubetest2 calls. Hence the rc of test run must be captured and returned.
