### PR TITLE
Add two postsubmit prow config to build the agent images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-agentic-net.yaml
+++ b/config/jobs/image-pushing/k8s-staging-agentic-net.yaml
@@ -68,3 +68,49 @@ postsubmits:
         - --build-dir=.
         - --with-git-dir
         - quickstart/mcpserver
+  - name: post-agentic-net-push-langchain-agent-image
+    cluster: k8s-infra-prow-build-trusted
+    annotations:
+      testgrid-dashboards: sig-network-kube-agentic-networking, sig-k8s-infra-gcb
+    decorate: true
+    run_if_changed: '^quickstart\/additional-agent-examples\/langchain-agent\/'
+    skip_branches:
+    # do not run on dependabot branches, these exist prior to merge
+    # only merged code should trigger these jobs
+    - '^dependabot'
+    spec:
+      serviceAccountName: gcb-builder
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20251215-d7853fe2a6
+        command:
+        - /run.sh
+        args:
+        - --project=k8s-staging-images
+        - --scratch-bucket=gs://k8s-staging-images-gcb
+        - --env-passthrough=PULL_BASE_REF
+        - --build-dir=.
+        - --with-git-dir
+        - quickstart/additional-agent-examples/langchain-agent
+  - name: post-agentic-net-push-openai-agent-image
+    cluster: k8s-infra-prow-build-trusted
+    annotations:
+      testgrid-dashboards: sig-network-kube-agentic-networking, sig-k8s-infra-gcb
+    decorate: true
+    run_if_changed: '^quickstart\/additional-agent-examples\/openai-agent\/'
+    skip_branches:
+    # do not run on dependabot branches, these exist prior to merge
+    # only merged code should trigger these jobs
+    - '^dependabot'
+    spec:
+      serviceAccountName: gcb-builder
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/image-builder:v20251215-d7853fe2a6
+        command:
+        - /run.sh
+        args:
+        - --project=k8s-staging-images
+        - --scratch-bucket=gs://k8s-staging-images-gcb
+        - --env-passthrough=PULL_BASE_REF
+        - --build-dir=.
+        - --with-git-dir
+        - quickstart/additional-agent-examples/openai-agent


### PR DESCRIPTION
Add config to build two images.

source code is https://github.com/kubernetes-sigs/kube-agentic-networking/tree/main/quickstart/additional-agent-examples/langchain-agent

and https://github.com/kubernetes-sigs/kube-agentic-networking/tree/main/quickstart/additional-agent-examples/openai-agent

