### PR TITLE
Fix tempelis postsubmit to watch `main` instead of `master`

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-tempelis.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-tempelis.yaml
@@ -4,7 +4,7 @@ postsubmits:
     cluster: k8s-infra-prow-build-trusted
     decorate: true
     branches:
-    - ^master$
+    - ^main$
     run_if_changed: '^communication/slack-config'
     annotations:
       testgrid-num-failures-to-alert: "1"


### PR DESCRIPTION
The kubernetes/community repo default branch was renamed from master to main, but the post-community-tempelis-apply job still watches ^master$, so it never triggers on merge.