### PR TITLE
Add new lable for WAS/TAS workstreams

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -610,6 +610,7 @@ larger set of contributors to apply/remove them.
 | <a id="wg/lts" href="#wg/lts">`wg/lts`</a> | Categorizes an issue or PR as relevant to WG LTS.| humans | |
 | <a id="wg/machine-learning" href="#wg/machine-learning">`wg/machine-learning`</a> | Categorizes an issue or PR as relevant to WG Machine Learning.| humans | |
 | <a id="wg/security-audit" href="#wg/security-audit">`wg/security-audit`</a> | Categorizes an issue or PR as relevant to WG Security Audit.| humans | |
+| <a id="ws/workload-aware" href="#ws/workload-aware">`ws/workload-aware`</a> | Categorizes an issue or PR as relevant to WAS or TAS Workstreams.| humans | |
 
 ## Labels that apply to kubernetes/kubernetes, only for issues
 

--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -594,6 +594,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/workload-api/deployment" href="#area/workload-api/deployment">`area/workload-api/deployment`</a> | | label | |
 | <a id="area/workload-api/job" href="#area/workload-api/job">`area/workload-api/job`</a> | | label | |
 | <a id="area/workload-api/replicaset" href="#area/workload-api/replicaset">`area/workload-api/replicaset`</a> | | label | |
+| <a id="area/workload-aware" href="#area/workload-aware">`area/workload-aware`</a> | Categorizes an issue or PR as relevant to WAS or TAS Workstreams.| humans | |
 | <a id="kind/dependency" href="#kind/dependency">`kind/dependency`</a> | Categorizes issue or PR as related to a dependency update.| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
 | <a id="kind/design" href="#kind/design">`kind/design`</a> | Categorizes issue or PR as related to design.| humans | |
 | <a id="milestone/incomplete-labels" href="#milestone/incomplete-labels">`milestone/incomplete-labels`</a> | | humans | |
@@ -610,7 +611,6 @@ larger set of contributors to apply/remove them.
 | <a id="wg/lts" href="#wg/lts">`wg/lts`</a> | Categorizes an issue or PR as relevant to WG LTS.| humans | |
 | <a id="wg/machine-learning" href="#wg/machine-learning">`wg/machine-learning`</a> | Categorizes an issue or PR as relevant to WG Machine Learning.| humans | |
 | <a id="wg/security-audit" href="#wg/security-audit">`wg/security-audit`</a> | Categorizes an issue or PR as relevant to WG Security Audit.| humans | |
-| <a id="ws/workload-aware" href="#ws/workload-aware">`ws/workload-aware`</a> | Categorizes an issue or PR as relevant to WAS or TAS Workstreams.| humans | |
 
 ## Labels that apply to kubernetes/kubernetes, only for issues
 

--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -594,7 +594,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/workload-api/deployment" href="#area/workload-api/deployment">`area/workload-api/deployment`</a> | | label | |
 | <a id="area/workload-api/job" href="#area/workload-api/job">`area/workload-api/job`</a> | | label | |
 | <a id="area/workload-api/replicaset" href="#area/workload-api/replicaset">`area/workload-api/replicaset`</a> | | label | |
-| <a id="area/workload-aware" href="#area/workload-aware">`area/workload-aware`</a> | Categorizes an issue or PR as relevant to WAS or TAS Workstreams.| humans | |
+| <a id="area/workload-aware" href="#area/workload-aware">`area/workload-aware`</a> | Categorizes an issue or PR as relevant to Workload-aware and Topology-aware scheduling subprojects.| humans | |
 | <a id="kind/dependency" href="#kind/dependency">`kind/dependency`</a> | Categorizes issue or PR as related to a dependency update.| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
 | <a id="kind/design" href="#kind/design">`kind/design`</a> | Categorizes issue or PR as related to design.| humans | |
 | <a id="milestone/incomplete-labels" href="#milestone/incomplete-labels">`milestone/incomplete-labels`</a> | | humans | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1566,6 +1566,11 @@ repos:
         name: wg/security-audit
         target: both
         addedBy: humans
+      - color: d2b48c
+        description: Categorizes an issue or PR as relevant to WAS or TAS Workstreams.
+        name: ws/workload-aware
+        target: both
+        addedBy: humans
 
   kubernetes/org:
     labels:

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1567,7 +1567,7 @@ repos:
         target: both
         addedBy: humans
       - color: d2b48c
-        description: Categorizes an issue or PR as relevant to WAS or TAS Workstreams.
+        description: Categorizes an issue or PR as relevant to Workload-aware and Topology-aware scheduling subprojects.
         name: area/workload-aware
         target: both
         addedBy: humans

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1568,7 +1568,7 @@ repos:
         addedBy: humans
       - color: d2b48c
         description: Categorizes an issue or PR as relevant to WAS or TAS Workstreams.
-        name: ws/workload-aware
+        name: area/workload-aware
         target: both
         addedBy: humans
 


### PR DESCRIPTION
Create new label to identify Workload-aware-scheduling and Topology-aware-scheduling workstreams.

cc @mm4tt @kannon92 @andreyvelich @dom4ha @wojtek-t @johnbelamaric 

/cc @kubernetes/sig-contributor-experience 