### PR TITLE
Rename Lambda Cloud API key secret to lambda-ai-api-key

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
@@ -11,7 +11,7 @@ presets:
   volumes:
   - name: lambda-cred
     secret:
-      secretName: lambda-api-key
+      secretName: lambda-ai-api-key
 
 presubmits:
   kubernetes/kubernetes:


### PR DESCRIPTION
Renames the Kubernetes secret reference from `lambda-api-key` to `lambda-ai-api-key` in the Lambda Cloud GPU e2e test preset configuration.

please see https://github.com/kubernetes/k8s.io/pull/9301 for context