### PR TITLE
release 1.36 should be excluded in tide for freeze

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -748,7 +748,7 @@ tide:
     - kubernetes/kubernetes
     excludedBranches:
     - master
-    - release-1.35
+    - release-1.36
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
/kind cleanup



https://github.com/kubernetes/test-infra/pull/36677/changes#r2967404803