### PR TITLE
Switch periodic EC2 e2e jobs from dl.k8s.io to gcsweb.k8s.io

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -35,9 +35,9 @@ periodics:
             AMI_ID=$(aws ssm get-parameters --names \
                      /aws/service/eks/optimized-ami/1.34/amazon-linux-2023/x86_64/nvidia/recommended/image_id \
                      --query 'Parameters[0].[Value]' --output text)
-            VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
+            VERSION=$(curl -Ls --retry 5 --retry-delay 10 --retry-all-errors https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/latest-fast.txt)
             kubetest2 ec2 \
-             --stage https://dl.k8s.io/ci/fast/ \
+             --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/ \
              --version $VERSION \
              --worker-instance-type=g4dn.12xlarge \
              --device-plugin-nvidia true \
@@ -48,7 +48,7 @@ periodics:
              --test=ginkgo \
              -- \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
-             --test-package-url=https://dl.k8s.io/ \
+             --test-package-url=https://gcsweb.k8s.io/gcs/k8s-release-dev/ \
              --test-package-dir=ci/fast \
              --test-package-marker=latest-fast.txt \
              --focus-regex="\[Feature:GPUDevicePlugin\]" \
@@ -101,9 +101,9 @@ periodics:
             source $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/scripts/check-ami.sh
 
             GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
-            VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
+            VERSION=$(curl -Ls --retry 5 --retry-delay 10 --retry-all-errors https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/latest-fast.txt)
             kubetest2 ec2 \
-             --stage https://dl.k8s.io/ci/fast/ \
+             --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/ \
              --version $VERSION \
              --feature-gates="AllAlpha=true,AllBeta=true,EventedPLEG=false" \
              --runtime-config="api/all=true" \
@@ -113,7 +113,7 @@ periodics:
              --test=ginkgo \
              -- \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
-             --test-package-url=https://dl.k8s.io/ \
+             --test-package-url=https://gcsweb.k8s.io/gcs/k8s-release-dev/ \
              --test-package-dir=ci/fast \
              --test-package-marker=latest-fast.txt \
              --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0|Services should preserve source pod IP for traffic thru service cluster IP" \
@@ -167,9 +167,9 @@ periodics:
             source $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/scripts/check-ami.sh
 
             GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
-            VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
+            VERSION=$(curl -Ls --retry 5 --retry-delay 10 --retry-all-errors https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/latest-fast.txt)
             kubetest2 ec2 \
-             --stage https://dl.k8s.io/ci/fast/ \
+             --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/ \
              --version $VERSION \
              --feature-gates="AllAlpha=true,AllBeta=true,EventedPLEG=false" \
              --runtime-config="api/all=true" \
@@ -178,7 +178,7 @@ periodics:
              --test=ginkgo \
              -- \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
-             --test-package-url=https://dl.k8s.io/ \
+             --test-package-url=https://gcsweb.k8s.io/gcs/k8s-release-dev/ \
              --test-package-dir=ci/fast \
              --test-package-marker=latest-fast.txt \
              --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking" \


### PR DESCRIPTION
dl.k8s.io/ci/fast/ is returning 404 for CI build artifacts, causing all three periodic EC2 e2e jobs (device-plugin-gpu, alpha-enabled-default, alpha-features) to fail during cloud-init when downloading kubernetes-server-linux-amd64.tar.gz.

Switch to gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/ which serves directly from the GCS bucket, matching the fix already applied to presubmit jobs in b234a6ef47c90203bcad9679c30c4af157edbf3e.

Also add --retry 5 --retry-delay 10 --retry-all-errors to the latest-fast.txt curl for resilience.

Follow up similar to:
https://github.com/kubernetes/test-infra/pull/36488

xref: https://github.com/kubernetes/kubernetes/issues/137209