### PR TITLE
Enable trigger_github_workflows for controller-runtime and controller…

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -47,6 +47,12 @@ triggers:
   join_org_url: "https://git.k8s.io/community/community-membership.md#member"
   only_org_members: true
   trigger_github_workflows: true
+- repos:
+  - kubernetes-sigs/controller-runtime
+  - kubernetes-sigs/controller-tools
+  join_org_url: "https://git.k8s.io/community/community-membership.md#member"
+  only_org_members: true
+  trigger_github_workflows: true
 
 owners:
   mdyamlrepos:


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables trigger_github_workflows: true for kubernetes-sigs/controller-runtime
and kubernetes-sigs/controller-tools so that Prow natively handles workflow
approvals when /ok-to-test is added, allowing removal of the custom
pr-gh-workflow-approve.yaml workflow in those repos.

**Which issue(s) this PR fixes**:
Part of kubernetes-sigs/cluster-api#13532