### PR TITLE
🌱 ci(kuebuilder): Increase Prow job resources and timeout to reduce timeout flakes

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -16,11 +16,11 @@ presubmits:
         - ./test.sh
         resources:
           limits:
-            cpu: 4000m
-            memory: 8Gi
+            cpu: 7
+            memory: 16Gi
           requests:
-            cpu: 4000m
-            memory: 8Gi
+            cpu: 7
+            memory: 16Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
@@ -28,7 +28,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
-      timeout: 40m
+      timeout: 60m
     optional: false
     skip_if_only_changed: "^docs/|^designs/|^roadmap/|^scripts/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/kubebuilder
@@ -47,11 +47,11 @@ presubmits:
               value: "true"
           resources:
             limits:
-              cpu: 6
-              memory: 8Gi
+              cpu: 7
+              memory: 16Gi
             requests:
-              cpu: 6
-              memory: 8Gi
+              cpu: 7
+              memory: 16Gi
           securityContext:
             privileged: true
     annotations:
@@ -64,7 +64,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
-      timeout: 40m
+      timeout: 60m
     optional: false
     skip_if_only_changed: "^docs/|^designs/|^roadmap/|^scripts/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/kubebuilder
@@ -83,11 +83,11 @@ presubmits:
               value: "true"
           resources:
             limits:
-              cpu: 6
-              memory: 8Gi
+              cpu: 7
+              memory: 16Gi
             requests:
-              cpu: 6
-              memory: 8Gi
+              cpu: 7
+              memory: 16Gi
           securityContext:
             privileged: true
     annotations:
@@ -100,7 +100,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     decorate: true
     decoration_config:
-      timeout: 40m
+      timeout: 60m
     optional: false
     skip_if_only_changed: "^docs/|^designs/|^roadmap/|^scripts/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/kubebuilder
@@ -120,10 +120,10 @@ presubmits:
           resources:
             limits:
               cpu: 6
-              memory: 8Gi
+              memory: 16Gi
             requests:
               cpu: 6
-              memory: 8Gi
+              memory: 16Gi
           securityContext:
             privileged: true
     annotations:


### PR DESCRIPTION
## Why this change
These timeout/resource values were set years ago when the test suite was much smaller (roughly old go/v4 coverage). **Since then we’ve expanded scenarios and scaffold tests** (Helm + deploy-image variants) and recently added namespaced layout coverage that means we have at least 3 to 4 times the same amount of tests that we had when those values were set. 

Locally the suite is fast (~<20m), but in Prow it often runs slower due to shared CI contention **(avg ~38/40m)**, c**ausing frequent timeout flakes and manual retriggers.** Example

Time when it pass:

<img width="537" height="98" alt="Screenshot 2026-02-13 at 12 54 41" src="https://github.com/user-attachments/assets/5639d66c-68b9-4bf0-afbd-f1ae38b51bfd" />

<img width="491" height="81" alt="Screenshot 2026-02-13 at 12 54 47" src="https://github.com/user-attachments/assets/47440c05-dfc6-499b-bba0-22f3351757f1" />

Ref: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kubebuilder/5456/pull-kubebuilder-e2e-k8s-1-34-0/2021245374068428800 and https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kubebuilder/5456/pull-kubebuilder-e2e-k8s-1-35-0/2021245373976154112

## What’s changing
- Memory: 8Gi → 16Gi
- CPU: 6 → 7
- Timeout: 40m → 60m

## Rationale
- **Stability / flake reduction:** Current 40m timeout is too tight for Prow variability; retriggers waste CI capacity and time.
- **Scale of tests:** Suite is ~3/4× larger than when these values were set and will continue to grow; ( we need to add more )
- **Consistency with other Prow jobs:** 16Gi and CPU=7 match commonly used values in kubernetes/test-infra:
  - https://github.com/search?q=repo%3Akubernetes%2Ftest-infra+memory%3A+16Gi&type=code
  - https://github.com/search?q=repo%3Akubernetes%2Ftest-infra+%22cpu%3A+7%22&type=code
