### PR TITLE
Skip [KubeRay] tests in CAPZ periodic e2e job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -292,7 +292,7 @@ periodics:
         - name: GINKGO_FOCUS
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
-          value: \[Managed Kubernetes\]|\[WINDOWS\]
+          value: \[Managed Kubernetes\]|\[WINDOWS\]|\[KubeRay\]
         - name: KUBERNETES_VERSION
           value: v1.33.9 # TODO: Remove this once v1.33.10 artifacts are published for Flatcar and RKE2 tests
       # docker-in-docker needs privileged mode


### PR DESCRIPTION
Mea culpa, I realized the main periodic job would probably inadvertently pull in the KubeRay test without this change.