### PR TITLE
automatically enforce release-blocking job runtime policy

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -1211,6 +1211,37 @@ func TestKubernetesReleaseBlockingJobsCIPolicy(t *testing.T) {
 	jobsToFix := 0
 	numJobs := len(allStaticJobs())
 
+	// TODO: finish eliminating this list and remove the known-failures logic
+	knownFailures := map[string]bool{
+		"ci-kubernetes-conformance-kind-ga-only":          true,
+		"ci-kubernetes-e2e-gce-cos-alphafeatures-beta":    true,
+		"ci-kubernetes-e2e-gce-cos-alphafeatures-master":  true,
+		"ci-kubernetes-e2e-gce-cos-alphafeatures-stable1": true,
+		"ci-kubernetes-e2e-gce-cos-alphafeatures-stable2": true,
+		"ci-kubernetes-e2e-gce-cos-alphafeatures-stable3": true,
+		"ci-kubernetes-e2e-gce-cos-reboot-beta":           true,
+		"ci-kubernetes-e2e-gce-cos-reboot-master":         true,
+		"ci-kubernetes-e2e-gce-cos-reboot-stable1":        true,
+		"ci-kubernetes-e2e-gce-cos-reboot-stable2":        true,
+		"ci-kubernetes-e2e-gce-cos-reboot-stable3":        true,
+		"ci-kubernetes-e2e-gce-device-plugin-gpu":         true,
+		"ci-kubernetes-e2e-gce-device-plugin-gpu-1-32":    true,
+		"ci-kubernetes-e2e-gce-device-plugin-gpu-1-33":    true,
+		"ci-kubernetes-e2e-gce-device-plugin-gpu-1-34":    true,
+		"ci-kubernetes-e2e-gce-device-plugin-gpu-1-35":    true,
+		"ci-kubernetes-e2e-gce-scale-performance-100":     true,
+		"ci-kubernetes-e2e-gci-gce-alpha-features":        true,
+		"ci-kubernetes-e2e-gci-gce-reboot":                true,
+		"ci-kubernetes-gce-conformance-latest":            true,
+		"ci-kubernetes-gce-conformance-latest-1-32":       true,
+		"ci-kubernetes-gce-conformance-latest-1-33":       true,
+		"ci-kubernetes-gce-conformance-latest-1-34":       true,
+		"ci-kubernetes-gce-conformance-latest-1-35":       true,
+		"ci-kubernetes-kind-cloud-provider-loadbalancer":  true,
+		"ci-kubernetes-node-e2e-containerd":               true,
+		"ci-node-crio-conformance":                        true,
+	}
+
 	for _, job := range c.AllPeriodics() {
 		// Only consider Pods that are release-blocking
 		if job.Spec == nil || !isKubernetesReleaseBlocking(job.JobBase) {
@@ -1243,7 +1274,11 @@ func TestKubernetesReleaseBlockingJobsCIPolicy(t *testing.T) {
 			jobsToFix++
 		}
 		for _, err := range errs {
-			t.Errorf("%v: %v", job.Name, err)
+			if _, ok := knownFailures[job.Name]; ok {
+				t.Logf("%v: %v", job.Name, err)
+			} else {
+				t.Errorf("%v: %v", job.Name, err)
+			}
 		}
 	}
 
@@ -1278,7 +1313,11 @@ func TestKubernetesReleaseBlockingJobsCIPolicy(t *testing.T) {
 				jobsToFix++
 			}
 			for _, err := range errs {
-				t.Errorf("%v: %v", job.Name, err)
+				if _, ok := knownFailures[job.Name]; ok {
+					t.Logf("%v: %v", job.Name, err)
+				} else {
+					t.Errorf("%v: %v", job.Name, err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Spun out from https://github.com/kubernetes/test-infra/pull/35336, this PR has **no changes to the jobs** and instead lists all currently failing jobs in a "known failures" list we can work on eliminating incrementally, with separate PRs for updating the job configs to follow.


/cc @kubernetes/sig-testing-leads @kubernetes/sig-release 