### PR TITLE
fix remaining release-blocking job timeouts

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -155,7 +155,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 3h20m0s
+    timeout: 2h20m0s
   interval: 30m
   labels:
     preset-k8s-ssh: "true"
@@ -176,7 +176,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking
         --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Example)\]|IPv6|csi-hostpath-v0
         --minStartupPods=8
-      - --timeout=180m
+      - --timeout=120m
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
@@ -274,7 +274,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 3h20m0s
+    timeout: 1h20m0s
   interval: 30m
   labels:
     preset-k8s-ssh: "true"
@@ -289,7 +289,7 @@ periodics:
       - --gcp-region=us-central1
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
-      - --timeout=180m
+      - --timeout=60m
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes/sig-release/gce-cos-e2e-master.yaml
+++ b/config/jobs/kubernetes/sig-release/gce-cos-e2e-master.yaml
@@ -10,7 +10,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 200m
+    timeout: 2h20m0s
   extra_refs:
   - base_ref: master
     org: kubernetes
@@ -29,7 +29,7 @@ periodics:
       - --gcp-region=us-central1
       - --gcp-node-image=gci
       - --extract=ci/latest
-      - --timeout=180m
+      - --timeout=120m
       - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -105,7 +105,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 200m
+    timeout: 1h20m0s
   extra_refs:
   - base_ref: master
     org: kubernetes
@@ -124,7 +124,7 @@ periodics:
       - --gcp-region=us-central1
       - --gcp-node-image=gci
       - --extract=ci/latest
-      - --timeout=180m
+      - --timeout=60m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       command:
       - runner.sh

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -988,7 +988,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 3h20m0s
+    timeout: 2h20m0s
     skip_cloning: true
   extra_refs:
   - base_ref: release-1.33
@@ -1008,7 +1008,7 @@ periodics:
       - --gcp-region=us-central1
       - --gcp-node-image=gci
       - --extract=ci/latest-1.33
-      - --timeout=180m
+      - --timeout=120m
       - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -1081,7 +1081,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 3h20m0s
+    timeout: 1h20m0s
     skip_cloning: true
   extra_refs:
   - base_ref: release-1.33
@@ -1101,7 +1101,7 @@ periodics:
       - --gcp-region=us-central1
       - --gcp-node-image=gci
       - --extract=ci/latest-1.33
-      - --timeout=180m
+      - --timeout=60m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       command:
       - runner.sh

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1264,7 +1264,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 3h20m0s
+    timeout: 2h20m0s
     skip_cloning: true
   extra_refs:
   - base_ref: release-1.34
@@ -1284,7 +1284,7 @@ periodics:
       - --gcp-region=us-central1
       - --gcp-node-image=gci
       - --extract=ci/latest-1.34
-      - --timeout=180m
+      - --timeout=120m
       - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -1357,7 +1357,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 3h20m0s
+    timeout: 1h20m0s
     skip_cloning: true
   extra_refs:
   - base_ref: release-1.34
@@ -1377,7 +1377,7 @@ periodics:
       - --gcp-region=us-central1
       - --gcp-node-image=gci
       - --extract=ci/latest-1.34
-      - --timeout=180m
+      - --timeout=60m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       command:
       - runner.sh

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -1383,7 +1383,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 3h20m0s
+    timeout: 2h20m0s
     skip_cloning: true
   extra_refs:
   - base_ref: release-1.35
@@ -1403,7 +1403,7 @@ periodics:
       - --gcp-region=us-central1
       - --gcp-node-image=gci
       - --extract=ci/latest-1.35
-      - --timeout=180m
+      - --timeout=120m
       - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -1476,7 +1476,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 3h20m0s
+    timeout: 1h20m0s
     skip_cloning: true
   extra_refs:
   - base_ref: release-1.35
@@ -1496,7 +1496,7 @@ periodics:
       - --gcp-region=us-central1
       - --gcp-node-image=gci
       - --extract=ci/latest-1.35
-      - --timeout=180m
+      - --timeout=60m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       command:
       - runner.sh

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -985,7 +985,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 3h20m0s
+    timeout: 2h20m0s
   extra_refs:
   - base_ref: release-1.36
     org: kubernetes
@@ -1004,7 +1004,7 @@ periodics:
       - --gcp-region=us-central1
       - --gcp-node-image=gci
       - --extract=ci/latest-1.36
-      - --timeout=180m
+      - --timeout=120m
       - --env=ENABLE_POD_PRIORITY=true
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
@@ -1078,7 +1078,7 @@ periodics:
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
-    timeout: 3h20m0s
+    timeout: 1h20m0s
   extra_refs:
   - base_ref: release-1.36
     org: kubernetes
@@ -1097,7 +1097,7 @@ periodics:
       - --gcp-region=us-central1
       - --gcp-node-image=gci
       - --extract=ci/latest-1.36
-      - --timeout=180m
+      - --timeout=60m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       command:
       - runner.sh

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -1210,23 +1210,6 @@ func TestClusterName(t *testing.T) {
 func TestKubernetesReleaseBlockingJobsCIPolicy(t *testing.T) {
 	jobsToFix := 0
 	numJobs := len(allStaticJobs())
-
-	// TODO: finish eliminating this list and remove the known-failures logic
-	knownFailures := map[string]bool{
-		"ci-kubernetes-e2e-gce-cos-alphafeatures-beta":    false,
-		"ci-kubernetes-e2e-gce-cos-alphafeatures-master":  false,
-		"ci-kubernetes-e2e-gce-cos-alphafeatures-stable1": false,
-		"ci-kubernetes-e2e-gce-cos-alphafeatures-stable2": false,
-		"ci-kubernetes-e2e-gce-cos-alphafeatures-stable3": false,
-		"ci-kubernetes-e2e-gce-cos-reboot-beta":           false,
-		"ci-kubernetes-e2e-gce-cos-reboot-master":         false,
-		"ci-kubernetes-e2e-gce-cos-reboot-stable1":        false,
-		"ci-kubernetes-e2e-gce-cos-reboot-stable2":        false,
-		"ci-kubernetes-e2e-gce-cos-reboot-stable3":        false,
-		"ci-kubernetes-e2e-gci-gce-alpha-features":        false,
-		"ci-kubernetes-e2e-gci-gce-reboot":                false,
-	}
-
 	for _, job := range c.AllPeriodics() {
 		// Only consider Pods that are release-blocking
 		if job.Spec == nil || !isKubernetesReleaseBlocking(job.JobBase) {
@@ -1259,12 +1242,7 @@ func TestKubernetesReleaseBlockingJobsCIPolicy(t *testing.T) {
 			jobsToFix++
 		}
 		for _, err := range errs {
-			if _, ok := knownFailures[job.Name]; ok {
-				t.Logf("%v: %v", job.Name, err)
-				knownFailures[job.Name] = true
-			} else {
-				t.Errorf("%v: %v", job.Name, err)
-			}
+			t.Errorf("%v: %v", job.Name, err)
 		}
 	}
 
@@ -1299,23 +1277,12 @@ func TestKubernetesReleaseBlockingJobsCIPolicy(t *testing.T) {
 				jobsToFix++
 			}
 			for _, err := range errs {
-				if _, ok := knownFailures[job.Name]; ok {
-					t.Logf("%v: %v", job.Name, err)
-					knownFailures[job.Name] = true
-				} else {
-					t.Errorf("%v: %v", job.Name, err)
-				}
+				t.Errorf("%v: %v", job.Name, err)
 			}
 		}
 	}
 
 	t.Logf("summary: %4d/%4d jobs fail to meet kubernetes/kubernetes release-blocking CI policy", jobsToFix, numJobs)
-
-	for name, stillFailing := range knownFailures {
-		if !stillFailing {
-			t.Errorf("%v: job is not failing anymore, remove it from knownFailures", name)
-		}
-	}
 }
 
 func kubernetesBranch(refs []prowapi.Refs) string {


### PR DESCRIPTION
Fixes #36574

Align the remaining release blocking jobs and remove the now empty `knownFailures` handling.