### PR TITLE
prow: enable issue-management plugin for kubernetes-sigs/external-dns

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1572,6 +1572,10 @@ plugins:
     - mergecommitblocker
     - override
 
+  kubernetes-sigs/external-dns:
+    plugins:
+    - issue-management
+
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
     plugins:
     - release-note


### PR DESCRIPTION
Why: Contributors to external-dns have no way to link/unlink GitHub issues to PRs via prow commands.

What: Adds a kubernetes-sigs/external-dns entry to plugins.yaml enabling the issue-management plugin, which provides /link-issue and /unlink-issue commands (org members only).

https://github.com/kubernetes-sigs/external-dns/blob/master/OWNERS