### PR TITLE
fix: remove trailing slash in --test-package-url URLs causing CI 404 errors

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
@@ -234,7 +234,7 @@ periodics:
            --test=ginkgo \
            -- \
            --parallel=30 \
-           --test-package-url=https://dl.k8s.io/ \
+           --test-package-url=https://dl.k8s.io \
            --test-package-dir=ci/fast \
            --test-package-marker=latest-fast.txt \
            --focus-regex='Pods should be submitted and removed'

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-presubmit.yaml
@@ -186,7 +186,7 @@ presubmits:
                --test=ginkgo \
                -- \
                --parallel=30 \
-               --test-package-url=https://dl.k8s.io/ \
+               --test-package-url=https://dl.k8s.io \
                --test-package-dir=ci/fast \
                --test-package-marker=latest-fast.txt \
                --focus-regex='Pods should be submitted and removed'

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -967,7 +967,7 @@ presubmits:
                  --test=ginkgo \
                  -- \
                  --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
-                 --test-package-url=https://dl.k8s.io/ \
+                 --test-package-url=https://dl.k8s.io \
                  --test-package-dir=ci/fast \
                  --test-package-marker=latest-fast.txt \
                  --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking" \


### PR DESCRIPTION
A follow up to https://github.com/kubernetes/test-infra/pull/36528 as the job got further but still broke afterwards.

--

Remove trailing slashes from --test-package-url URLs in kubetest2 ec2 job configurations. When combined in these spots
- https://github.com/kubernetes-sigs/kubetest2/blob/beaf896881019d46bdf961228a117993c1d813db/pkg/testers/ginkgo/package.go#L42
- https://github.com/kubernetes-sigs/kubetest2/blob/beaf896881019d46bdf961228a117993c1d813db/pkg/testers/ginkgo/package.go#L183-L200

these trailing slashes resulted in double slashes in download URLs (e.g. `https://dl.k8s.io//ci/fast/latest-fast.txt`).

Causing the following error:
```
I0226 13:35:18.842783   26057 package.go:51] Test package version was not specified. Defaulting to version from latest-fast.txt: <?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: 767373bbdcb8270361b96548387bf2a9ad0d48758c35//ci/fast/latest-fast.txt</Details></Error>
I0226 13:35:18.842890   26057 package.go:201] Downloading test tar ball from: https://dl.k8s.io//ci/fast/NoSuchKeyThe specified key does not exist.
Details
No such object: 767373bbdcb8270361b96548387bf2a9ad0d48758c35//ci/fast/latest-fast.txt
/kubernetes-test-linux-amd64.tar.gz
F0226 13:35:18.854134   26057 ginkgo.go:259] failed to run ginkgo tester: failed to get ginkgo test package from published releases: failed to create gzip reader: EOF
```

This previously worked because the dl.k8s.io CDN would redirect malformed URLs, but as of Feb 16, 2026, the CDN serves directly from the origin, causing 404 errors for URLs with double slashes.

Affected jobs:
- cloud-provider-aws periodics and presubmits
- sig-node presubmits

Fixes CI failures observed since mid-February in pull-cloud-provider-aws-e2e-kubetest2-quick and related jobs.

Context on thread here: https://kubernetes.slack.com/archives/C09QZ4DQB/p1772041962062339