### PR TITLE
Update prow plugin with CAPZ release 1.24

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -576,9 +576,9 @@ milestone_applier:
     release-2.6: v2.6
     release-2.5: v2.5
   kubernetes-sigs/cluster-api-provider-azure:
-    main: v1.23
+    main: v1.24
+    release-1.23: v1.23
     release-1.22: v1.22
-    release-1.21: v1.21
   kubernetes-sigs/cluster-api-provider-digitalocean:
     main: v1.1.0
     release-1.0: v1.0.0


### PR DESCRIPTION
Updates the current milestone and supported branches for CAPZ to 1.24