### PR TITLE
Reduce signature replication frequency to every 2h on weekdays

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -291,7 +291,7 @@ periodics:
 # promotion pipeline to avoid rate limit contention with cosign signing.
 # The operation is idempotent; missed or failed replications are caught
 # on the next run.
-- cron: '*/30 * * * *'
+- cron: '0 */2 * * 1-5'
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
   name: ci-k8sio-image-signature-replication


### PR DESCRIPTION
Reduces the `ci-k8sio-image-signature-replication` job from every 30 minutes 24/7 to every 2 hours on weekdays. The job is idempotent and promotions are triggered by human merges, so this frequency is sufficient while reducing Artifact Registry API quota consumption.

/kind cleanup

Related promo-tools optimization: https://github.com/kubernetes-sigs/promo-tools/pull/1761
