### PR TITLE
Enable all APIs in HPA test

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -599,6 +599,7 @@ periodics:
       - --extract=ci/latest
       - --timeout=240m
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true
+      - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:HPA\]
         --minStartupPods=8
       - --ginkgo-parallel=10


### PR DESCRIPTION
My previous [PR](https://github.com/kubernetes/test-infra/pull/36465) has been failing. 
I believe this change will fix it.