### PR TITLE
Rename ci-kubernetes-node-kubelet-serial-cri-o to use crio

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -152,7 +152,7 @@ periodics:
     description: "Uses kubetest to run serial node-e2e tests (+Serial|+Flaky, (Benchmark|Node*Feature|Feature:OffByDefault)"
 
 
-- name: ci-kubernetes-node-kubelet-serial-cri-o
+- name: ci-kubernetes-node-kubelet-serial-crio
   cluster: k8s-infra-prow-build
   interval: 12h
   labels:
@@ -173,7 +173,7 @@ periodics:
     path_alias: k8s.io/test-infra
   annotations:
     testgrid-dashboards: sig-node-cri-o
-    testgrid-tab-name: node-kubelet-serial-crio
+    testgrid-tab-name: ci-kubernetes-node-kubelet-serial-crio
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "OWNER: sig-node; runs serial node-e2e tests with CRI-O (+Serial, -Flaky|Benchmark|Node*Feature|Feature:OffByDefault)"
   spec:


### PR DESCRIPTION
- Rename `ci-kubernetes-node-kubelet-serial-cri-o` to `ci-kubernetes-node-kubelet-serial-crio` for consistency with all other CRI-O jobs
- Align `testgrid-tab-name` with the job name

Part of https://github.com/kubernetes/test-infra/issues/36474

/sig node
/area test-infra

cc @kubernetes/sig-node-cri-o-test-maintainers