### PR TITLE
add config for 1.32 back and update to go 1.24.13

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -28,4 +28,9 @@ variants:
     K8S_RELEASE: latest-1.33
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
-
+  '1.32':
+    CONFIG: '1.32'
+    GO_VERSION: 1.24.13
+    K8S_RELEASE: latest-1.32
+    BAZEL_VERSION: 3.4.1
+    DOCKER_VERSION: 5:28.*


### PR DESCRIPTION
- add config for 1.32 back and update to go 1.24.13


xref: https://github.com/kubernetes/release/issues/4265


/assign @dims @saschagrunert @Verolop 
cc @kubernetes/release-managers 