### PR TITLE
🌱 ci: drop tests against k8s 1.33 and 1.34 for reduce the costs and increase resources for latest version

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -24,47 +24,12 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
-  - name: pull-kubebuilder-e2e-k8s-1-33-0
-    cluster: eks-prow-build-cluster
-    decorate: true
-    decoration_config:
-      timeout: 40m
-    optional: false
-    skip_if_only_changed: "^docs/|^designs/|^roadmap/|^scripts/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-      - ^master$
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
-          command:
-            - runner.sh
-            - ./test_e2e.sh
-          env:
-            - name: KIND_K8S_VERSION
-              value: "v1.33.0"
-            - name: KIND_E2E
-              value: "true"
-          resources:
-            limits:
-              cpu: 6
-              memory: 8Gi
-            requests:
-              cpu: 6
-              memory: 8Gi
-          securityContext:
-            privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-33-0
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
   - name: pull-kubebuilder-e2e-k8s-1-35-0
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
-      timeout: 40m
+      timeout: 75m
+      grace_period: 15m
     optional: false
     skip_if_only_changed: "^docs/|^designs/|^roadmap/|^scripts/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/kubebuilder
@@ -84,51 +49,15 @@ presubmits:
           resources:
             limits:
               cpu: 6
-              memory: 8Gi
+              memory: 12Gi
             requests:
               cpu: 6
-              memory: 8Gi
+              memory: 12Gi
           securityContext:
             privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder-e2e-1-35-0
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-  - name: pull-kubebuilder-e2e-k8s-1-34-0
-    cluster: eks-prow-build-cluster
-    decorate: true
-    decoration_config:
-      timeout: 40m
-    optional: false
-    skip_if_only_changed: "^docs/|^designs/|^roadmap/|^scripts/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    path_alias: sigs.k8s.io/kubebuilder
-    branches:
-      - ^master$
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
-          command:
-            - runner.sh
-            - ./test_e2e.sh
-          env:
-            - name: KIND_K8S_VERSION
-              value: "v1.34.0"
-            - name: KIND_E2E
-              value: "true"
-          resources:
-            limits:
-              cpu: 6
-              memory: 8Gi
-            requests:
-              cpu: 6
-              memory: 8Gi
-          securityContext:
-            privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kubebuilder
-      testgrid-tab-name: kubebuilder-e2e-1-34-0
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
## What
- Stop running e2e on every PR for the last 3 Kubernetes versions.
- Keep e2e running on the newest supported Kubernetes version (required) and bump its resources/timeout.

## Why
We still support the latest 3 Kubernetes releases, but running e2e for all 3 on every PR is too expensive and often provides little extra signal. We can bring the older versions back (or run them periodically/on-demand) if k8s make changes that are likely to break compatibility (e.g. CRD or API changes).
