### PR TITLE
DRA: update run_if_changed

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -8,7 +8,7 @@ presubmits:
     skip_branches:
     - release-\d+\.\d+  # per-release image
     always_run: false
-    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
     optional: true
     labels:
       preset-service-account: "true"
@@ -96,7 +96,7 @@ presubmits:
     skip_branches:
     - release-\d+\.\d+  # per-release image
     always_run: false
-    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
     optional: true
     labels:
       preset-service-account: "true"
@@ -293,7 +293,7 @@ presubmits:
     skip_branches:
     - release-\d+\.\d+  # per-release image
     always_run: false
-    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
     optional: true
     labels:
       preset-service-account: "true"
@@ -430,7 +430,7 @@ presubmits:
     skip_branches:
     - release-\d+\.\d+  # per-release image
     always_run: false
-    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
     optional: true
     labels:
       preset-service-account: "true"
@@ -567,7 +567,7 @@ presubmits:
     skip_branches:
     - release-\d+\.\d+  # per-release image
     always_run: false
-    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
     optional: true
     labels:
       preset-service-account: "true"
@@ -704,7 +704,7 @@ presubmits:
     skip_branches:
     - release-\d+\.\d+  # per-release image
     always_run: false
-    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource|test/e2e_dra)/.*\.(go|yaml)
+    run_if_changed: /(dra|e2e_dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
     optional: true
     labels:
       preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-node/dra.generate.conf
+++ b/config/jobs/kubernetes/sig-node/dra.generate.conf
@@ -33,7 +33,7 @@ description = Runs E2E tests for Dynamic Resource Allocation beta features again
 job_type = e2e
 use_dind = true
 cluster = eks-prow-build-cluster
-run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 release_informing = true
 
 # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha, soon beta)
@@ -46,7 +46,7 @@ job_type = e2e
 cluster = eks-prow-build-cluster
 all_features = true
 use_dind = true
-run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 
 # Compared to ci-kind-dra-all, this one also enables slow tests.
 # Needs to be triggered manually.
@@ -67,7 +67,7 @@ description = Runs E2E tests for Dynamic Resource Allocation beta features again
 job_type = e2e
 use_dind = true
 cluster = eks-prow-build-cluster
-run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 kubelet_skew = 1
 
 # This job runs the current e2e.test against a cluster where the kubelet is from the "current - 2" release.
@@ -78,7 +78,7 @@ description = Runs E2E tests for Dynamic Resource Allocation beta features again
 job_type = e2e
 use_dind = true
 cluster = eks-prow-build-cluster
-run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 kubelet_skew = 2
 
 # This job runs the current e2e.test against a cluster where the kubelet is from the "current - 3" release.
@@ -89,7 +89,7 @@ description = Runs E2E tests for Dynamic Resource Allocation beta features again
 job_type = e2e
 use_dind = true
 cluster = eks-prow-build-cluster
-run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 kubelet_skew = 3
 
 # This executes tests in test/e2e_dra with special requirements (local-up-cluster.sh!).
@@ -101,7 +101,7 @@ use_dind = true
 use_dind_cdi = true
 job_type = integration
 cluster = eks-prow-build-cluster
-run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource|test/e2e_dra)/.*\.(go|yaml)
+run_if_changed = /(dra|e2e_dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 
 # This job runs the node e2e tests for DRA with CRI-O
 [node-crio-dra]


### PR DESCRIPTION
As we noticed when adding /(...|test/e2e_dra)/... = /test/e2e_dra/... to pull-kubernetes-dra-integration, that pattern didn't trigger the job. Probably the reason is that the path which gets matched against is e.g. test/e2e_dra/upgradedowngrade_test.go without the leading slash.

This means we can match sub-directories, but not the top-level directory. This seems sufficient. pkg/apis/resource had the same problem, hidden by typically trigger via some other pattern.

/assign @bart0sh 