### PR TITLE
job policy test: rerun on input file changes

### DIFF
--- a/config/jobs/jobs.go
+++ b/config/jobs/jobs.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import "embed"
+
+//go:embed *
+var Jobs embed.FS

--- a/config/prow/prow.go
+++ b/config/prow/prow.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prow
+
+import _ "embed"
+
+//go:embed config.yaml
+var ConfigYAML []byte

--- a/config/tests/jobs/policy/policy_test.go
+++ b/config/tests/jobs/policy/policy_test.go
@@ -20,7 +20,6 @@ package policy
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,22 +33,21 @@ import (
 	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
 	cfg "sigs.k8s.io/prow/pkg/config"
+
+	// Importing these packages triggers rerunning the test
+	// each time some input file changes.
+	_ "k8s.io/test-infra/config/jobs"
+	_ "k8s.io/test-infra/config/prow"
 )
 
-var configPath = flag.String("config", "../../../../config/prow/config.yaml", "Path to prow config")
-var jobConfigPath = flag.String("job-config", "../../../jobs", "Path to prow job config")
+const configPath = "../../../../config/prow/config.yaml"
+const jobConfigPath = "../../../jobs"
 
 // Loaded at TestMain.
 var c *cfg.Config
 
 func TestMain(m *testing.M) {
-	flag.Parse()
-	if *configPath == "" {
-		fmt.Println("--config must set")
-		os.Exit(1)
-	}
-
-	conf, err := cfg.Load(*configPath, *jobConfigPath, nil, "")
+	conf, err := cfg.Load(configPath, jobConfigPath, nil, "")
 	if err != nil {
 		fmt.Printf("Could not load config: %v", err)
 		os.Exit(1)
@@ -60,6 +58,15 @@ func TestMain(m *testing.M) {
 }
 
 func TestKubernetesPresubmitJobs(t *testing.T) {
+	// If sigs.k8s.io/prow/pkg/config could load from io.FS and bytes,
+	// then we could load from jobs.Jobs  and prow.ConfigYAML directly.
+	// Probably not important, so instead we use those package only to
+	// trigger rerunning the test and load files directly.
+	c, err := cfg.Load(configPath, jobConfigPath, nil, "")
+	if err != nil {
+		t.Fatalf("Could not load config: %v", err)
+	}
+
 	jobs := c.AllStaticPresubmits([]string{"kubernetes/kubernetes"})
 	var expected presubmitJobs
 


### PR DESCRIPTION
Previously, having some cached test results and then changing job YAML files did not automatically rerun the test, which also prevented updating the test fixture:

    $ go test ./config/tests/jobs/policy/
    ok  	k8s.io/test-infra/config/tests/jobs/policy
    $ emacsclient config/jobs/kubernetes/sig-node/dra-presubmit.yaml
    Waiting for Emacs...^C
    $ git diff
    diff --git a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
    index 7ea56d1e3f7..cea371dc445 100644
    --- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
    +++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
    @@ -8,7 +8,6 @@ presubmits:
         skip_branches:
         - release-\d+\.\d+  # per-release image
         always_run: false
    -    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
         optional: true
         labels:
           preset-service-account: "true"
    $ go test ./config/tests/jobs/policy/
    ok  	k8s.io/test-infra/config/tests/jobs/policy	(cached)

Embedding the config and job definitions and importing that into the test makes the dependency visible to Go, so now `go test` will always run the test if anything changed in the input.

While at it, loading gets simplified. We don't need flags and only need to load once, so this can be done in the test itself. This would be even nicer if the Prow config package could load from memory (io.FS and bytes), but that's probably not worth adding to it.

/assign @BenTheElder 

Follow-up to https://github.com/kubernetes/test-infra/pull/36648#issuecomment-4060164933.