### PR TITLE
Fix HPA alpha/beta presubmit job

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -137,6 +137,7 @@ presubmits:
         - --gcp-zone=us-central1-b
         - --gcp-node-image=gci
         - --gcp-node-size=e2-highcpu-8
+        - --runtime-config=api/all=true
         - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true
         - --test_args=--ginkgo.focus=\[Feature:HPA\]
           --minStartupPods=8


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/test-infra/pull/36497

This is required for the api-server to start with the alpha and beta gates enabled.