### PR TITLE
DRA: enable GenericWorkload feature gate for 1.35+

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -124,6 +124,14 @@ presubmits:
           kind_node_source=.
           # Which DRA features exist can change over time.
           features=( $( grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/' ) )
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+          # These extra features are dependencies for some DRA features but only
+          # valid for Kubernetes 1.35+. Additional features here should not
+          # affect behavior of tests that don't require them.
+          if ((major >= 1 && minor - 0 >= 35)); then
+            features+=('GenericWorkload')
+          fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo
@@ -221,6 +229,14 @@ presubmits:
           kind_node_source=.
           # Which DRA features exist can change over time.
           features=( $( grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/' ) )
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+          # These extra features are dependencies for some DRA features but only
+          # valid for Kubernetes 1.35+. Additional features here should not
+          # affect behavior of tests that don't require them.
+          if ((major >= 1 && minor - 0 >= 35)); then
+            features+=('GenericWorkload')
+          fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -154,6 +154,16 @@ presubmits:
           {%- if all_features %}
           # Which DRA features exist can change over time.
           features=( $( {%- if ci %} curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/pkg/features/kube_features.go" | grep '"DRA' {% else %} grep '"DRA' pkg/features/kube_features.go {%- endif %} | sed 's/.*"\(.*\)"/\1/' ) )
+          {%- if canary %}
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+          # These extra features are dependencies for some DRA features but only
+          # valid for Kubernetes 1.35+. Additional features here should not
+          # affect behavior of tests that don't require them.
+          if ((major >= 1 && minor - {{ kubelet_skew }} >= 35)); then
+            features+=('GenericWorkload')
+          fi
+          {%- endif %}
           : "Enabling DRA feature(s): ${features[*]}."
           {%- else %}
           features=( )


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/136989 adds a new feature gate that depends on the GenericWorkload feature gate which isn't automatically enabled like the other `DRA*` feature gates. Hardcoding that feature gate like that PR currently does breaks the `n-2` and `n-3` jobs which run versions of the kubelet where the GenericWorkload feature gate doesn't exist. This PR adds GenericWorkload to the generated list of `DRA*` feature gates when it can be set for the canary jobs. If they work as expected on https://github.com/kubernetes/kubernetes/pull/136989 then I'll follow up with this change for the other relevant jobs.

/assign @pohly