### PR TITLE
Bump CRI-O commit for all node e2e jobs

### DIFF
--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D14e7ced5d93fb2dedf7afd65111dc6f739301f23%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_drop_infra_ctr.ign
+++ b/jobs/e2e_node/crio/crio_drop_infra_ctr.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D14e7ced5d93fb2dedf7afd65111dc6f739301f23%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_eventedpleg.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D14e7ced5d93fb2dedf7afd65111dc6f739301f23%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_hugepages.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D14e7ced5d93fb2dedf7afd65111dc6f739301f23%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_imagefs.ign
+++ b/jobs/e2e_node/crio/crio_imagefs.ign
@@ -78,7 +78,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D14e7ced5d93fb2dedf7afd65111dc6f739301f23%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_splitfs.ign
+++ b/jobs/e2e_node/crio/crio_splitfs.ign
@@ -78,7 +78,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D14e7ced5d93fb2dedf7afd65111dc6f739301f23%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D14e7ced5d93fb2dedf7afd65111dc6f739301f23%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_userns.ign
+++ b/jobs/e2e_node/crio/crio_userns.ign
@@ -70,7 +70,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D14e7ced5d93fb2dedf7afd65111dc6f739301f23%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/latest/image-config-serial.yaml
+++ b/jobs/e2e_node/crio/latest/image-config-serial.yaml
@@ -3,4 +3,4 @@ images:
     image_family: fedora-coreos-stable
     project: fedora-coreos-cloud
     machine: e2-standard-4
-    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio_canary.ign"
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/crio.ign"

--- a/jobs/e2e_node/crio/templates/base/env.yaml
+++ b/jobs/e2e_node/crio/templates/base/env.yaml
@@ -7,4 +7,4 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
+          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"

--- a/jobs/e2e_node/crio/templates/crio.yaml
+++ b/jobs/e2e_node/crio/templates/crio.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
+          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_drop_infra_ctr.yaml
+++ b/jobs/e2e_node/crio/templates/crio_drop_infra_ctr.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
+          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
     - path: /etc/crio/crio.conf.d/30-crio-drop-infra-ctr.conf
       contents:
         local: 30-crio-drop-infra-ctr.conf

--- a/jobs/e2e_node/crio/templates/crio_eventedpleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_eventedpleg.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
+          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
     - path: /etc/crio/crio.conf.d/40-evented-pleg.conf
       contents:
         local: 40-evented-pleg.conf

--- a/jobs/e2e_node/crio/templates/crio_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_hugepages.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
+          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_imagefs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_imagefs.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
+          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
     - path: /etc/containers/storage.conf
       contents:
         local: 50-storage.conf

--- a/jobs/e2e_node/crio/templates/crio_splitfs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_splitfs.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
+          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
     - path: /etc/containers/storage.conf
       contents:
         local: 60-storage-split-disk.conf

--- a/jobs/e2e_node/crio/templates/crio_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_swap1g.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
+          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_userns.yaml
+++ b/jobs/e2e_node/crio/templates/crio_userns.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=14e7ced5d93fb2dedf7afd65111dc6f739301f23"
+          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
     # Note: this ignition file assumes FCOS has shadow-utils installed.
     # As of the time of writing this, it does.
     - path: /etc/subuid


### PR DESCRIPTION
Promote CRI-O canary commit [34f5b852c](https://github.com/cri-o/cri-o/commit/34f5b852c54c6c99e5686b9dfa99578d79502790) to all jobs, which returns the image ID from `PullImage` fixing compatibility with Kubernetes credential verification. Also move serial tests back from canary to the regular ignition config.