### PR TITLE
Use CRI-O canary for serial node e2e tests

### DIFF
--- a/jobs/e2e_node/crio/crio_canary.ign
+++ b/jobs/e2e_node/crio/crio_canary.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D14e7ced5d93fb2dedf7afd65111dc6f739301f23%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/latest/image-config-serial.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-serial.yaml
@@ -3,4 +3,4 @@ images:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     machine: e2-standard-4
-    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_canary.ign"

--- a/jobs/e2e_node/crio/templates/base/env-canary.yaml
+++ b/jobs/e2e_node/crio/templates/base/env-canary.yaml
@@ -7,4 +7,4 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
+          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"

--- a/jobs/e2e_node/crio/templates/crio_canary.yaml
+++ b/jobs/e2e_node/crio/templates/crio_canary.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
+          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
 systemd:
   units:
     - name: configure-sysctl.service


### PR DESCRIPTION
Point serial tests to the canary ignition config with CRI-O commit [34f5b852c](https://github.com/cri-o/cri-o/commit/34f5b852c54c6c99e5686b9dfa99578d79502790) which returns the image ID from PullImage, fixing compatibility with Kubernetes credential verification.

Requires: https://github.com/cri-o/packaging/actions/runs/22482902225
Related: https://github.com/cri-o/cri-o/pull/9728