### PR TITLE
[sig-windows] Enable GMSA tests for Hyper-V serial-slow job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -361,6 +361,7 @@ periodics:
     preset-capz-windows-2025: "true"
     preset-capz-containerd-2-0-latest: "true"
     preset-capz-serial-slow: "true"
+    preset-capz-gmsa-setup: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure


### PR DESCRIPTION
## Summary

Add `preset-capz-gmsa-setup` label to `ci-kubernetes-e2e-capz-master-windows-hyperv-serial-slow` to enable GMSA domain controller provisioning, matching the process-isolated serial-slow job (`ci-kubernetes-e2e-capz-master-windows-serial-slow`).

## Changes

1 line added: `preset-capz-gmsa-setup: "true"`

## Context

The Hyper-V serial-slow job added in #36609 was missing the GMSA preset, causing 2 test cases to be skipped:
- `[sig-windows] [Feature:Windows] GMSA Full [Serial] [Slow] GMSA support can read and write file to remote SMB folder`
- `[sig-windows] [Feature:Windows] GMSA Full [Serial] [Slow] GMSA support works end to end`

GMSA (Group Managed Service Account) is an AD credential mechanism independent of container isolation mode, so it should be tested with Hyper-V isolation as well.
