### PR TITLE
Add securityContext to kueue website links periodic job

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -68,6 +68,9 @@ periodics:
           args:
             - make
             - verify-website-links
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
           resources:
             requests:
               cpu: "6"


### PR DESCRIPTION
## Summary

- Add missing `securityContext: privileged: true` to `periodic-kueue-verify-website-links-main`
- The job uses `runner.sh` with DIND presets, which requires privileged mode
- Aligns with all other runner.sh-based jobs in the file

Ref: https://github.com/kubernetes-sigs/kueue/issues/9875

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).