### PR TITLE
CAPZ: narrow run_if_changed for KubeRay job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -896,7 +896,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    run_if_changed: 'test\/e2e\/azure_kuberay\.go|test\/e2e\/azure_test\.go|templates\/test.*kuberay|^scripts\/'
+    run_if_changed: 'test\/e2e\/azure_kuberay\.go'
     decoration_config:
       timeout: 4h
     max_concurrency: 5


### PR DESCRIPTION
The previous regex matched azure_test.go and scripts/, causing the job to trigger on unrelated PRs. Narrow it to only the kuberay test file so the job remains optional for other changes.