### PR TITLE
Bump kpromo image to v4.2.0-0

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v4.0.5-0
+      - image: registry.k8s.io/artifact-promoter/kpromo:v4.2.0-0
         command:
         - /kpromo
         args:
@@ -67,7 +67,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v4.0.5-0
+      - image: registry.k8s.io/artifact-promoter/kpromo:v4.2.0-0
         command:
         - /kpromo
         args:
@@ -103,7 +103,7 @@ presubmits:
       - name: promote-to-primary
         # TODO(justinsb): replace with released image once this is working
         # Curently lacking S3 support - at least
-        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.0.5-0
+        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.2.0-0
         resources:
           limits:
             cpu: 2
@@ -120,7 +120,7 @@ presubmits:
       - name: promote-to-mirrors
         # TODO(justinsb): replace with released image once this is working
         # Curently lacking S3 support - at least
-        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.0.5-0
+        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.2.0-0
         resources:
           limits:
             cpu: 2
@@ -137,7 +137,7 @@ presubmits:
       - name: promote-to-mirrors-staging
         # TODO(justinsb): replace with released image once this is working
         # Curently lacking S3 support - at least
-        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.0.5-0
+        image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.2.0-0
         resources:
           limits:
             cpu: 2

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v4.0.5-0
+      - image: registry.k8s.io/artifact-promoter/kpromo:v4.2.0-0
         command:
         - /kpromo
         args:
@@ -54,7 +54,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v4.0.5-0
+      - image: registry.k8s.io/artifact-promoter/kpromo:v4.2.0-0
         command:
         - /kpromo
         args:
@@ -122,7 +122,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v4.0.5-0
+    - image: registry.k8s.io/artifact-promoter/kpromo:v4.2.0-0
       command:
       - /kpromo
       args:
@@ -155,7 +155,7 @@ periodics:
     serviceAccountName: k8s-infra-promoter
     containers:
     - name: promote-to-mirrors
-      image: registry.k8s.io/artifact-promoter/kpromo:v4.0.5-0
+      image: registry.k8s.io/artifact-promoter/kpromo:v4.2.0-0
       command:
       - /kpromo
       args:
@@ -184,7 +184,7 @@ periodics:
           name: aws-iam-token
           readOnly: true
     - name: promote-to-mirrors-staging
-      image: registry.k8s.io/artifact-promoter/kpromo:v4.0.5-0
+      image: registry.k8s.io/artifact-promoter/kpromo:v4.2.0-0
       command:
       - /kpromo
       args:
@@ -255,7 +255,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v4.0.5-0
+    - image: registry.k8s.io/artifact-promoter/kpromo:v4.2.0-0
       command:
       - /kpromo
       args:
@@ -370,7 +370,7 @@ periodics:
     path_alias: sigs.k8s.io/promo-tools
   spec:
     containers:
-    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.0.1-0
+    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.2.0-0
       imagePullPolicy: Always
       command:
         - /kpromo


### PR DESCRIPTION

- Bump all kpromo image references from v4.0.5-0 (and v4.0.1-0) to v4.2.0-0
- Release notes: https://github.com/kubernetes-sigs/promo-tools/releases/tag/v4.2.0
- Image promotion: https://github.com/kubernetes/k8s.io/pull/9140

The new pipeline engine is the default in v4.2.0. If anything goes wrong, adding `--use-legacy-pipeline` to the Prow job args rolls back to the previous code path without a new release.

cc @kubernetes/release-engineering