### PR TITLE
Add an e2e test job for the ChangeContainerStatusOnKubeletRestart feature

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1144,6 +1144,58 @@ presubmits:
             env:
               - name: GOPATH
                 value: /go
+    # This test job takes about ten minutes to run and will be removed after the ChangeContainerStatusOnKubeletRestart feature gate is removed.
+    - name: pull-kubernetes-node-kubelet-serial-change-container-status-on-kubelet-restart
+      cluster: k8s-infra-prow-build
+      always_run: false
+      optional: true
+      skip_report: false
+      skip_branches:
+        - release-\d+\.\d+ # per-release image
+      annotations:
+        testgrid-dashboards: sig-node-presubmits
+        testgrid-tab-name: pr-kubelet-serial-change-container-status-on-kubelet-restart
+      labels:
+        preset-service-account: "true"
+        preset-k8s-ssh: "true"
+      decorate: true
+      decoration_config:
+        timeout: 240m
+      path_alias: k8s.io/kubernetes
+      extra_refs:
+        - org: kubernetes
+          repo: release
+          base_ref: master
+          path_alias: k8s.io/release
+        - org: kubernetes
+          repo: test-infra
+          base_ref: master
+          path_alias: k8s.io/test-infra
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
+            resources:
+              limits:
+                cpu: 4
+                memory: 6Gi
+              requests:
+                cpu: 4
+                memory: 6Gi
+            command:
+              - runner.sh
+              - /workspace/scenarios/kubernetes_e2e.py
+            args:
+              - --deployment=node
+              - --gcp-zone=us-central1-b
+              - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
+              - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}" --service-feature-gates="ChangeContainerStatusOnKubeletRestart=false" --feature-gates="ChangeContainerStatusOnKubeletRestart=false"'
+              - --node-tests=true
+              - --provider=gce
+              - '--test_args=--nodes=1 --label-filter="Feature: containsAny ChangeContainerStatusOnKubeletRestart"'
+              - --timeout=180m
+            env:
+              - name: GOPATH
+                value: /go
     - name: pull-kubernetes-node-kubelet-serial-topology-manager-kubetest2
       cluster: k8s-infra-prow-build
       # explicitly needs /test pull-kubernetes-node-kubelet-serial-topology-manager-kubetest2 to run


### PR DESCRIPTION
Due to the merge of #36109, the pull-kubernetes-node-kubelet-serial-containerd test job now skips tests of the `ChangeContainerStatusOnKubeletRestart` feature gate.

Because in #36109 we excluded test jobs with the `Feature:OffByDefault` label, and `ChangeContainerStatusOnKubeletRestart` is a deprecated feature gate that defaults to false. When set to false, it means the feature is enabled.

Therefore, this PR adds a separate test job for `ChangeContainerStatusOnKubeletRestart`.