### PR TITLE
feat: add 100-node scalability perf test for fieldsv1string build tag

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1221,3 +1221,103 @@ periodics:
         limits:
           cpu: 7
           memory: "32Gi"
+
+# NOTE: When making changes to this job, please ensure that you also keep the original job
+# ci-kubernetes-e2e-gce-scale-performance-100 in sig-scalability-release-blocking-jobs.yaml
+# in sync (except for the fieldsv1string-specific env vars).
+- cron: '1 8 * * *' # Run daily at 00:01 PST (08:01 UTC)
+  name: ci-kubernetes-e2e-gce-scale-performance-100-fieldsv1string
+  tags:
+  - "perfDashPrefix: gce-100Nodes-fieldsv1string"
+  - "perfDashJobType: performance"
+  - "perfDashBuildsCount: 500"
+  cluster: k8s-infra-prow-build
+  labels:
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    path_alias: k8s.io/kops
+    workdir: true
+  annotations:
+    testgrid-dashboards: sig-api-machinery-fieldsv1string, sig-scalability-gce
+    testgrid-tab-name: gce-scale-performance-100-fieldsv1string
+    description: "Uses kubetest2 to run k8s.io/perf-tests/run-e2e.sh against a 100-node cluster created with kops, with fieldsv1string build tag enabled"
+  spec:
+    serviceAccountName: prow-build
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260217-29ba10ecec-master
+      command:
+      - runner.sh
+      args:
+      - ./tests/e2e/scenarios/scalability/run-test.sh
+      securityContext:
+        privileged: true
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/ssh-key-secret/ssh-private
+      - name: KUBE_SSH_USER
+        value: prow
+      - name: GOPATH
+        value: /home/prow/go
+      - name: GOFLAGS
+        value: "-tags=fieldsv1string"
+      - name: KUBERNETES_VERSION
+        value: master
+      - name: CNI_PLUGIN
+        value: gce
+      - name: KUBE_NODE_COUNT
+        value: "100"
+      - name: CL2_LOAD_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_DELETE_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_RATE_LIMIT_POD_CREATION
+        value: "false"
+      - name: NODE_MODE
+        value: "master"
+      - name: KUBE_PROXY_MODE
+        value: "nftables"
+      - name: CONTROL_PLANE_COUNT
+        value: "1"
+      - name: CONTROL_PLANE_SIZE
+        value: "c4-standard-32"
+      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+        value: "true"
+      - name: CL2_ENABLE_DNS_PROGRAMMING
+        value: "true"
+      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+        value: "true"
+      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+        value: "99.5"
+      - name: CL2_ALLOWED_SLOW_API_CALLS
+        value: "1"
+      - name: ENABLE_PROMETHEUS_SERVER
+        value: "true"
+      - name: TEAR_DOWN_PROMETHEUS_SERVER
+        value: "false"
+      - name: PROMETHEUS_PVC_STORAGE_CLASS
+        value: "ssd-csi"
+      - name: CLOUD_PROVIDER
+        value: "gce"
+      - name: BOSKOS_RESOURCE_TYPE
+        value: "scalability-project"
+      resources:
+        requests:
+          cpu: 2
+          memory: 6Gi
+        limits:
+          cpu: 2
+          memory: 6Gi


### PR DESCRIPTION
Adds a daily periodic Prow job (`ci-kubernetes-e2e-gce-scale-performance-100-fieldsv1string`) that runs the ClusterLoader2 load test against a 100-node GCE cluster with the `fieldsv1string` build tag enabled.

Job measures the memory impact of the FieldsV1 string interning optimization ([kubernetes/kubernetes#137581](https://github.com/kubernetes/kubernetes/pull/137581)).

This PR:
- Adds a new periodic job to `sig-scalability-periodic-jobs.yaml`, modeled on `ci-kubernetes-e2e-gce-scale-performance-100` with one modification of setting `GOFLAGS`:
  - `GOFLAGS="-tags=fieldsv1string"` — builds kube-apiserver with FieldsV1 string interning enabled
- Job runs daily at 8:01am provisioning a 100-node cluster via kops
- Results appear in:
  - **perfdash** (http://perf-dash.k8s.io/) under job `gce-100Nodes-fieldsv1string` for side-by-side comparison with baseline `gce-100Nodes-master`
  - **TestGrid** under `sig-api-machinery-fieldsv1string` and `sig-scalability-gce` dashboards

### Why sig-scalability directory
Job is placed in `sig-scalability-periodic-jobs.yaml` (rather than `sig-api-machinery-config.yaml` with the other fieldsv1string correctness tests) because perfdash only scans the `sig-scalability` directory for jobs with `perfDashPrefix` tags.

### Key metrics to compare (fieldsv1string vs baseline)

| Metric | Category | What to look for |
|--------|----------|-----------------|
| `ResourceUsageSummary` | Resources | kube-apiserver memory reduction (primary goal) |
| `APIResponsivenessPrometheus` | Responsiveness | No latency regression |
| `PodStartupLatency` | PodStartup | No regression |
| `SchedulingThroughput` | Scheduler | No regression |

### Related PRs

- kubernetes/kubernetes#137581 - FieldsV1 string interning implementation (must merge first for the build tag to have effect)
- kubernetes/test-infra#36627 - Existing fieldsv1string correctness tests (unit, integration, e2e-kind)

### Related issue

- kubernetes/kubernetes#137109 - kube-apiserver memory bloat from managedFields

/sig scalability
/sig api-machinery
/kind feature
