### PR TITLE
testgrid: rename master to main in OpenShift nightly test groups for 4.8-4.11

### DIFF
--- a/config/testgrids/openshift/assisted-installer.yaml
+++ b/config/testgrids/openshift/assisted-installer.yaml
@@ -55,8 +55,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-single-node-live-iso
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-single-node-live-iso
+  - name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-single-node-live-iso
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -82,8 +82,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-single-node-live-iso
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-single-node-live-iso
+  - name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-single-node-live-iso
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.10-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.10-informing.yaml
@@ -1639,14 +1639,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-console-aws
+    name: periodic-ci-openshift-release-main-nightly-4.10-console-aws
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-console-aws
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-console-aws
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1666,14 +1666,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-credentials-request-freeze
+    name: periodic-ci-openshift-release-main-nightly-4.10-credentials-request-freeze
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-credentials-request-freeze
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-credentials-request-freeze
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1693,14 +1693,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-alibaba
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-alibaba
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-alibaba
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-alibaba
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1720,14 +1720,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-alibaba-csi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-alibaba-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-alibaba-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-alibaba-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1747,14 +1747,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1774,14 +1774,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-cgroupsv2
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-cgroupsv2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-cgroupsv2
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-cgroupsv2
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1801,14 +1801,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-crun
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-crun
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-crun
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-crun
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1828,14 +1828,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-csi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1855,14 +1855,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-fips
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1882,14 +1882,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1909,14 +1909,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-ovn-local-gateway
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-ovn-local-gateway
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-ovn-local-gateway
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-ovn-local-gateway
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1936,14 +1936,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-proxy
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-proxy
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-proxy
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-proxy
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1963,14 +1963,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1990,14 +1990,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node-serial
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2017,14 +2017,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2044,14 +2044,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade-rollback-oldest-supported
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upgrade-rollback-oldest-supported
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade-rollback-oldest-supported
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upgrade-rollback-oldest-supported
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2071,14 +2071,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2098,14 +2098,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-workers-rhel8
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-workers-rhel8
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-workers-rhel8
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-workers-rhel8
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2125,14 +2125,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2152,14 +2152,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-csi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2179,14 +2179,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-deploy-cnv
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-deploy-cnv
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-deploy-cnv
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-deploy-cnv
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2206,14 +2206,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-fips
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2233,14 +2233,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2260,14 +2260,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-upgrade-cnv
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-upgrade-cnv
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-upgrade-cnv
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-upgrade-cnv
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2287,14 +2287,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-upi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2314,14 +2314,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azurestack-csi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azurestack-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azurestack-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azurestack-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2341,14 +2341,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azurestack-upi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azurestack-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azurestack-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azurestack-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2368,14 +2368,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2395,14 +2395,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-csi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2422,14 +2422,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-fips
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2449,14 +2449,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2476,14 +2476,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-rt
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-rt
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-rt
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-rt
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2503,14 +2503,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-serial
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2530,14 +2530,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-upi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2557,14 +2557,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ibmcloud-csi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ibmcloud-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ibmcloud-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ibmcloud-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2584,14 +2584,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2611,14 +2611,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-bm
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-bm
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-bm
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-bm
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2638,14 +2638,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-ovn-dualstack
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-ovn-dualstack
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-ovn-dualstack
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-ovn-dualstack
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2665,14 +2665,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-ovn-ipv6
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-ovn-ipv6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-ovn-ipv6
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-ovn-ipv6
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2692,14 +2692,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ipv4
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ipv4
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ipv4
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ipv4
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2719,14 +2719,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ovn-dualstack
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ovn-dualstack
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ovn-dualstack
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ovn-dualstack
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2746,14 +2746,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ovn-ipv6
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ovn-ipv6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ovn-ipv6
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ovn-ipv6
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2773,14 +2773,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-virtualmedia
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-virtualmedia
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-virtualmedia
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-virtualmedia
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2800,14 +2800,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2827,14 +2827,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2854,14 +2854,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-single-node-live-iso
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-single-node-live-iso
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-single-node-live-iso
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2881,14 +2881,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2908,14 +2908,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt-csi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2935,14 +2935,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt-ovn
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt-ovn
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt-ovn
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt-ovn
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2962,14 +2962,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2989,14 +2989,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-csi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3016,14 +3016,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-ovn
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-ovn
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-ovn
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-ovn
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3043,14 +3043,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-serial
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3070,14 +3070,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-techpreview
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-techpreview
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-techpreview
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-techpreview
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3097,14 +3097,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-techpreview-serial
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-techpreview-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-techpreview-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-techpreview-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3124,14 +3124,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-upi
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3151,14 +3151,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-upi-serial
+    name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-upi-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3178,14 +3178,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.8-e2e-aws-upgrade-paused
+    name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.8-e2e-aws-upgrade-paused
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.8-e2e-aws-upgrade-paused
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.8-e2e-aws-upgrade-paused
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3205,14 +3205,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3232,14 +3232,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade-ovn-single-node
+    name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade-ovn-single-node
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade-ovn-single-node
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade-ovn-single-node
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3259,14 +3259,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3286,14 +3286,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade-ovn-ipv6
+    name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade-ovn-ipv6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade-ovn-ipv6
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade-ovn-ipv6
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3497,130 +3497,130 @@ test_groups:
   name: periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-e2e-vsphere-upgrade
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-from-stable-4.8-e2e-aws-upgrade
   name: periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-from-stable-4.8-e2e-aws-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-console-aws
-  name: periodic-ci-openshift-release-master-nightly-4.10-console-aws
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-credentials-request-freeze
-  name: periodic-ci-openshift-release-master-nightly-4.10-credentials-request-freeze
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-alibaba
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-alibaba
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-alibaba-csi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-alibaba-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-cgroupsv2
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-cgroupsv2
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-crun
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-crun
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-csi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-fips
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-ovn-local-gateway
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-ovn-local-gateway
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-proxy
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-proxy
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node-serial
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade-rollback-oldest-supported
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade-rollback-oldest-supported
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-workers-rhel8
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-workers-rhel8
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-azure
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-csi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-deploy-cnv
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-deploy-cnv
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-fips
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-upgrade-cnv
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-upgrade-cnv
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-upi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-azurestack-csi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azurestack-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-azurestack-upi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-azurestack-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-csi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-fips
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-rt
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-rt
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-serial
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-upi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-ibmcloud-csi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ibmcloud-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-bm
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-bm
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-ovn-dualstack
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-ovn-dualstack
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-ovn-ipv6
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-ovn-ipv6
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ipv4
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ipv4
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ovn-dualstack
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ovn-dualstack
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ovn-ipv6
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-ovn-ipv6
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-virtualmedia
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-serial-virtualmedia
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-single-node-live-iso
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-single-node-live-iso
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt-csi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt-ovn
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt-ovn
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-csi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-ovn
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-ovn
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-serial
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-techpreview
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-techpreview
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-techpreview-serial
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-techpreview-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-upi
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-upi-serial
-  name: periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-upi-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.8-e2e-aws-upgrade-paused
-  name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.8-e2e-aws-upgrade-paused
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade-ovn-single-node
-  name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade-ovn-single-node
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade-ovn-ipv6
-  name: periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade-ovn-ipv6
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-console-aws
+  name: periodic-ci-openshift-release-main-nightly-4.10-console-aws
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-credentials-request-freeze
+  name: periodic-ci-openshift-release-main-nightly-4.10-credentials-request-freeze
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-alibaba
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-alibaba
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-alibaba-csi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-alibaba-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-cgroupsv2
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-cgroupsv2
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-crun
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-crun
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-csi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-fips
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-ovn-local-gateway
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-ovn-local-gateway
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-proxy
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-proxy
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node-serial
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upgrade-rollback-oldest-supported
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upgrade-rollback-oldest-supported
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-workers-rhel8
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-workers-rhel8
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-azure
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-csi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-deploy-cnv
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-deploy-cnv
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-fips
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-upgrade-cnv
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-upgrade-cnv
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-upi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azure-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-azurestack-csi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azurestack-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-azurestack-upi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-azurestack-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-csi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-fips
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-rt
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-rt
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-serial
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-upi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-gcp-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-ibmcloud-csi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ibmcloud-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-bm
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-bm
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-ovn-dualstack
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-ovn-dualstack
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-ovn-ipv6
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-ovn-ipv6
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ipv4
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ipv4
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ovn-dualstack
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ovn-dualstack
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ovn-ipv6
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-ovn-ipv6
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-virtualmedia
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-serial-virtualmedia
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-single-node-live-iso
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-single-node-live-iso
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt-csi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt-ovn
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-ovirt-ovn
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-csi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-ovn
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-ovn
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-serial
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-techpreview
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-techpreview
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-techpreview-serial
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-techpreview-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi-serial
+  name: periodic-ci-openshift-release-main-nightly-4.10-e2e-vsphere-upi-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.8-e2e-aws-upgrade-paused
+  name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.8-e2e-aws-upgrade-paused
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade-ovn-single-node
+  name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade-ovn-single-node
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade-ovn-ipv6
+  name: periodic-ci-openshift-release-main-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade-ovn-ipv6
 - gcs_prefix: test-platform-results/logs/promote-release-openshift-machine-os-content-e2e-aws-4.10-ppc64le
   name: promote-release-openshift-machine-os-content-e2e-aws-4.10-ppc64le
 - gcs_prefix: test-platform-results/logs/promote-release-openshift-machine-os-content-e2e-aws-4.10-s390x

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.11-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.11-informing.yaml
@@ -1936,14 +1936,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-console-aws
+    name: periodic-ci-openshift-release-main-nightly-4.11-console-aws
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-console-aws
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-console-aws
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1963,14 +1963,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-credentials-request-freeze
+    name: periodic-ci-openshift-release-main-nightly-4.11-credentials-request-freeze
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-credentials-request-freeze
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-credentials-request-freeze
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1990,14 +1990,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-alibaba
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-alibaba
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-alibaba
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-alibaba
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2017,14 +2017,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-alibaba-csi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-alibaba-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-alibaba-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-alibaba-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2044,14 +2044,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2071,14 +2071,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-cgroupsv2
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-cgroupsv2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-cgroupsv2
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-cgroupsv2
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2098,14 +2098,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-crun
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-crun
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-crun
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-crun
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2125,14 +2125,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-csi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2152,14 +2152,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-csi-migration
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-csi-migration
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-csi-migration
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-csi-migration
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2179,14 +2179,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-fips
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2206,14 +2206,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2233,14 +2233,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-local-gateway
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-local-gateway
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-local-gateway
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-local-gateway
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2260,14 +2260,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-serial
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2287,14 +2287,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-single-node-workers
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-single-node-workers
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-single-node-workers
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-single-node-workers
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2314,14 +2314,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-single-node-workers-serial
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-single-node-workers-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-single-node-workers-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-single-node-workers-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2341,14 +2341,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-proxy
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-proxy
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-proxy
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-proxy
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2368,14 +2368,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-serial
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2395,14 +2395,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2422,14 +2422,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node-serial
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2449,14 +2449,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2476,14 +2476,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-upi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2503,14 +2503,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-workers-rhel8
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-workers-rhel8
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-workers-rhel8
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-workers-rhel8
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2530,14 +2530,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2557,14 +2557,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-csi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2584,14 +2584,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-deploy-cnv
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-deploy-cnv
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-deploy-cnv
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-deploy-cnv
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2611,14 +2611,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-fips
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2638,14 +2638,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2665,14 +2665,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-upgrade-cnv
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-upgrade-cnv
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-upgrade-cnv
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-upgrade-cnv
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2692,14 +2692,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-upi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2719,14 +2719,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azurestack-csi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azurestack-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azurestack-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azurestack-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2746,14 +2746,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azurestack-upi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azurestack-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azurestack-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azurestack-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2773,14 +2773,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2800,14 +2800,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-csi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2827,14 +2827,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-csi-migration
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-csi-migration
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-csi-migration
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-csi-migration
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2854,14 +2854,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-fips
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2881,14 +2881,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2908,14 +2908,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-rt
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-rt
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-rt
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-rt
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2935,14 +2935,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-serial
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2962,14 +2962,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-upi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2989,14 +2989,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ibmcloud-csi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ibmcloud-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ibmcloud-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ibmcloud-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3016,14 +3016,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-bm
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-bm
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-bm
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-bm
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3043,14 +3043,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-dualstack
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-dualstack
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-dualstack
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-dualstack
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3070,14 +3070,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-dualstack-local-gateway
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-dualstack-local-gateway
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-dualstack-local-gateway
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-dualstack-local-gateway
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3097,14 +3097,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-ipv4
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-ipv4
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-ipv4
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-ipv4
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3124,14 +3124,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-ipv6
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-ipv6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-ipv6
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-ipv6
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3151,14 +3151,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ipv4
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ipv4
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ipv4
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ipv4
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3178,14 +3178,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ovn-dualstack
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ovn-dualstack
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ovn-dualstack
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ovn-dualstack
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3205,14 +3205,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ovn-ipv6
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ovn-ipv6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ovn-ipv6
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ovn-ipv6
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3232,14 +3232,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-virtualmedia
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-virtualmedia
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-virtualmedia
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-virtualmedia
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3259,14 +3259,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3286,14 +3286,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-upgrade-ovn-ipv6
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-upgrade-ovn-ipv6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-upgrade-ovn-ipv6
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-upgrade-ovn-ipv6
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3313,14 +3313,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-live-iso
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-single-node-live-iso
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-single-node-live-iso
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3340,14 +3340,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-with-worker-live-iso
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-single-node-with-worker-live-iso
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-with-worker-live-iso
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-single-node-with-worker-live-iso
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3367,14 +3367,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3394,14 +3394,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt-csi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3421,14 +3421,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt-ovn
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt-ovn
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt-ovn
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt-ovn
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3448,14 +3448,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3475,14 +3475,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-csi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3502,14 +3502,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-ovn
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-ovn
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-ovn
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-ovn
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3529,14 +3529,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-serial
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3556,14 +3556,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-techpreview
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-techpreview
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-techpreview
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-techpreview
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3583,14 +3583,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-techpreview-serial
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-techpreview-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-techpreview-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-techpreview-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3610,14 +3610,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-upi
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3637,14 +3637,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-upi-serial
+    name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-upi-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-upi-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-upi-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3664,14 +3664,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-install-analysis-all
+    name: periodic-ci-openshift-release-main-nightly-4.11-install-analysis-all
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-install-analysis-all
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-install-analysis-all
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3691,14 +3691,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3718,14 +3718,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade-ovn-single-node
+    name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade-ovn-single-node
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade-ovn-single-node
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade-ovn-single-node
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3745,14 +3745,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3772,14 +3772,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
+    name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -3799,14 +3799,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.9-e2e-aws-upgrade-paused
+    name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.9-e2e-aws-upgrade-paused
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.9-e2e-aws-upgrade-paused
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.9-e2e-aws-upgrade-paused
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -4032,146 +4032,146 @@ test_groups:
   name: periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-vsphere-upgrade
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-from-stable-4.9-e2e-aws-upgrade
   name: periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-from-stable-4.9-e2e-aws-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-console-aws
-  name: periodic-ci-openshift-release-master-nightly-4.11-console-aws
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-credentials-request-freeze
-  name: periodic-ci-openshift-release-master-nightly-4.11-credentials-request-freeze
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-alibaba
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-alibaba
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-alibaba-csi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-alibaba-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-cgroupsv2
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-cgroupsv2
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-crun
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-crun
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-csi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-csi-migration
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-csi-migration
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-fips
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-local-gateway
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-local-gateway
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-serial
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-single-node-workers
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-single-node-workers
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-single-node-workers-serial
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-ovn-single-node-workers-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-proxy
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-proxy
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-serial
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node-serial
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-upi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-workers-rhel8
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-workers-rhel8
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azure
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-csi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-deploy-cnv
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-deploy-cnv
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-fips
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-upgrade-cnv
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-upgrade-cnv
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-upi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azurestack-csi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azurestack-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-azurestack-upi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-azurestack-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-csi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-csi-migration
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-csi-migration
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-fips
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-rt
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-rt
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-serial
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-upi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-ibmcloud-csi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ibmcloud-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-bm
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-bm
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-dualstack
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-dualstack
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-dualstack-local-gateway
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-dualstack-local-gateway
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-ipv4
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-ipv4
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-ipv6
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-ipv6
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ipv4
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ipv4
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ovn-dualstack
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ovn-dualstack
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ovn-ipv6
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-ovn-ipv6
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-virtualmedia
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-serial-virtualmedia
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-upgrade-ovn-ipv6
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-upgrade-ovn-ipv6
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-live-iso
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-live-iso
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-with-worker-live-iso
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-with-worker-live-iso
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt-csi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt-ovn
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-ovirt-ovn
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-csi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-ovn
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-ovn
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-serial
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-techpreview
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-techpreview
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-techpreview-serial
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-techpreview-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-upi
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-upi-serial
-  name: periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-upi-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-install-analysis-all
-  name: periodic-ci-openshift-release-master-nightly-4.11-install-analysis-all
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade-ovn-single-node
-  name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade-ovn-single-node
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
-  name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.9-e2e-aws-upgrade-paused
-  name: periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.9-e2e-aws-upgrade-paused
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-console-aws
+  name: periodic-ci-openshift-release-main-nightly-4.11-console-aws
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-credentials-request-freeze
+  name: periodic-ci-openshift-release-main-nightly-4.11-credentials-request-freeze
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-alibaba
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-alibaba
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-alibaba-csi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-alibaba-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-cgroupsv2
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-cgroupsv2
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-crun
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-crun
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-csi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-csi-migration
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-csi-migration
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-fips
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-local-gateway
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-local-gateway
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-serial
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-single-node-workers
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-single-node-workers
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-single-node-workers-serial
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-ovn-single-node-workers-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-proxy
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-proxy
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-serial
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node-serial
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-upi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-workers-rhel8
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-workers-rhel8
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-azure
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-csi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-deploy-cnv
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-deploy-cnv
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-fips
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-upgrade-cnv
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-upgrade-cnv
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-upi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azure-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-azurestack-csi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azurestack-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-azurestack-upi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-azurestack-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-csi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-csi-migration
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-csi-migration
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-fips
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-rt
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-rt
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-serial
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-upi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-gcp-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-ibmcloud-csi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ibmcloud-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-bm
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-bm
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-dualstack
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-dualstack
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-dualstack-local-gateway
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-dualstack-local-gateway
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-ipv4
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-ipv4
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-ipv6
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-ovn-ipv6
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ipv4
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ipv4
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ovn-dualstack
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ovn-dualstack
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ovn-ipv6
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-ovn-ipv6
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-virtualmedia
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-serial-virtualmedia
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-upgrade-ovn-ipv6
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-ipi-upgrade-ovn-ipv6
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-single-node-live-iso
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-single-node-live-iso
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-single-node-with-worker-live-iso
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-single-node-with-worker-live-iso
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt-csi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt-ovn
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-ovirt-ovn
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-csi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-ovn
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-ovn
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-serial
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-techpreview
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-techpreview
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-techpreview-serial
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-techpreview-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-upi
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-upi-serial
+  name: periodic-ci-openshift-release-main-nightly-4.11-e2e-vsphere-upi-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-install-analysis-all
+  name: periodic-ci-openshift-release-main-nightly-4.11-install-analysis-all
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade-ovn-single-node
+  name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade-ovn-single-node
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
+  name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.9-e2e-aws-upgrade-paused
+  name: periodic-ci-openshift-release-main-nightly-4.11-upgrade-from-stable-4.9-e2e-aws-upgrade-paused
 - gcs_prefix: test-platform-results/logs/promote-release-openshift-machine-os-content-e2e-aws-4.11-ppc64le
   name: promote-release-openshift-machine-os-content-e2e-aws-4.11-ppc64le
 - gcs_prefix: test-platform-results/logs/promote-release-openshift-machine-os-content-e2e-aws-4.11-s390x

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.8-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.8-informing.yaml
@@ -964,14 +964,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-console-aws
+    name: periodic-ci-openshift-release-main-nightly-4.8-console-aws
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-console-aws
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-console-aws
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -991,14 +991,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-credentials-request-freeze
+    name: periodic-ci-openshift-release-main-nightly-4.8-credentials-request-freeze
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-credentials-request-freeze
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-credentials-request-freeze
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1018,14 +1018,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1045,14 +1045,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1072,14 +1072,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-ovn-local-gateway
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-ovn-local-gateway
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-ovn-local-gateway
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-ovn-local-gateway
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1099,14 +1099,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-proxy
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-proxy
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1126,14 +1126,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-single-node
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-single-node
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1153,14 +1153,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1180,14 +1180,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade-rollback-oldest-supported
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-upgrade-rollback-oldest-supported
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade-rollback-oldest-supported
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-upgrade-rollback-oldest-supported
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1207,14 +1207,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-workers-rhel7
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-workers-rhel7
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-workers-rhel7
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-workers-rhel7
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1234,14 +1234,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-azure
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-azure
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-azure
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-azure
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1261,14 +1261,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-azure-fips
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-azure-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-azure-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-azure-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1288,14 +1288,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-azure-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-azure-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-azure-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-azure-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1315,14 +1315,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1342,14 +1342,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-fips
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1369,14 +1369,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1396,14 +1396,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-rt
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-rt
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-rt
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-rt
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1423,14 +1423,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-serial
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1450,14 +1450,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1477,14 +1477,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-compact
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-compact
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-compact
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-compact
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1504,14 +1504,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-ovn-dualstack
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-ovn-dualstack
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1531,14 +1531,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-ipv6
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-ovn-ipv6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-ipv6
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-ovn-ipv6
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1558,14 +1558,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-serial-ipv4
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-serial-ipv4
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1585,14 +1585,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1612,14 +1612,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-virtualmedia
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-virtualmedia
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1639,14 +1639,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-single-node-live-iso
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-single-node-live-iso
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-single-node-live-iso
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1666,14 +1666,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-ovirt
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-ovirt
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-ovirt
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-ovirt
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1693,14 +1693,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1720,14 +1720,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-ovn
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-ovn
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-ovn
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-ovn
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1747,14 +1747,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-serial
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1774,14 +1774,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1801,14 +1801,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial
+    name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1828,14 +1828,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1855,14 +1855,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1989,74 +1989,74 @@ test_groups:
   name: periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-ovirt-upgrade
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-vsphere-upgrade
   name: periodic-ci-openshift-release-master-ci-4.8-upgrade-from-stable-4.7-e2e-vsphere-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-console-aws
-  name: periodic-ci-openshift-release-master-nightly-4.8-console-aws
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-credentials-request-freeze
-  name: periodic-ci-openshift-release-master-nightly-4.8-credentials-request-freeze
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-ovn-local-gateway
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-ovn-local-gateway
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-proxy
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade-rollback-oldest-supported
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-upgrade-rollback-oldest-supported
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-workers-rhel7
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-workers-rhel7
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-azure
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-azure
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-azure-fips
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-azure-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-azure-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-azure-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-fips
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-rt
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-rt
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-serial
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-gcp-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-compact
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-compact
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-dualstack
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-ipv6
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-ovn-ipv6
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-serial-ipv4
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-ipi-virtualmedia
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-single-node-live-iso
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-single-node-live-iso
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-ovirt
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-ovirt
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-ovn
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-ovn
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-serial
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial
-  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-vsphere-upi-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-console-aws
+  name: periodic-ci-openshift-release-main-nightly-4.8-console-aws
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-credentials-request-freeze
+  name: periodic-ci-openshift-release-main-nightly-4.8-credentials-request-freeze
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-fips
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-ovn-local-gateway
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-ovn-local-gateway
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-proxy
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-proxy
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-single-node
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-single-node
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-upgrade-rollback-oldest-supported
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-upgrade-rollback-oldest-supported
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-workers-rhel7
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-workers-rhel7
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-azure
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-azure
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-azure-fips
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-azure-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-azure-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-azure-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-fips
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-rt
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-rt
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-serial
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-gcp-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-compact
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-compact
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-ovn-dualstack
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-ovn-dualstack
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-ovn-ipv6
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-ovn-ipv6
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-serial-ipv4
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-serial-ipv4
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-virtualmedia
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-ipi-virtualmedia
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-single-node-live-iso
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-single-node-live-iso
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-ovirt
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-ovirt
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-ovn
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-ovn
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-serial
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi-serial
+  name: periodic-ci-openshift-release-main-nightly-4.8-e2e-vsphere-upi-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.8-upgrade-from-stable-4.7-e2e-aws-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.8-upgrade-from-stable-4.7-e2e-metal-ipi-upgrade
 - gcs_prefix: test-platform-results/logs/promote-release-openshift-machine-os-content-e2e-aws-4.8-ppc64le
   name: promote-release-openshift-machine-os-content-e2e-aws-4.8-ppc64le
 - gcs_prefix: test-platform-results/logs/promote-release-openshift-machine-os-content-e2e-aws-4.8-s390x

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.9-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.9-informing.yaml
@@ -1234,14 +1234,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-console-aws
+    name: periodic-ci-openshift-release-main-nightly-4.9-console-aws
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-console-aws
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-console-aws
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1261,14 +1261,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-credentials-request-freeze
+    name: periodic-ci-openshift-release-main-nightly-4.9-credentials-request-freeze
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-credentials-request-freeze
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-credentials-request-freeze
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1288,14 +1288,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-fips
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1315,14 +1315,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1342,14 +1342,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-ovn-local-gateway
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-ovn-local-gateway
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-ovn-local-gateway
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-ovn-local-gateway
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1369,14 +1369,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-proxy
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-proxy
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-proxy
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-proxy
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1396,14 +1396,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1423,14 +1423,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node-serial
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1450,14 +1450,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1477,14 +1477,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade-rollback-oldest-supported
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upgrade-rollback-oldest-supported
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade-rollback-oldest-supported
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upgrade-rollback-oldest-supported
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1504,14 +1504,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upi
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1531,14 +1531,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel7
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-workers-rhel7
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel7
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-workers-rhel7
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1558,14 +1558,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel8
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-workers-rhel8
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel8
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-workers-rhel8
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1585,14 +1585,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1612,14 +1612,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-deploy-cnv
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-deploy-cnv
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-deploy-cnv
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-deploy-cnv
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1639,14 +1639,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-fips
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1666,14 +1666,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1693,14 +1693,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-upgrade-cnv
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-upgrade-cnv
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-upgrade-cnv
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-upgrade-cnv
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1720,14 +1720,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-upi
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1747,14 +1747,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azurestack-csi
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azurestack-csi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azurestack-csi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azurestack-csi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1774,14 +1774,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azurestack-upi
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azurestack-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azurestack-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azurestack-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1801,14 +1801,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1828,14 +1828,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-fips
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-fips
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-fips
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-fips
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1855,14 +1855,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-fips-serial
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-fips-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-fips-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-fips-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1882,14 +1882,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-rt
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-rt
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-rt
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-rt
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1909,14 +1909,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-serial
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1936,14 +1936,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-upi
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1963,14 +1963,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1990,14 +1990,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-compact
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-compact
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-compact
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-compact
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2017,14 +2017,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-dualstack
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-ovn-dualstack
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-dualstack
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-ovn-dualstack
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2044,14 +2044,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-ipv6
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-ovn-ipv6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-ipv6
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-ovn-ipv6
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2071,14 +2071,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-serial-ipv4
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-serial-ipv4
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-serial-ipv4
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-serial-ipv4
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2098,14 +2098,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2125,14 +2125,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-virtualmedia
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-virtualmedia
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-virtualmedia
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-virtualmedia
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2152,14 +2152,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-single-node-live-iso
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-single-node-live-iso
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-single-node-live-iso
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2179,14 +2179,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-ovirt
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-ovirt
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-ovirt
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-ovirt
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2206,14 +2206,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-ovirt-ovn
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-ovirt-ovn
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-ovirt-ovn
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-ovirt-ovn
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2233,14 +2233,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2260,14 +2260,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-ovn
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-ovn
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-ovn
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-ovn
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2287,14 +2287,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-serial
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2314,14 +2314,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-upi
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-upi
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2341,14 +2341,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-upi-serial
+    name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi-serial
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-upi-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi-serial
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2368,14 +2368,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2395,14 +2395,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade-ovn-single-node
+    name: periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade-ovn-single-node
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade-ovn-single-node
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade-ovn-single-node
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2422,14 +2422,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
+    name: periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -2576,96 +2576,96 @@ test_groups:
   name: periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-e2e-vsphere-upgrade
 - gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-from-stable-4.7-e2e-aws-upgrade
   name: periodic-ci-openshift-release-master-ci-4.9-upgrade-from-stable-4.8-from-stable-4.7-e2e-aws-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-console-aws
-  name: periodic-ci-openshift-release-master-nightly-4.9-console-aws
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-credentials-request-freeze
-  name: periodic-ci-openshift-release-master-nightly-4.9-credentials-request-freeze
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-fips
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-ovn-local-gateway
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-ovn-local-gateway
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-proxy
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-proxy
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node-serial
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade-rollback-oldest-supported
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade-rollback-oldest-supported
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upi
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel7
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel7
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel8
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-workers-rhel8
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-azure
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-deploy-cnv
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-deploy-cnv
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-fips
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-upgrade-cnv
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-upgrade-cnv
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-upi
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azure-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-azurestack-csi
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azurestack-csi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-azurestack-upi
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-azurestack-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-fips
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-fips
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-fips-serial
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-fips-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-rt
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-rt
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-serial
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-upi
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-gcp-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-compact
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-compact
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-dualstack
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-dualstack
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-ipv6
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-ovn-ipv6
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-serial-ipv4
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-serial-ipv4
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-virtualmedia
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-ipi-virtualmedia
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-single-node-live-iso
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-single-node-live-iso
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-ovirt
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-ovirt
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-ovirt-ovn
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-ovirt-ovn
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-ovn
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-ovn
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-serial
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-upi
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-upi
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-upi-serial
-  name: periodic-ci-openshift-release-master-nightly-4.9-e2e-vsphere-upi-serial
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade-ovn-single-node
-  name: periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade-ovn-single-node
-- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
-  name: periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-console-aws
+  name: periodic-ci-openshift-release-main-nightly-4.9-console-aws
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-credentials-request-freeze
+  name: periodic-ci-openshift-release-main-nightly-4.9-credentials-request-freeze
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-fips
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-ovn-local-gateway
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-ovn-local-gateway
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-proxy
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-proxy
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node-serial
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upgrade-rollback-oldest-supported
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upgrade-rollback-oldest-supported
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upi
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-workers-rhel7
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-workers-rhel7
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-workers-rhel8
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-workers-rhel8
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-azure
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-deploy-cnv
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-deploy-cnv
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-fips
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-upgrade-cnv
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-upgrade-cnv
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-upi
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azure-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-azurestack-csi
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azurestack-csi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-azurestack-upi
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-azurestack-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-fips
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-fips
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-fips-serial
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-fips-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-rt
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-rt
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-serial
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-upi
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-gcp-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-compact
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-compact
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-ovn-dualstack
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-ovn-dualstack
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-ovn-ipv6
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-ovn-ipv6
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-serial-ipv4
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-serial-ipv4
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-virtualmedia
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-ipi-virtualmedia
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-single-node-live-iso
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-single-node-live-iso
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-ovirt
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-ovirt
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-ovirt-ovn
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-ovirt-ovn
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-ovn
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-ovn
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-serial
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi-serial
+  name: periodic-ci-openshift-release-main-nightly-4.9-e2e-vsphere-upi-serial
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade-ovn-single-node
+  name: periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-aws-upgrade-ovn-single-node
+- gcs_prefix: test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
+  name: periodic-ci-openshift-release-main-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
 - gcs_prefix: test-platform-results/logs/promote-release-openshift-machine-os-content-e2e-aws-4.9-ppc64le
   name: promote-release-openshift-machine-os-content-e2e-aws-4.9-ppc64le
 - gcs_prefix: test-platform-results/logs/promote-release-openshift-machine-os-content-e2e-aws-4.9-s390x

--- a/config/testgrids/openshift/single-node.yaml
+++ b/config/testgrids/openshift/single-node.yaml
@@ -1,8 +1,8 @@
 dashboards:
 - name: redhat-single-node
   dashboard_tab:
-  - name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node-serial
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node-serial
+  - name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node-serial
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -28,8 +28,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-aws-single-node
+  - name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-aws-single-node
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -55,8 +55,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node-serial
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node-serial
+  - name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node-serial
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -82,8 +82,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node
+  - name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-aws-single-node
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -109,8 +109,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node-serial
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node-serial
+  - name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node-serial
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node-serial
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -136,8 +136,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-single-node
+  - name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-aws-single-node
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -163,8 +163,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-aws-single-node
+  - name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-single-node
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-aws-single-node
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -190,8 +190,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-single-node-live-iso
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-single-node-live-iso
+  - name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.8-e2e-metal-single-node-live-iso
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -217,8 +217,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-single-node-live-iso
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-single-node-live-iso
+  - name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.9-e2e-metal-single-node-live-iso
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -244,8 +244,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-single-node-live-iso
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-single-node-live-iso
+  - name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.10-e2e-metal-single-node-live-iso
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -271,8 +271,8 @@ dashboards:
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-  - name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-live-iso
-    test_group_name: periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-single-node-live-iso
+  - name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-single-node-live-iso
+    test_group_name: periodic-ci-openshift-release-main-nightly-4.11-e2e-metal-single-node-live-iso
     base_options: width=10
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>


### PR DESCRIPTION
fixes https://github.com/kubernetes/test-infra/pull/36470

follow-up after https://github.com/openshift/release/pull/74615

