### PR TITLE
chore: update mcp-lifecycle-operator ci job image golang version to 1.25

### DIFF
--- a/config/jobs/kubernetes-sigs/mcp-lifecycle-operator/mcp-lifecycle-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/mcp-lifecycle-operator/mcp-lifecycle-operator-presubmits-main.yaml
@@ -6,7 +6,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.24
+      - image: public.ecr.aws/docker/library/golang:1.25
         command:
         - make
         args:


### PR DESCRIPTION
updates mcp-lifecycle-operator ci job image golang version to 1.25