### PR TITLE
Change for ci-kubernetes-ppc64le-e2e-slow-kubetest2 to use s1022 system type

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -356,6 +356,7 @@ periodics:
               #Setup of kubetest2 tf deployer
               make install-deployer-tf
 
+              export TF_VAR_powervs_system_type=s1022
               kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \


### PR DESCRIPTION
Moving pp64le e2e-slow job to `s1022` system type to improve performance.