### PR TITLE
hack/make-rules: Fix array expansion in failure reporting for verify checks

### DIFF
--- a/hack/make-rules/verify/all.sh
+++ b/hack/make-rules/verify/all.sh
@@ -106,7 +106,7 @@ if [[ "${#FAILED[@]}" == 0 ]]; then
 else
   echo ""
   echo "One or more verify checks failed! See details above. Failed check:"
-  for failed in "${FAILED}"; do
+  for failed in "${FAILED[@]}"; do
     echo "  FAILED: $failed"
   done
   res=1


### PR DESCRIPTION
A for loop in the `hack/make-rules/verify/all.sh` script accidentally tried to iterate over a bash array without properly indexing it, which resulted in iterating over only the first element of the array.