### PR TITLE
enable GOTOOLCHAIN=auto by default in all prow.k8s.io CI jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-sdk/release-sdk-presubmits.yaml
@@ -15,9 +15,6 @@ presubmits:
         - run
         - mage.go
         - Test
-        env:
-        - name: GOTOOLCHAIN
-          value: auto
         resources:
           limits:
             cpu: 4
@@ -48,9 +45,6 @@ presubmits:
         - run
         - mage.go
         - IntegrationTest
-        env:
-        - name: GOTOOLCHAIN
-          value: auto
         # docker-in-docker needs privileged mode
         resources:
           limits:
@@ -81,9 +75,6 @@ presubmits:
         - run
         - mage.go
         - Verify
-        env:
-        - name: GOTOOLCHAIN
-          value: auto
         resources:
           limits:
             cpu: 4

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -1131,3 +1131,9 @@ presets:
 - env:
   - name: GOPROXY
     value: "https://proxy.golang.org"
+# enable GOTOOLCHAIN=auto by default
+# to match running locally outside of a golang container image
+# https://github.com/kubernetes/test-infra/issues/36080
+- env:
+  - name: GOTOOLCHAIN
+    value: "auto"


### PR DESCRIPTION
This matches local go behavior unless explicitly set.

Jobs can still explicitly set it inline (NOT as a container env, they can set it in their shell command), which will take precedence over presets.

Fixes: https://github.com/kubernetes/test-infra/issues/36080

/hold

Will draft and send a PSA. 