### PR TITLE
Add language/zh-tw label for Traditional Chinese

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -727,6 +727,7 @@ larger set of contributors to apply/remove them.
 | <a id="language/uk" href="#language/uk">`language/uk`</a> | Issues or PRs related to Ukrainian language| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
 | <a id="language/vi" href="#language/vi">`language/vi`</a> | Issues or PRs related to Vietnamese language| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
 | <a id="language/zh" href="#language/zh">`language/zh`</a> | Issues or PRs related to Chinese language <br><br> This was previously `language/cn`, | anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
+| <a id="language/zh-tw" href="#language/zh-tw">`language/zh-tw`</a> | Issues or PRs related to Traditional Chinese language| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
 
 ## Labels that apply to kubernetes/website, only for issues
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1884,6 +1884,12 @@ repos:
         prowPlugin: label
         addedBy: anyone
       - color: e9b3f9
+        description: Issues or PRs related to Traditional Chinese language
+        name: language/zh-tw
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: e9b3f9
         description: Issues or PRs related to Russian language
         name: language/ru
         target: both


### PR DESCRIPTION
This PR adds the `language/zh-tw` label for the k8s-docs being translated to Traditional Chinese.

ref: 
https://github.com/kubernetes/website/issues/54645 
https://github.com/kubernetes/website/issues/53043

/cc @kubernetes/sig-contributor-experience-pr-reviews