### PR TITLE
Add Metis glibc floor test Prow job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -233,5 +233,5 @@ presubmits:
             cpu: 2
             memory: 4Gi
           limits:
-            cpu: 4
-            memory: 8Gi
+            cpu: 2
+            memory: 4Gi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new Prow presubmit job `pull-cloud-provider-gcp-metis-glibc-floor-test` for the `kubernetes/cloud-provider-gcp` repository.

This job is designed to run a GLIBC floor compatibility test for the `metis` component to ensure that the CGO binary built in Metis does not violate link constraints against GLIBC 2.35.

**Details**:
- **Trigger**: Runs on changes matching `^metis/`.
- **Command**: `cd metis && make test-glibc-floor`.
- **Image**: `gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master`.
- **Requirements**: Requires Docker-in-Docker and privileged security context.

This test job consumes the new Makefile target added in the corresponding PR in `cloud-provider-gcp`:
- Reference PR: https://github.com/kubernetes/cloud-provider-gcp/pull/1036

**Special notes for your reviewer**:
The job was added to `config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml`. To pass the repository's configuration tests, I added the required TestGrid annotations and explicitly assigned it to the `k8s-infra-prow-build` cluster.

**Verification done**:
Ran `go test ./config/tests/...` locally and all tests passed successfully after addressing deprecations and missing annotations.


PTAL: @gnossen @YifeiZhuang 