### PR TITLE
headlamp: Filter to v* tags for image version in cloudbuild

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-headlamp.yaml
+++ b/config/jobs/image-pushing/k8s-staging-headlamp.yaml
@@ -20,6 +20,7 @@ postsubmits:
               - --project=k8s-staging-images
               - --scratch-bucket=gs://k8s-staging-images-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --version-tag-filter=v*
               - --with-git-dir
               - .
             env:


### PR DESCRIPTION
Add --version-tag-filter=v* so the image-builder only considers v* tags when generating _GIT_TAG. Without this, non-v tags like headlamp-helm-* or headlamp-plugin-* get picked up.