### PR TITLE
Add CAPZ optional KubeRay presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -143,7 +143,7 @@ presubmits:
           - name: GINKGO_FOCUS
             value: \[OPTIONAL\]
           - name: GINKGO_SKIP
-            value: ""
+            value: \[KubeRay\]
           - name: KUBERNETES_VERSION
             value: v1.33.9 # TODO: Remove this once v1.33.10 artifacts are published for Flatcar and RKE2 tests
         resources:
@@ -890,3 +890,53 @@ presubmits:
       testgrid-tab-name: capz-pr-aks-mgmt-e2e-main
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Runs E2E tests using AKS as the management cluster to validate the aks-as-mgmt.sh flow"
+  - name: pull-cluster-api-provider-azure-e2e-kuberay
+    cluster: eks-prow-build-cluster
+    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    always_run: false
+    optional: true
+    decorate: true
+    run_if_changed: 'test\/e2e\/azure_kuberay\.go|test\/e2e\/azure_test\.go|templates\/test.*kuberay|^scripts\/'
+    decoration_config:
+      timeout: 4h
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    branches:
+    - ^main$
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: master
+      path_alias: sigs.k8s.io/cloud-provider-azure
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.32
+        command:
+          - runner.sh
+        args:
+          - ./scripts/ci-e2e.sh
+        env:
+          - name: GINKGO_FOCUS
+            value: \[KubeRay\]
+          - name: GINKGO_SKIP
+            value: ""
+          - name: TEST_CCM
+            value: "true"
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
+          requests:
+            cpu: 4
+            memory: 9Gi
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      testgrid-tab-name: capz-pr-e2e-kuberay-main
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+      description: Runs KubeRay end-to-end tests on AKS and self-managed clusters with in-development Kubernetes.


### PR DESCRIPTION
Adds an optional presubmit job to run any `[KubeRay]`-labeled e2e tests in CAPZ.

Also tells the -ci-e2e-optional job to skip those tests.