### PR TITLE
Update sig-autoscaling leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,8 +20,10 @@ aliases:
     - mikedanese
     - ritazh
   sig-autoscaling-leads:
+    - adrianmoisey
     - gjtempleton
-    - maciekpytel
+    - jackfrancis
+    - towca
   sig-cli-leads:
     - ardaguclu
     - eddiezane


### PR DESCRIPTION
Making it match https://github.com/kubernetes/autoscaler/blob/5a868623997c8472449aac963ec2d0e8c1a7a792/OWNERS_ALIASES#L32C1-L36C1

Also see https://github.com/kubernetes/community/blob/2e5223f19ef1416c0898a1dc67833aa677ca7cb5/sig-autoscaling/README.md#L20-L33