### PR TITLE
Allow exec service to run on control plane

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1160,6 +1160,8 @@ periodics:
         value: "2"
       - name: CL2_EXECSERVICE_MEMORY_REQUESTS
         value: "4Gi"
+      - name: CL2_EXECSERVICE_TOLERATE_CONTROL_PLANE
+        value: "true"
       # Override for 1.93GB pod resource size
       - name: CL2_DAEMONSET_POD_PAYLOAD_SIZE
         value: "8000"


### PR DESCRIPTION
/kind feature

Needed to fit exec service when resources are requested.

/cc @upodroid @mborsz

Depends on https://github.com/kubernetes/perf-tests/pull/3798 but can be merged regardless.