### PR TITLE
DRA integration canary: run as Go test

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -715,15 +715,13 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          # test/e2e_dra is a separate Ginkgo suite with a dependency on local-up-cluster.sh.
-          # We could use "make test WHAT=./test/e2e_dra", but then we would get a test JUnit file
-          # in addition to the better one from Ginkgo, so instead we build the test binary and
-          # invoke it directly. The Ginkgo CLI doesn't add any benefit because we cannot run
-          # tests in parallel.
-          #
-          # We also need the control plane binaries.
-          make WHAT="./test/e2e_dra/e2e_dra.test cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
-          KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir _output/local/go/bin/e2e_dra.test -ginkgo.timeout=30m -ginkgo.junit-report=${ARTIFACTS}/junit.xml -ginkgo.v -test.v
+          # test/e2e_dra is a Go unit test with a dependency on local-up-cluster.sh
+          # and the the control plane binaries.
+          # We can run it via "make test" to get a JUnit file from gotestsum.
+          # The full log output gets enabled to see progress while the test runs
+          # and to debug potential cross-test interactions.
+          make WHAT="cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
+          make test WHAT=./test/e2e_dra FULL_LOG=y KUBE_TIMEOUT=30m KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -120,6 +120,15 @@ presubmits:
         - /bin/bash
         - -xce
         - |
+          {%- if canary %}
+          # test/e2e_dra is a Go unit test with a dependency on local-up-cluster.sh
+          # and the the control plane binaries.
+          # We can run it via "make test" to get a JUnit file from gotestsum.
+          # The full log output gets enabled to see progress while the test runs
+          # and to debug potential cross-test interactions.
+          make WHAT="cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
+          make test WHAT=./test/e2e_dra FULL_LOG=y KUBE_TIMEOUT=30m KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir
+          {%- else %}
           # test/e2e_dra is a separate Ginkgo suite with a dependency on local-up-cluster.sh.
           # We could use "make test WHAT=./test/e2e_dra", but then we would get a test JUnit file
           # in addition to the better one from Ginkgo, so instead we build the test binary and
@@ -129,6 +138,7 @@ presubmits:
           # We also need the control plane binaries.
           make WHAT="./test/e2e_dra/e2e_dra.test cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
           KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir _output/local/go/bin/e2e_dra.test -ginkgo.timeout=30m -ginkgo.junit-report=${ARTIFACTS}/junit.xml -ginkgo.v -test.v
+          {%- endif %}
 
         {%- elif job_type == "e2e" %}
         args:


### PR DESCRIPTION
When switching from Ginkgo to Go test, the job continued to work (extra test args ignored) but did not produce a useful JUnit file anymore.

/assign @bart0sh 