### PR TITLE
Stop doing LoadBalancer tests in gce-master-scale-correctness

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -63,7 +63,7 @@ periodics:
       - --gcp-zone=us-east1-b
       - --ginkgo-parallel=40
       - --provider=gce
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\] --minStartupPods=8 --node-schedulable-timeout=90m
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8 --node-schedulable-timeout=90m
       - --timeout=240m
       - --use-logexporter
       - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)


### PR DESCRIPTION
`gce-master-scale-correctness` periodically starts flaking because the LoadBalancer tests do not reliably pass under GCE at that scale, at least in the way this test configures the cluster.

Discussion with @bowei and @serathius at KubeCon led to the conclusion that we should just drop the LB tests from this particular job.

(Which is to say, we should change the skip rule from "skip any tests with `[Feature:...]` tags that aren't `[Feature:LoadBalancer]`" to "skip any tests with `[Feature:...]` tags".)

Fixes https://github.com/kubernetes/kubernetes/issues/131863
