### PR TITLE
[Compatibility] Exclude Alpha->Deprecated features from missing check.

### DIFF
--- a/experiment/compatibility-versions/test_versioned_specs_util.sh
+++ b/experiment/compatibility-versions/test_versioned_specs_util.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+source "${SCRIPT_DIR}/versioned_specs_util.sh"
+
+run_tests() {
+  local failures=0
+
+  echo "Running tests for versioned_specs_util.sh"
+
+  local mock_specs='[{"version":"1.30","preRelease":"Alpha"},{"version":"1.32","preRelease":"Beta"},{"version":"1.34","preRelease":"GA"}]'
+
+  # Test get_target_spec
+  local got
+  got=$(get_target_spec "$mock_specs" "1.33")
+  if [[ "$got" != *'"1.32"'* ]]; then
+    echo "FAIL: get_target_spec expected 1.32, got: $got"
+    failures=$((failures+1))
+  else
+    echo "PASS: get_target_spec"
+  fi
+
+  # Test get_prev_target_spec
+  got=$(get_prev_target_spec "$mock_specs" "1.33")
+  if [[ "$got" != *'"1.30"'* ]]; then
+    echo "FAIL: get_prev_target_spec expected 1.30, got: $got"
+    failures=$((failures+1))
+  else
+    echo "PASS: get_prev_target_spec"
+  fi
+
+  got=$(get_prev_target_spec "$mock_specs" "1.30")
+  if [[ "$got" != "null" ]]; then
+    echo "FAIL: get_prev_target_spec (first element) expected null, got: $got"
+    failures=$((failures+1))
+  else
+    echo "PASS: get_prev_target_spec (first element)"
+  fi
+
+  # Test get_version_1_0_spec
+  local mock_specs_1_0='[{"version":"1.0","preRelease":"GA"},{"version":"1.33","preRelease":"Deprecated"}]'
+  got=$(get_version_1_0_spec "$mock_specs_1_0")
+  if [[ "$got" != *'"1.0"'* ]]; then
+    echo "FAIL: get_version_1_0_spec expected 1.0 spec, got: $got"
+    failures=$((failures+1))
+  else
+    echo "PASS: get_version_1_0_spec"
+  fi
+
+  # Test get_exact_version_spec
+  got=$(get_exact_version_spec "$mock_specs" "1.30")
+  if [[ "$got" != *'"1.30"'* ]]; then
+    echo "FAIL: get_exact_version_spec expected 1.30 spec, got: $got"
+    failures=$((failures+1))
+  else
+    echo "PASS: get_exact_version_spec"
+  fi
+
+  got=$(get_exact_version_spec "$mock_specs" "1.31")
+  if [[ "$got" != "null" ]]; then
+    echo "FAIL: get_exact_version_spec for non-existent version expected null, got: $got"
+    failures=$((failures+1))
+  else
+    echo "PASS: get_exact_version_spec for non-existent version"
+  fi
+
+  if [[ $failures -gt 0 ]]; then
+    echo "Tests failed ($failures failures)."
+    exit 1
+  else
+    echo "All tests passed!"
+    exit 0
+  fi
+}
+
+run_tests

--- a/experiment/compatibility-versions/validate-compatibility-versions-feature-gates.sh
+++ b/experiment/compatibility-versions/validate-compatibility-versions-feature-gates.sh
@@ -18,6 +18,10 @@
 #
 # Usage: validate-compatibility-versions-feature-gates.sh <emulated_version> <current_version> <metrics_file> <feature_list> <prev_feature_list> <results_file>
 set -o errexit -o nounset -o pipefail
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+source "${SCRIPT_DIR}/versioned_specs_util.sh"
+
 # Check arg count
 if [[ $# -ne 6 ]]; then
   echo "Usage: ${0} <emulated_version> <current_version> <metrics_file> <feature_list> <prev_feature_list> <results_file>"
@@ -73,19 +77,10 @@ while IFS= read -r feature_entry; do
   specs_json=$(echo "${feature_entry}"   | jq -c '.versionedSpecs')
 
   # Numeric parse for .version vs emulated_version
-  target_spec="$(
-    echo "${specs_json}" \
-    | jq -r --arg ver "${emulated_version}" '
-        [ .[]
-          | select(
-              ( .version | sub("^v"; "") | tonumber )
-              <=
-              ($ver | sub("^v"; "") | tonumber)
-            )
-        ]
-        | last
-      '
-  )"
+  target_spec="$(get_target_spec "${specs_json}" "${emulated_version}")"
+
+  prev_target_spec="$(get_prev_target_spec "${specs_json}" "${emulated_version}")"
+
 
   # If no matching spec, skip
   if [[ -z "$target_spec" || "$target_spec" == "null" ]]; then
@@ -94,6 +89,7 @@ while IFS= read -r feature_entry; do
 
   # Read fields
   raw_stage=$(echo "$target_spec"       | jq -r '.preRelease')
+  prev_raw_stage=$(echo "$prev_target_spec" | jq -r '.preRelease')
   lockToDefault=$(echo "$target_spec"   | jq -r '.lockToDefault')
   defaultVal=$(echo "$target_spec"      | jq -r '.default')
 
@@ -104,6 +100,7 @@ while IFS= read -r feature_entry; do
   fi
 
   expected_stage["$feature_name"]="${raw_stage^^}"
+  expected_prev_stage["$feature_name"]="${prev_raw_stage^^}"
   expected_lock["$feature_name"]="$lockToDefault"
   expected_value["$feature_name"]="$want"
 done < <(echo "$prev_feature_stream")
@@ -114,6 +111,7 @@ done < <(echo "$prev_feature_stream")
 # - If present & stage!=ALPHA => compare numeric value
 for feature_name in "${!expected_stage[@]}"; do
   stage="${expected_stage[$feature_name]}"
+  prev_stage="${expected_prev_stage[$feature_name]}"
   locked="${expected_lock[$feature_name]}"
   want="${expected_value[$feature_name]}"
   got="${actual_features[$feature_name]:-}"  # empty if missing
@@ -126,6 +124,11 @@ for feature_name in "${!expected_stage[@]}"; do
   if [[ -z "$got" ]]; then
     # Missing from metrics
     if [[ "$locked" == "true" ]]; then
+      continue
+    fi
+
+    # If the feature is deprecated but not locked, and was alpha in the previous version, it can be missing from metrics
+    if [[ "$prev_stage" == "ALPHA" && "$stage" == "DEPRECATED" ]]; then
       continue
     fi
 
@@ -161,19 +164,9 @@ while IFS= read -r feature_entry; do
   feature_name=$(echo "${feature_entry}" | jq -r '.name')
   specs_json=$(echo "${feature_entry}"   | jq -c '.versionedSpecs')
   # We want the spec matching or below the emulated_version
-  target_spec="$(
-    echo "${specs_json}" \
-    | jq -r --arg ver "${emulated_version}" '
-        [ .[]
-          | select(
-              ( .version | sub("^v"; "") | tonumber )
-              <=
-              ($ver | sub("^v"; "") | tonumber)
-            )
-        ]
-        | last
-      '
-  )"
+  target_spec="$(get_target_spec "${specs_json}" "${emulated_version}")"
+
+  prev_target_spec="$(get_prev_target_spec "${specs_json}" "${emulated_version}")"
   # If no matching spec, skip
   if [[ -z "$target_spec" || "$target_spec" == "null" ]]; then
     continue
@@ -201,36 +194,14 @@ while IFS= read -r feature_entry; do
   specs_json=$(echo "${feature_entry}"   | jq -c '.versionedSpecs')
   
   # Check for version 1.0 features
-  version_1_0_spec="$(
-    echo "${specs_json}" \
-    | jq -r '
-        [ .[]
-          | select(
-              (.version | sub("^v"; "") | tonumber) == 1.0
-            )
-        ]
-        | if length > 0 then .[0] else null end
-      '
-  )"
+  version_1_0_spec="$(get_version_1_0_spec "${specs_json}")"
   if [[ -n "$version_1_0_spec" && "$version_1_0_spec" != "null" ]]; then
     ga_stage=$(echo "$version_1_0_spec" | jq -r '.preRelease')
     version_1_0_stage["$feature_name"]="${ga_stage^^}"  # uppercase
   fi
   
   # We want the spec matching EXACTLY the current_version
-  current_version_spec="$(
-    echo "${specs_json}" \
-    | jq -r --arg ver "${current_version}" '
-        [ .[]
-          | select(
-              ( .version | sub("^v"; "") | tonumber )
-              ==
-              ($ver | sub("^v"; "") | tonumber)
-            )
-        ]
-        | if length > 0 then .[0] else null end
-      '
-  )"
+  current_version_spec="$(get_exact_version_spec "${specs_json}" "${current_version}")"
   # If no exact matching spec, skip
   if [[ -z "$current_version_spec" || "$current_version_spec" == "null" ]]; then
     continue

--- a/experiment/compatibility-versions/versioned_specs_util.sh
+++ b/experiment/compatibility-versions/versioned_specs_util.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+# get_target_spec takes two arguments: specs_json and emulated_version
+# Returns the highest spec strictly less than or equal to the emulated_version.
+function get_target_spec() {
+  local specs_json="$1"
+  local emulated_version="$2"
+
+  echo "${specs_json}" | jq -r --arg ver "${emulated_version}" '
+        [ .[]
+          | select(
+              ( .version | sub("^v"; "") | tonumber )
+              <=
+              ($ver | sub("^v"; "") | tonumber)
+            )
+        ]
+        | last
+      '
+}
+
+# get_prev_target_spec takes two arguments: specs_json and emulated_version
+# Returns the spec immediately preceding target_spec in the original sorted array.
+function get_prev_target_spec() {
+  local specs_json="$1"
+  local emulated_version="$2"
+
+  echo "${specs_json}" | jq -r --arg ver "${emulated_version}" '
+        . as $arr |
+        [ range(length)
+          | select(
+              ( $arr[.] | .version | sub("^v"; "") | tonumber )
+              <=
+              ($ver | sub("^v"; "") | tonumber)
+            )
+        ] | last as $idx
+        | if $idx != null and $idx > 0 then $arr[$idx - 1] else null end
+      '
+}
+
+# get_version_1_0_spec takes one argument: specs_json
+# Returns the spec corresponding exactly to version 1.0.
+function get_version_1_0_spec() {
+  local specs_json="$1"
+  get_exact_version_spec "$specs_json" "1.0"
+}
+
+# get_exact_version_spec takes two arguments: specs_json and target_version
+# Returns the spec uniquely matching the exact target_version.
+function get_exact_version_spec() {
+  local specs_json="$1"
+  local target_version="$2"
+
+  echo "${specs_json}" | jq -r --arg ver "${target_version}" '
+        [ .[]
+          | select(
+              ( .version | sub("^v"; "") | tonumber )
+              ==
+              ($ver | sub("^v"; "") | tonumber)
+            )
+        ]
+        | if length > 0 then .[0] else null end
+      '
+}


### PR DESCRIPTION
Currently when a deprecated feature is removed, it needs to be locked first.
But there are cases when an Alpha feature is deprecated and not locked, it is ok to be removed.

This should fix test failures caused by https://github.com/kubernetes/kubernetes/pull/136959