### PR TITLE
Bump SPO Prow jobs to golang 1.26

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         command:
         - hack/pull-security-profiles-operator-build
         resources:
@@ -29,7 +29,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         command:
         - hack/pull-security-profiles-operator-verify
         resources:
@@ -49,7 +49,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         command:
         - hack/pull-security-profiles-operator-test-unit
         resources:


### PR DESCRIPTION
Bump the Go image from `golang:1.25` to `golang:1.26` for the
security-profiles-operator presubmit jobs (build, verify, test-unit).

This aligns with the Go version bump in the SPO repository
(kubernetes-sigs/security-profiles-operator#3105).