### PR TITLE
feat: add area/api-validation label to kubernetes/kubernetes

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -522,6 +522,7 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="area/HA" href="#area/HA">`area/HA`</a> | | label | |
 | <a id="area/admission-control" href="#area/admission-control">`area/admission-control`</a> | | label | |
+| <a id="area/api-validation" href="#area/api-validation">`area/api-validation`</a> | Issues or PRs related to API validation and declarative validation| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
 | <a id="area/apiserver" href="#area/apiserver">`area/apiserver`</a> | | label | |
 | <a id="area/app-lifecycle" href="#area/app-lifecycle">`area/app-lifecycle`</a> | | label | |
 | <a id="area/artifacts" href="#area/artifacts">`area/artifacts`</a> | Issues or PRs related to the hosting of release artifacts for subprojects| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1160,6 +1160,12 @@ repos:
         target: issues
         addedBy: label
       - color: 0052cc
+        description: Issues or PRs related to API validation and declarative validation
+        name: area/api-validation
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: 0052cc
         name: area/apiserver
         target: both
         addedBy: label


### PR DESCRIPTION
PR adds new `area/api-validation` GitHub label to `kubernetes/kubernetes` for tracking issues and PRs related to API validation and the declarative validation feature

As DV is picking up steam and more issues are being created in k/k we are hoping to add a proper area/api-validation tag to track items related to this workstream.  Currently our issue titles are prefixed w/ `[Declarative Validation]` but this is not standard on all related issues/PRs etc. and we are hoping to use a standard Github label for tracking here.

### Changes
- `label_sync/labels.yaml`: Added `area/api-validation` label entry under the `kubernetes/kubernetes` repo section
- `label_sync/labels.md`: Regenerated label documentation to include the new label

### Label Details
| Field | Value |
|-------|-------|
| Name | `area/api-validation` |
| Color | `0052cc` (standard area blue) |
| Target | `both` (issues and PRs) |
| Prow Plugin | `label` |
| Added By | `anyone` |
| Description | Issues or PRs related to API validation and declarative validation |

### Test plan
- [x] Ran `hack/make-rules/verify/labels.sh` to verify `labels.md` is in sync with `labels.yaml`