### PR TITLE
test: add preset-k8s-ssh to CAPG e2e and conformance jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
@@ -67,6 +67,7 @@ periodics:
       preset-service-account: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 3h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-10.yaml
@@ -67,6 +67,7 @@ periodics:
     preset-service-account: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+    preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
     timeout: 3h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-11.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-11.yaml
@@ -67,6 +67,7 @@ periodics:
     preset-service-account: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+    preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
     timeout: 3h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-9.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-9.yaml
@@ -67,6 +67,7 @@ periodics:
     preset-service-account: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+    preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
     timeout: 3h

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -119,6 +119,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^main$
@@ -157,6 +158,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^main$
@@ -205,6 +207,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^main$
@@ -243,6 +246,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^main$
@@ -281,6 +285,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^main$

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-10.yaml
@@ -112,6 +112,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.10$
@@ -147,6 +148,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.10$
@@ -182,6 +184,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.10$
@@ -220,6 +223,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.10$

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-11.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-11.yaml
@@ -112,6 +112,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.11$
@@ -147,6 +148,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.11$
@@ -182,6 +184,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.11$
@@ -220,6 +223,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.11$

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-9.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-9.yaml
@@ -111,6 +111,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.9$
@@ -146,6 +147,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.9$
@@ -181,6 +183,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.9$
@@ -219,6 +222,7 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     branches:
     - ^release-1.9$


### PR DESCRIPTION
Enable SSH key access for Cluster API Provider GCP jobs that create real GCP clusters by adding the preset-k8s-ssh label. This mounts the ssh-key-secret and sets GCE_SSH_* environment variables in the job pods, matching what kops and others use.

Affected jobs across main and release-1.{9,10,11} branches:
- pull-cluster-api-provider-gcp-e2e-test
- pull-cluster-api-provider-gcp-conformance (+ conformance-ci-artifacts on main)
- pull-cluster-api-provider-gcp-capi-e2e
- pull-cluster-api-provider-gcp-e2e-workload-upgrade
- periodic-cluster-api-provider-gcp-make-conformance