### PR TITLE
[sig-windows] Add periodic Hyper-V container e2e test job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -128,6 +128,64 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io, release-team@kubernetes.io
     testgrid-dashboards: sig-release-master-informing, sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-master
+- name: ci-kubernetes-e2e-capz-master-windows-hyperv
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-capz-windows-common: "true"
+    preset-capz-windows-2025: "true"
+    preset-capz-containerd-2-0-latest: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260217-29ba10ecec-master
+        command:
+          - "runner.sh"
+          - "env"
+          - "KUBERNETES_VERSION=latest"
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: HYPERV
+            value: "true"
+          - name: GINKGO_FOCUS
+            value: \[Feature:WindowsHyperVContainers\]
+          - name: GINKGO_SKIP
+            value: \[LinuxOnly\]
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-master-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-master-hyperv
 - name: ci-kubernetes-e2e-capz-master-windows-containerd17
   cluster: eks-prow-build-cluster
   interval: 24h


### PR DESCRIPTION
Add ci-kubernetes-e2e-capz-master-windows-hyperv periodic job that runs daily to test Hyper-V isolated Windows containers on CAPZ clusters.

The job uses HYPERV=true which triggers the Hyper-V webhook deployment and containerd v2.1.6 pinning (added in windows-testing PR #546), then runs [Feature:WindowsHyperVContainers] e2e tests.

Results appear on sig-windows-master-release and sig-windows-signal testgrid dashboards under the capz-windows-master-hyperv tab.