### PR TITLE
alpha/beta race: increase and sync timeouts

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -366,7 +366,8 @@ periodics:
     preset-dind-enabled: "true"
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 90m
+    grace_period: 15m
   extra_refs:
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -644,7 +644,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
     decoration_config:
-      timeout: 90m
+      timeout: 100m # 10 minutes more than periodic because it needs to build from source.
       grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:


### PR DESCRIPTION
Recent periodic runs got closer to the 1h limit, then sometimes failed. This seems normal because more tests got added, so we have to grant them more time to complete.

Also, the periodic job used the same limit as the non-race-detection jobs, not the extended limit of the presubmit. This was unintentional.

https://testgrid.k8s.io/sig-testing-kind#kind-master-alpha-beta-features-race