### PR TITLE
Standardize CRI-O job names to ci-node-crio-*/pull-node-crio-* prefix

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: ci-crio-node-e2e-features
+- name: ci-node-crio-features
   cluster: k8s-infra-prow-build
   interval: 1h
   labels:
@@ -20,7 +20,7 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-node-e2e-features
+    testgrid-tab-name: ci-node-crio-features
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-node; runs Features e2e tests with crio master and cgroup v2"
   spec:
@@ -54,7 +54,7 @@ periodics:
           value: core
         - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
           value: "1"
-- name: ci-crio-node-e2e-unlabelled
+- name: ci-node-crio-unlabelled
   cluster: k8s-infra-prow-build
   interval: 12h
   labels:
@@ -75,7 +75,7 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-node-e2e-unlabelled
+    testgrid-tab-name: ci-node-crio-unlabelled
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Contains all uncategorized tests, these are tests which are not marked with a [Node] tag. All node tests should be marked with [Feature] or [NodeConformance] classification. Also skipped are [Flaky], [Benchmark], [Legacy]."
   spec:
@@ -109,7 +109,7 @@ periodics:
         requests:
           cpu: 4
           memory: 6Gi
-- name: ci-crio-node-e2e-eviction
+- name: ci-node-crio-eviction
   cluster: k8s-infra-prow-build
   interval: 4h30m
   labels:
@@ -130,7 +130,7 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-node-e2e-eviction
+    testgrid-tab-name: ci-node-crio-eviction
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
   spec:
@@ -165,7 +165,7 @@ periodics:
           value: core
         - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
           value: "1"
-- name: ci-node-kubelet-crio-performance-test
+- name: ci-node-crio-performance
   cluster: k8s-infra-prow-build
   interval: 12h
   labels:
@@ -186,9 +186,9 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: node-kubelet-crio-performance-test
+    testgrid-tab-name: ci-node-crio-performance
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
-    description: "OWNER: sig-node; runs Eviction e2e tests with crio master and cgroup v2"
+    description: "OWNER: sig-node; runs Performance e2e tests with crio master and cgroup v2"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -221,7 +221,7 @@ periodics:
         requests:
           cpu: 4
           memory: 6Gi
-- name: ci-crio-node-e2e-conformance
+- name: ci-node-crio-conformance
   cluster: k8s-infra-prow-build
   interval: 1h
   labels:
@@ -242,7 +242,7 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-node-cri-o, sig-node-release-blocking
-    testgrid-tab-name: ci-crio-node-e2e-conformance
+    testgrid-tab-name: ci-node-crio-conformance
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, release-team@kubernetes.io
     description: "OWNER: sig-node; runs NodeConformance e2e tests with crio master and cgroup v2"
   spec:
@@ -277,7 +277,7 @@ periodics:
         requests:
           cpu: 4
           memory: 6Gi
-- name: ci-crio-node-e2e-resource-managers
+- name: ci-node-crio-resource-managers
   cluster: k8s-infra-prow-build
   interval: 4h
   labels:
@@ -298,7 +298,7 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-node-e2e-resource-managers
+    testgrid-tab-name: ci-node-crio-resource-managers
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Executes CPU, Memory and Topology manager e2e tests with cgroup v2"
   spec:
@@ -333,7 +333,7 @@ periodics:
           value: core
         - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
           value: "1"
-- name: ci-crio-node-e2e-hugepages
+- name: ci-node-crio-hugepages
   cluster: k8s-infra-prow-build
   interval: 4h
   labels:
@@ -356,7 +356,7 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-node-e2e-hugepages
+    testgrid-tab-name: ci-node-crio-hugepages
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Executes hugepages e2e tests"
   spec:
@@ -390,7 +390,7 @@ periodics:
           value: core
         - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
           value: "1"
-- name: ci-crio-userns-e2e-serial
+- name: ci-node-crio-userns-serial
   cluster: k8s-infra-prow-build
   interval: 24h
   decorate: true
@@ -414,7 +414,7 @@ periodics:
     preset-pull-kubernetes-e2e-gce: "true"
   annotations:
     testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-crio-userns-e2e-serial
+    testgrid-tab-name: ci-node-crio-userns-serial
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     # Before UserNamespacesHostNetworkSupport reaches GA, if we need to migrate the userns tests to the conformance tests,
     # we must retain the test job for UserNamespacesHostNetworkSupport.

--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -15,6 +15,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra-canary
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
@@ -100,6 +101,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra-all-canary
       description: Runs E2E tests for Dynamic Resource Allocation alpha and beta features against a Kubernetes master cluster created with sigs.k8s.io/kind
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
@@ -196,6 +198,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra-all-slow-canary
       description: Runs E2E tests for Dynamic Resource Allocation alpha and beta features against a Kubernetes master cluster created with sigs.k8s.io/kind, including slow tests
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
@@ -292,6 +295,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra-n-1-canary
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind with kubelet from the "current - 1" release.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
@@ -426,6 +430,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra-n-2-canary
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind with kubelet from the "current - 2" release.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
@@ -560,6 +565,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra-n-3-canary
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind with kubelet from the "current - 3" release.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
@@ -694,6 +700,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-dra-integration-canary
       description: Runs integration tests for DRA which need some additional setup in the job.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
@@ -728,7 +735,7 @@ presubmits:
             cpu: 2
             memory: 6Gi
 
-  - name: pull-kubernetes-node-e2e-crio-dra-canary
+  - name: pull-kubernetes-node-crio-dra-canary
     cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+\.\d+  # per-release image
@@ -740,6 +747,7 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-cri-o
+      testgrid-tab-name: pull-kubernetes-node-crio-dra-canary
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
@@ -796,6 +804,7 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-containerd
+      testgrid-tab-name: pull-kubernetes-node-e2e-containerd-1-7-dra-canary
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 1.7
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
@@ -845,6 +854,7 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-containerd
+      testgrid-tab-name: pull-kubernetes-node-e2e-containerd-2-0-dra-canary
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 2.1
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
@@ -897,6 +907,7 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-containerd
+      testgrid-tab-name: pull-kubernetes-node-e2e-containerd-2-0-dra-alpha-beta-features-canary
       description: Runs all E2E node tests for Dynamic Resource Allocation features with containerd 2.1 and with all feature gates enabled (including non-DRA feature gates)
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -11,6 +11,7 @@ periodics:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-master-informing
+      testgrid-tab-name: ci-kind-dra
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
       fork-per-release: "true"
@@ -105,6 +106,7 @@ periodics:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation
+      testgrid-tab-name: ci-kind-dra-all
       description: Runs E2E tests for Dynamic Resource Allocation alpha and beta features against a Kubernetes master cluster created with sigs.k8s.io/kind
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true
@@ -207,6 +209,7 @@ periodics:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation
+      testgrid-tab-name: ci-kind-dra-n-1
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind with kubelet from the "current - 1" release.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -335,6 +338,7 @@ periodics:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation
+      testgrid-tab-name: ci-kind-dra-n-2
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind with kubelet from the "current - 2" release.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -463,6 +467,7 @@ periodics:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation
+      testgrid-tab-name: ci-kind-dra-n-3
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind with kubelet from the "current - 3" release.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -591,6 +596,7 @@ periodics:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation
+      testgrid-tab-name: ci-dra-integration
       description: Runs integration tests for DRA which need some additional setup in the job.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -633,7 +639,7 @@ periodics:
             cpu: 2
             memory: 6Gi
 
-  - name: ci-node-e2e-crio-dra
+  - name: ci-node-crio-dra
     cluster: k8s-infra-prow-build
     interval: 6h
     labels:
@@ -641,6 +647,7 @@ periodics:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o, sig-release-master-informing
+      testgrid-tab-name: ci-node-crio-dra
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
       fork-per-release: "true"
@@ -700,6 +707,7 @@ periodics:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-containerd, sig-release-master-informing
+      testgrid-tab-name: ci-node-e2e-containerd-1-7-dra
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 1.7
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
       fork-per-release: "true"
@@ -752,6 +760,7 @@ periodics:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-containerd, sig-release-master-informing
+      testgrid-tab-name: ci-node-e2e-containerd-2-0-dra
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 2.1
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
       fork-per-release: "true"
@@ -807,6 +816,7 @@ periodics:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-containerd
+      testgrid-tab-name: ci-node-e2e-containerd-2-0-dra-alpha-beta-features
       description: Runs all E2E node tests for Dynamic Resource Allocation features with containerd 2.1 and with all feature gates enabled (including non-DRA feature gates)
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     decorate: true

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -16,6 +16,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -103,6 +104,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra-all
       description: Runs E2E tests for Dynamic Resource Allocation alpha and beta features against a Kubernetes master cluster created with sigs.k8s.io/kind
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -200,6 +202,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra-all-slow
       description: Runs E2E tests for Dynamic Resource Allocation alpha and beta features against a Kubernetes master cluster created with sigs.k8s.io/kind, including slow tests
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -298,6 +301,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra-n-1
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind with kubelet from the "current - 1" release.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -434,6 +438,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra-n-2
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind with kubelet from the "current - 2" release.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -570,6 +575,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-kind-dra-n-3
       description: Runs E2E tests for Dynamic Resource Allocation beta features against a Kubernetes master cluster created with sigs.k8s.io/kind with kubelet from the "current - 3" release.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -706,6 +712,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits
+      testgrid-tab-name: pull-kubernetes-dra-integration
       description: Runs integration tests for DRA which need some additional setup in the job.
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -741,7 +748,7 @@ presubmits:
             cpu: 2
             memory: 6Gi
 
-  - name: pull-kubernetes-node-e2e-crio-dra
+  - name: pull-kubernetes-node-crio-dra
     cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+\.\d+  # per-release image
@@ -753,6 +760,7 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-cri-o
+      testgrid-tab-name: pull-kubernetes-node-crio-dra
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -810,6 +818,7 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-containerd
+      testgrid-tab-name: pull-kubernetes-node-e2e-containerd-1-7-dra
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 1.7
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -861,6 +870,7 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-containerd
+      testgrid-tab-name: pull-kubernetes-node-e2e-containerd-2-0-dra
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 2.1
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
@@ -915,6 +925,7 @@ presubmits:
       preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-containerd
+      testgrid-tab-name: pull-kubernetes-node-e2e-containerd-2-0-dra-alpha-beta-features
       description: Runs all E2E node tests for Dynamic Resource Allocation features with containerd 2.1 and with all feature gates enabled (including non-DRA feature gates)
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"

--- a/config/jobs/kubernetes/sig-node/dra.generate.conf
+++ b/config/jobs/kubernetes/sig-node/dra.generate.conf
@@ -104,7 +104,7 @@ cluster = eks-prow-build-cluster
 run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
 
 # This job runs the node e2e tests for DRA with CRI-O
-[node-e2e-crio-dra]
+[node-crio-dra]
 job_type = node
 need_test_infra_repo = true
 description = Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O
@@ -112,7 +112,7 @@ image_config_file = /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/lates
 inject_ssh_public_key = true
 release_informing = true
 
-# This job runs the same tests as ci-node-e2e-crio-dra with Containerd 1.7 runtime
+# This job runs the same tests as ci-node-crio-dra with Containerd 1.7 runtime
 [node-e2e-containerd-1-7-dra]
 job_type = node
 need_test_infra_repo = true
@@ -120,7 +120,7 @@ description = Runs E2E node tests for Dynamic Resource Allocation on-by-default 
 image_config_file = /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
 release_informing = true
 
-# This job runs the same tests as ci-node-e2e-crio-dra with Containerd 2.0 runtime
+# This job runs the same tests as ci-node-crio-dra with Containerd 2.0 runtime
 [node-e2e-containerd-2-0-dra]
 job_type = node
 need_test_infra_repo = true

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -49,6 +49,7 @@ presubmits:
       {%- endif %}
     annotations:
       testgrid-dashboards: {{testgrid_dashboards}}
+      testgrid-tab-name: {{job_name}}
       description: {{description}}
       testgrid-alert-email: {{testgrid_alert_email}}
       {%- if not canary and ( not all_features or presubmit ) %}

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -152,7 +152,7 @@ periodics:
     description: "Uses kubetest to run serial node-e2e tests (+Serial|+Flaky, (Benchmark|Node*Feature|Feature:OffByDefault)"
 
 
-- name: ci-kubernetes-node-kubelet-serial-crio
+- name: ci-node-crio-kubelet-serial
   cluster: k8s-infra-prow-build
   interval: 12h
   labels:
@@ -173,7 +173,7 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: ci-kubernetes-node-kubelet-serial-crio
+    testgrid-tab-name: ci-node-crio-kubelet-serial
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-node; runs serial node-e2e tests with CRI-O (+Serial, -Flaky|Benchmark|Node*Feature|Feature:OffByDefault)"
   spec:
@@ -268,7 +268,7 @@ periodics:
             cpu: 4
             memory: 6Gi
 
-- name: ci-kubernetes-node-swap-fedora
+- name: ci-node-crio-swap
   cluster: k8s-infra-prow-build
   interval: 4h
   labels:
@@ -289,7 +289,7 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-node-kubelet, sig-node-cri-o
-    testgrid-tab-name: kubelet-gce-e2e-swap-fedora
+    testgrid-tab-name: ci-node-crio-swap
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: Executes E2E suite with swap enabled on Fedora
   spec:
@@ -377,12 +377,12 @@ periodics:
             cpu: 4
             memory: 6Gi
 
-- name: ci-kubernetes-node-swap-fedora-serial
+- name: ci-node-crio-swap-serial
   interval: 4h
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-dashboards: sig-node-kubelet, sig-node-cri-o
-    testgrid-tab-name: kubelet-gce-e2e-swap-fedora-serial
+    testgrid-tab-name: ci-node-crio-swap-serial
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Run serial node e2e tests with swap environment on Fedora"
   labels:
@@ -487,12 +487,12 @@ periodics:
             cpu: 4
             memory: 6Gi
 
-- name: ci-kubernetes-node-swap-conformance-fedora-serial
+- name: ci-node-crio-swap-conformance-serial
   interval: 4h
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-dashboards: sig-node-kubelet, sig-node-cri-o
-    testgrid-tab-name: kubelet-swap-conformance-fedora-serial
+    testgrid-tab-name: ci-node-crio-swap-conformance-serial
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Run serial swap conformance e2e tests with swap environment on Fedora"
   labels:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1251,7 +1251,7 @@ presubmits:
             env:
               - name: GOPATH
                 value: /go
-    - name: pull-kubernetes-node-crio-imagefs-e2e
+    - name: pull-node-crio-imagefs-e2e
       cluster: k8s-infra-prow-build
       always_run: false
       optional: true
@@ -1274,7 +1274,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-imagefs-e2e
+        testgrid-tab-name: pull-node-crio-imagefs-e2e
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -1305,9 +1305,9 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-kubernetes-node-crio-userns-e2e-serial
+    - name: pull-node-crio-userns-serial
       cluster: k8s-infra-prow-build
-      # explicitly needs /test pull-kubernetes-node-crio-userns-e2e-serial to run
+      # explicitly needs /test pull-node-crio-userns-serial to run
       always_run: false
       optional: true
       max_concurrency: 12
@@ -1329,7 +1329,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-userns-e2e-serial
+        testgrid-tab-name: pull-node-crio-userns-serial
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -1358,7 +1358,7 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-kubernetes-node-crio-splitfs-e2e
+    - name: pull-node-crio-splitfs-e2e
       cluster: k8s-infra-prow-build
       always_run: false
       optional: true
@@ -1381,7 +1381,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-splitfs-e2e
+        testgrid-tab-name: pull-node-crio-splitfs-e2e
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -1412,9 +1412,9 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-kubernetes-node-crio-evented-pleg-e2e
+    - name: pull-node-crio-evented-pleg
       cluster: k8s-infra-prow-build
-      # explicitly needs /test pull-kubernetes-node-crio-evented-pleg-e2e to run
+      # explicitly needs /test pull-node-crio-evented-pleg to run
       always_run: false
       optional: true
       skip_branches:
@@ -1435,7 +1435,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-evented-pleg-gce-e2e
+        testgrid-tab-name: pull-node-crio-evented-pleg
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -1513,9 +1513,9 @@ presubmits:
               requests:
                 cpu: 4
                 memory: 6Gi
-    - name: pull-kubernetes-node-crio-e2e
+    - name: pull-node-crio-e2e
       cluster: k8s-infra-prow-build
-      # explicitly needs /test pull-kubernetes-node-crio-e2e to run
+      # explicitly needs /test pull-node-crio-e2e to run
       always_run: false
       # if at all it is run and fails, don't block the PR
       optional: true
@@ -1539,7 +1539,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-gce-e2e
+        testgrid-tab-name: pull-node-crio-e2e
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -1569,9 +1569,9 @@ presubmits:
               - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:PodLevelResources\]|\[Alpha\]
               - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
               - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config.yaml
-    - name: pull-kubernetes-node-crio-e2e-canary
+    - name: pull-node-crio-e2e-canary
       cluster: k8s-infra-prow-build
-      # explicitly needs /test pull-kubernetes-node-crio-e2e-canary to run
+      # explicitly needs /test pull-node-crio-e2e-canary to run
       always_run: false
       # if at all it is run and fails, don't block the PR
       optional: true
@@ -1595,7 +1595,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-gce-e2e-canary
+        testgrid-tab-name: pull-node-crio-e2e-canary
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -1625,9 +1625,9 @@ presubmits:
               - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:PodLevelResources\]|\[Alpha\]
               - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
               - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-canary.yaml
-    - name: pull-kubernetes-node-kubelet-serial-crio
+    - name: pull-node-crio-kubelet-serial
       cluster: k8s-infra-prow-build
-      # explicitly needs /test pull-kubernetes-node-kubelet-serial-crio to run
+      # explicitly needs /test pull-node-crio-kubelet-serial to run
       always_run: false
       optional: true
       skip_report: false
@@ -1650,7 +1650,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-node-kubelet-serial-crio
+        testgrid-tab-name: pull-node-crio-kubelet-serial
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -1684,7 +1684,7 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-crio-node-e2e-hugepages
+    - name: pull-node-crio-hugepages
       cluster: k8s-infra-prow-build
       always_run: false
       optional: true
@@ -1711,7 +1711,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-kubelet-crio-node-e2e-hugepages
+        testgrid-tab-name: pull-node-crio-hugepages
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -1743,7 +1743,7 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-crio-node-e2e-resource-managers
+    - name: pull-node-crio-resource-managers
       cluster: k8s-infra-prow-build
       always_run: false
       optional: true
@@ -1770,7 +1770,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-node-e2e-resource-managers
+        testgrid-tab-name: pull-node-crio-resource-managers
         description: "Executes CPU, Memory and Topology manager e2e tests for crio"
       spec:
         containers:
@@ -1856,9 +1856,9 @@ presubmits:
             env:
               - name: GOPATH
                 value: /go
-    - name: pull-kubernetes-crio-node-memoryqos
+    - name: pull-node-crio-memoryqos
       cluster: k8s-infra-prow-build
-      # explicitly needs /test pull-kubernetes-crio-node-memoryqos to run
+      # explicitly needs /test pull-node-crio-memoryqos to run
       always_run: false
       optional: true
       max_concurrency: 12
@@ -1881,7 +1881,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-node-memoryqos
+        testgrid-tab-name: pull-node-crio-memoryqos
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -1911,13 +1911,13 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-kubernetes-node-swap-fedora
+    - name: pull-node-crio-swap
       cluster: k8s-infra-prow-build
       skip_branches:
         - release-\d+\.\d+ # per-release image
       annotations:
         testgrid-dashboards: sig-node-presubmits
-        testgrid-tab-name: pr-kubelet-gce-e2e-swap-fedora
+        testgrid-tab-name: pull-node-crio-swap
       always_run: false
       skip_report: false
       optional: true
@@ -2016,13 +2016,13 @@ presubmits:
                 cpu: 4
                 memory: 6Gi
 
-    - name: pull-kubernetes-node-swap-fedora-serial
+    - name: pull-node-crio-swap-serial
       cluster: k8s-infra-prow-build
       skip_branches:
         - release-\d+\.\d+ # per-release image
       annotations:
         testgrid-dashboards: sig-node-presubmits
-        testgrid-tab-name: pr-kubelet-gce-e2e-swap-fedora-serial
+        testgrid-tab-name: pull-node-crio-swap-serial
       always_run: false
       skip_report: false
       optional: true
@@ -2125,13 +2125,13 @@ presubmits:
                 cpu: 4
                 memory: 6Gi
 
-    - name: pull-kubernetes-node-swap-conformance-fedora-serial
+    - name: pull-node-crio-swap-conformance-serial
       cluster: k8s-infra-prow-build
       skip_branches:
         - release-\d+\.\d+ # per-release image
       annotations:
         testgrid-dashboards: sig-node-presubmits
-        testgrid-tab-name: pr-kubelet-swap-conformance-fedora-serial
+        testgrid-tab-name: pull-node-crio-swap-conformance-serial
       always_run: false
       skip_report: false
       optional: true
@@ -2490,7 +2490,7 @@ presubmits:
               limits:
                 cpu: 4
                 memory: 6Gi
-    - name: pull-crio-node-e2e-eviction
+    - name: pull-node-crio-eviction
       cluster: k8s-infra-prow-build
       always_run: false
       optional: true
@@ -2514,7 +2514,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-node-e2e-eviction
+        testgrid-tab-name: pull-node-crio-eviction
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -2547,7 +2547,7 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-crio-imagefs-separatedisktest
+    - name: pull-node-crio-imagefs-separatedisk
       cluster: k8s-infra-prow-build
       always_run: false
       optional: true
@@ -2571,7 +2571,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-imagefs-e2e-separatedisktest
+        testgrid-tab-name: pull-node-crio-imagefs-separatedisk
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
@@ -2603,7 +2603,7 @@ presubmits:
                 value: core
               - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
                 value: "1"
-    - name: pull-crio-splitfs-separate-disk
+    - name: pull-node-crio-splitfs-separatedisk
       cluster: k8s-infra-prow-build
       always_run: false
       optional: true
@@ -2627,7 +2627,7 @@ presubmits:
         preset-pull-kubernetes-e2e-gce: "true"
       annotations:
         testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
-        testgrid-tab-name: pr-crio-splitfs-separate-disk
+        testgrid-tab-name: pull-node-crio-splitfs-separatedisk
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -219,6 +219,7 @@ periodics:
 - annotations:
     testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o, sig-release-1.33-informing
+    testgrid-tab-name: ci-node-crio-dra-1-33
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
@@ -237,7 +238,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-node-e2e-crio-dra-1-33
+  name: ci-node-crio-dra-1-33
   spec:
     containers:
     - args:
@@ -1762,7 +1763,7 @@ presubmits:
     branches:
     - release-1.33
     cluster: k8s-infra-prow-build
-    context: pull-kubernetes-node-e2e-crio-dra
+    context: pull-kubernetes-node-crio-dra
     decorate: true
     decoration_config:
       timeout: 1h30m0s
@@ -1774,7 +1775,7 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
-    name: pull-kubernetes-node-e2e-crio-dra
+    name: pull-kubernetes-node-crio-dra
     optional: true
     path_alias: k8s.io/kubernetes
     spec:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -499,6 +499,7 @@ periodics:
 - annotations:
     testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
     testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o, sig-release-1.34-informing
+    testgrid-tab-name: ci-node-crio-dra-1-34
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
@@ -517,7 +518,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-node-e2e-crio-dra-1-34
+  name: ci-node-crio-dra-1-34
   spec:
     containers:
     - args:
@@ -2572,7 +2573,7 @@ presubmits:
     branches:
     - release-1.34
     cluster: k8s-infra-prow-build
-    context: pull-kubernetes-node-e2e-crio-dra
+    context: pull-kubernetes-node-crio-dra
     decorate: true
     decoration_config:
       timeout: 1h30m0s
@@ -2584,7 +2585,7 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
-    name: pull-kubernetes-node-e2e-crio-dra
+    name: pull-kubernetes-node-crio-dra
     optional: true
     path_alias: k8s.io/kubernetes
     spec:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -620,6 +620,7 @@ periodics:
 - annotations:
     testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
     testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o, sig-release-1.35-informing
+    testgrid-tab-name: ci-node-crio-dra-1-35
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
@@ -638,7 +639,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-node-e2e-crio-dra-1-35
+  name: ci-node-crio-dra-1-35
   spec:
     containers:
     - args:
@@ -2854,7 +2855,7 @@ presubmits:
     branches:
     - release-1.35
     cluster: k8s-infra-prow-build
-    context: pull-kubernetes-node-e2e-crio-dra
+    context: pull-kubernetes-node-crio-dra
     decorate: true
     decoration_config:
       timeout: 1h30m0s
@@ -2866,7 +2867,7 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
-    name: pull-kubernetes-node-e2e-crio-dra
+    name: pull-kubernetes-node-crio-dra
     optional: true
     path_alias: k8s.io/kubernetes
     spec:

--- a/jobs/e2e_node/crio/README.md
+++ b/jobs/e2e_node/crio/README.md
@@ -72,4 +72,4 @@ Make sure the specified cri-o version is uploaded to
 otherwise the tests should fail.
 
 You can test the cri-o version change by changing [env-canary.yaml](./templates/base/env-canary.yaml)
-and run `pull-kubernetes-node-crio-e2e-canary`.
+and run `pull-node-crio-e2e-canary`.


### PR DESCRIPTION
Standardize all CRI-O job names to use consistent `ci-node-crio-*` / `pull-node-crio-*` prefixes, set `testgrid-tab-name` = job name for all jobs, and fix a copy-paste description error.

Fixes https://github.com/kubernetes/test-infra/issues/36474
Supersedes https://github.com/kubernetes/test-infra/pull/36478

/sig node

cc @kubernetes/sig-node-cri-o-test-maintainers

### Periodic Jobs

| Old Name | New Name |
|---|---|
| `ci-crio-node-e2e-features` | `ci-node-crio-features` |
| `ci-crio-node-e2e-unlabelled` | `ci-node-crio-unlabelled` |
| `ci-crio-node-e2e-eviction` | `ci-node-crio-eviction` |
| `ci-crio-node-e2e-conformance` | `ci-node-crio-conformance` |
| `ci-crio-node-e2e-resource-managers` | `ci-node-crio-resource-managers` |
| `ci-crio-node-e2e-hugepages` | `ci-node-crio-hugepages` |
| `ci-crio-userns-e2e-serial` | `ci-node-crio-userns-serial` |
| `ci-node-kubelet-crio-performance-test` | `ci-node-crio-performance` |
| `ci-kubernetes-node-kubelet-serial-crio` | `ci-node-crio-kubelet-serial` |
| `ci-kubernetes-node-swap-fedora` | `ci-node-crio-swap` |
| `ci-kubernetes-node-swap-fedora-serial` | `ci-node-crio-swap-serial` |
| `ci-kubernetes-node-swap-conformance-fedora-serial` | `ci-node-crio-swap-conformance-serial` |
| `ci-node-e2e-crio-dra` | `ci-node-crio-dra` |
| `ci-node-e2e-crio-dra-1-33` | `ci-node-crio-dra-1-33` |
| `ci-node-e2e-crio-dra-1-34` | `ci-node-crio-dra-1-34` |
| `ci-node-e2e-crio-dra-1-35` | `ci-node-crio-dra-1-35` |

### Presubmit Jobs

| Old Name | New Name |
|---|---|
| `pull-kubernetes-node-crio-e2e` | `pull-node-crio-e2e` |
| `pull-kubernetes-node-crio-e2e-canary` | `pull-node-crio-e2e-canary` |
| `pull-kubernetes-node-crio-imagefs-e2e` | `pull-node-crio-imagefs-e2e` |
| `pull-kubernetes-node-crio-userns-e2e-serial` | `pull-node-crio-userns-serial` |
| `pull-kubernetes-node-crio-splitfs-e2e` | `pull-node-crio-splitfs-e2e` |
| `pull-kubernetes-node-crio-evented-pleg-e2e` | `pull-node-crio-evented-pleg` |
| `pull-kubernetes-node-kubelet-serial-crio` | `pull-node-crio-kubelet-serial` |
| `pull-crio-node-e2e-hugepages` | `pull-node-crio-hugepages` |
| `pull-crio-node-e2e-resource-managers` | `pull-node-crio-resource-managers` |
| `pull-crio-node-e2e-eviction` | `pull-node-crio-eviction` |
| `pull-crio-imagefs-separatedisktest` | `pull-node-crio-imagefs-separatedisk` |
| `pull-crio-splitfs-separate-disk` | `pull-node-crio-splitfs-separatedisk` |
| `pull-kubernetes-crio-node-memoryqos` | `pull-node-crio-memoryqos` |
| `pull-kubernetes-node-swap-fedora` | `pull-node-crio-swap` |
| `pull-kubernetes-node-swap-fedora-serial` | `pull-node-crio-swap-serial` |
| `pull-kubernetes-node-swap-conformance-fedora-serial` | `pull-node-crio-swap-conformance-serial` |
| `pull-kubernetes-node-e2e-crio-dra` | `pull-kubernetes-node-crio-dra` |
| `pull-kubernetes-node-e2e-crio-dra-canary` | `pull-kubernetes-node-crio-dra-canary` |

### Other Changes

| Change | Details |
|---|---|
| Fix description | `ci-node-crio-performance` said "Eviction" instead of "Performance" |
| DRA template | Added `testgrid-tab-name` to `dra.jinja` for all DRA jobs |
| DRA config | Renamed section `node-e2e-crio-dra` → `node-crio-dra` in `dra.generate.conf` |
| README | Updated job name reference in `jobs/e2e_node/crio/README.md` |

> **Note:** DRA presubmit jobs keep the `pull-kubernetes-` prefix (`pull-kubernetes-node-crio-dra`) because it is generated by the shared DRA template (`dra.jinja`).