### PR TITLE
Add ppc64le conformance jobs for 1.32–1.35 and enable config-forker/rotator

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -81,8 +81,8 @@ periodics:
             cpu: 6
             memory: 20Gi
 
-  - name: ci-kubernetes-ppc64le-conformance-latest-kubetest2
-    cron: "0 2-23/3 * * *" # every 3h starting at 02:00 UTC
+  - name: ci-kubernetes-ppc64le-conformance-latest
+    cron: "0 2-23/4 * * *" # every 4h starting at 02:00 UTC
     cluster: k8s-infra-ppc64le-prow-build
     labels:
       preset-ibmcloud-cred: "true"
@@ -96,9 +96,12 @@ periodics:
         repo: provider-ibmcloud-test-infra
         workdir: true
     annotations:
+      fork-per-release: "true"
+      fork-per-release-cron: 10 3-23/4 * * *, 20 0-23/4 * * *, 30 1-23/4 * * *, 40 4-23/4 * * *, 50 2-23/4 * * *
+      fork-per-release-replacements: "MARKER_VERSION=latest.txt -> MARKER_VERSION=latest-{{.Version}}.txt"
       description: Runs conformance tests using kubetest2 against kubernetes ci latest on IBM powervs
       testgrid-dashboards: ibm-ppc64le-e2e, ibm-ppc64le-k8s, conformance-ppc64le, ibm-k8s-e2e
-      testgrid-tab-name: ci-kubernetes-ppc64le-conformance-latest-kubetest2
+      testgrid-tab-name: ci-kubernetes-ppc64le-conformance-latest-master
       testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '2'
     spec:
@@ -120,6 +123,9 @@ periodics:
             - -c
             - |
               set -o xtrace
+              MARKER_VERSION=latest.txt;
+              # Fetch build version only once
+              K8S_BUILD_VERSION=$(curl -Ls https://dl.k8s.io/ci/$MARKER_VERSION);
 
               #Setup of kubetest2 tf deployer
               make install-deployer-tf
@@ -131,8 +137,9 @@ periodics:
                 --workers-count 2 --cluster-name conformance-$(date +%s) \
                 --up --down --auto-approve --retry-on-tf-failure 3 \
                 --break-kubetest-on-upfail true --ignore-destroy-errors \
-                --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt) \
-                --test=ginkgo -- --test-package-dir ci --test-package-marker latest.txt --focus-regex='\[Conformance\]'
+                --build-version $K8S_BUILD_VERSION \
+                --release-marker $K8S_BUILD_VERSION \
+                --test=ginkgo -- --test-package-dir ci --test-package-marker $MARKER_VERSION --focus-regex='\[Conformance\]'
 
   - name: ci-kubernetes-ppc64le-e2e-node-latest-kubetest2
     cron: "30 3-21/6 * * *" #  every 6h starting at 03:30 UTC
@@ -315,7 +322,7 @@ periodics:
                 --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|KubeProxy.should.update.metric"
 
   - name: ci-kubernetes-ppc64le-e2e-slow-kubetest2
-    cron: "30 7-22/3 * * *" # every 3h starting at 07:30 UTC
+    cron: "30 8-23/3 * * *" # every 3h starting at 08:30 UTC
     cluster: k8s-infra-ppc64le-prow-build
     labels:
       preset-ibmcloud-cred: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -558,6 +558,63 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
+    fork-per-release-cron: 50 2-23/4 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
+    testgrid-dashboards: ibm-ppc64le-e2e, ibm-ppc64le-k8s, conformance-ppc64le, ibm-k8s-e2e,
+      sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-ppc64le-conformance-latest-1.32
+  cluster: k8s-infra-ppc64le-prow-build
+  cron: 40 4-23/4 * * *
+  decorate: true
+  decoration_config:
+    timeout: 5h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    repo: provider-ibmcloud-test-infra
+    workdir: true
+  labels:
+    preset-ibmcloud-cred: "true"
+  name: ci-kubernetes-ppc64le-conformance-latest-1-32
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        set -o xtrace
+        MARKER_VERSION=latest-1.32.txt;
+        # Fetch build version only once
+        K8S_BUILD_VERSION=$(curl -Ls https://dl.k8s.io/ci/$MARKER_VERSION);
+
+        #Setup of kubetest2 tf deployer
+        make install-deployer-tf
+
+        export TF_VAR_powervs_system_type=e980
+        kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
+          --powervs-ssh-key k8s-prow-sshkey \
+          --ssh-private-key /etc/secret-volume/ssh-privatekey \
+          --workers-count 2 --cluster-name conformance-$(date +%s) \
+          --up --down --auto-approve --retry-on-tf-failure 3 \
+          --break-kubetest-on-upfail true --ignore-destroy-errors \
+          --build-version $K8S_BUILD_VERSION \
+          --release-marker $K8S_BUILD_VERSION \
+          --test=ginkgo -- --test-package-dir ci --test-package-marker $MARKER_VERSION --focus-regex='\[Conformance\]'
+      command:
+      - runner.sh
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260209-dbbff72479-1.32
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 14Gi
+        requests:
+          cpu: "4"
+          memory: 14Gi
+      securityContext:
+        privileged: true
+- annotations:
     fork-per-release-cron: 0 7 * * *
     testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
     testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -840,6 +840,63 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
+    fork-per-release-cron: 40 4-23/4 * * *, 50 2-23/4 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
+    testgrid-dashboards: ibm-ppc64le-e2e, ibm-ppc64le-k8s, conformance-ppc64le, ibm-k8s-e2e,
+      sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-ppc64le-conformance-latest-1.33
+  cluster: k8s-infra-ppc64le-prow-build
+  cron: 30 1-23/4 * * *
+  decorate: true
+  decoration_config:
+    timeout: 5h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    repo: provider-ibmcloud-test-infra
+    workdir: true
+  labels:
+    preset-ibmcloud-cred: "true"
+  name: ci-kubernetes-ppc64le-conformance-latest-1-33
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        set -o xtrace
+        MARKER_VERSION=latest-1.33.txt;
+        # Fetch build version only once
+        K8S_BUILD_VERSION=$(curl -Ls https://dl.k8s.io/ci/$MARKER_VERSION);
+
+        #Setup of kubetest2 tf deployer
+        make install-deployer-tf
+
+        export TF_VAR_powervs_system_type=e980
+        kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
+          --powervs-ssh-key k8s-prow-sshkey \
+          --ssh-private-key /etc/secret-volume/ssh-privatekey \
+          --workers-count 2 --cluster-name conformance-$(date +%s) \
+          --up --down --auto-approve --retry-on-tf-failure 3 \
+          --break-kubetest-on-upfail true --ignore-destroy-errors \
+          --build-version $K8S_BUILD_VERSION \
+          --release-marker $K8S_BUILD_VERSION \
+          --test=ginkgo -- --test-package-dir ci --test-package-marker $MARKER_VERSION --focus-regex='\[Conformance\]'
+      command:
+      - runner.sh
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260209-dbbff72479-1.33
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 14Gi
+        requests:
+          cpu: "4"
+          memory: 14Gi
+      securityContext:
+        privileged: true
+- annotations:
     fork-per-release-cron: ""
     testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
     testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1118,6 +1118,63 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
+    fork-per-release-cron: 30 1-23/4 * * *, 40 4-23/4 * * *, 50 2-23/4 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
+    testgrid-dashboards: ibm-ppc64le-e2e, ibm-ppc64le-k8s, conformance-ppc64le, ibm-k8s-e2e,
+      sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-ppc64le-conformance-latest-1.34
+  cluster: k8s-infra-ppc64le-prow-build
+  cron: 20 3-23/4 * * *
+  decorate: true
+  decoration_config:
+    timeout: 5h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    repo: provider-ibmcloud-test-infra
+    workdir: true
+  labels:
+    preset-ibmcloud-cred: "true"
+  name: ci-kubernetes-ppc64le-conformance-latest-1-34
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        set -o xtrace
+        MARKER_VERSION=latest-1.34.txt;
+        # Fetch build version only once
+        K8S_BUILD_VERSION=$(curl -Ls https://dl.k8s.io/ci/$MARKER_VERSION);
+
+        #Setup of kubetest2 tf deployer
+        make install-deployer-tf
+
+        export TF_VAR_powervs_system_type=e980
+        kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
+          --powervs-ssh-key k8s-prow-sshkey \
+          --ssh-private-key /etc/secret-volume/ssh-privatekey \
+          --workers-count 2 --cluster-name conformance-$(date +%s) \
+          --up --down --auto-approve --retry-on-tf-failure 3 \
+          --break-kubetest-on-upfail true --ignore-destroy-errors \
+          --build-version $K8S_BUILD_VERSION \
+          --release-marker $K8S_BUILD_VERSION \
+          --test=ginkgo -- --test-package-dir ci --test-package-marker $MARKER_VERSION --focus-regex='\[Conformance\]'
+      command:
+      - runner.sh
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260209-dbbff72479-1.34
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 14Gi
+        requests:
+          cpu: "4"
+          memory: 14Gi
+      securityContext:
+        privileged: true
+- annotations:
     fork-per-release-cron: 0 2 * * *
     testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
     testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -1236,6 +1236,63 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
+    fork-per-release-cron: 20 0-23/4 * * *, 30 1-23/4 * * *, 40 4-23/4 * * *, 50 2-23/4 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
+    testgrid-dashboards: ibm-ppc64le-e2e, ibm-ppc64le-k8s, conformance-ppc64le, ibm-k8s-e2e,
+      sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-ppc64le-conformance-latest-1.35
+  cluster: k8s-infra-ppc64le-prow-build
+  cron: 10 3-23/4 * * *
+  decorate: true
+  decoration_config:
+    timeout: 5h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    repo: provider-ibmcloud-test-infra
+    workdir: true
+  labels:
+    preset-ibmcloud-cred: "true"
+  name: ci-kubernetes-ppc64le-conformance-latest-1-35
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        set -o xtrace
+        MARKER_VERSION=latest-1.35.txt;
+        # Fetch build version only once
+        K8S_BUILD_VERSION=$(curl -Ls https://dl.k8s.io/ci/$MARKER_VERSION);
+
+        #Setup of kubetest2 tf deployer
+        make install-deployer-tf
+
+        export TF_VAR_powervs_system_type=e980
+        kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
+          --powervs-ssh-key k8s-prow-sshkey \
+          --ssh-private-key /etc/secret-volume/ssh-privatekey \
+          --workers-count 2 --cluster-name conformance-$(date +%s) \
+          --up --down --auto-approve --retry-on-tf-failure 3 \
+          --break-kubetest-on-upfail true --ignore-destroy-errors \
+          --build-version $K8S_BUILD_VERSION \
+          --release-marker $K8S_BUILD_VERSION \
+          --test=ginkgo -- --test-package-dir ci --test-package-marker $MARKER_VERSION --focus-regex='\[Conformance\]'
+      command:
+      - runner.sh
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260209-dbbff72479-1.35
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 14Gi
+        requests:
+          cpu: "4"
+          memory: 14Gi
+      securityContext:
+        privileged: true
+- annotations:
     fork-per-release-cron: 0 1/6 * * *, 0 2 * * *
     testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
     testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics


### PR DESCRIPTION
This PR adds PPC conformance test jobs for k8s releases 1.32, 1.33, 1.34, and 1.35 and sets up automation for future release branch job creation.

- Added K8s conformance test jobs for the 1.35 branch for the ppc64le provider.
- Updated jobs for releases 1.32,1.33 and 1.34 to ensure consistency.
- Updated the cron schedule for **ci-kubernetes-ppc64le-e2e-slow-kubetest2**.
- Added fork-per-release and fork-per-release-cron annotations.
- Configured jobs to be automatically generated for future releases using config-forker and config-rotator if needed.