### PR TITLE
test-infra: increase unit-test memory requirements

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -86,10 +86,10 @@ presubmits:
         resources:
           requests:
             cpu: "7"
-            memory: "8Gi"
+            memory: "12Gi"
           limits:
             cpu: "7"
-            memory: "8Gi"
+            memory: "12Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: unit-test


### PR DESCRIPTION
A recent PR seems to suffer from OOM killing (output ends in the middle of unit testing, job is not cleaned up).