### PR TITLE
Use depstat diff --stats for compact before/after/delta summary

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-depstat.yaml
@@ -33,6 +33,14 @@ presubmits:
 
           MAIN_MODULES="k8s.io/kubernetes$(ls staging/src/k8s.io | awk '{printf ",k8s.io/" $0}')"
 
+          echo "=== Dependency Stats: ${PULL_BASE_SHA}..HEAD ==="
+          echo ""
+
+          # Show compact before/after/delta stats summary
+          depstat diff "${PULL_BASE_SHA}" HEAD -m "${MAIN_MODULES}" --stats | tee "${WORKDIR}/stats.txt"
+          depstat diff "${PULL_BASE_SHA}" HEAD -m "${MAIN_MODULES}" --stats --json > "${WORKDIR}/stats.json"
+
+          echo ""
           echo "=== Dependency Diff: ${PULL_BASE_SHA}..HEAD ==="
           echo ""
 


### PR DESCRIPTION
Replace the two separate `depstat stats` calls (before and after dependency updates) in the experiment script with a single `depstat diff --stats` that provides a compact before/after/delta table in one invocation.

Also add `--stats` output at the top of the presubmit job so PR reviewers see the high-level impact (direct/transitive/total deps and max depth changes) before the detailed diff.