### PR TITLE
Fix gomod_staleness.py crash when --skip has no arguments

### DIFF
--- a/experiment/dependencies/gomod_staleness.py
+++ b/experiment/dependencies/gomod_staleness.py
@@ -113,7 +113,7 @@ def source(pkg, old, new):
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Update Go module dependencies and report on changes.')
-    parser.add_argument('--skip', nargs='+', default=["github.com/libopenstorage/openstorage"],
+    parser.add_argument('--skip', nargs='*', default=["github.com/libopenstorage/openstorage"],
                         help='List of packages to skip updating (default: github.com/libopenstorage/openstorage)')
     parser.add_argument('--patch-output', type=str,
                         help='Path to save the output from git patch for go.mod/sum')
@@ -172,7 +172,7 @@ go get -u %s""" % pkg
         print(">>>> Running command %r" % update_command)
         os.system(update_command)
 
-    print(">>>> Ensuring Packages that will be skipped are at their previous versions" % args.skip)
+    print(">>>> Ensuring Packages that will be skipped are at their previous versions %r" % (args.skip,))
     for pkg in args.skip:
         if pkg in before.keys():
             update_command = """\


### PR DESCRIPTION
The CI job passes --skip with packages from unwanted-dependencies.json. When that list is empty, --skip receives zero arguments, which fails with nargs='+'. Change to nargs='*' to accept zero or more values.

Also fix a format string bug on the "skipped versions" print statement that would crash with TypeError at runtime (missing %r placeholder).

fix failure in [log](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-dependencies/2021029334025768960/build-log.txt):
```
+ ./../test-infra/experiment/dependencies/gomod_staleness.py --skip --patch-output /logs/artifacts/latest-go-mod-sum.patch --markdown-output /logs/artifacts/differences.md
usage: gomod_staleness.py [-h] [--skip SKIP [SKIP ...]]
                          [--patch-output PATCH_OUTPUT]
                          [--markdown-output MARKDOWN_OUTPUT]
gomod_staleness.py: error: argument --skip: expected at least one argument
```