### PR TITLE
set SystemdCgroup to true for containerd 1.7 DRA job

### DIFF
--- a/jobs/e2e_node/dra/init-containerd-1.7.yaml
+++ b/jobs/e2e_node/dra/init-containerd-1.7.yaml
@@ -41,8 +41,9 @@ runcmd:
   - echo "Configure Containerd"
   - mkdir -p /etc/containerd
   - containerd config default > /etc/containerd/config.toml
-  - echo "Enabling CDI"
+  - echo "Enabling CDI and SystemdCgroup"
   - sed -ie 's/enable_cdi = false/enable_cdi = true/' /etc/containerd/config.toml
+  - sed -ie 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
 
   - echo "Restarting containerd"
   - systemctl daemon-reload


### PR DESCRIPTION
The containerd 2.0 job for DRA sets the SystemdCgroup to true while the containerd 1.7 job doesn't. 


xref : https://kubernetes.slack.com/archives/C0BP8PW9G/p1772656144303909?thread_ts=1772610066.607189&cid=C0BP8PW9G 

cc @mikebrow 