### PR TITLE
Update kubernetes/release jobs to Go 1.25

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -101,7 +101,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
         imagePullPolicy: Always
         command:
         - make
@@ -127,7 +127,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
         imagePullPolicy: Always
         command:
         - make
@@ -152,7 +152,7 @@ presubmits:
     path_alias: k8s.io/release
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
         imagePullPolicy: Always
         command:
         - make
@@ -177,7 +177,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
https://github.com/kubernetes/release/pull/4280 is updating Go to 1.25 but we need to update jobs so tests can pass.

cc @kubernetes/release-engineering 