### PR TITLE
headlamp: Filter to v* tags for image version in cloudbuild

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-headlamp.yaml
+++ b/config/jobs/image-pushing/k8s-staging-headlamp.yaml
@@ -20,6 +20,7 @@ postsubmits:
               - --project=k8s-staging-images
               - --scratch-bucket=gs://k8s-staging-images-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --version-tag-filter=v*
               - --with-git-dir
               - .
             env:


### PR DESCRIPTION
Add --version-tag-filter=v* so the image-builder only considers v* tags when generating _GIT_TAG. Without this, non-v tags like headlamp-helm-* or headlamp-plugin-* get picked up.

This is the same PR as https://github.com/kubernetes/test-infra/pull/36543 , which @upodroid closed. Opening just because I noticed that there's another project with it this arg https://github.com/kubernetes/test-infra/blob/03eb50e03be472d400ca24c06a733cb9c5967a81/config/jobs/image-pushing/k8s-staging-external-dns.yaml#L24 .

It's fine if this should be closed too. Since I couldn't attend to the PR until today, I just want to make sure that there was no mistake on closing it.