### PR TITLE
chore: refine run_if_changed for presubmit-agent-sandbox-lint-api

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -64,7 +64,7 @@ presubmits:
       testgrid-tab-name: presubmit-lint-go
   - name: presubmit-agent-sandbox-lint-api
     cluster: eks-prow-build-cluster
-    run_if_changed: "^.*\\.go$|^go\\.(mod|sum)$|^dev/ci/presubmits/lint-api$"
+    run_if_changed: "^(extensions/)?api/|^dev/(ci/presubmits|tools)/lint-api|^dev/tools/(build-kal|\\.golangci-kal\\.yml|\\.custom-gcl\\.yaml)$"
     decorate: true
     spec:
       containers:


### PR DESCRIPTION
Tighten the regex to trigger only on API changes, linter scripts, or specific linter configurations. This avoids unnecessary runs on every Go file or dependency change.

Follow up on #36685 