### PR TITLE
Bump publishing-bot ci jobs to use go 1.26

### DIFF
--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         command:
         - make
         resources:
@@ -27,7 +27,7 @@ presubmits:
     path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         command:
         - make
         - test
@@ -53,7 +53,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         env:
         - name: "GOWORK"
           value: "off"
@@ -158,7 +158,7 @@ presubmits:
       path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         env:
         - name: "GOWORK"
           value: "off"


### PR DESCRIPTION
Since k/k master is now on 1.26

https://github.com/kubernetes/kubernetes/blob/master/.go-version#L1