### PR TITLE
Add a dual networking stack presubmit for AWS EC2

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -422,6 +422,63 @@ presubmits:
             requests:
               cpu: 8
               memory: 10Gi
+  - name: pull-kubernetes-e2e-ec2-cloud-provider-dual-stack-quick
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: presubmits-ec2
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    path_alias: sigs.k8s.io/provider-aws-test-infra
+    always_run: true
+    optional: true
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250815-171060767f-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              cd kubetest2-ec2 && GOPROXY=direct go install .
+              VERSION=$(curl -Ls https://dl.k8s.io/ci/fast/latest-fast.txt)
+              kubetest2 ec2 \
+               --stage https://dl.k8s.io/ci/fast/ \
+               --external-cloud-provider true \
+               --ip-family=dual \
+               --version $VERSION \
+               --up \
+               --down \
+               --test=ginkgo \
+               -- \
+               --parallel=30 \
+               --test-package-url=https://dl.k8s.io/ \
+               --test-package-dir=ci/fast \
+               --test-package-marker=latest-fast.txt \
+               --focus-regex='Pods should be submitted and removed'
+          env:
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 8
+              memory: 10Gi
+            requests:
+              cpu: 8
+              memory: 10Gi
   - name: pull-kubernetes-e2e-ec2-canary
     skip_branches:
       - release-\d+\.\d+  # per-release image


### PR DESCRIPTION
Created to verify functionality of the kubetest2-ec2 deployer added at https://github.com/kubernetes-sigs/provider-aws-test-infra/pull/530