### PR TITLE
Add sig-k8s-infra-dns-admins team to DNS job rerun permissions

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-dns.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-dns.yaml
@@ -14,12 +14,10 @@ postsubmits:
       testgrid-num-failures-to-alert: '1'
     rerun_auth_config:
       github_team_slugs:
-      # TODO(spiffxp): team specifically for this service
-      # - org: kubernetes
-      #   slug: k8s-infra-dns-admins
       - org: kubernetes
         slug: sig-k8s-infra-leads
-
+      - org: kubernetes
+        slug: sig-k8s-infra-dns-admins
     spec:
       serviceAccountName: k8s-infra-dns-updater
       containers:
@@ -54,11 +52,10 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   rerun_auth_config:
     github_team_slugs:
-    # TODO(spiffxp): team specifically for this service
-    # - org: kubernetes
-    #   slug: k8s-infra-dns-admins
     - org: kubernetes
       slug: sig-k8s-infra-leads
+    - org: kubernetes
+      slug: sig-k8s-infra-dns-admins
   spec:
     serviceAccountName: k8s-infra-dns-updater
     containers:


### PR DESCRIPTION
## Summary

This PR enables the `sig-k8s-infra-dns-admins` team to rerun DNS-related Prow jobs by adding them to the `rerun_auth_config` for both `post-k8sio-dns` and `ci-k8sio-dns` jobs.

## Changes

- Added `sig-k8s-infra-dns-admins` team slug to `rerun_auth_config.github_team_slugs` for `post-k8sio-dns` job
- Added `sig-k8s-infra-dns-admins` team slug to `rerun_auth_config.github_team_slugs` for `ci-k8sio-dns` job
- Removed TODO comments that suggested adding a dedicated team for DNS job rerun permissions

## Context

Previously, only the `sig-k8s-infra-leads` team could rerun these DNS jobs. The configuration included TODO comments indicating that a dedicated team should be added for this service. This change implements that TODO by adding the `sig-k8s-infra-dns-admins` team.

## Testing

- YAML validation passed with `make verify-yamllint`
- No syntax errors or warnings introduced