### PR TITLE
Fix do-janitor: Update image

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-janitor.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics-janitor.yaml
@@ -14,7 +14,7 @@ periodics:
         path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.20-bookworm
+        - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
           imagePullPolicy: Always
           command:
             - "./scripts/ci-janitor.sh"


### PR DESCRIPTION
The referenced image isn't available anymore at the registry. The janitor job wasn't run for a while. This change updates it to the latest version of the image.