### PR TITLE
Target only main branch for community presubmit job

### DIFF
--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -3,7 +3,6 @@ presubmits:
   - name: pull-community-verify
     cluster: eks-prow-build-cluster
     branches:
-    - master
     - main
     always_run: true
     decorate: true


### PR DESCRIPTION
## Summary
- Remove `master` from the `branches` list for `pull-community-verify`, leaving only `main`
- The kubernetes/community default branch rename from `master` to `main` is now complete
- The commented-out `pull-community-tempelis-check` job is not modified

fixes https://github.com/kubernetes/community/issues/6290

## Test plan
- [ ] Verify prow config validation passes
- [ ] Confirm `pull-community-verify` triggers on PRs targeting `main`