### PR TITLE
Increase CPU and memory of pull-ingress2gateway-e2e

### DIFF
--- a/config/jobs/kubernetes-sigs/ingress2gateway/ingress2gateway-config.yaml
+++ b/config/jobs/kubernetes-sigs/ingress2gateway/ingress2gateway-config.yaml
@@ -88,8 +88,8 @@ presubmits:
             privileged: true
           resources:
             limits:
-              cpu: 1
-              memory: 4Gi
+              cpu: 4
+              memory: 8Gi
             requests:
-              cpu: 1
-              memory: 4Gi
+              cpu: 4
+              memory: 8Gi


### PR DESCRIPTION
Locally the job runs in roughly 2 minutes whereas on Prow it takes more than 20.