### PR TITLE
add scaffolding for AI Conformance CI jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/ai-conformance/OWNERS
+++ b/config/jobs/kubernetes-sigs/ai-conformance/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - janetkuo
+  - mfahlandt
+  - ritazh
+  - terrytangyuan
+  - dims

--- a/config/jobs/kubernetes-sigs/ai-conformance/ai-conformance-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/ai-conformance/ai-conformance-periodics-main.yaml
@@ -1,0 +1,1 @@
+periodics:

--- a/config/jobs/kubernetes-sigs/ai-conformance/ai-conformance-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/ai-conformance/ai-conformance-presubmits-main.yaml
@@ -1,0 +1,2 @@
+presubmits:
+  kubernetes-sigs/wg-ai-conformance:


### PR DESCRIPTION
@mfahlandt @ritazh @terrytangyuan @dims @johnbelamaric @derekwaynecarr 

Note: it's created under kubernetes-sigs/ai-conformance folder (instead of kubernetes-sigs/wg-ai-conformance) due to the upcoming repo rename in https://github.com/kubernetes/org/issues/5998