### PR TITLE
Add pull-kubernetes-e2e-gce-cos-serial

### DIFF
--- a/config/jobs/kubernetes/sig-release/gce-cos-e2e-master.yaml
+++ b/config/jobs/kubernetes/sig-release/gce-cos-e2e-master.yaml
@@ -227,3 +227,53 @@ periodics:
         requests:
           cpu: 1000m
           memory: 6Gi
+presubmits:
+  kubernetes/kubernetes:
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-dashboards: presubmits-kubernetes-nonblocking
+      testgrid-num-failures-to-alert: "10"
+    cluster: k8s-infra-prow-build
+    decorate: true
+    decoration_config:
+      timeout: 680m
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce-cos-serial
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --check-leaked-resources
+        - --provider=gce
+        - --gcp-region=us-central1
+        - --gcp-node-image=gci
+        - --timeout=660m
+        - --ginkgo-parallel=1
+        - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\]
+          --minStartupPods=8
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260217-29ba10ecec-master
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi


### PR DESCRIPTION
`pull-kubernetes-e2e-gce-serial` is permafailing (see https://github.com/kubernetes/kubernetes/pull/137822 for a failed attempt to fix it). This copies the (passing, release-informing) serial job to a presubmit.

This is sort of a combination of `ci-kubernetes-e2e-gce-cos-serial-master` and `pull-kubernetes-e2e-gce-serial`...

diff from `ci-kubernetes-e2e-gce-cos-serial-master`:
```diff
@@ -1 +1,2 @@
-- annotations:
+- always_run: false
+  annotations:
@@ -3,6 +4,4 @@
-    fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: "1h 2h 6h 24h"
-    fork-per-release-replacements: "extract=ci/latest -> extract=ci/latest-{{.Version}}"
-    testgrid-dashboards: sig-release-master-informing
-    testgrid-num-failures-to-alert: "6"
-    testgrid-tab-name: gce-cos-serial-master
+    testgrid-alert-stale-results-hours: "24"
+    testgrid-create-test-group: "true"
+    testgrid-dashboards: presubmits-kubernetes-nonblocking
+    testgrid-num-failures-to-alert: "10"
@@ -16,3 +15,2 @@
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
-  interval: 1h
+    path_alias: k8s.io/release
+    repo: release
@@ -19,0 +18 @@
+    preset-dind-enabled: "true"
@@ -20,0 +20,2 @@
+    preset-pull-kubernetes-e2e: "true"
+    preset-pull-kubernetes-e2e-gce: "true"
@@ -22 +23,3 @@
-  name: ci-kubernetes-e2e-gce-cos-serial-master
+  name: pull-kubernetes-e2e-gce-cos-serial
+  optional: true
+  path_alias: k8s.io/kubernetes
```

diff from `pull-kubernetes-e2e-gce-serial`:
```diff
@@ -6 +6 @@
-    testgrid-dashboards: google-gce
+    testgrid-dashboards: presubmits-kubernetes-nonblocking
@@ -11 +11 @@
-    timeout: 8h40m0s
+    timeout: 680m
@@ -23 +23 @@
-  name: pull-kubernetes-e2e-gce-serial
+  name: pull-kubernetes-e2e-gce-cos-serial
@@ -26,2 +25,0 @@
-  skip_branches:
-  - release-\d+\.\d+
@@ -31,11 +29,2 @@
-      - --build=quick
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.1.0
-      - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.3.0
-      - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
-      - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
-      - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-      - --env=KUBE_GCE_IMAGE_FAMILY=ubuntu-2404-lts-amd64
-      - --env=KUBE_GCE_IMAGE_PROJECT=ubuntu-os-cloud
-      - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-      - --gcp-master-image=ubuntu
-      - --gcp-node-image=ubuntu
+      - --check-leaked-resources
+      - --provider=gce
@@ -42,0 +32,3 @@
+      - --gcp-node-image=gci
+      - --extract=ci/latest
+      - --timeout=660m
@@ -44,2 +36 @@
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Flaky\]|\[Feature:.+\]
+      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\]
@@ -47 +37,0 @@
-      - --timeout=500m
@@ -52 +41,0 @@
-      name: ""
@@ -55,2 +44,2 @@
-          cpu: "4"
-          memory: 14Gi
+          cpu: 1000m
+          memory: 3Gi
@@ -58,4 +47,2 @@
-          cpu: "4"
-          memory: 14Gi
-      securityContext:
-        privileged: true
+          cpu: 1000m
+          memory: 3Gi
```

/assign @BenTheElder @pohly 
@kairosci fyi