### PR TITLE
Add main branch to community presubmit job

### DIFF
--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -4,6 +4,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     branches:
     - master
+    - main
     always_run: true
     decorate: true
     spec:


### PR DESCRIPTION
## Summary
- Add `main` to the `branches` list for `pull-community-verify` presubmit job
- Prerequisite for renaming the default branch of `kubernetes/community` from `master` to `main`
- Does not modify the commented-out `pull-community-tempelis-check` job

Ref: https://github.com/kubernetes/community/issues/6290

## Test plan
- [ ] Verify the YAML is valid and the prow config passes validation
- [ ] Confirm `pull-community-verify` triggers on PRs targeting both `master` and `main`