### PR TITLE
Gate disruptive e2e test as required CI for aws-ebs-csi-driver; add periodic

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -139,3 +139,39 @@ periodics:
     testgrid-tab-name: ci-external-test
     description: kubernetes/kubernetes external test, continuous
     testgrid-num-columns-recent: '30'
+- name: ci-aws-ebs-csi-driver-e2e-disruptive
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 1h20m
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+    preset-aws-credential-aws-shared-testing: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: aws-ebs-csi-driver
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
+      command:
+      - runner.sh
+      args:
+      - make
+      - test-e2e-disruptive
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: "2"
+          memory: "8Gi"
+        requests:
+          cpu: "2"
+          memory: "8Gi"
+  annotations:
+    testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-periodics
+    testgrid-tab-name: ci-e2e-test-disruptive
+    description: aws ebs csi driver e2e test for disruptive features (metadata labeler), continuous
+    testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -225,8 +225,7 @@ presubmits:
   - name: pull-aws-ebs-csi-driver-e2e-disruptive
     cluster: eks-prow-build-cluster
     decorate: true
-    optional: true
-    skip_report: true
+    optional: false
     skip_branches:
     - gh-pages
     skip_if_only_changed: "^docs/|^examples/|.md$|OWNERS$|^.github/"


### PR DESCRIPTION
The metadata labeler disruptive e2e test currently runs in CI but is configured as optional so failures don't post to PRs and don't block merges. This means regressions in the metadata labeler code paths can slip through unnoticed. This PR marks the disruptive e2e test as a required, visible check on every PR and adds a periodic that runs daily.