### PR TITLE
DRA e2e: promote GangScheduling from canary to default jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -146,7 +146,10 @@ periodics:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - 0 >= 35)); then
-            features+=('GenericWorkload')
+            features+=(
+              'GangScheduling'
+              'GenericWorkload'
+            )
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           curl --fail --silent --show-error --location "https://dl.k8s.io/ci/fast/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -136,7 +136,10 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - 0 >= 35)); then
-            features+=('GenericWorkload')
+            features+=(
+              'GangScheduling'
+              'GenericWorkload'
+            )
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
@@ -242,7 +245,10 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - 0 >= 35)); then
-            features+=('GenericWorkload')
+            features+=(
+              'GangScheduling'
+              'GenericWorkload'
+            )
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -162,14 +162,10 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - {{ kubelet_skew }} >= 35)); then
-          {%- if canary %}
             features+=(
               'GangScheduling'
               'GenericWorkload'
             )
-          {%- else %}
-            features+=('GenericWorkload')
-          {%- endif %}
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           {%- else %}


### PR DESCRIPTION
This PR follows up from #36615 to set the GangScheduling feature gate for the default jobs enabling all DRA features in support of https://github.com/kubernetes/kubernetes/pull/136989.

[Running the canary job there](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/136989/pull-kubernetes-kind-dra-all-canary/2031401068209901568), the new gang scheduling e2e test added by that PR fails as expected and no other tests failed.

/assign @pohly @bart0sh 