### PR TITLE
DRA: trigger integration job on test/e2e_dra changes

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -704,7 +704,7 @@ presubmits:
     skip_branches:
     - release-\d+\.\d+  # per-release image
     always_run: false
-    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource|test/e2e_dra)/.*\.(go|yaml)
     optional: true
     labels:
       preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-node/dra.generate.conf
+++ b/config/jobs/kubernetes/sig-node/dra.generate.conf
@@ -101,7 +101,7 @@ use_dind = true
 use_dind_cdi = true
 job_type = integration
 cluster = eks-prow-build-cluster
-run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource|test/e2e_dra)/.*\.(go|yaml)
 
 # This job runs the node e2e tests for DRA with CRI-O
 [node-crio-dra]


### PR DESCRIPTION
Added test/e2e_dra to the run_if_changed pattern for the dra-integration job.
This ensures that changes to the DRA integration tests will trigger the job.

/assign @pohly 