### PR TITLE
[sig-windows] Expand Hyper-V periodic jobs to run full test suite

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -178,10 +178,6 @@ periodics:
         env:
           - name: HYPERV
             value: "true"
-          - name: GINKGO_FOCUS
-            value: \[Feature:WindowsHyperVContainers\]
-          - name: GINKGO_SKIP
-            value: \[LinuxOnly\]
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
@@ -351,6 +347,66 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-containerd-master-serial-slow-hpa
+- name: ci-kubernetes-e2e-capz-master-windows-hyperv-serial-slow
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+    preset-capz-windows-common: "true"
+    preset-capz-windows-2025: "true"
+    preset-capz-containerd-2-0-latest: "true"
+    preset-capz-serial-slow: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260217-29ba10ecec-master
+        command:
+          - "runner.sh"
+          - "env"
+          - "KUBERNETES_VERSION=latest"
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: HYPERV
+            value: "true"
+          - name: GINKGO_FOCUS
+            value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
+          - name: GINKGO_SKIP
+            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|\[Alpha\]|\[FeatureGate:SchedulerAsyncPreemption\]|\[Beta\]
+          - name: NODE_FEATURE_GATES
+            value: "WindowsGracefulNodeShutdown=true"
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-master-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-master-hyperv-serial-slow
 - name: ci-kubernetes-e2e-capz-master-containerd-nightly-windows
   cluster: eks-prow-build-cluster
   interval: 24h


### PR DESCRIPTION
## Summary

The existing Hyper-V periodic job (`ci-kubernetes-e2e-capz-master-windows-hyperv`) only runs a single test case because `GINKGO_FOCUS` was set to `[Feature:WindowsHyperVContainers]`, which matches only one test in `	est/e2e/windows/hyperv.go`.

## Changes

1. **Update `ci-kubernetes-e2e-capz-master-windows-hyperv`**: Remove explicit `GINKGO_FOCUS`/`GINKGO_SKIP` so the default broad Windows test suite runs (~200+ tests including Conformance, NodeConformance, sig-windows, etc.). The `HYPERV=true` env var configures the cluster with a mutating webhook that runs all Windows pods as Hyper-V isolated containers.

2. **Add `ci-kubernetes-e2e-capz-master-windows-hyperv-serial-slow`**: New job mirroring `capz-windows-master-serial-slow` but with `HYPERV=true`. Runs Serial/Slow tests on Hyper-V clusters with `WindowsGracefulNodeShutdown` feature gate enabled.

Both jobs use Windows Server 2025 (`preset-capz-windows-2025`) and containerd 2.0 latest.

## Context

This follows up on #36570 which added the initial Hyper-V periodic job. The split into non-serial and serial-slow jobs mirrors how process-isolated container tests are organized (`capz-windows-master` + `capz-windows-master-serial-slow`).