### PR TITLE
compatibility-versions: Move `kind-upgrade.sh` usage function to the top

### DIFF
--- a/experiment/compatibility-versions/kind-upgrade.sh
+++ b/experiment/compatibility-versions/kind-upgrade.sh
@@ -18,6 +18,13 @@
 set -e
 set -o pipefail
 
+usage()
+{
+    echo "usage: kind_upgrade.sh [-n|--name <cluster_name>]"
+    echo "                       [--no-control-plane]  [--no-kubelet]"
+    echo ""
+}
+
 # Set default values
 CLUSTER_NAME=${CLUSTER_NAME:-kind}
 BUILD_MODE=${BUILD_MODE:-docker}
@@ -102,13 +109,6 @@ update_control_plane(){
       sleep 1
     done
   done
-}
-
-usage()
-{
-    echo "usage: kind_upgrade.sh [-n|--name <cluster_name>]"
-    echo "                       [--no-control-plane]  [--no-kubelet]"
-    echo ""
 }
 
 # Main


### PR DESCRIPTION
The usage function was used before it was defined, which caused the script to crash instead of printing out the usage string when wrong arguments were passed to it.