### PR TITLE
sig-autoscaling: remove deprecated flags from CA E2E tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -502,16 +502,11 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --cluster=ca
-      # Override GCE default for cluster size autoscaling purposes.
-      - --env=ENABLE_CUSTOM_METRICS=true
-      - --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,Priority
-      - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=3
       - --gcp-zone=us-central1-b
       - --provider=gce
-      - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test=false
       - --test-cmd=../cluster-autoscaler/hack/e2e/run-e2e.sh
       - --timeout=400m

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -429,16 +429,11 @@ presubmits:
           - runner.sh
           - /workspace/scenarios/kubernetes_e2e.py
         args:
-        # Override GCE default for cluster size autoscaling purposes.
-        - --env=ENABLE_CUSTOM_METRICS=true
-        - --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,Priority
-        - --env=ENABLE_POD_PRIORITY=true
         - --extract=ci/latest
         - --gcp-node-image=gci
         - --gcp-nodes=3
         - --gcp-zone=us-central1-b
         - --provider=gce
-        - --runtime-config=scheduling.k8s.io/v1alpha1=true
         - --test=false
         - --test-cmd=../cluster-autoscaler/hack/e2e/run-e2e.sh
         - --test-cmd-args=--presubmit


### PR DESCRIPTION
Following the Kubernetes 1.36 bump, Cluster Autoscaler E2E tests and presubmits were failing with "Cluster failed to initialize within 300 seconds". This was caused by the removal of several deprecated settings in Kubernetes 1.36.

https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gci-gce-autoscaling

Remove the following deprecated flags from CA job configurations:
- --env=KUBE_ADMISSION_CONTROL=...
- --env=ENABLE_POD_PRIORITY=true (true by default)
- --runtime-config=scheduling.k8s.io/v1alpha1=true

While VPA tests are functionally different, both VPA and CA E2E tests use the same tooling and project for cluster creation. Since VPA tests are still passing and do not use these flags, it confirms these deprecated settings are the cause of the initialization failures.