### PR TITLE
ci-kubernetes-kops-gce-small-scale-kindnet-using-cl2: set CLUSTER_NAME

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-networking.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-networking.yaml
@@ -209,6 +209,8 @@ periodics:
       securityContext:
         privileged: true
       env:
+      - name: CLUSTER_NAME
+        value: e2e-kops-gce-small-kindnet
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
       - name: KUBE_SSH_USER


### PR DESCRIPTION
This avoid a problem where the default cluster name produces resources
with names that are too long for the GCE API.
