### PR TITLE
prow: update secrets-store-csi-driver unit image to go1.25-trixie

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -47,6 +47,7 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
+        imagePullPolicy: Always
         command:
           - make
           - test


### PR DESCRIPTION
The unit test job for secrets-store-csi-driver is currently failing with a Go toolchain mismatch:
"compile: version go1.25.7 does not match go tool version go1.25.6"

This happens because the current go.mod in the driver was updated to 1.25.7 (due to a security CVE), but the 'kubekins-e2e' image used in Prow is still on 1.25.6.

This PR switches the image to 'releng-ci:latest-go1.25-trixie', which is already being used by other sig-release projects and contains the correct Go 1.25.7 toolchain.

Signed-off-by: Benjamin Leon <bleondubos@gmail.com>