### PR TITLE
fix: remove trailing slash in --stage URLs causing 404 errors

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
@@ -227,7 +227,7 @@ periodics:
           GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
           VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
           kubetest2 ec2 \
-           --stage https://dl.k8s.io/ci/fast/ \
+           --stage https://dl.k8s.io/ci/fast \
            --version $VERSION \
            --up \
            --down \

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
@@ -177,7 +177,7 @@ presubmits:
 
               VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
               kubetest2 ec2 \
-               --stage https://dl.k8s.io/ci/fast/ \
+               --stage https://dl.k8s.io/ci/fast \
                --external-cloud-provider true \
                --external-cloud-provider-image="${IMAGE_NAME}:${IMAGE_TAG}" \
                --version $VERSION \

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -409,7 +409,7 @@ presubmits:
               cd kubetest2-ec2 && GOPROXY=direct go install .
               VERSION=$(curl -Ls --retry 5 --retry-delay 10 --retry-all-errors https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/latest-fast.txt)
               kubetest2 ec2 \
-               --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/ \
+               --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast \
                --version $VERSION \
                --up \
                --down \
@@ -464,7 +464,7 @@ presubmits:
               cd kubetest2-ec2 && GOPROXY=direct go install .
               VERSION=$(curl -Ls --retry 5 --retry-delay 10 --retry-all-errors https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/latest-fast.txt)
               kubetest2 ec2 \
-               --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/ \
+               --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast \
                --external-cloud-provider true \
                --version $VERSION \
                --up \

--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -37,7 +37,7 @@ periodics:
                      --query 'Parameters[0].[Value]' --output text)
             VERSION=$(curl -Ls --retry 5 --retry-delay 10 --retry-all-errors https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/latest-fast.txt)
             kubetest2 ec2 \
-             --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/ \
+             --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast \
              --version $VERSION \
              --worker-instance-type=g4dn.12xlarge \
              --device-plugin-nvidia true \
@@ -103,7 +103,7 @@ periodics:
             GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
             VERSION=$(curl -Ls --retry 5 --retry-delay 10 --retry-all-errors https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/latest-fast.txt)
             kubetest2 ec2 \
-             --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/ \
+             --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast \
              --version $VERSION \
              --feature-gates="AllAlpha=true,AllBeta=true,EventedPLEG=false" \
              --runtime-config="api/all=true" \
@@ -169,7 +169,7 @@ periodics:
             GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
             VERSION=$(curl -Ls --retry 5 --retry-delay 10 --retry-all-errors https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/latest-fast.txt)
             kubetest2 ec2 \
-             --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast/ \
+             --stage https://gcsweb.k8s.io/gcs/k8s-release-dev/ci/fast \
              --version $VERSION \
              --feature-gates="AllAlpha=true,AllBeta=true,EventedPLEG=false" \
              --runtime-config="api/all=true" \

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -958,7 +958,7 @@ presubmits:
                 GOPROXY=direct go install sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2@latest
                 VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
                 kubetest2 ec2 \
-                 --stage https://dl.k8s.io/ci/fast/ \
+                 --stage https://dl.k8s.io/ci/fast \
                  --version $VERSION \
                  --feature-gates="AllAlpha=true,AllBeta=true,EventedPLEG=false,StorageVersionAPI=true,APIServerIdentity=true" \
                  --runtime-config="api/all=true" \


### PR DESCRIPTION
Remove trailing slashes from --stage URLs in kubetest2 ec2 job configurations. When combined with the version path, these trailing slashes resulted in double slashes in download URLs (e.g., `dl.k8s.io/ci/fast//v1.36.0-alpha...`).

This previously worked because the dl.k8s.io CDN would redirect malformed URLs, but as of Feb 16, 2026, the CDN serves directly from the origin, causing 404 errors for URLs with double slashes.

Affected jobs:
- cloud-provider-aws periodics and presubmits
- sig-cloud-provider/aws ec2-e2e presubmits
- sig-cloud-provider periodic-e2e
- sig-node presubmits

Fixes CI failures observed since mid-February in pull-cloud-provider-aws-e2e-kubetest2-quick and related jobs.

Context on thread here: https://kubernetes.slack.com/archives/C09QZ4DQB/p1772041962062339