### PR TITLE
Revert "Half the resource size to fix instability after migrating to kops"

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1164,14 +1164,15 @@ periodics:
         value: "8Gi"
       - name: CL2_EXECSERVICE_TOLERATE_CONTROL_PLANE
         value: "true"
+      # Override for 1.93GB pod resource size
       - name: CL2_DAEMONSET_POD_PAYLOAD_SIZE
-        value: "4000"
+        value: "8000"
       - name: CL2_DEPLOYMENT_POD_PAYLOAD_SIZE
-        value: "4000"
+        value: "8000"
       - name: CL2_STATEFULSET_POD_PAYLOAD_SIZE
-        value: "4000"
+        value: "8000"
       - name: CL2_JOB_POD_PAYLOAD_SIZE
-        value: "4000"
+        value: "8000"
       #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private


### PR DESCRIPTION
This reverts commit https://github.com/kubernetes/test-infra/pull/36468

We can go back to previous setup as the test became stable thanks to  increased exec service resources and fixed base scalablity test.

https://testgrid.k8s.io/sig-scalability-gce#gce-master-scale-resource-size

/cc @mborsz @upodroid 