### PR TITLE
Add lint as required status check for kubernetes/klog

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -363,6 +363,11 @@ branch-protection:
             users: []
             teams:
             - stage-bots
+        klog:
+          required_status_checks:
+            contexts:
+            - "lint (.)"
+            - "lint (examples)"
         kompose:
           required_pull_request_reviews:
             required_approving_review_count: 1


### PR DESCRIPTION
## Summary

- Add `lint (.)` and `lint (examples)` as required status checks in Prow branch protection for `kubernetes/klog`
- These checks correspond to the GitHub Actions lint workflow matrix in [klog's `.github/workflows/lint.yml`](https://github.com/kubernetes/klog/blob/main/.github/workflows/lint.yml)

## Why

PR [kubernetes/klog#432](https://github.com/kubernetes/klog/pull/432) was merged by Tide with a `gofmt` formatting error because:

1. The lint workflow **never ran** on the PR — it was a fork PR requiring maintainer approval for GitHub Actions, which was never granted
2. Even if lint **had run and failed**, Tide would have merged anyway since lint was **not a required status check**

The formatting error was only detected after the merge, when the `push` event to `main` triggered the lint workflow and it failed. This required a follow-up fix in [kubernetes/klog#435](https://github.com/kubernetes/klog/pull/435).

## What this changes

Adds `klog` to the `branch-protection.orgs.kubernetes.repos` section in `config/prow/config.yaml` with required status checks for the two lint matrix jobs.

## Test plan

- [x] Verified the exact check names (`lint (.)`, `lint (examples)`) match the GitHub Actions workflow matrix
- [x] Entry is in alphabetical order within the `repos` section
- [x] YAML syntax is valid

/kind bug
/area prow/config
/sig testing