### PR TITLE
Remove Kubernetes 1.32 e2e test jobs from jobset configs

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -69,46 +69,6 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-e2e-main-1-32
-    cluster: eks-prow-build-cluster
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: jobset
-        base_ref: main
-        path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-jobset-test-e2e-main-1-32
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset end to end tests for Kubernetes 1.32"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-    decorate: true
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.0
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - test-e2e-kind
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 3
-              memory: 10Gi
-            requests:
-              cpu: 3
-              memory: 10Gi
-  - interval: 12h
     name: periodic-jobset-test-e2e-main-1-33
     cluster: eks-prow-build-cluster
     extra_refs:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-10.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-10.yaml
@@ -69,46 +69,6 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-e2e-release-0-10-1-32
-    cluster: eks-prow-build-cluster
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: jobset
-        base_ref: release-0.10
-        path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-jobset-test-e2e-release-0-10-1-32
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset end to end tests for Kubernetes 1.32 on release 0.10"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.32.0
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.25
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - test-e2e-kind
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 3
-            memory: 10Gi
-          requests:
-            cpu: 3
-            memory: 10Gi
-  - interval: 12h
     name: periodic-jobset-test-e2e-release-0-10-1-33
     cluster: eks-prow-build-cluster
     extra_refs:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-11.yaml
@@ -69,46 +69,6 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-e2e-release-0-11-1-32
-    cluster: eks-prow-build-cluster
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: jobset
-        base_ref: release-0.11
-        path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: periodic-jobset-test-e2e-release-0-11-1-32
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset end to end tests for Kubernetes 1.32 on release 0.11"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.32.0
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.25
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - test-e2e-kind
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 3
-            memory: 10Gi
-          requests:
-            cpu: 3
-            memory: 10Gi
-  - interval: 12h
     name: periodic-jobset-test-e2e-release-0-11-1-33
     cluster: eks-prow-build-cluster
     extra_refs:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -59,43 +59,6 @@ presubmits:
           requests:
             cpu: 3
             memory: 10Gi
-  - name: pull-jobset-test-e2e-main-1-32
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^main
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: pull-jobset-test-e2e-main-1-32
-      description: "Run jobset end to end tests for Kubernetes 1.32"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.0
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - test-e2e-kind
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 3
-              memory: 10Gi
-            requests:
-              cpu: 3
-              memory: 10Gi
   - name: pull-jobset-test-e2e-main-1-33
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-10.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-10.yaml
@@ -59,43 +59,6 @@ presubmits:
           requests:
             cpu: 3
             memory: 10Gi
-  - name: pull-jobset-test-e2e-release-0-10-1-32
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^release-0.10
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: pull-jobset-test-e2e-release-0-10-1-32
-      description: "Run jobset end to end tests for Kubernetes 1.32"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.0
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - test-e2e-kind
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 3
-              memory: 10Gi
-            requests:
-              cpu: 3
-              memory: 10Gi
   - name: pull-jobset-test-e2e-release-0-10-1-33
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-11.yaml
@@ -59,43 +59,6 @@ presubmits:
           requests:
             cpu: 3
             memory: 10Gi
-  - name: pull-jobset-test-e2e-release-0-11-1-32
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^release-0.11
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps
-      testgrid-tab-name: pull-jobset-test-e2e-release-0-11-1-32
-      description: "Run jobset end to end tests for Kubernetes 1.32"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.0
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.25
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - test-e2e-kind
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 3
-              memory: 10Gi
-            requests:
-              cpu: 3
-              memory: 10Gi
   - name: pull-jobset-test-e2e-release-0-11-1-33
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
## Summary
- Remove Kubernetes 1.32 e2e test jobs from jobset periodic and presubmit
  configurations since k8s 1.32 has reached end of life
- Affects main, release-0.10, and release-0.11 branches
- 6 files changed, 231 lines removed

---
> **AI Assistance Disclosure**: This pull request was created with the
> assistance of AI (Claude Code by Anthropic).