### PR TITLE
Lower the resource size to 1.5GB to address flake

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1113,7 +1113,7 @@ periodics:
 - cron: '1 17 1-31/1 * *' # Run on odd days at 9:01PST (17:01 UTC)
   name: ci-kubernetes-e2e-gce-scale-resource-size
   tags:
-  - "perfDashPrefix: gce-5000Nodes-ResourceSize"
+  - "perfDashPrefix: gce-5000Nodes-1.5GB-pods"
   - "perfDashBuildsCount: 270"
   - "perfDashJobType: performance"
   cluster: k8s-infra-prow-build
@@ -1164,15 +1164,15 @@ periodics:
         value: "8Gi"
       - name: CL2_EXECSERVICE_TOLERATE_CONTROL_PLANE
         value: "true"
-      # Override for 1.93GB pod resource size
+      # Override for 1.5GB pod resource size
       - name: CL2_DAEMONSET_POD_PAYLOAD_SIZE
-        value: "8000"
+        value: "6000"
       - name: CL2_DEPLOYMENT_POD_PAYLOAD_SIZE
-        value: "8000"
+        value: "6000"
       - name: CL2_STATEFULSET_POD_PAYLOAD_SIZE
-        value: "8000"
+        value: "6000"
       - name: CL2_JOB_POD_PAYLOAD_SIZE
-        value: "8000"
+        value: "6000"
       #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private


### PR DESCRIPTION
Hopefully the last adjustment before merging into release blocking tests.

After https://github.com/kubernetes/test-infra/pull/36500 we got out of LIST SLO with 36/30s.

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/2025979259918487552

Meaning that kops setup is less scalable than old kubeup which handled 2GB.

renamed the perfdash to reset history.

/cc @mborsz @upodroid 