### PR TITLE
Enable ENABLE_IP_TAG_MUTATION for cloud-provider-azure e2e jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -596,6 +596,8 @@ presubmits:
           value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
         - name: LABEL_FILTER  # cloud-provider-azure config
           value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: ENABLE_IP_TAG_MUTATION  # cloud-provider-azure config
+          value: "true"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
         - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.32.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.32.yaml
@@ -272,6 +272,8 @@ presubmits:
           value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
         - name: LABEL_FILTER  # cloud-provider-azure config
           value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: ENABLE_IP_TAG_MUTATION  # cloud-provider-azure config
+          value: "true"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
         - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.33.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.33.yaml
@@ -272,6 +272,8 @@ presubmits:
           value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
         - name: LABEL_FILTER  # cloud-provider-azure config
           value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: ENABLE_IP_TAG_MUTATION  # cloud-provider-azure config
+          value: "true"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
         - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.34.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.34.yaml
@@ -272,6 +272,8 @@ presubmits:
           value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
         - name: LABEL_FILTER  # cloud-provider-azure config
           value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: ENABLE_IP_TAG_MUTATION  # cloud-provider-azure config
+          value: "true"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
         - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.35.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.35.yaml
@@ -272,6 +272,8 @@ presubmits:
           value: "-ginkgo.skip=\"\\[Serial\\]\\[Slow\\]|Private\\slink\\sservice|\\[MultipleAgentPools\\]\""
         - name: LABEL_FILTER  # cloud-provider-azure config
           value: "!Serial && !Slow && !PLS && !Multi-Nodepool"
+        - name: ENABLE_IP_TAG_MUTATION  # cloud-provider-azure config
+          value: "true"
         - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
           value: "capz"
         - name: ENABLE_VMSS_FLEX  # cloud-provider-azure config


### PR DESCRIPTION
Add `ENABLE_IP_TAG_MUTATION=true` env var to the `pull-cloud-provider-azure-e2e-ccm-vmss-ip-lb-capz` jobs for master and release branches 1.32–1.35.

This enables the new FirstPartyUsage IP tag in-place mutation e2e test added in https://github.com/kubernetes-sigs/cloud-provider-azure/pull/10133.

Jobs updated:
- `cloud-provider-azure-config.yaml` (master)
- `cloud-provider-azure-presubmit-1.32.yaml`
- `cloud-provider-azure-presubmit-1.33.yaml`
- `cloud-provider-azure-presubmit-1.34.yaml`
- `cloud-provider-azure-presubmit-1.35.yaml`