### PR TITLE
cloud-provider-gcp: enable cherrypicker plugin

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1854,6 +1854,12 @@ external_plugins:
     - issue_comment
     - pull_request
     endpoint: http://cherrypicker
+  kubernetes/cloud-provider-gcp:
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request
+    endpoint: http://cherrypicker
   kubernetes/cloud-provider-openstack:
   - name: cherrypicker
     events:


### PR DESCRIPTION
Discussed in https://github.com/kubernetes/cloud-provider-gcp/issues/1017.