### PR TITLE
only run pull-autoscaling-e2e-gci-gce-ca-test on 1.35+

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -410,6 +410,9 @@ presubmits:
       timeout: 450m
     run_if_changed: '^cluster-autoscaler\/'
     path_alias: k8s.io/autoscaler
+    branches:
+      - ^master$
+      - ^cluster-autoscaler-release-1\.(3[5-9]|[4-9][0-9]|[1-9][0-9]{2,})$
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"


### PR DESCRIPTION
This PR updates the CA E2E presubmit job configuration so it only runs on branches (release-1.35+ and master) that support the test.