### PR TITLE
node: dracpu: add presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-cpu/OWNERS
+++ b/config/jobs/kubernetes-sigs/dra-driver-cpu/OWNERS
@@ -1,0 +1,19 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-node-leads
+  - johnbelamaric
+  - pohly
+  - klueska
+  - ffromani
+  - pravk03
+
+reviewers:
+  - johnbelamaric
+  - pohly
+  - klueska
+  - ffromani
+  - pravk03
+
+labels:
+  - sig/node

--- a/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
@@ -1,0 +1,75 @@
+# sigs.k8s.io/dra-driver-cpu presubmits
+presubmits:
+  kubernetes-sigs/dra-driver-cpu:
+  - name: pull-dra-driver-cpu-e2e-device-mode-individual
+    cluster: eks-prow-build-cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    path_alias: sigs.k8s.io/dra-driver-cpu
+    always_run: true
+    optional: false
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-dra-driver-cpu
+      testgrid-tab-name: e2e-test-master-individual
+      description: "Build image and run e2e-tests in individual mode"
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260217-29ba10ecec-master
+        env:
+        - name: DRACPU_E2E_CPU_DEVICE_MODE
+          value: "individual"
+        - name: DRACPU_E2E_VERBOSE
+          value: "1"
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - hack/ci/prow.sh
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 8Gi
+          requests:
+            cpu: 4
+            memory: 8Gi
+  - name: pull-dra-driver-cpu-e2e-device-mode-grouped
+    cluster: eks-prow-build-cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    path_alias: sigs.k8s.io/dra-driver-cpu
+    always_run: true
+    optional: false
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-dra-driver-cpu
+      testgrid-tab-name: e2e-test-master-grouped
+      description: "Build image and run e2e-tests in grouped mode"
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260217-29ba10ecec-master
+        env:
+        - name: DRACPU_E2E_CPU_DEVICE_MODE
+          value: "grouped"
+        - name: DRACPU_E2E_VERBOSE
+          value: "1"
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - hack/ci/prow.sh
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 8Gi
+          requests:
+            cpu: 4
+            memory: 8Gi

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -12,6 +12,7 @@ dashboard_groups:
     - sig-node-ppc64le
     # These dashboards are for out-of-tree SIG Node projects
     - sig-node-cri-tools
+    - sig-node-dra-driver-cpu
     - sig-node-node-feature-discovery
     - sig-node-kernel-module-management
     - sig-node-node-problem-detector
@@ -101,6 +102,7 @@ dashboards:
 - name: sig-node-ppc64le
 - name: sig-node-cri-o
 - name: sig-node-cri-tools
+- name: sig-node-dra-driver-cpu
 - name: sig-node-node-feature-discovery
 - name: sig-node-kernel-module-management
 


### PR DESCRIPTION
we are switching to prow for the gating CI lanes