### PR TITLE
DRA: Promote GenericWorkload feature gate to default jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -36,6 +36,8 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo
@@ -122,10 +124,10 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
-          # Which DRA features exist can change over time.
-          features=( $( grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/' ) )
           major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
           minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+          # Which DRA features exist can change over time.
+          features=( $( grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/' ) )
           # These extra features are dependencies for some DRA features but only
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
@@ -227,10 +229,10 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
-          # Which DRA features exist can change over time.
-          features=( $( grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/' ) )
           major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
           minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+          # Which DRA features exist can change over time.
+          features=( $( grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/' ) )
           # These extra features are dependencies for some DRA features but only
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
@@ -332,6 +334,8 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo
@@ -373,8 +377,6 @@ presubmits:
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
-          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
-          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 1))
           if [[ $revision == *alpha.0* ]]; then
               : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
@@ -467,6 +469,8 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo
@@ -508,8 +512,6 @@ presubmits:
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
-          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
-          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 2))
           if [[ $revision == *alpha.0* ]]; then
               : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
@@ -602,6 +604,8 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo
@@ -643,8 +647,6 @@ presubmits:
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
-          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
-          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 3))
           if [[ $revision == *alpha.0* ]]; then
               : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -44,6 +44,8 @@ periodics:
           hash=${revision/*+/}
           kind_yaml_cmd=(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
           kind_node_source="https://dl.k8s.io/ci/fast/$revision/kubernetes-server-linux-amd64.tar.gz"
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           curl --fail --silent --show-error --location "https://dl.k8s.io/ci/fast/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
           ginkgo=kubernetes/test/bin/ginkgo
@@ -136,8 +138,16 @@ periodics:
           hash=${revision/*+/}
           kind_yaml_cmd=(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
           kind_node_source="https://dl.k8s.io/ci/fast/$revision/kubernetes-server-linux-amd64.tar.gz"
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           # Which DRA features exist can change over time.
           features=( $( curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/pkg/features/kube_features.go" | grep '"DRA'  | sed 's/.*"\(.*\)"/\1/' ) )
+          # These extra features are dependencies for some DRA features but only
+          # valid for Kubernetes 1.35+. Additional features here should not
+          # affect behavior of tests that don't require them.
+          if ((major >= 1 && minor - 0 >= 35)); then
+            features+=('GenericWorkload')
+          fi
           : "Enabling DRA feature(s): ${features[*]}."
           curl --fail --silent --show-error --location "https://dl.k8s.io/ci/fast/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
           ginkgo=kubernetes/test/bin/ginkgo
@@ -242,6 +252,8 @@ periodics:
           hash=${revision/*+/}
           kind_yaml_cmd=(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
           kind_node_source="https://dl.k8s.io/ci/fast/$revision/kubernetes-server-linux-amd64.tar.gz"
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           curl --fail --silent --show-error --location "https://dl.k8s.io/ci/fast/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
           ginkgo=kubernetes/test/bin/ginkgo
@@ -283,8 +295,6 @@ periodics:
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
-          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
-          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 1))
           if [[ $revision == *alpha.0* ]]; then
               : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
@@ -371,6 +381,8 @@ periodics:
           hash=${revision/*+/}
           kind_yaml_cmd=(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
           kind_node_source="https://dl.k8s.io/ci/fast/$revision/kubernetes-server-linux-amd64.tar.gz"
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           curl --fail --silent --show-error --location "https://dl.k8s.io/ci/fast/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
           ginkgo=kubernetes/test/bin/ginkgo
@@ -412,8 +424,6 @@ periodics:
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
-          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
-          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 2))
           if [[ $revision == *alpha.0* ]]; then
               : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
@@ -500,6 +510,8 @@ periodics:
           hash=${revision/*+/}
           kind_yaml_cmd=(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
           kind_node_source="https://dl.k8s.io/ci/fast/$revision/kubernetes-server-linux-amd64.tar.gz"
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           curl --fail --silent --show-error --location "https://dl.k8s.io/ci/fast/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
           ginkgo=kubernetes/test/bin/ginkgo
@@ -541,8 +553,6 @@ periodics:
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
-          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
-          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 3))
           if [[ $revision == *alpha.0* ]]; then
               : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -38,6 +38,8 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo
@@ -126,8 +128,16 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           # Which DRA features exist can change over time.
           features=( $( grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/' ) )
+          # These extra features are dependencies for some DRA features but only
+          # valid for Kubernetes 1.35+. Additional features here should not
+          # affect behavior of tests that don't require them.
+          if ((major >= 1 && minor - 0 >= 35)); then
+            features+=('GenericWorkload')
+          fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo
@@ -224,8 +234,16 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           # Which DRA features exist can change over time.
           features=( $( grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/' ) )
+          # These extra features are dependencies for some DRA features but only
+          # valid for Kubernetes 1.35+. Additional features here should not
+          # affect behavior of tests that don't require them.
+          if ((major >= 1 && minor - 0 >= 35)); then
+            features+=('GenericWorkload')
+          fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo
@@ -323,6 +341,8 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo
@@ -364,8 +384,6 @@ presubmits:
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
-          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
-          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 1))
           if [[ $revision == *alpha.0* ]]; then
               : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
@@ -460,6 +478,8 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo
@@ -501,8 +521,6 @@ presubmits:
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
-          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
-          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 2))
           if [[ $revision == *alpha.0* ]]; then
               : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
@@ -597,6 +615,8 @@ presubmits:
           revision=$(git describe --tags)
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           features=( )
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
           ginkgo=_output/bin/ginkgo
@@ -638,8 +658,6 @@ presubmits:
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
-          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
-          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - 3))
           if [[ $revision == *alpha.0* ]]; then
               : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -161,19 +161,17 @@ presubmits:
           kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
           kind_node_source=.
           {%- endif %}
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           {%- if all_features %}
           # Which DRA features exist can change over time.
           features=( $( {%- if ci %} curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/pkg/features/kube_features.go" | grep '"DRA' {% else %} grep '"DRA' pkg/features/kube_features.go {%- endif %} | sed 's/.*"\(.*\)"/\1/' ) )
-          {%- if canary %}
-          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
-          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           # These extra features are dependencies for some DRA features but only
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - {{ kubelet_skew }} >= 35)); then
             features+=('GenericWorkload')
           fi
-          {%- endif %}
           : "Enabling DRA feature(s): ${features[*]}."
           {%- else %}
           features=( )
@@ -225,8 +223,6 @@ presubmits:
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
-          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
-          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
           previous_minor=$((minor - {{kubelet_skew}}))
           if [[ $revision == *alpha.0* ]]; then
               : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.


### PR DESCRIPTION
#36568 enabled the GenericWorkload feature gate for the canary DRA e2e job which is working as expected on https://github.com/kubernetes/kubernetes/pull/136989. There, `pull-kubernetes-kind-dra-all-canary` is [passing](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/136989/pull-kubernetes-kind-dra-all-canary/2029714589251276800) and the default `pull-kubernetes-kind-dra-all` job is [failing](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/136989/pull-kubernetes-kind-dra-all/2029714513925771264), presumably because the DRAWorkloadResourceClaims feature gate is enabled and GenericWorkload (its dependency) is not.

This PR adds that feature gate for the non-canary jobs that run by default.

/assign @pohly