### PR TITLE
Prow block merge without tests

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -831,12 +831,13 @@ tide:
   # agent-sandbox: only merge if approved, LGTM, and required CI checks pass
   - repos:
     - kubernetes-sigs/agent-sandbox
-    labels:
+  labels:
     - lgtm
     - approved
-    missingLabels:
+  missingLabels:
     - do-not-merge
-    required_contexts:
+    - needs-ok-to-test
+  required_contexts:
     - ci/prow/unit
     - ci/prow/integration
   merge_method:


### PR DESCRIPTION
## What I did
Added Tide rules for `kubernetes-sigs/agent-sandbox` to require `lgtm`, `approved`, `ok-to-test` labels and passing `ci/prow/unit` and `ci/prow/integration` checks; any `do-not-merge` or missing `ok-to-test` will block merges.


## Related issue
- Fixes: #36391 
