### PR TITLE
Use staging latest image for image promotion jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -54,7 +54,8 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v4.3.0-0
+      - image: gcr.io/k8s-staging-artifact-promoter/kpromo:latest
+        imagePullPolicy: Always
         command:
         - /kpromo
         args:
@@ -255,7 +256,8 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v4.3.0-0
+    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:latest
+      imagePullPolicy: Always
       command:
       - /kpromo
       args:


### PR DESCRIPTION

- Switch `post-k8sio-image-promo` and `ci-k8sio-image-promo` to use `gcr.io/k8s-staging-artifact-promoter/kpromo:latest` instead of `registry.k8s.io/artifact-promoter/kpromo:v4.3.0-0`
- The v4.3.0 release has a regression that causes all images to be reported as `_LOST_` due to a registry inventory key mismatch (fix: https://github.com/kubernetes-sigs/promo-tools/pull/1731)

/cc @kubernetes/release-managers
/area release-eng
/priority critical-urgent