### PR TITLE
Serialize signature replication with image promotion jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -292,6 +292,9 @@ periodics:
 - cron: '0 */2 * * 1-5'
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
+  # Serialize with image promotion jobs to avoid Artifact Registry quota
+  # exhaustion when both run concurrently.
+  job_queue_name: "k8sio-image-promo"
   name: ci-k8sio-image-signature-replication
   decorate: true
   extra_refs:


### PR DESCRIPTION
Add `job_queue_name: "k8sio-image-promo"` to `ci-k8sio-image-signature-replication` so it shares the existing queue with `post-k8sio-image-promo` and `ci-k8sio-image-promo`. This prevents concurrent runs that exhaust the Artifact Registry per-project quota.

Recent failures:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-k8sio-image-promo/2034421228172742656
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-k8sio-image-signature-replication/2034389450028486656
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-k8sio-image-promo/2033954960114192384