### PR TITLE
Add pull-autoscaling-e2e-gci-gce-ca-test presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -398,3 +398,50 @@ presubmits:
           requests:
             cpu: 4
             memory: 8Gi
+  - name: pull-autoscaling-e2e-gci-gce-ca-test
+    cluster: k8s-infra-prow-build
+    annotations:
+      testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+      testgrid-tab-name: cluster-autoscaler-gci-gce-e2e-test
+    # Make the job optional as the duration is long.
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 450m
+    run_if_changed: '^cluster-autoscaler\/'
+    path_alias: k8s.io/autoscaler
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - command:
+          - runner.sh
+          - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        # Override GCE default for cluster size autoscaling purposes.
+        - --env=ENABLE_CUSTOM_METRICS=true
+        - --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,Priority
+        - --env=ENABLE_POD_PRIORITY=true
+        - --extract=ci/latest
+        - --gcp-node-image=gci
+        - --gcp-nodes=3
+        - --gcp-zone=us-central1-b
+        - --provider=gce
+        - --runtime-config=scheduling.k8s.io/v1alpha1=true
+        - --test=false
+        - --test-cmd=../cluster-autoscaler/hack/e2e/run-e2e.sh
+        - --test-cmd-args=--presubmit
+        - --timeout=400m
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true


### PR DESCRIPTION
This adds a new E2E presubmit job for cluster-autoscaler on GCE. The job is optional and runs when files in cluster-autoscaler/ are changed.

#### Special notes for reviewer 
I decided to reuse existing testgrid-dashboard: `sig-autoscaling-cluster-autoscaler`
I'm not sure if it will autocreate a new tab `cluster-autoscaler-gci-gce-e2e-test` 🤔 

Relates to kubernetes/autoscaler#9023
Do not merge before kubernetes/autoscaler#9198