### PR TITLE
Switch system type for ppc64le e2e jobs

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -130,7 +130,7 @@ periodics:
               #Setup of kubetest2 tf deployer
               make install-deployer-tf
 
-              export TF_VAR_powervs_system_type=e980
+              export TF_VAR_powervs_system_type=s1022
               kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
@@ -310,7 +310,7 @@ periodics:
               #Setup of kubetest2 tf deployer
               make install-deployer-tf
 
-              export TF_VAR_powervs_system_type=e980
+              export TF_VAR_powervs_system_type=s1022
               export TF_VAR_controlplane_powervs_memory=32
               kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-ssh-key k8s-prow-sshkey \

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
@@ -592,7 +592,7 @@ periodics:
         #Setup of kubetest2 tf deployer
         make install-deployer-tf
 
-        export TF_VAR_powervs_system_type=e980
+        export TF_VAR_powervs_system_type=s1022
         kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
           --powervs-ssh-key k8s-prow-sshkey \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -875,7 +875,7 @@ periodics:
         #Setup of kubetest2 tf deployer
         make install-deployer-tf
 
-        export TF_VAR_powervs_system_type=e980
+        export TF_VAR_powervs_system_type=s1022
         kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
           --powervs-ssh-key k8s-prow-sshkey \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1153,7 +1153,7 @@ periodics:
         #Setup of kubetest2 tf deployer
         make install-deployer-tf
 
-        export TF_VAR_powervs_system_type=e980
+        export TF_VAR_powervs_system_type=s1022
         kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
           --powervs-ssh-key k8s-prow-sshkey \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -1272,7 +1272,7 @@ periodics:
         #Setup of kubetest2 tf deployer
         make install-deployer-tf
 
-        export TF_VAR_powervs_system_type=e980
+        export TF_VAR_powervs_system_type=s1022
         kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
           --powervs-ssh-key k8s-prow-sshkey \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \


### PR DESCRIPTION
Have to change the system type of the nodes where k8s is setup and conformance suite is run on ppc64le infra.

- ci-kubernetes-ppc64le-conformance-latest
- ci-kubernetes-ppc64le-conformance-latest-1.35
- ci-kubernetes-ppc64le-conformance-latest-1.34
- ci-kubernetes-ppc64le-conformance-latest-1.33
- ci-kubernetes-ppc64le-conformance-latest-1.32

Will also change system type for 
- ci-kubernetes-e2e-ppc64le-default