### PR TITLE
Remove PARALLEL=true from the pull-kubernetes-e2e-storage-kind-volume-group-snapshots prow job to stop forcing parallel execution.

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
@@ -84,8 +84,6 @@ presubmits:
           value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
         - name: FOCUS
           value: \[Feature:volumegroupsnapshot\]
-        - name: PARALLEL
-          value: "true"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
Remove PARALLEL=true from the pull-kubernetes-e2e-storage-kind-volume-group-snapshots prow job to stop forcing parallel execution.

Note: [Stress Test is serial](https://github.com/kubernetes/kubernetes/pull/136845)
