### PR TITLE
Refactor HPA alpha/beta tests to run all alpha/beta

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -598,8 +598,8 @@ periodics:
       - --gcp-node-size=e2-highcpu-8
       - --extract=ci/latest
       - --timeout=240m
-      - --env=KUBE_FEATURE_GATES=HPAConfigurableTolerance=true
-      - --test_args=--ginkgo.focus=\[Feature:HPAConfigurableTolerance\]
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true
+      - --test_args=--ginkgo.focus=\[Feature:HPA\]
         --minStartupPods=8
       - --ginkgo-parallel=10
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master


### PR DESCRIPTION
This way we don't need to manually edit tests every time we add alpha or beta feature

For now I've only set this on the periodic CI job, just to test that it works.
I'll follow up with a PR for presubmit if this works.