### PR TITLE
Use latest CAPZ version for Azure Scalability test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
@@ -17,7 +17,7 @@ periodics:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.22
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     - org: kubernetes-sigs
       repo: cloud-provider-azure


### PR DESCRIPTION
This updates the Azure Scalability test to use the latest CAPZ release.