### PR TITLE
Add prow job for e2e test for kube-agentic-networking project

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-agentic-networking/kube-agentic-networking-config.yaml
+++ b/config/jobs/kubernetes-sigs/kube-agentic-networking/kube-agentic-networking-config.yaml
@@ -62,3 +62,34 @@ presubmits:
             requests:
               cpu: 1
               memory: 4Gi
+  - name: pull-kube-agentic-networking-e2e
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-network-kube-agentic-networking
+      testgrid-tab-name: e2e
+    labels:
+      preset-kind-volume-mounts: "true"
+      preset-dind-enabled: "true"
+    decorate: true
+    path_alias: sigs.k8s.io/kube-agentic-networking
+    always_run: true
+    skip_report: false
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260209-dbbff72479-master
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e
+          # docker-in-docker needs privileged mode.
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 4
+              memory: 8Gi
+            requests:
+              cpu: 4
+              memory: 8Gi


### PR DESCRIPTION
The script is defined in https://github.com/kubernetes-sigs/kube-agentic-networking/pull/132.

The job will do the following within dind
- create a kind cluster
- install Gateway API and project CRDs
- create a fresh controller image
- load the image to the cluster
- deploy controller to the cluster
- run e2e tests