### PR TITLE
triage: add repository include/exclude filter

### DIFF
--- a/triage/Dockerfile
+++ b/triage/Dockerfile
@@ -41,14 +41,16 @@ FROM alpine:3.15.6
 # update_summaries.sh requires bash.
 RUN apk add --no-cache \
     python3 \
+    py3-yaml \
     bash
 
 # Copy the Google Cloud SDK and link the binaries
 COPY --from=build /google-cloud-sdk/ /google-cloud-sdk/
 RUN ln -s /google-cloud-sdk/bin/* /bin/
 
-# Copy over the triage binary and shell script that orchestrates everything
+# Copy over the triage binary, shell script, and job repos generator
 COPY --from=build /test-infra/triage/triage /
 COPY --from=build /test-infra/triage/update_summaries.sh /
+COPY --from=build /test-infra/triage/generate_job_repos.py /
 
 ENTRYPOINT ["timeout", "10800", "/update_summaries.sh"]

--- a/triage/Makefile
+++ b/triage/Makefile
@@ -22,6 +22,10 @@ test:
 
 STATIC_FILES=index.html interactive.js model.js render.js style.css
 
+.PHONY: generate-job-repos
+generate-job-repos:
+	python3 generate_job_repos.py ../config/jobs job_repos.json
+
 # these need to be run by k8s-infra-prow or community members with access to the kubernetes.io GCP org
 push-static:
 	gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp $(STATIC_FILES) gs://k8s-triage/
@@ -36,5 +40,4 @@ redirect-static:
 redirect-staging:
 	gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp -a public-read redirect/index.html gs://k8s-gubernator/triage/staging/
 
-.PHONY: push push-static push-staging redirect-static redirect-staging
-
+.PHONY: push push-static push-staging redirect-static redirect-staging generate-job-repos

--- a/triage/generate_job_repos.py
+++ b/triage/generate_job_repos.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate job_repos.json mapping Prow job names to org/repo."""
+
+import json
+import os
+import sys
+
+import yaml
+
+
+def generate_job_repos(jobs_dir):
+    """Parse Prow job configs and return a dict mapping job name to org/repo."""
+    if not os.path.isdir(jobs_dir):
+        raise FileNotFoundError(f'jobs directory not found: {jobs_dir}')
+
+    mapping = {}
+
+    for root, _, files in os.walk(jobs_dir):
+        for fname in files:
+            if not fname.endswith(('.yaml', '.yml')):
+                continue
+            filepath = os.path.join(root, fname)
+            with open(filepath) as f:
+                try:
+                    data = yaml.safe_load(f)
+                except Exception:
+                    continue
+                if not data:
+                    continue
+
+            # Presubmits: repo is the YAML key (already org/repo format)
+            for repo, jobs in (data.get('presubmits') or {}).items():
+                for job in (jobs or []):
+                    if isinstance(job, dict) and 'name' in job:
+                        mapping[job['name']] = repo
+
+            # Postsubmits: same structure as presubmits
+            for repo, jobs in (data.get('postsubmits') or {}).items():
+                for job in (jobs or []):
+                    if isinstance(job, dict) and 'name' in job:
+                        mapping[job['name']] = repo
+
+            # Periodics: repo from first extra_refs entry
+            for job in (data.get('periodics') or []):
+                if not isinstance(job, dict) or 'name' not in job:
+                    continue
+                extra_refs = job.get('extra_refs', [])
+                if extra_refs:
+                    ref = extra_refs[0]
+                    org = ref.get('org', '')
+                    repo = ref.get('repo', '')
+                    if org and repo:
+                        mapping[job['name']] = f'{org}/{repo}'
+
+    return mapping
+
+
+def main():
+    jobs_dir = sys.argv[1] if len(sys.argv) > 1 else 'config/jobs'
+    output = sys.argv[2] if len(sys.argv) > 2 else 'job_repos.json'
+
+    mapping = generate_job_repos(jobs_dir)
+
+    with open(output, 'w') as f:
+        json.dump(mapping, f, sort_keys=True)
+
+    print(f'Generated {output} with {len(mapping)} job mappings')
+
+
+if __name__ == '__main__':
+    main()

--- a/triage/index.html
+++ b/triage/index.html
@@ -55,6 +55,7 @@ Include Filter (these are regexes):
 <label><tr><td>Failure text<td><input type="text" id="filter-include-text"></label><br>
 <label><tr><td>Job<td><input type="text" id="filter-include-job"></label><br>
 <label><tr><td>Test<td><input type="text" id="filter-include-test"></label><br>
+<label><tr><td>Repo<td><input type="text" id="filter-include-repo"></label><br>
 </table>
 <td>
 Exclude Filter (these are regexes):
@@ -62,6 +63,7 @@ Exclude Filter (these are regexes):
 <label><tr><td>Failure text<td><input type="text" id="filter-exclude-text"></label><br>
 <label><tr><td>Job<td><input type="text" id="filter-exclude-job"></label><br>
 <label><tr><td>Test<td><input type="text" id="filter-exclude-test"></label><br>
+<label><tr><td>Repo<td><input type="text" id="filter-exclude-repo"></label><br>
 </table>
 </table>
 </span>

--- a/triage/interactive.js
+++ b/triage/interactive.js
@@ -53,9 +53,11 @@ function readOptions() {
     reText: read('filter-include-text'),
     reJob: read('filter-include-job'),
     reTest: read('filter-include-test'),
+    reRepo: read('filter-include-repo'),
     reXText: read('filter-exclude-text'),
     reXJob: read('filter-exclude-job'),
     reXTest: read('filter-exclude-test'),
+    reXRepo: read('filter-exclude-repo'),
     showNormalize: read('show-normalize'),
     sort: read('sort'),
     sig: readSigs(),
@@ -66,7 +68,7 @@ function readOptions() {
   if (!opts.ci) url += '&ci=0';
   if (opts.pr) url += '&pr=1';
   if (opts.sig.length) url += '&sig=' + opts.sig.join(',');
-  for (var name of ["text", "job", "test", "xtext", "xjob", "xtest"]) {
+  for (var name of ["text", "job", "test", "repo", "xtext", "xjob", "xtest", "xrepo"]) {
     var re = (name[0] == 'x') ?
       opts['reX' + name[1].toUpperCase() + name.slice(2)] :
       opts['re'  + name[0].toUpperCase() + name.slice(1)];
@@ -126,9 +128,11 @@ function setOptionsFromURL() {
   write('filter-include-text', qs.text);
   write('filter-include-job', qs.job);
   write('filter-include-test', qs.test);
+  write('filter-include-repo', qs.repo);
   write('filter-exclude-text', qs.xtext);
   write('filter-exclude-job', qs.xjob);
   write('filter-exclude-test', qs.xtest);
+  write('filter-exclude-repo', qs.xrepo);
   writeSigs(qs.sig);
 }
 
@@ -294,6 +298,10 @@ function get(uri, callback, onprogress) {
   req.send();
 }
 
+// Cached job-to-repo mapping, loaded from job_repos.json.
+// null if not yet loaded or unavailable (graceful fallback).
+var jobReposMapping = null;
+
 function getData() {
   var clusterId = null;
   if (/^#[a-f0-9]{20}$/.test(window.location.hash)) {
@@ -303,12 +311,36 @@ function getData() {
     setElementVisibility('btn-sig-group', false);
   }
 
-  var url = '/triage/';
+  var baseUrl = '/triage/';
   if (document.location.host == 'storage.googleapis.com' && document.location.pathname.endsWith('index.html')) {
     // Use the bucket name where available
     var pathname = document.location.pathname;
-    url = pathname.substring(0, pathname.lastIndexOf('/')+1);
+    baseUrl = pathname.substring(0, pathname.lastIndexOf('/')+1);
   }
+
+  // Load job_repos.json in parallel (best-effort, not blocking)
+  if (!jobReposMapping) {
+    get(baseUrl + 'job_repos.json',
+      req => {
+        if (req.status < 300) {
+          try {
+            jobReposMapping = JSON.parse(req.response);
+            // If builds already loaded, attach the mapping
+            if (builds) {
+              builds.setJobRepos(jobReposMapping);
+              if (clusteredAll) {
+                rerender();
+              }
+            }
+          } catch(e) {
+            console.warn('Could not parse job_repos.json:', e);
+          }
+        }
+      }
+    );
+  }
+
+  var url = baseUrl;
   var date = document.getElementById('date');
   if (date && date.value) {
     url += 'history/' + date.value.replace(/-/g, '') + '.json';
@@ -337,6 +369,10 @@ function getData() {
       setTimeout(() => {
         var data = JSON.parse(req.response);
         builds = new Builds(data.builds);
+        // Attach job repos mapping if already loaded
+        if (jobReposMapping) {
+          builds.setJobRepos(jobReposMapping);
+        }
         if (clusterId) {
           // rendering just one cluster, filter here.
           for (let c of data.clustered) {

--- a/triage/model.js
+++ b/triage/model.js
@@ -26,6 +26,11 @@ class Builds {
     this.colPr = this.cols.pr;
     this.timespan = minMaxArray(this.cols.started);
     this.runCount = this.cols.started.length;
+    this.jobRepos = null;  // populated from job_repos.json if available
+  }
+
+  setJobRepos(mapping) {
+    this.jobRepos = mapping;
   }
 
   // Create a build object given a job and build number.
@@ -66,6 +71,33 @@ class Builds {
 
   getEndTime() {
     return tsToString(this.timespan[1]);
+  }
+
+  // Return the repository (org/repo) for a job.
+  // Checks job_repos.json mapping first, falls back to parsing job_paths.
+  repoForJob(jobName) {
+    // Strip pr: prefix used in triage data
+    let lookupName = jobName.startsWith('pr:') ? jobName.slice(3) : jobName;
+
+    // Try authoritative mapping from job_repos.json
+    if (this.jobRepos && this.jobRepos[lookupName]) {
+      return this.jobRepos[lookupName];
+    }
+
+    // Fallback: parse repo from GCS path (works for PR jobs only)
+    let path = this.jobPaths[jobName];
+    if (!path) return '';
+    let prMatch = path.match(/\/pr-logs\/pull\/([^\/]+)\//);
+    if (!prMatch) return '';
+    let identifier = prMatch[1];
+    if (/^\d+$/.test(identifier)) {
+      return 'kubernetes/kubernetes';
+    }
+    let idx = identifier.indexOf('_');
+    if (idx > 0) {
+      return identifier.substring(0, idx) + '/' + identifier.substring(idx + 1);
+    }
+    return 'kubernetes/' + identifier;
   }
 }
 
@@ -197,6 +229,13 @@ class Clusters {
           if ((opts.reJob && !opts.reJob.test(job.name)) ||
               (opts.reXJob && opts.reXJob.test(job.name))) {
             continue;
+          }
+          if (opts.reRepo || opts.reXRepo) {
+            let repo = builds.repoForJob(job.name);
+            if ((opts.reRepo && !opts.reRepo.test(repo)) ||
+                (opts.reXRepo && opts.reXRepo.test(repo))) {
+              continue;
+            }
           }
           if (job.name.startsWith("pr:")) {
             if (opts.pr) jobsOut.push(job);

--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -100,6 +100,11 @@ gsutil_cp() {
   gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp -Z "$@"
 }
 
+# Generate job-to-repo mapping from Prow configs
+jobs_dir="${JOBS_DIR:-${GOPATH:-/home/prow/go}/src/k8s.io/test-infra/config/jobs}"
+python3 /generate_job_repos.py "${jobs_dir}" job_repos.json
+
+gsutil_cp job_repos.json "${TRIAGE_GCS_PATH}/"
 gsutil_cp failure_data.json "${TRIAGE_GCS_PATH}/"
 gsutil_cp slices/*.json "${TRIAGE_GCS_PATH}/slices/"
 gsutil_cp failure_data.json "${TRIAGE_GCS_PATH}/history/$(date -u +%Y%m%d).json"


### PR DESCRIPTION
Add repo filtering to the k8s-triage UI, allowing users to filter failure clusters by GitHub org/repo (e.g. kubernetes/kubernetes, kubernetes-sigs/cluster-api-provider-azure).

A new generate_job_repos.py script scans Prow job configs in config/jobs/ to produce a job_repos.json mapping (job name -> org/repo). This mapping is generated during the ci-test-infra-triage periodic run and uploaded to gs://k8s-triage/. The frontend loads it in parallel with failure_data.json, falling back to GCS path parsing if the mapping is unavailable.