### PR TITLE
For AgentSandbox repo, mark stale after 30d and close after another 15d.

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -310,6 +310,131 @@ periodics:
       secret:
         secretName: k8s-triage-robot-github-token
 
+- name: ci-k8s-triage-robot-stale-prs-agent-sandbox
+  interval: 1h
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: org
+    base_ref: main
+    path_alias: k8s.io/org
+  annotations:
+    testgrid-dashboards: sig-contribex-k8s-triage-robot
+    description: Adds lifecycle/stale to inactive agent-sandbox PRs after 30d
+    testgrid-tab-name: stale-prs-agent-sandbox
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20260226-ccc15f6c33
+      command:
+      - commenter
+      args:
+      - |-
+        --query=repo:kubernetes-sigs/agent-sandbox
+        is:pr
+        is:open
+        -label:lifecycle/frozen
+        -label:lifecycle/stale
+      - --updated=720h
+      - --token=/etc/github-token/token
+      - --endpoint=http://ghproxy.test-pods.svc.cluster.local
+      - |-
+        --comment=The Kubernetes project currently lacks enough active contributors to adequately respond to all PRs.
+
+        This bot triages PRs according to the following rules:
+        - After 30d of inactivity, `lifecycle/stale` is applied
+        - After 15d of inactivity since `lifecycle/stale` was applied, the PR is closed
+
+        You can:
+        - Mark this PR as fresh with `/remove-lifecycle stale`
+        - Close this PR with `/close`
+        - Offer to help out with [Issue Triage][1]
+
+        Please send feedback to us at [Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox/tree/main#community-discussion-contribution-and-support).
+
+        /lifecycle stale
+
+        [1]: https://www.kubernetes.dev/docs/guide/issue-triage/
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
+    volumes:
+    - name: token
+      secret:
+        secretName: k8s-triage-robot-github-token
+
+- name: ci-k8s-triage-robot-close-prs-agent-sandbox
+  interval: 1h
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: org
+    base_ref: main
+    path_alias: k8s.io/org
+  annotations:
+    testgrid-dashboards: sig-contribex-k8s-triage-robot
+    description: Closes stale agent-sandbox PRs after 15d of inactivity
+    testgrid-tab-name: close-prs-agent-sandbox
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20260226-ccc15f6c33
+      command:
+      - commenter
+      args:
+      - |-
+        --query=repo:kubernetes-sigs/agent-sandbox
+        is:pr
+        is:open
+        -label:lifecycle/frozen
+        label:lifecycle/stale
+      - --updated=360h
+      - --token=/etc/github-token/token
+      - --endpoint=http://ghproxy.test-pods.svc.cluster.local
+      - |-
+        --comment=The Kubernetes project currently lacks enough active contributors to adequately respond to all PRs.
+
+        This bot triages PRs according to the following rules:
+        - After 30d of inactivity, `lifecycle/stale` is applied
+        - After 15d of inactivity since `lifecycle/stale` was applied, the PR is closed
+
+        You can:
+        - Reopen this PR with `/reopen`
+        - Offer to help out with [Issue Triage][1]
+
+        Please send feedback to us at [Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox/tree/main#community-discussion-contribution-and-support).
+
+        /close
+
+        [1]: https://www.kubernetes.dev/docs/guide/issue-triage/
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github-token
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
+    volumes:
+    - name: token
+      secret:
+        secretName: k8s-triage-robot-github-token
+
 - name: ci-k8s-triage-robot-rotten-issues
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
@@ -413,6 +538,7 @@ periodics:
         -repo:kubernetes/ingress-nginx
         -repo:kubernetes/steering
         -repo:kubernetes-sigs/ingate
+        -repo:kubernetes-sigs/agent-sandbox
         -label:lifecycle/frozen
         -label:lifecycle/rotten
         label:lifecycle/stale
@@ -558,6 +684,7 @@ periodics:
         -repo:kubernetes/ingress-nginx
         -repo:kubernetes/steering
         -repo:kubernetes-sigs/ingate
+        -repo:kubernetes-sigs/agent-sandbox
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten


### PR DESCRIPTION
I want to reduce the number of inactive PRs on the repo faster than the default configuration for various k8s repos.
This change does that.