### PR TITLE
Add periodic signature replication job for image promoter

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -284,6 +284,47 @@ periodics:
       - org: kubernetes
         slug: release-managers
 
+# ci-k8sio-image-signature-replication replicates cosign signatures from
+# primary registries to all mirror registries. Runs independently of the
+# promotion pipeline to avoid rate limit contention with cosign signing.
+# The operation is idempotent; missed or failed replications are caught
+# on the next run.
+- cron: '*/30 * * * *'
+  cluster: k8s-infra-prow-build-trusted
+  max_concurrency: 1
+  name: ci-k8sio-image-signature-replication
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: k8s.io
+    base_ref: main
+  spec:
+    serviceAccountName: k8s-infra-gcr-promoter
+    containers:
+    - image: registry.k8s.io/artifact-promoter/kpromo:v4.3.0-0
+      command:
+      - /kpromo
+      args:
+      - cip
+      - replicate-signatures
+      - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/registry.k8s.io
+      - --confirm
+      resources:
+        requests:
+          cpu: 1
+          memory: "2Gi"
+        limits:
+          cpu: 1
+          memory: "2Gi"
+  annotations:
+    testgrid-dashboards: sig-release-releng-informing, sig-k8s-infra-k8sio
+    testgrid-alert-email: release-managers+alerts@kubernetes.io
+    testgrid-num-failures-to-alert: '3'
+  rerun_auth_config:
+    github_team_slugs:
+      - org: kubernetes
+        slug: release-managers
+
 # This job is a canary job to test promoting the image promoter before
 # rolling changes out to production instances
 - interval: 1h


### PR DESCRIPTION
Add `ci-k8sio-image-signature-replication` periodic Prow job that runs every 30 minutes to copy cosign signatures from primary registries to mirrors, decoupled from the promotion pipeline.

The job uses the new `kpromo cip replicate-signatures` subcommand from kubernetes-sigs/promo-tools#1715.

Depends on: https://github.com/kubernetes-sigs/promo-tools/issues/1714

/hold