### PR TITLE
Use xlarge EC2 instances for serial node e2e tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/ec2-containerd-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd-presubmit.yaml
@@ -131,7 +131,7 @@ presubmits:
               - name: IMAGE_CONFIG_DIR
                 value: config
               - name: IMAGE_CONFIG_FILE
-                value: aws-instance.yaml
+                value: aws-instance-serial.yaml
               - name: SKIP
                 value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:OffByDefault\]
               - name: TEST_ARGS
@@ -183,7 +183,7 @@ presubmits:
               - name: IMAGE_CONFIG_DIR
                 value: config
               - name: IMAGE_CONFIG_FILE
-                value: aws-instance-arm64.yaml
+                value: aws-instance-arm64-serial.yaml
               - name: TEST_ARGS
                 value: '--kubelet-flags="--cgroup-driver=systemd"'
             # docker-in-docker needs privileged mode

--- a/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/ec2-containerd.yaml
@@ -153,7 +153,7 @@ periodics:
             - name: IMAGE_CONFIG_DIR
               value: config
             - name: IMAGE_CONFIG_FILE
-              value: aws-instance-arm64.yaml
+              value: aws-instance-arm64-serial.yaml
             - name: TEST_ARGS
               value: '--kubelet-flags="--cgroup-driver=systemd"'
           # docker-in-docker needs privileged mode
@@ -201,7 +201,7 @@ periodics:
             - name: IMAGE_CONFIG_DIR
               value: config
             - name: IMAGE_CONFIG_FILE
-              value: aws-instance.yaml
+              value: aws-instance-serial.yaml
             - name: SKIP
               value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]|\[Feature:OffByDefault\]
             - name: TEST_ARGS

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -244,7 +244,7 @@ presubmits:
               - name: IMAGE_CONFIG_DIR
                 value: config
               - name: IMAGE_CONFIG_FILE
-                value: aws-instance-arm64.yaml
+                value: aws-instance-arm64-serial.yaml
               - name: TEST_ARGS
                 value: '--kubelet-flags="--cgroup-driver=systemd"'
             # docker-in-docker needs privileged mode
@@ -3068,7 +3068,7 @@ presubmits:
               - name: IMAGE_CONFIG_DIR
                 value: config
               - name: IMAGE_CONFIG_FILE
-                value: aws-instance.yaml
+                value: aws-instance-serial.yaml
               - name: SKIP
                 value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:PodLevelResources\]
               - name: TEST_ARGS


### PR DESCRIPTION
Serial node e2e tests restart the kubelet repeatedly with different configurations. On m6a.large/m6g.large (2 vCPU) instances the kubelet sometimes cannot restart within the /configz polling timeout, causing cascading failures (30-40 tests) and 4-hour suite timeouts. This is intermittent and depends on system load during the restart window.

Needs https://github.com/kubernetes-sigs/provider-aws-test-infra/pull/540 to land first.