### PR TITLE
optimize DRANET presubmit test alert

### DIFF
--- a/config/jobs/kubernetes-sigs/dranet/dranet-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/dranet/dranet-presubmits.yaml
@@ -47,7 +47,8 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-network-dranet
       testgrid-tab-name: pull-dranet conformance, master (dev) [non-serial]
-      testgrid-alert-email: maspinwall@google.com, gauravkg@google.com, antonio.ojea.garcia@gmail.com
+      testgrid-alert-email: antonio.ojea.garcia@gmail.com
+      testgrid-num-failures-to-alert: "8"
   - name: pull-dranet-nftables-ipv6
     cluster: k8s-infra-prow-build
     labels:
@@ -100,4 +101,5 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-network-dranet
       testgrid-tab-name: pull-dranet-ipv6 conformance, master (dev) [non-serial]
-      testgrid-alert-email: maspinwall@google.com, gauravkg@google.com, antonio.ojea.garcia@gmail.com
+      testgrid-alert-email: antonio.ojea.garcia@gmail.com
+      testgrid-num-failures-to-alert: "8"


### PR DESCRIPTION
The initial setup triggers email alerts for test failure of DRANET presubmit builds. As presubmit failures are non-critical for the codebase, remove this alert to reduce noise.