### PR TITLE
SIG testing: adjust memory for race detection

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -409,12 +409,12 @@ periodics:
         privileged: true
       resources:
         limits:
-          memory: 9Gi
+          memory: 16Gi
           cpu: 7
         requests:
           # these are both a bit below peak usage during build
           # this is mostly for building kubernetes
-          memory: 9Gi
+          memory: 16Gi
           cpu: 7
 
 - interval: 2h

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -675,10 +675,10 @@ presubmits:
         resources:
           limits:
             cpu: 7
-            memory: 26Gi
+            memory: 16Gi
           requests:
             cpu: 7
-            memory: 26Gi
+            memory: 16Gi
 
   - name: pull-kubernetes-e2e-kind-evented-pleg
     cluster: k8s-infra-prow-build


### PR DESCRIPTION
ci-kubernetes-e2e-kind-alpha-beta-features-race failed a few times lately, with (lack of) log output and
https://monitoring-gke.prow.k8s.io/d/96Q8oOOZk/builds?var-org=kubernetes&var-repo=kubernetes&var-job=ci-kubernetes-e2e-kind-alpha-beta-features-race&orgId=1&from=now-2d&to=now&timezone=browser&var-datasource=prometheus&var-build=$__all&refresh=30s pointing towards OOM killing.

The peak memory usage is too close to the 9GiB limit. Given that RAM isn't the limiting factor in our CI, 16GiB get picked instead. The presubmit gets adapted accordingly (was actually higher).

/assign @upodroid @BenTheElder 
