### PR TITLE
test-infra: increase unit-test memory requirements, II

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -86,10 +86,10 @@ presubmits:
         resources:
           requests:
             cpu: "7"
-            memory: "12Gi"
+            memory: "16Gi"
           limits:
             cpu: "7"
-            memory: "12Gi"
+            memory: "16Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: unit-test


### PR DESCRIPTION
A recent PR seems to suffer from OOM killing (output ends in the middle of unit testing, job is not cleaned up). The dashboards shows a peak that ends at 9GiB, so the original 8Gi were definitely not enough, but even more seems to be needed.

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/test-infra/33958/pull-test-infra-unit-test/2024189294251347968 is the one which died despite the increased limit, peaking at 9GiB before dying.

