### PR TITLE
Bump CAPZ version to 1.24 for azure scalability test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
@@ -17,7 +17,7 @@ periodics:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.24
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     - org: kubernetes-sigs
       repo: cloud-provider-azure


### PR DESCRIPTION
This PR bumps the capz test branch to `release-1.24` which includes a fix for the following error:
`error: featureGates: Invalid value: {"ControlPlaneKubeletLocalMode":true}: ControlPlaneKubeletLocalMode is not a valid feature name.`

Ref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6044