### PR TITLE
Migrate ci-kubernetes-node-kubelet-serial-cri-o to kubetest2

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -171,27 +171,36 @@ periodics:
     repo: test-infra
     base_ref: master
     path_alias: k8s.io/test-infra
+  annotations:
+    testgrid-dashboards: sig-node-cri-o
+    testgrid-tab-name: node-kubelet-serial-crio
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
+    description: "OWNER: sig-node; runs serial node-e2e tests with CRI-O (+Serial, -Flaky|Benchmark|Node*Feature|Feature:OffByDefault)"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
       command:
         - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
       args:
-          - --deployment=node
-          - --env=KUBE_SSH_USER=core
-          - --gcp-zone=us-central1-b
-          - '--node-test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
-          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-serial.yaml
-          - --node-tests=true
-          - --provider=gce
-          # *Manager jobs are skipped because they have corresponding test lanes with the right image
-          # These jobs in serial get partially skipped and are long jobs.
-          - --test_args=--nodes=1 --timeout=5h --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:OffByDefault\]"
-          - --timeout=300m
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=1
+        - --focus-regex=\[Serial\]
+        # *Manager jobs are skipped because they have corresponding test lanes with the right image
+        # These jobs in serial get partially skipped and are long jobs.
+        - --skip-regex=\[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:OffByDefault\]
+        - '--test-args=--ginkgo.timeout=3h --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}" --service-feature-gates="PodLevelResources=true" --feature-gates="PodLevelResources=true"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-serial.yaml
+        - --timeout=300m
       env:
       - name: GOPATH
         value: /go
+      - name: KUBE_SSH_USER
+        value: core
       - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
         value: "1"
       resources:
@@ -201,11 +210,6 @@ periodics:
         requests:
           cpu: 4
           memory: 12Gi
-  annotations:
-    testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: node-kubelet-serial-crio
-    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
-    description: "Uses kubetest to run serial node-e2e tests (+Serial, -Flaky|Benchmark|Node*Feature|Feature:OffByDefault)"
 
 - name: ci-kubernetes-node-arm64-ubuntu-serial
   interval: 4h


### PR DESCRIPTION
Migrate the `ci-kubernetes-node-kubelet-serial-cri-o` periodic job from
the deprecated `kubernetes_e2e.py` script to `kubetest2`, following the
pattern of its presubmit equivalent `pull-kubernetes-node-kubelet-serial-crio`.

Ref: https://github.com/kubernetes/test-infra/issues/32567

/sig node
/hold