### PR TITLE
Fix up the HPA jobs more

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -556,7 +556,7 @@ periodics:
       - --gcp-node-size=e2-highcpu-8
       - --extract=ci/latest
       - --timeout=240m
-      - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Alpha\]|\[Beta\]
+      - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Feature:OffByDefault\]
         --minStartupPods=8
       - --ginkgo-parallel=10
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -89,7 +89,7 @@ presubmits:
         - --gcp-zone=us-central1-b
         - --gcp-node-image=gci
         - --gcp-node-size=e2-highcpu-8
-        - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Alpha\]|\[Beta\]
+        - --test_args=--ginkgo.focus=\[Feature:HPA\] --ginkgo.skip=\[Feature:OffByDefault\]
           --minStartupPods=8
         - --ginkgo-parallel=10
         - --timeout=300m
@@ -114,6 +114,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 310m
+    run_if_changed: '^(pkg\/controller\/podautoscaler\/|test\/e2e\/autoscaling\/horizontal_pod_autoscaling|test\/e2e\/framework\/autoscaling\/)'
     path_alias: k8s.io/kubernetes
     extra_refs:
     - org: kubernetes
@@ -135,9 +136,11 @@ presubmits:
         - --provider=gce
         - --gcp-zone=us-central1-b
         - --gcp-node-image=gci
-        - --env=KUBE_FEATURE_GATES=HPAConfigurableTolerance=true
-        - --test_args=--ginkgo.focus=\[Feature:HPAConfigurableTolerance\] --minStartupPods=8
-        - --ginkgo-parallel=1
+        - --gcp-node-size=e2-highcpu-8
+        - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true
+        - --test_args=--ginkgo.focus=\[Feature:HPA\]
+          --minStartupPods=8
+        - --ginkgo-parallel=10
         - --timeout=300m
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
         securityContext:


### PR DESCRIPTION
This is a follow-on to https://github.com/kubernetes/test-infra/pull/36496

This standardises the testing somewhat. We'll have 4 tests:
1. Periodic (24h) - All "on by default" tests
2. Periodic (24h) - All "on and off by default" tests
3. Presubmit - All "on by default" tests 
4. Presubmit - All "on and off by default" tests 

Baring any flakes, this should mean that our tests are now quick-ish (no longer 2h30) and mostly flake free (although, I'm certain some flakes will crop up).

Any new e2e tests, despite their feature gate, will be run on presubmit and periodic.

This should get us to a place where we're sure that HPA PRs are of high quality.

However, I think we need to also improve our tests somehow, we may need to move some e2e tests into integration tests, for example. But that's a future problem.