### PR TITLE
Update s390x conformance tests for latest versions

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-s390x-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-s390x-periodics.yaml
@@ -138,14 +138,14 @@ periodics:
             cpu: 6
             memory: 20Gi
 
-  - name: ci-kubernetes-s390x-conformance-latest-kubetest2
-    cron: "0 2-23/3 * * *" # every 3h starting at 02:00 UTC
+  - name: ci-kubernetes-s390x-conformance-master
+    cron: "0 3-23/4 * * *" # every 4h starting at 03:00 UTC
     cluster: k8s-infra-s390x-prow-build
     labels:
       preset-ibmcloud-cred-z: "true"
     decorate: true
     decoration_config:
-      timeout: 220m
+      timeout: 2h0m0s
     extra_refs:
       - base_ref: main
         org: kubernetes-sigs
@@ -153,8 +153,13 @@ periodics:
         workdir: true
     annotations:
       description: Runs conformance tests using kubetest2 against kubernetes ci latest on IBM VPC
+      fork-per-release: "true"
+      fork-per-release-cron: 0 1 * * *, 0 5 * * *, 0 9 * * *, 0 13 * * *, 0 17 * * *
+      fork-per-release-replacements: "MARKER_VERSION=latest.txt -> MARKER_VERSION=latest-{{.Version}}.txt"
       testgrid-dashboards: ibm-s390x-k8s, conformance-s390x, ibm-k8s-e2e
-      testgrid-tab-name: ci-kubernetes-s390x-conformance-latest-kubetest2
+      testgrid-tab-name: ci-kubernetes-s390x-conformance-master
+      testgrid-alert-email: sig-cloud-provider-ibm-s390x-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '2'
     spec:
       containers:
         - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260629-f759c32706-master
@@ -163,10 +168,10 @@ periodics:
           resources:
             requests:
               cpu: 4
-              memory: "14Gi"
+              memory: "12Gi"
             limits:
               cpu: 4
-              memory: "14Gi"
+              memory: "12Gi"
           command:
             - runner.sh
           args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -902,6 +902,64 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
+    fork-per-release-cron: 0 17 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-s390x-alerts@kubernetes.io
+    testgrid-dashboards: ibm-s390x-k8s, conformance-s390x, ibm-k8s-e2e, sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-s390x-conformance-1.33
+  cluster: k8s-infra-s390x-prow-build
+  cron: 0 13 * * *
+  decorate: true
+  decoration_config:
+    timeout: 2h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    repo: provider-ibmcloud-test-infra
+    workdir: true
+  labels:
+    preset-ibmcloud-cred-z: "true"
+  name: ci-kubernetes-s390x-conformance-1-33
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        set -o xtrace
+
+        MARKER_VERSION=latest-1.33.txt;
+        K8S_BUILD_VERSION=$(curl -Ls https://dl.k8s.io/ci/$MARKER_VERSION);
+
+        #Setup of kubetest2 tf deployer
+        make install-deployer-tf
+
+        kubetest2 tf --target-provider vpc --vpc-node-image-name ibm-ubuntu-22-04-4-minimal-s390x-3 \
+        --vpc-ssh-key k8s-s390x-ssh-key \
+        --vpc-node-profile bz2-4x16 --ssh-private-key /etc/secret-volume/ssh-privatekey \
+        --extra-vars=ansible_user:k8s-admin --extra-vars=ansible_become:true \
+        --extra-vars=ansible_become_method:sudo \
+        --extra-vars=k8s_tar_bundles:kubernetes-server-linux-s390x.tar.gz \
+        --extra-vars=pod_subnet:10.244.0.0/16 --extra-vars=cni_provider:flannel \
+        --workers-count 2 --cluster-name conformance-$(date +%s) --up --down --auto-approve \
+        --retry-on-tf-failure 3 --break-kubetest-on-upfail true --ignore-destroy-errors \
+        --build-version $K8S_BUILD_VERSION --release-marker $K8S_BUILD_VERSION \
+        --test=ginkgo -- --parallel 10 --test-package-dir ci --test-package-marker $MARKER_VERSION \
+        --focus-regex='\[Conformance\]'
+      command:
+      - runner.sh
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260629-f759c32706-1.33
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 12Gi
+        requests:
+          cpu: "4"
+          memory: 12Gi
+      securityContext:
+        privileged: true
+- annotations:
     fork-per-release-cron: 0 6 * * *
     testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
     testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1066,6 +1066,64 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
+    fork-per-release-cron: 0 13 * * *, 0 17 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-s390x-alerts@kubernetes.io
+    testgrid-dashboards: ibm-s390x-k8s, conformance-s390x, ibm-k8s-e2e, sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-s390x-conformance-1.34
+  cluster: k8s-infra-s390x-prow-build
+  cron: 0 9 * * *
+  decorate: true
+  decoration_config:
+    timeout: 2h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    repo: provider-ibmcloud-test-infra
+    workdir: true
+  labels:
+    preset-ibmcloud-cred-z: "true"
+  name: ci-kubernetes-s390x-conformance-1-34
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        set -o xtrace
+
+        MARKER_VERSION=latest-1.34.txt;
+        K8S_BUILD_VERSION=$(curl -Ls https://dl.k8s.io/ci/$MARKER_VERSION);
+
+        #Setup of kubetest2 tf deployer
+        make install-deployer-tf
+
+        kubetest2 tf --target-provider vpc --vpc-node-image-name ibm-ubuntu-22-04-4-minimal-s390x-3 \
+        --vpc-ssh-key k8s-s390x-ssh-key \
+        --vpc-node-profile bz2-4x16 --ssh-private-key /etc/secret-volume/ssh-privatekey \
+        --extra-vars=ansible_user:k8s-admin --extra-vars=ansible_become:true \
+        --extra-vars=ansible_become_method:sudo \
+        --extra-vars=k8s_tar_bundles:kubernetes-server-linux-s390x.tar.gz \
+        --extra-vars=pod_subnet:10.244.0.0/16 --extra-vars=cni_provider:flannel \
+        --workers-count 2 --cluster-name conformance-$(date +%s) --up --down --auto-approve \
+        --retry-on-tf-failure 3 --break-kubetest-on-upfail true --ignore-destroy-errors \
+        --build-version $K8S_BUILD_VERSION --release-marker $K8S_BUILD_VERSION \
+        --test=ginkgo -- --parallel 10 --test-package-dir ci --test-package-marker $MARKER_VERSION \
+        --focus-regex='\[Conformance\]'
+      command:
+      - runner.sh
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260629-f759c32706-1.34
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 12Gi
+        requests:
+          cpu: "4"
+          memory: 12Gi
+      securityContext:
+        privileged: true
+- annotations:
     fork-per-release-cron: 0 4 * * *, 0 6 * * *
     testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
     testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -1190,6 +1190,64 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
+    fork-per-release-cron: 0 9 * * *, 0 13 * * *, 0 17 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-s390x-alerts@kubernetes.io
+    testgrid-dashboards: ibm-s390x-k8s, conformance-s390x, ibm-k8s-e2e, sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-s390x-conformance-1.35
+  cluster: k8s-infra-s390x-prow-build
+  cron: 0 5 * * *
+  decorate: true
+  decoration_config:
+    timeout: 2h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    repo: provider-ibmcloud-test-infra
+    workdir: true
+  labels:
+    preset-ibmcloud-cred-z: "true"
+  name: ci-kubernetes-s390x-conformance-1-35
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        set -o xtrace
+
+        MARKER_VERSION=latest-1.35.txt;
+        K8S_BUILD_VERSION=$(curl -Ls https://dl.k8s.io/ci/$MARKER_VERSION);
+
+        #Setup of kubetest2 tf deployer
+        make install-deployer-tf
+
+        kubetest2 tf --target-provider vpc --vpc-node-image-name ibm-ubuntu-22-04-4-minimal-s390x-3 \
+        --vpc-ssh-key k8s-s390x-ssh-key \
+        --vpc-node-profile bz2-4x16 --ssh-private-key /etc/secret-volume/ssh-privatekey \
+        --extra-vars=ansible_user:k8s-admin --extra-vars=ansible_become:true \
+        --extra-vars=ansible_become_method:sudo \
+        --extra-vars=k8s_tar_bundles:kubernetes-server-linux-s390x.tar.gz \
+        --extra-vars=pod_subnet:10.244.0.0/16 --extra-vars=cni_provider:flannel \
+        --workers-count 2 --cluster-name conformance-$(date +%s) --up --down --auto-approve \
+        --retry-on-tf-failure 3 --break-kubetest-on-upfail true --ignore-destroy-errors \
+        --build-version $K8S_BUILD_VERSION --release-marker $K8S_BUILD_VERSION \
+        --test=ginkgo -- --parallel 10 --test-package-dir ci --test-package-marker $MARKER_VERSION \
+        --focus-regex='\[Conformance\]'
+      command:
+      - runner.sh
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260629-f759c32706-1.35
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 12Gi
+        requests:
+          cpu: "4"
+          memory: 12Gi
+      securityContext:
+        privileged: true
+- annotations:
     fork-per-release-cron: 0 2 * * *, 0 4 * * *, 0 6 * * *
     testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
     testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -130,6 +130,64 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
+    fork-per-release-cron: 0 5 * * *, 0 9 * * *, 0 13 * * *, 0 17 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-s390x-alerts@kubernetes.io
+    testgrid-dashboards: ibm-s390x-k8s, conformance-s390x, ibm-k8s-e2e, sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-s390x-conformance-1.36
+  cluster: k8s-infra-s390x-prow-build
+  cron: 0 1 * * *
+  decorate: true
+  decoration_config:
+    timeout: 2h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    repo: provider-ibmcloud-test-infra
+    workdir: true
+  labels:
+    preset-ibmcloud-cred-z: "true"
+  name: ci-kubernetes-s390x-conformance-1-36
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        set -o xtrace
+
+        MARKER_VERSION=latest-1.36.txt;
+        K8S_BUILD_VERSION=$(curl -Ls https://dl.k8s.io/ci/$MARKER_VERSION);
+
+        #Setup of kubetest2 tf deployer
+        make install-deployer-tf
+
+        kubetest2 tf --target-provider vpc --vpc-node-image-name ibm-ubuntu-22-04-4-minimal-s390x-3 \
+        --vpc-ssh-key k8s-s390x-ssh-key \
+        --vpc-node-profile bz2-4x16 --ssh-private-key /etc/secret-volume/ssh-privatekey \
+        --extra-vars=ansible_user:k8s-admin --extra-vars=ansible_become:true \
+        --extra-vars=ansible_become_method:sudo \
+        --extra-vars=k8s_tar_bundles:kubernetes-server-linux-s390x.tar.gz \
+        --extra-vars=pod_subnet:10.244.0.0/16 --extra-vars=cni_provider:flannel \
+        --workers-count 2 --cluster-name conformance-$(date +%s) --up --down --auto-approve \
+        --retry-on-tf-failure 3 --break-kubetest-on-upfail true --ignore-destroy-errors \
+        --build-version $K8S_BUILD_VERSION --release-marker $K8S_BUILD_VERSION \
+        --test=ginkgo -- --parallel 10 --test-package-dir ci --test-package-marker $MARKER_VERSION \
+        --focus-regex='\[Conformance\]'
+      command:
+      - runner.sh
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260629-f759c32706-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 12Gi
+        requests:
+          cpu: "4"
+          memory: 12Gi
+      securityContext:
+        privileged: true
+- annotations:
     testgrid-alert-email: release-team@kubernetes.io
     testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-1.36-blocking, conformance-all, conformance-gce

--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -86,6 +86,7 @@ dashboards:
 - name: conformance-ppc64le
 - name: conformance-arm64
 - name: conformance-kind
+- name: conformance-s390x
 
 # Gardener Conformance Dashboard
 - name: conformance-gardener
@@ -191,28 +192,7 @@ dashboards:
       alert_options:
         alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
-# s390x dashboard
-- name: conformance-s390x
-  dashboard_tab:
-    - name: Periodic s390x conformance test on local cluster , v1.33
-      test_group_name: s390x-conformance-v1.33
-      description: Runs conformance tests by using kubetest2 against latest v1.33 branch HEAD of kubernetes on local s390x cluster
-    - name: Periodic s390x conformance test on local cluster , v1.32
-      test_group_name: s390x-conformance-v1.32
-      description: Runs conformance tests by using kubetest2 against latest v1.32 branch HEAD of kubernetes on local s390x cluster
-    - name: Periodic s390x conformance test on local cluster , v1.31
-      test_group_name: s390x-conformance-v1.31
-      description: Runs conformance tests by using kubetest2 against latest v1.31 branch HEAD of kubernetes on local s390x cluster
-
 test_groups:
-
-#IBM s390x test results
-- name: s390x-conformance-v1.33
-  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.33
-- name: s390x-conformance-v1.32
-  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.32
-- name: s390x-conformance-v1.31
-  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.31
 
 # Gardener Conformance Test Groups
 - name: ci-gardener-e2e-conformance-aws-v1.35


### PR DESCRIPTION
This PR updates the s390x conformance tests to be triggered from community cluster instead of local Prow.
Added v1.33 - v1.36 jobs.
Added auto creation of jobs using using config-forker and config-rotator for future releases.
Cleaned up existing s390x entries from conformance-all.yaml 