### PR TITLE
Revert "DRA e2e: promote GangScheduling from canary to default jobs"

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -146,10 +146,7 @@ periodics:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - 0 >= 35)); then
-            features+=(
-              'GangScheduling'
-              'GenericWorkload'
-            )
+            features+=('GenericWorkload')
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           curl --fail --silent --show-error --location "https://dl.k8s.io/ci/fast/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -136,10 +136,7 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - 0 >= 35)); then
-            features+=(
-              'GangScheduling'
-              'GenericWorkload'
-            )
+            features+=('GenericWorkload')
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
@@ -245,10 +242,7 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - 0 >= 35)); then
-            features+=(
-              'GangScheduling'
-              'GenericWorkload'
-            )
+            features+=('GenericWorkload')
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -162,10 +162,14 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - {{ kubelet_skew }} >= 35)); then
+          {%- if canary %}
             features+=(
               'GangScheduling'
               'GenericWorkload'
             )
+          {%- else %}
+            features+=('GenericWorkload')
+          {%- endif %}
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           {%- else %}


### PR DESCRIPTION
Reverts kubernetes/test-infra#36622.

This seems to have caused a problem, despite testing the canary before promoting the change:

https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-kind-dra-all
https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#pull-kubernetes-kind-dra-all

https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kind-dra-all/20314494214047047[…]ane_50835376a5ae3ea087d0765f922e0cf9/kube-scheduler/0.log:

```
2026-03-10T19:46:41.092139029Z stderr F I0310 19:46:41.091985       1 reflector.go:490] "Data couldn't be fetched in watchlist mode. Falling back to regular list. This is expected if watchlist is not supported or disabled in kube-apiserver." err="the server could not find the requested resource"
2026-03-10T19:46:41.093702216Z stderr F E0310 19:46:41.093566       1 reflector.go:227] "Failed to watch" err="failed to list *v1alpha2.PodGroup: the server could not find the requested resource" logger="UnhandledError" reflector="k8s.io/client-go/informers/factory.go:177" type="*v1alpha2.PodGroup"
```

The scheduler doesn't come up and therefore doesn't schedule the kindnet pods.The feature gate seems to need some specific API group.

/assign @nojnhuh @bart0sh 