### PR TITLE
Use staging latest image for signature replication job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -301,7 +301,8 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v4.3.0-0
+    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:latest
+      imagePullPolicy: Always
       command:
       - /kpromo
       args:


### PR DESCRIPTION
Switch `ci-k8sio-image-signature-replication` from the pinned production image (`registry.k8s.io/artifact-promoter/kpromo:v4.3.0-0`) to the staging latest image (`gcr.io/k8s-staging-artifact-promoter/kpromo:latest`) with `imagePullPolicy: Always`.

This allows bug fixes merged to `main` (like kubernetes-sigs/promo-tools#1726) to take effect on the next job run without cutting a new release.

This matches the pattern used by `ci-promo-tools-image-promo-canary` and `post-promo-tools-image-promo-canary`.