### PR TITLE
Align resource-size test timeout to release blocking 5k test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1122,7 +1122,7 @@ periodics:
   job_queue_name: "5k-gce-scale-test" # DON'T REMOVE THIS
   decorate: true
   decoration_config:
-    timeout: 240m
+    timeout: 450m
   extra_refs:
   - org: kubernetes
     repo: kubernetes


### PR DESCRIPTION
/cc @mborsz 

https://github.com/kubernetes/test-infra/blob/d087ecc016b0fd0ac8c456a7aa8cf9229799d63e/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml#L92

After migrating to kops we started to timeout.