### PR TITLE
Kubespray image-builder presubmit canary build validation

### DIFF
--- a/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
@@ -22,3 +22,29 @@ presubmits:
           requests:
             cpu: 1
             memory: 4Gi
+  - name: pull-kubespray-kubevirt-image-builder-validate
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-kubespray
+      testgrid-tab-name: kubevirt-image-builder-validate
+    run_if_changed: '^test-infra/image-builder/.*'
+    always_run: false
+    skip_report: false
+    decorate: true
+    spec:
+      containers:
+      - image: quay.io/kubespray/kubespray:v2.13.0
+        command:
+        - /bin/bash
+        args:
+        - -ceu
+        - |
+          cd test-infra/image-builder
+          make validate-single image_name=ubuntu-2404
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds a Kubespray presubmit job to validate `test-infra/image-builder`.
I’m raising this as part of the Kubespray CI automation work tracked in:
- https://github.com/kubernetes-sigs/kubespray/issues/12383
- Context: https://github.com/kubernetes-sigs/kubespray/issues/12383#issuecomment-4066751982


This is safe and useful regardless of the final registry migration path (related discussion: https://github.com/kubernetes-sigs/kubespray/issues/13105).

## Note on runtime image

This job uses the existing Kubespray presubmit runtime image:
- `quay.io/kubespray/kubespray:v2.13.0`

This is intentional for low risk and consistency with current jobs. Any runtime image/registry migration will be handled in follow-up work after a decision is made in https://github.com/kubernetes-sigs/kubespray/issues/13105.
