### PR TITLE
bump cni plugins for node e2e jobs and fetch from github

### DIFF
--- a/jobs/e2e_node/arm/init.yaml
+++ b/jobs/e2e_node/arm/init.yaml
@@ -18,7 +18,7 @@ runcmd:
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
 
   - echo "Download and install CNI to /home/containerd"
-  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-arm64-v1.0.1.tgz'
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.9.0/cni-plugins-linux-arm64-v1.9.0.tgz'
   - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
 
   - echo "Set containerd configuration"

--- a/jobs/e2e_node/containerd/init-eviction.yaml
+++ b/jobs/e2e_node/containerd/init-eviction.yaml
@@ -24,7 +24,7 @@ runcmd:
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
 
   - echo "Download and install CNI to /home/containerd"
-  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.9.0/cni-plugins-linux-amd64-v1.9.0.tgz'
   - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
 
   - echo "Set containerd configuration"

--- a/jobs/e2e_node/containerd/init-v2.yaml
+++ b/jobs/e2e_node/containerd/init-v2.yaml
@@ -14,7 +14,7 @@ runcmd:
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
 
   - echo "Download and install CNI to /home/containerd"
-  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.9.0/cni-plugins-linux-amd64-v1.9.0.tgz'
   - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
 
   - echo "Set containerd configuration"

--- a/jobs/e2e_node/containerd/init.yaml
+++ b/jobs/e2e_node/containerd/init.yaml
@@ -14,7 +14,7 @@ runcmd:
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
 
   - echo "Download and install CNI to /home/containerd"
-  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.9.0/cni-plugins-linux-amd64-v1.9.0.tgz'
   - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
 
   - echo "Set containerd configuration"

--- a/jobs/e2e_node/containerd/ubuntu-init-hugepages-1G-allocation.yaml
+++ b/jobs/e2e_node/containerd/ubuntu-init-hugepages-1G-allocation.yaml
@@ -9,6 +9,6 @@ runcmd:
   - mkdir -p /etc/containerd
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/config.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-config'
-  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.9.0/cni-plugins-linux-amd64-v1.9.0.tgz'
   - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
   - systemctl restart containerd

--- a/jobs/e2e_node/dra/init-containerd-1.7.yaml
+++ b/jobs/e2e_node/dra/init-containerd-1.7.yaml
@@ -30,7 +30,7 @@ runcmd:
 
   - echo "Download and install CNI plugins"
   - mkdir -p /tmp/containerd
-  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /tmp/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /tmp/containerd/cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.9.0/cni-plugins-linux-amd64-v1.9.0.tgz'
   - mkdir -p /opt/cni/bin
   - tar xzf /tmp/containerd/cni.tgz -C /opt/cni/bin --overwrite
 

--- a/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml
+++ b/jobs/e2e_node/swap/ubuntu-swap-1G-allocation.yaml
@@ -8,7 +8,7 @@ runcmd:
   - mkdir -p /etc/containerd
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/containerd/cni.template http://metadata.google.internal/computeMetadata/v1/instance/attributes/cni-template'
   - 'curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /etc/containerd/config.toml http://metadata.google.internal/computeMetadata/v1/instance/attributes/containerd-config'
-  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://storage.googleapis.com/k8s-artifacts-cni/release/v1.0.1/cni-plugins-linux-amd64-v1.0.1.tgz'
+  - 'curl -sSL --fail --retry 5 --retry-delay 3 --silent --show-error -o /home/containerd/cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.9.0/cni-plugins-linux-amd64-v1.9.0.tgz'
   - tar xzf /home/containerd/cni.tgz -C /home/containerd --overwrite
   - systemctl restart containerd
   - 'echo current swappiness: $(sysctl vm.swappiness)'


### PR DESCRIPTION
xref: https://github.com/kubernetes/k8s.io/issues/7584

also bumped CNI plugins to v1.9.0