### PR TITLE
Bump kpromo to v4.4.0-0

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v4.3.0-0
+      - image: registry.k8s.io/artifact-promoter/kpromo:v4.4.0-0
         command:
         - /kpromo
         args:
@@ -54,8 +54,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: gcr.io/k8s-staging-artifact-promoter/kpromo:latest
-        imagePullPolicy: Always
+      - image: registry.k8s.io/artifact-promoter/kpromo:v4.4.0-0
         command:
         - /kpromo
         args:
@@ -123,7 +122,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v4.3.0-0
+    - image: registry.k8s.io/artifact-promoter/kpromo:v4.4.0-0
       command:
       - /kpromo
       args:
@@ -156,7 +155,7 @@ periodics:
     serviceAccountName: k8s-infra-promoter
     containers:
     - name: promote-to-mirrors
-      image: registry.k8s.io/artifact-promoter/kpromo:v4.3.0-0
+      image: registry.k8s.io/artifact-promoter/kpromo:v4.4.0-0
       command:
       - /kpromo
       args:
@@ -185,7 +184,7 @@ periodics:
           name: aws-iam-token
           readOnly: true
     - name: promote-to-mirrors-staging
-      image: registry.k8s.io/artifact-promoter/kpromo:v4.3.0-0
+      image: registry.k8s.io/artifact-promoter/kpromo:v4.4.0-0
       command:
       - /kpromo
       args:
@@ -256,8 +255,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:latest
-      imagePullPolicy: Always
+    - image: registry.k8s.io/artifact-promoter/kpromo:v4.4.0-0
       command:
       - /kpromo
       args:
@@ -303,8 +301,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:latest
-      imagePullPolicy: Always
+    - image: registry.k8s.io/artifact-promoter/kpromo:v4.4.0-0
       command:
       - /kpromo
       args:
@@ -414,7 +411,7 @@ periodics:
     path_alias: sigs.k8s.io/promo-tools
   spec:
     containers:
-    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.3.0-0
+    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.4.0-0
       imagePullPolicy: Always
       command:
         - /kpromo


### PR DESCRIPTION
Bump kpromo to v4.4.0-0 and pin the image promotion and signature
replication jobs back from staging latest to the released image.

Reverts kubernetes/test-infra#36525 and kubernetes/test-infra#36521.

/hold
cc: @kubernetes/release-engineering