### PR TITLE
Update go version for 1.25.7 in kustomize

### DIFF
--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24.6-bullseye
+      - image: public.ecr.aws/docker/library/golang:1.25.7
         command:
         - make
         args:


### PR DESCRIPTION
Update golang version in prow that used in test for https://github.com/kubernetes-sigs/kustomize repo

address: https://github.com/kubernetes-sigs/kustomize/pull/6075