### PR TITLE
Increase addons node size for 5000-node scale tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1192,6 +1192,8 @@ periodics:
         value: "1"
       - name: CONTROL_PLANE_SIZE
         value: "c4-standard-96"
+      - name: ADDONS_NODE_SIZE
+        value: "c3-standard-44"
       - name: KUBE_PROXY_MODE
         value: "nftables"
       - name: PROMETHEUS_SCRAPE_KUBE_PROXY

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -1240,6 +1240,8 @@ presubmits:
           value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-96"
+        - name: ADDONS_NODE_SIZE
+          value: "c3-standard-44"
         - name: KUBE_PROXY_MODE
           value: "nftables"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -163,6 +163,8 @@ periodics:
         value: "1"
       - name: CONTROL_PLANE_SIZE
         value: "c4-standard-96"
+      - name: ADDONS_NODE_SIZE
+        value: "c3-standard-44"
       - name: KUBE_PROXY_MODE
         value: "nftables"
       - name: PROMETHEUS_SCRAPE_KUBE_PROXY


### PR DESCRIPTION
The addons node runs out of CPU when the cluster is fully loaded. Pods like `informer-watch-list-off` can't be scheduled because all 5000 worker nodes are full and the addons node doesn't have enough CPU left either. 

The next available size in the `c3-standard` family is `c3-standard-44`. There is no size between `22` and `44`

xref: https://github.com/kubernetes/perf-tests/pull/3931