### PR TITLE
Bump go version 1.26.0 for kubekins-e2e/kubekins-e2e-v2/krte

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,12 +1,12 @@
 variants:
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.25.7
+    GO_VERSION: 1.26.0
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   master:
     CONFIG: master
-    GO_VERSION: 1.25.7
+    GO_VERSION: 1.26.0
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*


### PR DESCRIPTION
- Bump go version 1.26.0 for kubekins-e2e/kubekins-e2e-v2/krte


xref: https://github.com/kubernetes/release/issues/4266


/assign @dims @saschagrunert @Verolop 
cc @kubernetes/release-managers 