### PR TITLE
Bump go version 1.25.7/1.24.13 for kubekins-e2e/kubekins-e2e-v2/krte and drop 1.32 as it is eol

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,36 +1,31 @@
 variants:
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.25.6
+    GO_VERSION: 1.25.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   master:
     CONFIG: master
-    GO_VERSION: 1.25.6
+    GO_VERSION: 1.25.7
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
   '1.35':
     CONFIG: '1.35'
-    GO_VERSION: 1.25.6
+    GO_VERSION: 1.25.7
     K8S_RELEASE: latest-1.35
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
   '1.34':
     CONFIG: '1.34'
-    GO_VERSION: 1.24.12
+    GO_VERSION: 1.24.13
     K8S_RELEASE: latest-1.34
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
   '1.33':
     CONFIG: '1.33'
-    GO_VERSION: 1.24.12
+    GO_VERSION: 1.24.13
     K8S_RELEASE: latest-1.33
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
-  '1.32':
-    CONFIG: '1.32'
-    GO_VERSION: 1.24.12
-    K8S_RELEASE: latest-1.32
-    BAZEL_VERSION: 3.4.1
-    DOCKER_VERSION: 5:28.*
+


### PR DESCRIPTION
- Bump go version 1.25.7/1.24.13 for kubekins-e2e/kubekins-e2e-v2/krte and drop 1.32 as it is eol


xref: https://github.com/kubernetes/release/issues/4265


/assign @dims @saschagrunert @Verolop 
cc @kubernetes/release-managers 