### PR TITLE
Fix EC2 CI job reliability: switch to gcsweb and bump serial timeout

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -408,16 +408,16 @@ presubmits:
             - -c
             - |
               cd kubetest2-ec2 && GOPROXY=direct go install .
-              VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
+              VERSION=$(curl -Ls --retry 5 --retry-delay 10 --retry-all-errors https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/latest-fast.txt)
               kubetest2 ec2 \
-               --stage https://dl.k8s.io/ci/fast/ \
+               --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/ \
                --version $VERSION \
                --up \
                --down \
                --test=ginkgo \
                -- \
                --parallel=30 \
-               --test-package-url=https://dl.k8s.io/ \
+               --test-package-url=https://gcsweb.k8s.io/gcs/k8s-release-dev/ \
                --test-package-dir=ci/fast \
                --test-package-marker=latest-fast.txt \
                --focus-regex='Pods should be submitted and removed'
@@ -463,9 +463,9 @@ presubmits:
             - -c
             - |
               cd kubetest2-ec2 && GOPROXY=direct go install .
-              VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
+              VERSION=$(curl -Ls --retry 5 --retry-delay 10 --retry-all-errors https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/latest-fast.txt)
               kubetest2 ec2 \
-               --stage https://dl.k8s.io/ci/fast/ \
+               --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/ \
                --external-cloud-provider true \
                --version $VERSION \
                --up \
@@ -473,7 +473,7 @@ presubmits:
                --test=ginkgo \
                -- \
                --parallel=30 \
-               --test-package-url=https://dl.k8s.io/ \
+               --test-package-url=https://gcsweb.k8s.io/gcs/k8s-release-dev/ \
                --test-package-dir=ci/fast \
                --test-package-marker=latest-fast.txt \
                --focus-regex='Pods should be submitted and removed'

--- a/config/jobs/kubernetes/sig-node/ec2-containerd-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd-presubmit.yaml
@@ -110,6 +110,8 @@ presubmits:
       optional: true
       cluster: eks-prow-build-cluster
       decorate: true
+      decoration_config:
+        timeout: 4h
       extra_refs:
         - org: kubernetes
           repo: kubernetes


### PR DESCRIPTION
- Switch dl.k8s.io/ci/fast to gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast for ec2-quick and ec2-cloud-provider-quick presubmit jobs to avoid transient 404s from the dl.k8s.io CDN
- Add curl retry flags (--retry 5 --retry-delay 10 --retry-all-errors) when fetching latest-fast.txt version
- Add decoration_config timeout of 4h to the serial node e2e canary job which was using the 2h Prow default, insufficient for serial tests