### PR TITLE
fix: fix cloudbuild paths for the quickstart images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-agentic-net.yaml
+++ b/config/jobs/image-pushing/k8s-staging-agentic-net.yaml
@@ -27,7 +27,7 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-network-kube-agentic-networking, sig-k8s-infra-gcb
     decorate: true
-    run_if_changed: '^quickstart\/adk-agent\/'
+    run_if_changed: '^site-src\/guides\/quickstart\/adk-agent\/'
     skip_branches:
     # do not run on dependabot branches, these exist prior to merge
     # only merged code should trigger these jobs
@@ -44,13 +44,13 @@ postsubmits:
         - --env-passthrough=PULL_BASE_REF
         - --build-dir=.
         - --with-git-dir
-        - quickstart/adk-agent
+        - site-src/guides/quickstart/adk-agent
   - name: post-agentic-net-push-everything-mcp-image
     cluster: k8s-infra-prow-build-trusted
     annotations:
       testgrid-dashboards: sig-network-kube-agentic-networking, sig-k8s-infra-gcb
     decorate: true
-    run_if_changed: '^quickstart\/mcpserver\/'
+    run_if_changed: '^site-src\/guides\/quickstart\/mcpserver\/'
     skip_branches:
     # do not run on dependabot branches, these exist prior to merge
     # only merged code should trigger these jobs
@@ -67,13 +67,13 @@ postsubmits:
         - --env-passthrough=PULL_BASE_REF
         - --build-dir=.
         - --with-git-dir
-        - quickstart/mcpserver
+        - site-src/guides/quickstart/mcpserver
   - name: post-agentic-net-push-langchain-agent-image
     cluster: k8s-infra-prow-build-trusted
     annotations:
       testgrid-dashboards: sig-network-kube-agentic-networking, sig-k8s-infra-gcb
     decorate: true
-    run_if_changed: '^quickstart\/additional-agent-examples\/langchain-agent\/'
+    run_if_changed: '^site-src\/guides\/quickstart\/additional-agent-examples\/langchain-agent\/'
     skip_branches:
     # do not run on dependabot branches, these exist prior to merge
     # only merged code should trigger these jobs
@@ -90,13 +90,13 @@ postsubmits:
         - --env-passthrough=PULL_BASE_REF
         - --build-dir=.
         - --with-git-dir
-        - quickstart/additional-agent-examples/langchain-agent
+        - site-src/guides/quickstart/additional-agent-examples/langchain-agent
   - name: post-agentic-net-push-openai-agent-image
     cluster: k8s-infra-prow-build-trusted
     annotations:
       testgrid-dashboards: sig-network-kube-agentic-networking, sig-k8s-infra-gcb
     decorate: true
-    run_if_changed: '^quickstart\/additional-agent-examples\/openai-agent\/'
+    run_if_changed: '^site-src\/guides\/quickstart\/additional-agent-examples\/openai-agent\/'
     skip_branches:
     # do not run on dependabot branches, these exist prior to merge
     # only merged code should trigger these jobs
@@ -113,4 +113,4 @@ postsubmits:
         - --env-passthrough=PULL_BASE_REF
         - --build-dir=.
         - --with-git-dir
-        - quickstart/additional-agent-examples/openai-agent
+        - site-src/guides/quickstart/additional-agent-examples/openai-agent


### PR DESCRIPTION
cloudbuild files for quickstart images have been moved in the project repository in https://github.com/kubernetes-sigs/kube-agentic-networking/pull/152.

So we need to update the prow job