### PR TITLE
Reduce number of test execution count after adding new regression scenario

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -542,7 +542,7 @@ presubmits:
               make install-lazyfs
               set -euo pipefail
               go clean -testcache
-              GO_TEST_FLAGS="-v --count 10 --timeout '30m' --run TestRobustness"
+              GO_TEST_FLAGS="-v --count 8 --timeout '30m' --run TestRobustness"
               make gofail-enable
               make build
               make gofail-disable
@@ -589,7 +589,7 @@ presubmits:
               make install-lazyfs
               set -euo pipefail
               go clean -testcache
-              GO_TEST_FLAGS="-v --count 10 --timeout '30m' --run TestRobustness"
+              GO_TEST_FLAGS="-v --count 8 --timeout '30m' --run TestRobustness"
               make gofail-enable
               make build
               make gofail-disable


### PR DESCRIPTION
Got a timeout in https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/21488/pull-etcd-robustness-arm64/2033982963116412928 after adding regression scenario in https://github.com/etcd-io/etcd/pull/21367

/cc @henrybear327 @ivanvc @fuweid 