### PR TITLE
update release-utils jobs to use go1.26

### DIFF
--- a/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-utils/release-utils-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.26-trixie
         imagePullPolicy: Always
         command:
         - go
@@ -34,7 +34,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.26-trixie
         imagePullPolicy: Always
         command:
         - go


### PR DESCRIPTION
/assign @saschagrunert @Verolop @puerco 
cc @kubernetes/release-engineering 