### PR TITLE
Rename kube-dns benchmark job to coredns in sig-scalability

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -779,11 +779,11 @@ periodics:
           cpu: 6
           memory: "24Gi"
 
-- name: ci-benchmark-kube-dns-master
+- name: ci-benchmark-coredns-master
   cluster: k8s-infra-prow-build
   interval: 2h
   tags:
-  - "perfDashPrefix: kube-dns benchmark"
+  - "perfDashPrefix: coredns benchmark"
   - "perfDashJobType: dnsBenchmark"
   labels:
     preset-service-account: "true"
@@ -813,7 +813,7 @@ periodics:
       - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --check-leaked-resources
-      - --cluster=kube-dns-benchmark
+      - --cluster=coredns-benchmark
       - --extract=ci/latest
       - --gcp-node-size=e2-standard-2
       - --gcp-nodes=3
@@ -821,7 +821,7 @@ periodics:
       - --provider=gce
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
-      - --test-cmd-args=kube-dns
+      - --test-cmd-args=coredns
       - --test-cmd-args=$(ARTIFACTS)/out
       - --test-cmd-args=$(ARTIFACTS)
       - --test-cmd-name=KubeDnsBenchmark

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -501,7 +501,7 @@ presubmits:
             memory: 25Gi
 
   kubernetes/perf-tests:
-  - name: pull-perf-tests-benchmark-kube-dns
+  - name: pull-perf-tests-benchmark-coredns
     cluster: k8s-infra-prow-build
     always_run: false
     skip_report: false
@@ -519,7 +519,7 @@ presubmits:
       path_alias: k8s.io/release
     annotations:
       testgrid-dashboards: presubmits-kubernetes-scalability
-      testgrid-tab-name: pull-perf-tests-benchmark-kube-dns
+      testgrid-tab-name: pull-perf-tests-benchmark-coredns
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
@@ -532,14 +532,14 @@ presubmits:
         - /workspace/scenarios/kubernetes_e2e.py
         args:
         - --check-leaked-resources
-        - --cluster=kube-dns-benchmark
+        - --cluster=coredns-benchmark
         - --extract=ci/latest
         - --gcp-nodes=3
         - --gcp-zone=us-east1-b
         - --provider=gce
         - --test=false
         - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
-        - --test-cmd-args=kube-dns
+        - --test-cmd-args=coredns
         - --test-cmd-args=$(ARTIFACTS)/out
         - --test-cmd-args=$(ARTIFACTS)
         - --test-cmd-name=KubeDnsBenchmark


### PR DESCRIPTION
As discussed in the SIG-Scalability community, the kube-dns benchmark jobs are currently testing CoreDNS. This PR renames the job for technical accuracy while preserving the testgrid-tab-name to ensure no disruption to existing dashboards. Fixes part of the naming confusion in test-infra.