### PR TITLE
Remove unnecessary lines from pull-provider-ibmcloud-test-infra-kuber…

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-presubmits.yaml
@@ -17,11 +17,6 @@ presubmits:
         - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260217-29ba10ecec-master
           securityContext:
             privileged: true
-          env:
-            - name: "BOSKOS_HOST"
-              value: "boskos.test-pods.svc.cluster.local"
-            - name: "USER"
-              value: "pull-provider-ibmcloud-test-infra-kubernetes"
           resources:
             requests:
               cpu: 2
@@ -35,48 +30,24 @@ presubmits:
             - bash
             - -c
             - |
-              set -o errexit
-              set -o nounset
-              set -o pipefail
               set -o xtrace
 
-              RESOURCE_TYPE="powervs"
-              #Call to boskos to checkout resource
-              source "./hack/boskos.sh"
-
-              #Setup of kubetest2 tf deployer and ginkgo tester
+              #Setup of kubetest2 tf deployer
               make install-deployer-tf
-              go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
-
-              #Install ansible required to bring up k8s cluster on infra
-              apt-get update && apt-get install -y ansible
 
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
 
-              TIMESTAMP=$(date +%s)
-
-              set +o errexit
-              set -o xtrace
               kubetest2 tf --powervs-image-name CentOS-Stream-10 \
-                --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
-                --powervs-service-id ${BOSKOS_RESOURCE_ID} \
                 --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
                 --build-version $K8S_BUILD_VERSION \
                 --release-marker $K8S_BUILD_VERSION \
-                --cluster-name pull-$TIMESTAMP \
+                --cluster-name pull-$(date +%s) \
                 --workers-count 1 \
-                --up --down --auto-approve --retry-on-tf-failure 3 \
+                --up --down --auto-approve --retry-on-tf-failure 3 --ignore-destroy-errors \
                 --break-kubetest-on-upfail true \
                 --powervs-memory 32 \
-                --test=ginkgo -- --parallel 30 --test-package-dir ci --test-package-version $K8S_BUILD_VERSION --focus-regex='Pods should be submitted and removed'; rc=$?
-
-              [ -z "${BOSKOS_HOST:-}" ] || release_account >> "$ARTIFACTS/boskos.log" 2>&1
-
-              if [ $rc != 0 ]; then
-                  echo "ERROR: k8s setup and quick run exited with code: $rc"
-                  exit $rc
-              fi
+                --test=ginkgo -- --parallel 30 --test-package-dir ci --test-package-version $K8S_BUILD_VERSION --focus-regex='Pods should be submitted and removed'
 
   - name: pull-provider-ibmcloud-test-infra-kubetest2-secretmanager-build
     cluster: k8s-infra-ppc64le-prow-build


### PR DESCRIPTION
Clean up pull-provider-ibmcloud-test-infra-kubernetes presubmit job

- Remove unused USER environment variable
- Eliminate Bash strict mode settings (errexit, nounset, pipefail)
- Streamline kubetest2 TF deployer setup
- Use timestamp directly in cluster-name
- Drop explicit test exit code handling, rely on kubetest2
- Keep --ignore-destroy-errors to improve cleanup reliability
- Remove redundant comments and unnecessary lines