### PR TITLE
Double the exec service memory requests to handle OOM

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1159,9 +1159,9 @@ periodics:
       - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
         value: "21474836480"
       - name: CL2_EXECSERVICE_CPU_REQUESTS
-        value: "2"
+        value: "4"
       - name: CL2_EXECSERVICE_MEMORY_REQUESTS
-        value: "4Gi"
+        value: "8Gi"
       - name: CL2_EXECSERVICE_TOLERATE_CONTROL_PLANE
         value: "true"
       - name: CL2_DAEMONSET_POD_PAYLOAD_SIZE


### PR DESCRIPTION

```
W0217 18:46:33.178624   24470 api_availability_measurement.go:83] execservice issue: problem with RunCommand(): output="", err=signal: killed
W0217 18:46:33.178636   24470 api_availability_measurement.go:86] host 10.128.0.3 not available; HTTP status code:
```

/cc @mborsz @dims @upodroid 