### PR TITLE
Increase the parallel jobs for the HPA presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -88,8 +88,10 @@ presubmits:
         - --provider=gce
         - --gcp-zone=us-central1-b
         - --gcp-node-image=gci
-        - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Alpha\]|\[Beta\] --minStartupPods=8
-        - --ginkgo-parallel=1
+        - --gcp-node-size=e2-highcpu-8
+        - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Alpha\]|\[Beta\]
+          --minStartupPods=8
+        - --ginkgo-parallel=10
         - --timeout=300m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
         securityContext:


### PR DESCRIPTION
This job takes 2h30 to run.

Part of https://github.com/kubernetes/kubernetes/issues/135026
And this is the same change that Max did to the periodic jobs

I'm not a fan of throwing hardware at these jobs, but I think it's fine for now, until we can improve the tests we have.