### PR TITLE
test-infra: revert increase of unit-test memory requirements

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -86,10 +86,10 @@ presubmits:
         resources:
           requests:
             cpu: "7"
-            memory: "16Gi"
+            memory: "8Gi"
           limits:
             cpu: "7"
-            memory: "16Gi"
+            memory: "8Gi"
     annotations:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: unit-test


### PR DESCRIPTION
The job was failing because of [a broken test](https://github.com/kubernetes/test-infra/pull/33958#issuecomment-3925515370) which exhausted all available memory until it got killed. The original 8GiB are fine.

/assign @dims 