### PR TITLE
DRA e2e: add GangScheduling feature gate to canary

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -132,7 +132,10 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - 0 >= 35)); then
-            features+=('GenericWorkload')
+            features+=(
+              'GangScheduling'
+              'GenericWorkload'
+            )
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
@@ -237,7 +240,10 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - 0 >= 35)); then
-            features+=('GenericWorkload')
+            features+=(
+              'GangScheduling'
+              'GenericWorkload'
+            )
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -162,7 +162,14 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - {{ kubelet_skew }} >= 35)); then
+          {%- if canary %}
+            features+=(
+              'GangScheduling'
+              'GenericWorkload'
+            )
+          {%- else %}
             features+=('GenericWorkload')
+          {%- endif %}
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           {%- else %}


### PR DESCRIPTION
Gang scheduling is a canonical use case for https://github.com/kubernetes/enhancements/issues/5729, so I added an e2e test to https://github.com/kubernetes/kubernetes/pull/136989 that requires the GangScheduling feature gate to be enabled.

As long as this does negatively affect existing tests then I'll follow up and enable that feature gate for non-canary jobs too.

/assign @pohly