### PR TITLE
Use staging latest kpromo image for image promotion

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -54,7 +54,8 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v4.4.0-0
+      - image: gcr.io/k8s-staging-artifact-promoter/kpromo:latest
+        imagePullPolicy: Always
         command:
         - /kpromo
         args:


### PR DESCRIPTION
Use the staging latest image for the `post-k8sio-image-promo` job to pick up the fix for the promotion timeout when prow diff contains no digests (kubernetes-sigs/promo-tools#1798).

The `post-k8sio-image-promo` job has been timing out (4h) repeatedly since kubernetes/k8s.io#9260 merged. That commit only added a `promoter-manifest.yaml` without any digest changes, causing `--use-prow-manifest-diff` to skip filtering and load all images across all staging projects.

This should be reverted back to a pinned release once a new kpromo version is cut.