### PR TITLE
ksandbox: correct SRC_DIR path in build-images script

### DIFF
--- a/experiment/ksandbox/dev/tasks/build-images
+++ b/experiment/ksandbox/dev/tasks/build-images
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-SRC_DIR=${REPO_ROOT}/experimental/ksandbox
+SRC_DIR=${REPO_ROOT}/experiment/ksandbox
 cd "${SRC_DIR}"
 
 KO="go run github.com/google/ko@v0.17.1"


### PR DESCRIPTION
The script responsible for building the ksandbox images `cd`s into the wrong path in the repo (`experimental` instead of `experiment`). This PR fixes that typo.