### PR TITLE
Update kubespray OWNERS and skip misspell on OWNERS

### DIFF
--- a/config/jobs/kubernetes-sigs/kubespray/OWNERS
+++ b/config/jobs/kubernetes-sigs/kubespray/OWNERS
@@ -1,20 +1,16 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- ant31
-- mattymo
-- atoms
-- chadswen
-- mirwan
-- riverzhang
-- woopstar
-- miouge1
+- cyclinder
+- erikjiang
+- mzaian
+- tico88612
+- vannten
+- yankay
 approvers:
 - ant31
-- mattymo
-- atoms
 - chadswen
-- mirwan
-- riverzhang
-- woopstar
-- miouge1
+- mzaian
+- tico88612
+- vannten
+- yankay

--- a/hack/make-rules/update/misspell.sh
+++ b/hack/make-rules/update/misspell.sh
@@ -46,4 +46,5 @@ find -L . -type f -not \( \
     \) -prune \
     -o -name 'go.mod' \
     -o -name 'go.sum' \
+    -o -name 'OWNERS' \
     \) | xargs "${MISSPELL}" -w

--- a/hack/make-rules/verify/misspell.sh
+++ b/hack/make-rules/verify/misspell.sh
@@ -81,6 +81,7 @@ find -L . -type f -not \( \
     \) -prune \
     -o -name 'go.mod' \
     -o -name 'go.sum' \
+    -o -name 'OWNERS' \
     \) | xargs "$MISSPELL" --error
 
 echo 'PASS: No spelling issues detected'


### PR DESCRIPTION
## What this PR does / why we need it

This PR updates Kubespray job ownership in test-infra to match the current Kubespray maintainer lists.

It aligns `config/jobs/kubernetes-sigs/kubespray/OWNERS` with:
- [https://github.com/kubernetes-sigs/kubespray/blob/master/OWNERS_ALIASES](https://github.com/kubernetes-sigs/kubespray/blob/master/OWNERS_ALIASES)

## Changes made

- Updated `approvers` to match current `kubespray-approvers`
- Updated `reviewers` to match current `kubespray-reviewers`
- Removed inactive/emeritus entries that are not part of current active ownership

## Context

- Related discussion: https://github.com/kubernetes-sigs/kubespray/issues/12383

