### PR TITLE
Update dra-driver-cpu presubmits to run on arm64 and amd64

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
@@ -1,7 +1,7 @@
 # sigs.k8s.io/dra-driver-cpu presubmits
 presubmits:
   kubernetes-sigs/dra-driver-cpu:
-  - name: pull-dra-driver-cpu-e2e-device-mode-individual
+  - name: pull-dra-driver-cpu-e2e-device-mode-individual-amd64
     cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
@@ -15,6 +15,8 @@ presubmits:
       testgrid-tab-name: e2e-test-master-individual
       description: "Build image and run e2e-tests in individual mode"
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260217-29ba10ecec-master
         env:
@@ -37,7 +39,45 @@ presubmits:
           requests:
             cpu: 4
             memory: 8Gi
-  - name: pull-dra-driver-cpu-e2e-device-mode-grouped
+  - name: pull-dra-driver-cpu-e2e-device-mode-individual-arm64
+    cluster: eks-prow-build-cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    path_alias: sigs.k8s.io/dra-driver-cpu
+    always_run: true
+    optional: false
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-dra-driver-cpu
+      testgrid-tab-name: e2e-test-master-individual-arm
+      description: "Build image and run e2e-tests in individual mode"
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260217-29ba10ecec-master
+        env:
+        - name: DRACPU_E2E_CPU_DEVICE_MODE
+          value: "individual"
+        - name: DRACPU_E2E_VERBOSE
+          value: "1"
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - hack/ci/prow.sh
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 8Gi
+          requests:
+            cpu: 4
+            memory: 8Gi
+  - name: pull-dra-driver-cpu-e2e-device-mode-grouped-amd64
     cluster: eks-prow-build-cluster
     labels:
       preset-service-account: "true"
@@ -51,6 +91,46 @@ presubmits:
       testgrid-tab-name: e2e-test-master-grouped
       description: "Build image and run e2e-tests in grouped mode"
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260217-29ba10ecec-master
+        env:
+        - name: DRACPU_E2E_CPU_DEVICE_MODE
+          value: "grouped"
+        - name: DRACPU_E2E_VERBOSE
+          value: "1"
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - hack/ci/prow.sh
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 8Gi
+          requests:
+            cpu: 4
+            memory: 8Gi
+  - name: pull-dra-driver-cpu-e2e-device-mode-grouped-arm64
+    cluster: eks-prow-build-cluster
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    path_alias: sigs.k8s.io/dra-driver-cpu
+    always_run: true
+    optional: false
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-node-dra-driver-cpu
+      testgrid-tab-name: e2e-test-master-grouped-arm
+      description: "Build image and run e2e-tests in grouped mode"
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: arm64
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260217-29ba10ecec-master
         env:


### PR DESCRIPTION
Add separate presubmit tests for arm and x86