### PR TITLE
CAPZ fix: pin optional tests to v1.33.9 temporarily

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -293,6 +293,8 @@ periodics:
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
           value: \[Managed Kubernetes\]|\[WINDOWS\]
+        - name: KUBERNETES_VERSION
+          value: v1.33.9 # TODO: Remove this once v1.33.10 artifacts are published for Flatcar and RKE2 tests
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -144,6 +144,8 @@ presubmits:
             value: \[OPTIONAL\]
           - name: GINKGO_SKIP
             value: ""
+          - name: KUBERNETES_VERSION
+            value: v1.33.9 # TODO: Remove this once v1.33.10 artifacts are published for Flatcar and RKE2 tests
         resources:
           limits:
             cpu: 4


### PR DESCRIPTION
Tests are failing due to some upstream artifacts not existing for v1.33.10