### PR TITLE
Add Lambda Cloud GPU e2e test jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/lambda/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/lambda/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- ameukam
+- BenTheElder
+- dims
+- GenPage
+- stmcginnis
+approvers:
+- ameukam
+- BenTheElder
+- dims
+- GenPage
+- stmcginnis

--- a/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
@@ -1,0 +1,97 @@
+presets:
+- labels:
+    preset-lambda-credential: "true"
+  env:
+  - name: LAMBDA_API_KEY_FILE
+    value: /etc/lambda-cred/api-key
+  volumeMounts:
+  - name: lambda-cred
+    mountPath: /etc/lambda-cred
+    readOnly: true
+  volumes:
+  - name: lambda-cred
+    secret:
+      secretName: lambda-api-key
+
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-e2e-lambda-device-plugin-gpu
+    cluster: k8s-infra-prow-build
+    optional: true
+    always_run: false
+    max_concurrency: 1
+    skip_branches:
+    - release-\d+\.\d+
+    labels:
+      preset-lambda-credential: "true"
+    annotations:
+      testgrid-dashboards: sig-node-gpu
+      testgrid-tab-name: pull-lambda-device-plugin-gpu
+      description: "Runs [Feature:GPUDevicePlugin] e2e tests on a Lambda Cloud A100 GPU instance"
+    decorate: true
+    decoration_config:
+      timeout: 2h
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          exec "$(go env GOPATH)/src/k8s.io/test-infra/experiment/lambda/e2e-test.sh"
+        resources:
+          limits:
+            cpu: 4
+            memory: 8Gi
+          requests:
+            cpu: 4
+            memory: 8Gi
+
+periodics:
+- name: ci-kubernetes-e2e-lambda-device-plugin-gpu
+  cluster: k8s-infra-prow-build
+  interval: 6h
+  labels:
+    preset-lambda-credential: "true"
+  annotations:
+    testgrid-dashboards: sig-node-gpu
+    testgrid-tab-name: ci-lambda-device-plugin-gpu
+    description: "Runs [Feature:GPUDevicePlugin] e2e tests on a Lambda Cloud A100 GPU instance"
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        exec "$(go env GOPATH)/src/k8s.io/test-infra/experiment/lambda/e2e-test.sh"
+      resources:
+        limits:
+          cpu: 4
+          memory: 8Gi
+        requests:
+          cpu: 4
+          memory: 8Gi

--- a/experiment/lambda/e2e-test.sh
+++ b/experiment/lambda/e2e-test.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# e2e-test.sh — orchestrates GPU e2e tests on a Lambda Cloud instance.
+#
+# Must be run from a kubernetes source checkout directory.
+# Requires: LAMBDA_API_KEY_FILE, JOB_NAME, BUILD_ID, ARTIFACTS env vars.
+# Optional: GPU_TYPE (default: gpu_1x_a100_sxm4)
+set -o errexit
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+GPU_TYPE="${GPU_TYPE:-gpu_1x_a10}"
+SSH_KEY_NAME="prow-${JOB_NAME}-${BUILD_ID}"
+
+# --- Install lambdactl ---
+GOPROXY=direct go install github.com/dims/lambdactl@latest
+
+# --- Generate ephemeral SSH key ---
+rm -f /tmp/lambda-ssh /tmp/lambda-ssh.pub
+ssh-keygen -t ed25519 -f /tmp/lambda-ssh -N "" -q
+SSH_KEY_ID=$(lambdactl --json ssh-keys add "${SSH_KEY_NAME}" /tmp/lambda-ssh.pub | jq -r '.id')
+
+cleanup() {
+  echo "Cleaning up..."
+  [ -n "${INSTANCE_ID:-}" ] && lambdactl stop "${INSTANCE_ID}" --yes 2>/dev/null || true
+  [ -n "${SSH_KEY_ID:-}" ] && lambdactl ssh-keys rm "${SSH_KEY_ID}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# --- Launch instance with retries ---
+LAUNCH_OUTPUT=$(lambdactl --json start \
+  --gpu "${GPU_TYPE}" \
+  --ssh "${SSH_KEY_NAME}" \
+  --name "prow-${BUILD_ID}" \
+  --retries 4 \
+  --retry-delay 60 \
+  --wait-ssh)
+INSTANCE_IP=$(echo "${LAUNCH_OUTPUT}" | jq -r '.ip')
+INSTANCE_ID=$(echo "${LAUNCH_OUTPUT}" | jq -r '.id')
+
+remote() { ssh ${SSH_OPTS} -i /tmp/lambda-ssh "ubuntu@${INSTANCE_IP}" "$@"; }
+rsync_to() { rsync -e "ssh ${SSH_OPTS} -i /tmp/lambda-ssh" "$@"; }
+
+# --- Build k8s binaries ---
+git fetch --tags --depth 1 origin 2>/dev/null || true
+KUBE_GIT_VERSION=$(git describe --tags --match='v*' 2>/dev/null || echo "v1.35.0")
+make KUBE_GIT_VERSION="${KUBE_GIT_VERSION}" \
+  WHAT="cmd/kubeadm cmd/kubelet cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/v2/ginkgo"
+
+# --- Transfer binaries to Lambda instance ---
+rsync_to _output/local/go/bin/{kubeadm,kubelet,kubectl,e2e.test,ginkgo} "ubuntu@${INSTANCE_IP}:/tmp/"
+
+# --- Set up single-node k8s cluster with GPU support ---
+remote bash -s < "${SCRIPT_DIR}/setup-cluster.sh"
+
+# --- Run GPU e2e tests ---
+remote bash -s <<TESTEOF
+set -eux
+export KUBECONFIG=\$HOME/.kube/config
+mkdir -p /tmp/gpu-test-artifacts
+/tmp/ginkgo \
+  -timeout=60m \
+  -focus="\[Feature:GPUDevicePlugin\]" \
+  -skip="\[Flaky\]" \
+  -v \
+  /tmp/e2e.test \
+  -- \
+  --provider=aws \
+  --kubeconfig=\$KUBECONFIG \
+  --report-dir=/tmp/gpu-test-artifacts \
+  --minStartupPods=8
+TESTEOF
+
+# --- Collect artifacts ---
+mkdir -p "${ARTIFACTS}"
+rsync_to "ubuntu@${INSTANCE_IP}:/tmp/gpu-test-artifacts/" "${ARTIFACTS}/" || true

--- a/experiment/lambda/setup-cluster.sh
+++ b/experiment/lambda/setup-cluster.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# setup-cluster.sh — runs on the Lambda GPU instance via SSH.
+# Sets up a single-node kubeadm cluster with NVIDIA GPU support.
+# Expects k8s binaries (kubeadm, kubelet, kubectl) already in /tmp/.
+set -euxo pipefail
+
+sudo apt-get update -qq
+sudo apt-get install -y -qq \
+  build-essential pkg-config libseccomp-dev libseccomp2 \
+  iptables iproute2 conntrack ebtables kmod socat ethtool \
+  jq rsync psmisc curl wget
+
+# Install CNI plugins
+CNI_VERSION=$(curl -s https://api.github.com/repos/containernetworking/plugins/releases/latest | grep tag_name | cut -d'"' -f4)
+sudo mkdir -p /opt/cni/bin
+curl -sL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" \
+  | sudo tar -C /opt/cni/bin -xz
+
+# Configure CNI networking
+sudo mkdir -p /etc/cni/net.d
+sudo tee /etc/cni/net.d/10-containerd-net.conflist > /dev/null <<'EOF'
+{
+  "cniVersion": "1.0.0",
+  "name": "containerd-net",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [[{"subnet": "10.88.0.0/16"}]],
+        "routes": [{"dst": "0.0.0.0/0"}]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}
+EOF
+
+# Configure containerd with NVIDIA runtime
+sudo mkdir -p /etc/containerd
+sudo containerd config default | sudo tee /etc/containerd/config.toml > /dev/null
+sudo sed -i 's/SystemdCgroup = false/SystemdCgroup = true/g' /etc/containerd/config.toml
+sudo nvidia-ctk runtime configure --runtime=containerd --set-as-default
+sudo systemctl restart containerd
+
+# Enable IP forwarding and bridge netfilter
+sudo modprobe br_netfilter
+echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
+echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward
+sudo tee /etc/sysctl.d/99-kubernetes.conf > /dev/null <<'EOF'
+net.bridge.bridge-nf-call-iptables = 1
+net.ipv4.ip_forward = 1
+EOF
+sudo sysctl --system
+sudo swapoff -a || true
+
+# Install k8s binaries
+sudo cp /tmp/kubeadm /tmp/kubelet /tmp/kubectl /usr/local/bin/
+sudo chmod +x /usr/local/bin/{kubeadm,kubelet,kubectl}
+
+# Create kubelet systemd service
+sudo tee /etc/systemd/system/kubelet.service > /dev/null <<'EOF'
+[Unit]
+Description=kubelet: The Kubernetes Node Agent
+Wants=network-online.target
+After=network-online.target
+[Service]
+ExecStart=/usr/local/bin/kubelet
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo mkdir -p /etc/systemd/system/kubelet.service.d
+sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf > /dev/null <<'EOF'
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+ExecStart=
+ExecStart=/usr/local/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_EXTRA_ARGS
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable kubelet
+
+# Initialize cluster
+sudo kubeadm init \
+  --pod-network-cidr=10.88.0.0/16 \
+  --cri-socket=unix:///run/containerd/containerd.sock \
+  --ignore-preflight-errors=NumCPU,Mem,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,SystemVerification
+
+# Configure kubectl
+mkdir -p "$HOME/.kube"
+sudo cp /etc/kubernetes/admin.conf "$HOME/.kube/config"
+sudo chown "$(id -u):$(id -g)" "$HOME/.kube/config"
+
+# Allow pods on control-plane
+kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+
+# Fix pod networking
+sudo iptables -I FORWARD -i cni0 -j ACCEPT
+sudo iptables -I FORWARD -o cni0 -j ACCEPT
+sudo iptables -I FORWARD -i cni0 -o cni0 -j ACCEPT
+sudo iptables -t nat -A POSTROUTING -s 10.88.0.0/16 ! -o cni0 -j MASQUERADE
+
+# Deploy NVIDIA device plugin
+kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.1/deployments/static/nvidia-device-plugin.yml
+kubectl -n kube-system rollout status daemonset/nvidia-device-plugin-daemonset --timeout=120s
+
+# Verify GPU is visible
+for i in $(seq 1 30); do
+  GPU_COUNT=$(kubectl get nodes -o jsonpath='{.items[0].status.capacity.nvidia\.com/gpu}' 2>/dev/null || true)
+  [ -z "${GPU_COUNT}" ] && GPU_COUNT="0"
+  [ "${GPU_COUNT}" != "0" ] && break
+  sleep 2
+done
+echo "GPUs detected: ${GPU_COUNT}"
+if [ "${GPU_COUNT}" = "0" ]; then
+  echo "ERROR: No GPUs detected"
+  exit 1
+fi


### PR DESCRIPTION
Add presubmit and periodic jobs that run [Feature:GPUDevicePlugin] e2e tests on Lambda Cloud GPU instances (A100 SXM4).

The jobs provision a Lambda instance via lambdactl, build k8s from source, set up a single-node kubeadm cluster with NVIDIA GPU support, run the GPU device plugin test suite, and clean up.
