### PR TITLE
depstat: use --split-test-only to separate test-only deps in CI

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat-periodical.yaml
@@ -34,10 +34,10 @@ periodics:
 
           MAIN_MODULES="k8s.io/kubernetes$(ls staging/src/k8s.io | awk '{printf ",k8s.io/" $0}')"
 
-          # Generate stats in multiple formats
-          depstat stats -m "${MAIN_MODULES}" -v | tee "${WORKDIR}/stats.txt"
-          depstat stats -m "${MAIN_MODULES}" --json > "${WORKDIR}/stats.json"
-          depstat stats -m "${MAIN_MODULES}" --csv > "${WORKDIR}/stats.csv"
+          # Generate stats in multiple formats (with test-only split)
+          depstat stats -m "${MAIN_MODULES}" -v --split-test-only | tee "${WORKDIR}/stats.txt"
+          depstat stats -m "${MAIN_MODULES}" --split-test-only --json > "${WORKDIR}/stats.json"
+          depstat stats -m "${MAIN_MODULES}" --split-test-only --csv > "${WORKDIR}/stats.csv"
 
           # Generate full dependency graph with edge types
           depstat graph -m "${MAIN_MODULES}" --show-edge-types

--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -36,11 +36,11 @@ presubmits:
           echo "=== Dependency Diff: ${PULL_BASE_SHA}..HEAD ==="
           echo ""
 
-          # Generate dependency diff (text output)
-          depstat diff "${PULL_BASE_SHA}" HEAD -m "${MAIN_MODULES}" -v | tee "${WORKDIR}/diff.txt"
+          # Generate dependency diff (text output with split-test-only)
+          depstat diff "${PULL_BASE_SHA}" HEAD -m "${MAIN_MODULES}" -v --split-test-only | tee "${WORKDIR}/diff.txt"
 
-          # Generate JSON for programmatic consumption
-          depstat diff "${PULL_BASE_SHA}" HEAD -m "${MAIN_MODULES}" --json > "${WORKDIR}/diff.json"
+          # Generate JSON for programmatic consumption (includes split test-only/non-test sections)
+          depstat diff "${PULL_BASE_SHA}" HEAD -m "${MAIN_MODULES}" --split-test-only --json > "${WORKDIR}/diff.json"
 
           # Generate DOT and SVG visualization of changes
           depstat diff "${PULL_BASE_SHA}" HEAD -m "${MAIN_MODULES}" --dot > "${WORKDIR}/diff.dot"
@@ -58,10 +58,16 @@ presubmits:
             done | tee "${WORKDIR}/why-added.txt"
           fi
 
+          # Summarize test-only vs non-test changes
+          echo ""
+          echo "=== Test-only vs Non-test dependency changes ==="
+          jq -r '"Non-test added: \(.split.nonTestOnly.added // [] | length), removed: \(.split.nonTestOnly.removed // [] | length)"' "${WORKDIR}/diff.json"
+          jq -r '"Test-only added: \(.split.testOnly.added // [] | length), removed: \(.split.testOnly.removed // [] | length)"' "${WORKDIR}/diff.json"
+
           echo ""
           echo "Artifacts saved to: ${WORKDIR}"
-          echo "  - diff.txt: Human-readable diff"
-          echo "  - diff.json: Machine-readable diff"
+          echo "  - diff.txt: Human-readable diff with test-only split"
+          echo "  - diff.json: Machine-readable diff (includes .split.testOnly and .split.nonTestOnly)"
           echo "  - diff.svg: Visual dependency change graph"
         resources:
           requests:


### PR DESCRIPTION
The new --split-test-only flag (kubernetes-sigs/depstat#68) lets us tell apart test-only dependencies from production ones using `go mod why -m` under the hood.

Presubmit (check-dependency-stats):
- diff now shows split tables for test-only vs non-test changes
- JSON artifact gets .split.testOnly and .split.nonTestOnly sections
- build log prints a quick summary of what changed in each category

Periodical (check-dependency-stats-periodical):
- stats now include test-only and non-test counts in text/JSON/CSV

Related to: https://github.com/kubernetes-sigs/depstat/issues/68