### PR TITLE
Resolve image tags during config forking

### DIFF
--- a/releng/config-forker/README.md
+++ b/releng/config-forker/README.md
@@ -26,7 +26,9 @@ Only jobs annotated with `fork-per-release` will be forked.
 
 For all jobs:
 
-- If `spec` includes a container with an `image` ending in `-master`, it is replaced with `-1.15`.
+- If `spec` includes a container with an `image` ending in `-master`, it is replaced with `-1.15`. The resulting image
+  tag is then validated against the OCI registry; if it does not exist, the forker resolves to the latest available tag
+  with the same version suffix.
 - If `spec` includes a container with an `env` variable with `BRANCH` (case-insensitive) in the name and the value
   `master`, the value will be changed to `release-1.15`.
 - If the `fork-per-release-replacements` annotation is specified, those replacements will be performed in the `args`

--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -18,6 +18,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 
@@ -33,7 +34,9 @@ func main() {
 	flag.StringVar(&opts.GoVersion, "go-version", "", "Current go version in use")
 	flag.Parse()
 
-	if err := forker.Run(opts); err != nil {
+	opts.ImageResolver = forker.NewRegistryResolver(nil)
+
+	if err := forker.Run(context.Background(), opts); err != nil {
 		log.Fatalln(err)
 	}
 }

--- a/releng/config-forker/pkg/resolve.go
+++ b/releng/config-forker/pkg/resolve.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// ErrTagList is returned when the OCI tag list request fails.
+var ErrTagList = errors.New("tag list request failed")
+
+// registryResolver implements ImageResolver by querying OCI Distribution
+// tag list endpoints. It caches tag lists per repository.
+type registryResolver struct {
+	client *http.Client
+	mu     sync.Mutex
+	cache  map[string][]string
+}
+
+// NewRegistryResolver creates an ImageResolver that checks tags against
+// the OCI Distribution API. Pass nil to use http.DefaultClient.
+func NewRegistryResolver(client *http.Client) ImageResolver {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	return &registryResolver{
+		client: client,
+		mu:     sync.Mutex{},
+		cache:  make(map[string][]string),
+	}
+}
+
+// imageRef holds the parsed components of a container image reference.
+type imageRef struct {
+	registry string // e.g., "gcr.io" or "us-central1-docker.pkg.dev"
+	repo     string // e.g., "k8s-staging-test-infra/kubekins-e2e"
+	tag      string // e.g., "v20260205-38cfa9523f-1.34"
+}
+
+// parseImageRef parses "registry/repo:tag" into components.
+func parseImageRef(image string) (imageRef, bool) {
+	colonIdx := strings.LastIndex(image, ":")
+	if colonIdx < 0 {
+		return imageRef{registry: "", repo: "", tag: ""}, false
+	}
+
+	repoPath := image[:colonIdx]
+	tag := image[colonIdx+1:]
+
+	registry, repo, ok := strings.Cut(repoPath, "/")
+	if !ok {
+		return imageRef{registry: "", repo: "", tag: ""}, false
+	}
+
+	return imageRef{
+		registry: registry,
+		repo:     repo,
+		tag:      tag,
+	}, true
+}
+
+// tagSuffixPattern matches tags like "vYYYYMMDD-hexhash-suffix".
+// Submatch index 1 is the suffix portion (e.g., "1.34" or "master").
+var tagSuffixPattern = regexp.MustCompile(`^v\d{8}-[0-9a-f]+-(.+)$`)
+
+// tagSuffixSubmatch is the expected number of submatches from tagSuffixPattern.
+const tagSuffixSubmatch = 2
+
+// tagSuffix extracts the suffix portion of a tag (e.g., "1.34" from
+// "v20260205-38cfa9523f-1.34").
+func tagSuffix(tag string) string {
+	m := tagSuffixPattern.FindStringSubmatch(tag)
+	if len(m) < tagSuffixSubmatch {
+		return ""
+	}
+
+	return m[1]
+}
+
+func (r *registryResolver) Resolve(
+	ctx context.Context, image string,
+) (string, error) {
+	ref, ok := parseImageRef(image)
+	if !ok {
+		return image, nil
+	}
+
+	tags, err := r.getTags(ctx, ref)
+	if err != nil {
+		return "", err
+	}
+
+	if slices.Contains(tags, ref.tag) {
+		return image, nil
+	}
+
+	// Tag doesn't exist; find the latest tag with the same suffix.
+	wantSuffix := tagSuffix(ref.tag)
+	if wantSuffix == "" {
+		return image, nil
+	}
+
+	var candidates []string
+
+	for _, t := range tags {
+		if tagSuffix(t) == wantSuffix {
+			candidates = append(candidates, t)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return image, nil
+	}
+
+	sort.Strings(candidates)
+
+	bestTag := candidates[len(candidates)-1]
+
+	return image[:strings.LastIndex(image, ":")+1] + bestTag, nil
+}
+
+// tagListResponse is the JSON structure returned by the OCI tag list endpoint.
+type tagListResponse struct {
+	Tags []string `json:"tags"`
+}
+
+func (r *registryResolver) getTags(
+	ctx context.Context, ref imageRef,
+) ([]string, error) {
+	cacheKey := ref.registry + "/" + ref.repo
+
+	r.mu.Lock()
+	if tags, ok := r.cache[cacheKey]; ok {
+		r.mu.Unlock()
+
+		return tags, nil
+	}
+
+	r.mu.Unlock()
+
+	url := fmt.Sprintf(
+		"https://%s/v2/%s/tags/list", ref.registry, ref.repo,
+	)
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, url, http.NoBody,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating tag list request: %w", err)
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching tag list from %s: %w", url, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"%w: %s returned %d", ErrTagList, url, resp.StatusCode,
+		)
+	}
+
+	var tlr tagListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tlr); err != nil {
+		return nil, fmt.Errorf(
+			"decoding tag list from %s: %w", url, err,
+		)
+	}
+
+	r.mu.Lock()
+	r.cache[cacheKey] = tlr.Tags
+	r.mu.Unlock()
+
+	return tlr.Tags, nil
+}

--- a/releng/config-forker/pkg/resolve_test.go
+++ b/releng/config-forker/pkg/resolve_test.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestParseImageRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		image    string
+		wantOK   bool
+		wantRef  imageRef
+	}{
+		{
+			name:   "standard GCR image",
+			image:  "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-1.34",
+			wantOK: true,
+			wantRef: imageRef{
+				registry: "gcr.io",
+				repo:     "k8s-staging-test-infra/kubekins-e2e",
+				tag:      "v20260205-38cfa9523f-1.34",
+			},
+		},
+		{
+			name:   "artifact registry image",
+			image:  "us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260209-abc123-master",
+			wantOK: true,
+			wantRef: imageRef{
+				registry: "us-central1-docker.pkg.dev",
+				repo:     "k8s-staging-test-infra/images/kubekins-e2e",
+				tag:      "v20260209-abc123-master",
+			},
+		},
+		{
+			name:    "no tag",
+			image:   "gcr.io/k8s-staging-test-infra/kubekins-e2e",
+			wantOK:  false,
+			wantRef: imageRef{registry: "", repo: "", tag: ""},
+		},
+		{
+			name:    "no slash",
+			image:   "ubuntu:latest",
+			wantOK:  false,
+			wantRef: imageRef{registry: "", repo: "", tag: ""},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ref, ok := parseImageRef(test.image)
+			if ok != test.wantOK {
+				t.Fatalf("parseImageRef(%q) ok = %v, want %v", test.image, ok, test.wantOK)
+			}
+
+			if ok && ref != test.wantRef {
+				t.Errorf("parseImageRef(%q) = %+v, want %+v", test.image, ref, test.wantRef)
+			}
+		})
+	}
+}
+
+func TestTagSuffix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tag      string
+		expected string
+	}{
+		{"v20260205-38cfa9523f-1.34", "1.34"},
+		{"v20260205-38cfa9523f-master", "master"},
+		{"latest", ""},
+		{"latest-1.34", ""},
+		{"v20260205-UPPER-1.34", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.tag, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tagSuffix(test.tag); got != test.expected {
+				t.Errorf("tagSuffix(%q) = %q, want %q", test.tag, got, test.expected)
+			}
+		})
+	}
+}
+
+func newTestServer(t *testing.T, tags []string, callCount *atomic.Int32) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		if callCount != nil {
+			callCount.Add(1)
+		}
+
+		writer.Header().Set("Content-Type", "application/json")
+
+		resp := tagListResponse{Tags: tags}
+		if err := json.NewEncoder(writer).Encode(resp); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func testImage(serverURL, tag string) string {
+	return serverURL[len("https://"):] + "/repo/image:" + tag
+}
+
+func TestRegistryResolver_ExactTagExists(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, []string{
+		"v20260205-38cfa9523f-master",
+		"v20260205-38cfa9523f-1.34",
+	}, nil)
+
+	resolver := NewRegistryResolver(server.Client())
+	image := testImage(server.URL, "v20260205-38cfa9523f-1.34")
+
+	got, err := resolver.Resolve(context.Background(), image)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != image {
+		t.Errorf("Resolve() = %q, want %q (unchanged)", got, image)
+	}
+}
+
+func TestRegistryResolver_FallbackToLatest(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, []string{
+		"v20260101-aaa1111111-1.34",
+		"v20260115-bbb2222222-1.34",
+		"v20260205-38cfa9523f-master",
+	}, nil)
+
+	resolver := NewRegistryResolver(server.Client())
+	image := testImage(server.URL, "v20260205-38cfa9523f-1.34")
+	expected := testImage(server.URL, "v20260115-bbb2222222-1.34")
+
+	got, err := resolver.Resolve(context.Background(), image)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != expected {
+		t.Errorf("Resolve() = %q, want %q", got, expected)
+	}
+}
+
+func TestRegistryResolver_NoFallback(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, []string{
+		"v20260205-38cfa9523f-master",
+	}, nil)
+
+	resolver := NewRegistryResolver(server.Client())
+	image := testImage(server.URL, "v20260205-38cfa9523f-1.34")
+
+	got, err := resolver.Resolve(context.Background(), image)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != image {
+		t.Errorf("Resolve() = %q, want %q (unchanged)", got, image)
+	}
+}
+
+func TestRegistryResolver_UnparseableImage(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewRegistryResolver(nil)
+
+	got, err := resolver.Resolve(context.Background(), "ubuntu:latest")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "ubuntu:latest" {
+		t.Errorf("Resolve() = %q, want %q", got, "ubuntu:latest")
+	}
+}
+
+func TestRegistryResolver_CacheHit(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	server := newTestServer(t, []string{
+		"v20260205-38cfa9523f-1.34",
+	}, &calls)
+
+	resolver := NewRegistryResolver(server.Client())
+	image := testImage(server.URL, "v20260205-38cfa9523f-1.34")
+
+	for range 3 {
+		if _, err := resolver.Resolve(context.Background(), image); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected 1 HTTP call, got %d", got)
+	}
+}
+
+func TestRegistryResolver_HTTPError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	t.Cleanup(server.Close)
+
+	resolver := NewRegistryResolver(server.Client())
+	image := testImage(server.URL, "v20260205-38cfa9523f-1.34")
+
+	_, err := resolver.Resolve(context.Background(), image)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestRegistryResolver_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewRegistryResolver(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := resolver.Resolve(ctx, "gcr.io/some/repo:v20260205-38cfa9523f-1.34")
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestResolveImage_NilResolver(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveImage(context.Background(), nil, "some-image:tag")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "some-image:tag" {
+		t.Errorf("resolveImage() = %q, want %q", got, "some-image:tag")
+	}
+}
+
+func TestResolveImage_VariableRef(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewRegistryResolver(nil)
+	image := "${kubekins_e2e_image}-master"
+
+	got, err := resolveImage(context.Background(), resolver, image)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != image {
+		t.Errorf("resolveImage() = %q, want %q", got, image)
+	}
+}

--- a/releng/prepare-release-branch/internal/run/run.go
+++ b/releng/prepare-release-branch/internal/run/run.go
@@ -73,6 +73,7 @@ func RotateFiles(branchDir string, version release.Version) error {
 
 // ForkNewFile calls config-forker to create a config for the next version.
 func ForkNewFile(
+	ctx context.Context,
 	branchDir, jobConfigDir string,
 	version release.Version,
 	goVersion string,
@@ -89,11 +90,12 @@ func ForkNewFile(
 		return fmt.Errorf("resolving output path: %w", err)
 	}
 
-	if err := forker.Run(forker.Options{
-		JobConfig:  absJobConfig,
-		OutputPath: absOutput,
-		Version:    next.String(),
-		GoVersion:  goVersion,
+	if err := forker.Run(ctx, forker.Options{
+		JobConfig:     absJobConfig,
+		OutputPath:    absOutput,
+		Version:       next.String(),
+		GoVersion:     goVersion,
+		ImageResolver: forker.NewRegistryResolver(nil),
 	}); err != nil {
 		return fmt.Errorf("forking %s: %w", next.Filename(), err)
 	}

--- a/releng/prepare-release-branch/main.go
+++ b/releng/prepare-release-branch/main.go
@@ -72,7 +72,7 @@ func execute(ctx context.Context) error {
 
 	log.Println("Forking new file...")
 
-	if err := run.ForkNewFile(branchJobDir, jobConfigDir, version, goVersion); err != nil {
+	if err := run.ForkNewFile(ctx, branchJobDir, jobConfigDir, version, goVersion); err != nil {
 		return fmt.Errorf("forking new file: %w", err)
 	}
 


### PR DESCRIPTION
- When forking job configs for a new release branch, image tags are rewritten from `-master` to `-<version>`. If the version-specific tag doesn't exist yet in the registry, the forker now resolves to the latest available tag with the same version suffix via the OCI tag list API.
- Adds `ImageResolver` interface to `config-forker`, with a `registryResolver` implementation that queries public OCI registries and caches tag lists per repo.
- Both `config-forker` CLI and `prepare-release-branch` now always resolve images.

Fixes https://github.com/kubernetes/test-infra/issues/34675

/sig release testing
/kind bug