### PR TITLE
VPA: Enable alpha and beta feature gates in presubmit jobs

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -195,9 +195,53 @@ presubmits:
           requests:
             cpu: 2
             memory: 6Gi
+
+  - name: pull-autoscaling-e2e-vpa-full-alpha-beta
+    cluster: k8s-infra-prow-build
+    annotations:
+      testgrid-dashboards: sig-autoscaling-vpa
+      testgrid-tab-name: autoscaling-vpa-full-alpha-beta-presubmits
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 120m
+    run_if_changed: '^vertical-pod-autoscaler\/'
+    path_alias: k8s.io/autoscaler
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --check-leaked-resources
+        - --extract=ci/latest
+        - --gcp-node-image=gci
+        - --gcp-zone=us-central1-b
+        - --provider=gce
+        - --test=false
+        - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh
+        - --test-cmd-args=full-vpa
+        - --timeout=100m
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
         env:
         - name: FEATURE_GATES
-          value: "InPlaceOrRecreate=true"
+          value: "AllAlpha=true,AllBeta=true"
+        - name: TEST_WITH_FEATURE_GATES_ENABLED
+          value: "true"
+
   - name: pull-autoscaling-e2e-vpa-actuation
     cluster: k8s-infra-prow-build
     annotations:
@@ -241,8 +285,55 @@ presubmits:
         env:
         - name: NUMPROC
           value: "8"
+
+  - name: pull-autoscaling-e2e-vpa-actuation-alpha-beta
+    cluster: k8s-infra-prow-build
+    annotations:
+      testgrid-dashboards: sig-autoscaling-vpa
+      testgrid-tab-name: autoscaling-vpa-actuation-alpha-beta-presubmits
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 200m
+    run_if_changed: '^vertical-pod-autoscaler\/'
+    path_alias: k8s.io/autoscaler
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --check-leaked-resources
+        - --extract=ci/latest
+        - --gcp-node-image=gci
+        - --gcp-zone=us-central1-b
+        - --provider=gce
+        - --test=false
+        - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh
+        - --test-cmd-args=actuation
+        - --timeout=180m
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
+        env:
+        - name: NUMPROC
+          value: "8"
         - name: FEATURE_GATES
-          value: "InPlaceOrRecreate=true"
+          value: "AllAlpha=true,AllBeta=true"
+        - name: TEST_WITH_FEATURE_GATES_ENABLED
+          value: "true"
+
   - name: pull-autoscaling-e2e-vpa-admission-controller
     cluster: k8s-infra-prow-build
     annotations:
@@ -283,9 +374,53 @@ presubmits:
           requests:
             cpu: 2
             memory: 6Gi
+
+  - name: pull-autoscaling-e2e-vpa-admission-controller-alpha-beta
+    cluster: k8s-infra-prow-build
+    annotations:
+      testgrid-dashboards: sig-autoscaling-vpa
+      testgrid-tab-name: autoscaling-vpa-admission-controller-alpha-beta-presubmits
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 120m
+    run_if_changed: '^vertical-pod-autoscaler\/'
+    path_alias: k8s.io/autoscaler
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --check-leaked-resources
+        - --extract=ci/latest
+        - --gcp-node-image=gci
+        - --gcp-zone=us-central1-b
+        - --provider=gce
+        - --test=false
+        - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh
+        - --test-cmd-args=admission-controller
+        - --timeout=100m
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
         env:
         - name: FEATURE_GATES
-          value: "InPlaceOrRecreate=true"
+          value: "AllAlpha=true,AllBeta=true"
+        - name: TEST_WITH_FEATURE_GATES_ENABLED
+          value: "true"
+
   - name: pull-autoscaling-e2e-vpa-recommender
     cluster: k8s-infra-prow-build
     annotations:
@@ -326,9 +461,53 @@ presubmits:
           requests:
             cpu: 2
             memory: 6Gi
+
+  - name: pull-autoscaling-e2e-vpa-recommender-alpha-beta
+    cluster: k8s-infra-prow-build
+    annotations:
+      testgrid-dashboards: sig-autoscaling-vpa
+      testgrid-tab-name: autoscaling-vpa-recommender-alpha-beta-presubmits
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 120m
+    run_if_changed: '^vertical-pod-autoscaler\/'
+    path_alias: k8s.io/autoscaler
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --check-leaked-resources
+        - --extract=ci/latest
+        - --gcp-node-image=gci
+        - --gcp-zone=us-central1-b
+        - --provider=gce
+        - --test=false
+        - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh
+        - --test-cmd-args=recommender
+        - --timeout=100m
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
         env:
         - name: FEATURE_GATES
-          value: "InPlaceOrRecreate=true"
+          value: "AllAlpha=true,AllBeta=true"
+        - name: TEST_WITH_FEATURE_GATES_ENABLED
+          value: "true"
+
   - name: pull-autoscaling-e2e-vpa-updater
     cluster: k8s-infra-prow-build
     annotations:
@@ -369,9 +548,53 @@ presubmits:
           requests:
             cpu: 2
             memory: 6Gi
+
+  - name: pull-autoscaling-e2e-vpa-updater-alpha-beta
+    cluster: k8s-infra-prow-build
+    annotations:
+      testgrid-dashboards: sig-autoscaling-vpa
+      testgrid-tab-name: autoscaling-vpa-updater-alpha-beta-presubmits
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 120m
+    run_if_changed: '^vertical-pod-autoscaler\/'
+    path_alias: k8s.io/autoscaler
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --check-leaked-resources
+        - --extract=ci/latest
+        - --gcp-node-image=gci
+        - --gcp-zone=us-central1-b
+        - --provider=gce
+        - --test=false
+        - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh
+        - --test-cmd-args=updater
+        - --timeout=100m
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
         env:
         - name: FEATURE_GATES
-          value: "InPlaceOrRecreate=true"
+          value: "AllAlpha=true,AllBeta=true"
+        - name: TEST_WITH_FEATURE_GATES_ENABLED
+          value: "true"
+
   - name: pull-autoscaling-e2e-ca-build
     cluster: k8s-infra-prow-build
     annotations:


### PR DESCRIPTION
While developing a new feature for **VPA**, including new e2e tests, I realized that only one feature gate is enabled (`InPlaceOrRecreate`) in presubmit jobs. This means that the new e2e tests for my feature, which is behind a new feature gate, face the following issues:
1. They are not executed at all by default.
2. If they are executed (through a workaround), they fail because the new feature gate is not enabled for the VPA component.

I think e2e tests that depend on a feature flag should be executed in presubmit jobs. Furthermore, the VPA components should be started with all alpha and beta feature flags enabled in these jobs.


In this PR, I used the same approach as we do for alpha-beta CI jobs for VPA (e.g. `ci-kubernetes-e2e-autoscaling-vpa-recommender-alpha-beta`).