### PR TITLE
DRA version skew: promote -sem-ver-filter and DRAExtendedResource

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -299,15 +299,18 @@ periodics:
           worker_nodes=$(kind get nodes | grep worker)
           for n in $worker_nodes; do
               docker cp /tmp/kubelet $n:/usr/bin/kubelet
+              # DRAExtendedResource has been available since 1.34.
+              # We can do version-skew testing against Kubernetes >= 1.36
+              # where it is on by default, but only if we enable it
+              # explicitly for older kubelets.
+              if [[ $previous_minor -ge 34 ]]; then
+                  docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                  # Verify, intentionally not with --quiet.
+                  docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                  docker exec $n systemctl daemon-reload
+              fi
               docker exec $n systemctl restart kubelet
           done
-
-          # We need support for disabling tests which need a recent kubelet.
-          # If a test is labeled with `KubeletMinVersion:1.34`, then it cannot run
-          # when the deployed kubelet is 1.32. This is enforced by
-          # generating `! KubeletMinVersion: containsAny { 1.33, 1.34 }`, i.e.
-          # including all unsupportd kubelet versions in a deny list.
-          kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
 
           # Running tests which only cover control plane behavior are not useful
           # in a kubelet version skew job. We can filter them out by including
@@ -315,7 +318,7 @@ periodics:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
-          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode
@@ -428,15 +431,18 @@ periodics:
           worker_nodes=$(kind get nodes | grep worker)
           for n in $worker_nodes; do
               docker cp /tmp/kubelet $n:/usr/bin/kubelet
+              # DRAExtendedResource has been available since 1.34.
+              # We can do version-skew testing against Kubernetes >= 1.36
+              # where it is on by default, but only if we enable it
+              # explicitly for older kubelets.
+              if [[ $previous_minor -ge 34 ]]; then
+                  docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                  # Verify, intentionally not with --quiet.
+                  docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                  docker exec $n systemctl daemon-reload
+              fi
               docker exec $n systemctl restart kubelet
           done
-
-          # We need support for disabling tests which need a recent kubelet.
-          # If a test is labeled with `KubeletMinVersion:1.34`, then it cannot run
-          # when the deployed kubelet is 1.32. This is enforced by
-          # generating `! KubeletMinVersion: containsAny { 1.33, 1.34 }`, i.e.
-          # including all unsupportd kubelet versions in a deny list.
-          kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
 
           # Running tests which only cover control plane behavior are not useful
           # in a kubelet version skew job. We can filter them out by including
@@ -444,7 +450,7 @@ periodics:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
-          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode
@@ -557,15 +563,18 @@ periodics:
           worker_nodes=$(kind get nodes | grep worker)
           for n in $worker_nodes; do
               docker cp /tmp/kubelet $n:/usr/bin/kubelet
+              # DRAExtendedResource has been available since 1.34.
+              # We can do version-skew testing against Kubernetes >= 1.36
+              # where it is on by default, but only if we enable it
+              # explicitly for older kubelets.
+              if [[ $previous_minor -ge 34 ]]; then
+                  docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                  # Verify, intentionally not with --quiet.
+                  docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                  docker exec $n systemctl daemon-reload
+              fi
               docker exec $n systemctl restart kubelet
           done
-
-          # We need support for disabling tests which need a recent kubelet.
-          # If a test is labeled with `KubeletMinVersion:1.34`, then it cannot run
-          # when the deployed kubelet is 1.32. This is enforced by
-          # generating `! KubeletMinVersion: containsAny { 1.33, 1.34 }`, i.e.
-          # including all unsupportd kubelet versions in a deny list.
-          kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
 
           # Running tests which only cover control plane behavior are not useful
           # in a kubelet version skew job. We can filter them out by including
@@ -573,7 +582,7 @@ periodics:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
-          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -395,15 +395,18 @@ presubmits:
           worker_nodes=$(kind get nodes | grep worker)
           for n in $worker_nodes; do
               docker cp /tmp/kubelet $n:/usr/bin/kubelet
+              # DRAExtendedResource has been available since 1.34.
+              # We can do version-skew testing against Kubernetes >= 1.36
+              # where it is on by default, but only if we enable it
+              # explicitly for older kubelets.
+              if [[ $previous_minor -ge 34 ]]; then
+                  docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                  # Verify, intentionally not with --quiet.
+                  docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                  docker exec $n systemctl daemon-reload
+              fi
               docker exec $n systemctl restart kubelet
           done
-
-          # We need support for disabling tests which need a recent kubelet.
-          # If a test is labeled with `KubeletMinVersion:1.34`, then it cannot run
-          # when the deployed kubelet is 1.32. This is enforced by
-          # generating `! KubeletMinVersion: containsAny { 1.33, 1.34 }`, i.e.
-          # including all unsupportd kubelet versions in a deny list.
-          kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
 
           # Running tests which only cover control plane behavior are not useful
           # in a kubelet version skew job. We can filter them out by including
@@ -411,7 +414,7 @@ presubmits:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
-          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode
@@ -532,15 +535,18 @@ presubmits:
           worker_nodes=$(kind get nodes | grep worker)
           for n in $worker_nodes; do
               docker cp /tmp/kubelet $n:/usr/bin/kubelet
+              # DRAExtendedResource has been available since 1.34.
+              # We can do version-skew testing against Kubernetes >= 1.36
+              # where it is on by default, but only if we enable it
+              # explicitly for older kubelets.
+              if [[ $previous_minor -ge 34 ]]; then
+                  docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                  # Verify, intentionally not with --quiet.
+                  docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                  docker exec $n systemctl daemon-reload
+              fi
               docker exec $n systemctl restart kubelet
           done
-
-          # We need support for disabling tests which need a recent kubelet.
-          # If a test is labeled with `KubeletMinVersion:1.34`, then it cannot run
-          # when the deployed kubelet is 1.32. This is enforced by
-          # generating `! KubeletMinVersion: containsAny { 1.33, 1.34 }`, i.e.
-          # including all unsupportd kubelet versions in a deny list.
-          kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
 
           # Running tests which only cover control plane behavior are not useful
           # in a kubelet version skew job. We can filter them out by including
@@ -548,7 +554,7 @@ presubmits:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
-          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode
@@ -669,15 +675,18 @@ presubmits:
           worker_nodes=$(kind get nodes | grep worker)
           for n in $worker_nodes; do
               docker cp /tmp/kubelet $n:/usr/bin/kubelet
+              # DRAExtendedResource has been available since 1.34.
+              # We can do version-skew testing against Kubernetes >= 1.36
+              # where it is on by default, but only if we enable it
+              # explicitly for older kubelets.
+              if [[ $previous_minor -ge 34 ]]; then
+                  docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                  # Verify, intentionally not with --quiet.
+                  docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                  docker exec $n systemctl daemon-reload
+              fi
               docker exec $n systemctl restart kubelet
           done
-
-          # We need support for disabling tests which need a recent kubelet.
-          # If a test is labeled with `KubeletMinVersion:1.34`, then it cannot run
-          # when the deployed kubelet is 1.32. This is enforced by
-          # generating `! KubeletMinVersion: containsAny { 1.33, 1.34 }`, i.e.
-          # including all unsupportd kubelet versions in a deny list.
-          kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
 
           # Running tests which only cover control plane behavior are not useful
           # in a kubelet version skew job. We can filter them out by including
@@ -685,7 +694,7 @@ presubmits:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
-          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
         # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -256,7 +256,6 @@ presubmits:
           worker_nodes=$(kind get nodes | grep worker)
           for n in $worker_nodes; do
               docker cp /tmp/kubelet $n:/usr/bin/kubelet
-              {%- if canary %}
               # DRAExtendedResource has been available since 1.34.
               # We can do version-skew testing against Kubernetes >= 1.36
               # where it is on by default, but only if we enable it
@@ -267,18 +266,8 @@ presubmits:
                   docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
                   docker exec $n systemctl daemon-reload
               fi
-              {%- endif %}
               docker exec $n systemctl restart kubelet
           done
-          {%- if not canary %}
-
-          # We need support for disabling tests which need a recent kubelet.
-          # If a test is labeled with `KubeletMinVersion:1.34`, then it cannot run
-          # when the deployed kubelet is 1.32. This is enforced by
-          # generating `! KubeletMinVersion: containsAny { 1.33, 1.34 }`, i.e.
-          # including all unsupportd kubelet versions in a deny list.
-          kubelet_label_filter=" && ! KubeletMinVersion: containsAny { $( for v in $(seq $((previous_minor + 1)) $((minor - 1))); do echo "1.$v, "; done)1.$minor }"
-          {%- endif %}
 
           # Running tests which only cover control plane behavior are not useful
           # in a kubelet version skew job. We can filter them out by including
@@ -287,7 +276,7 @@ presubmits:
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
           {%- endif %}
 
-          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color {%- if canary and kubelet_skew|int > 0 %} --sem-ver-filter=kubelet=1.$previous_minor {%- endif %} --label-filter="DRA && Feature: isSubsetOf { {% if all_features %}OffByDefault, {% endif -%} DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus {%- if kubelet_skew|int > 0 %}$kubelet_label_filter{%- endif %} && !Flaky {%- if not ci and not allow_slow %} && !Slow {%- endif %}" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit {%- if all_features %} -logcheck-data-races{%endif%} &
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color {%- if kubelet_skew|int > 0 %} --sem-ver-filter=kubelet=1.$previous_minor {%- endif %} --label-filter="DRA && Feature: isSubsetOf { {% if all_features %}OffByDefault, {% endif -%} DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus {%- if kubelet_skew|int > 0 %}$kubelet_label_filter{%- endif %} && !Flaky {%- if not ci and not allow_slow %} && !Slow {%- endif %}" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit {%- if all_features %} -logcheck-data-races{%endif%} &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
         {%- if all_features %}


### PR DESCRIPTION
This enables re-enabling version-skew testing of the extended resource feature.

Both changes were previously tested in the canary jobs. Those jobs work fine with
- current master: https://github.com/kubernetes/kubernetes/pull/137664
- enabling version-skew testing: https://github.com/kubernetes/kubernetes/pull/137597

/assign @bart0sh 