### PR TITLE
Add presubmit job for srctl tool tests and lint

### DIFF
--- a/config/jobs/kubernetes/sig-security/sig-security-tooling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-security/sig-security-tooling-presubmits.yaml
@@ -1,0 +1,37 @@
+presubmits:
+  kubernetes/sig-security:
+  - name: pull-sig-security-srctl-tests
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-security-tooling
+      testgrid-create-test-group: "true"
+      description: Run unit tests and golangci-lint for the srctl tool
+    run_if_changed: "^sig-security-tooling/srctl/"
+    branches:
+    - main
+    decorate: true
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260209-dbbff72479-master
+        command:
+        - runner.sh
+        args:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          cd sig-security-tooling/srctl
+          echo "Starting testing..."
+          go test -v -cover ./...
+          echo "Running linter..."
+          # Usamos una forma más robusta de ejecutar el linter en entornos de CI
+          export GOBIN=$(pwd)/bin
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
+          ./bin/golangci-lint run ./...
+        resources:
+          limits:
+            cpu: 1
+            memory: "1Gi"
+          requests:
+            cpu: 1
+            memory: "1Gi"

--- a/config/jobs/kubernetes/sig-security/sig-security-tooling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-security/sig-security-tooling-presubmits.yaml
@@ -24,7 +24,6 @@ presubmits:
           echo "Starting testing..."
           go test -v -cover ./...
           echo "Running linter..."
-          # Usamos una forma más robusta de ejecutar el linter en entornos de CI
           export GOBIN=$(pwd)/bin
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
           ./bin/golangci-lint run ./...


### PR DESCRIPTION
### Description
This PR adds a new presubmit job for the `srctl` tool. 
It ensures that every PR touching files under `sig-security-tooling/srctl/` runs:
- Unit tests (`go test`)
- Golangci-lint analysis

This follows the request in kubernetes/sig-security#171 to automate CI for the new CVE template generation tool.

### Testing performed
- Validated YAML structure.
- Used `kubekins-e2e` image for Go 1.23+ compatibility.

Fixes kubernetes/sig-security#171