### PR TITLE
Bump Go to 1.26.2/1.25.9 for kubekins-e2e/kubekins-e2e-v2/krte

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -1,36 +1,30 @@
 variants:
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.26.0
+    GO_VERSION: 1.26.2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
   master:
     CONFIG: master
-    GO_VERSION: 1.26.0
+    GO_VERSION: 1.26.2
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
   '1.35':
     CONFIG: '1.35'
-    GO_VERSION: 1.25.7
+    GO_VERSION: 1.25.9
     K8S_RELEASE: latest-1.35
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
   '1.34':
     CONFIG: '1.34'
-    GO_VERSION: 1.24.13
+    GO_VERSION: 1.25.9
     K8S_RELEASE: latest-1.34
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
   '1.33':
     CONFIG: '1.33'
-    GO_VERSION: 1.24.13
+    GO_VERSION: 1.25.9
     K8S_RELEASE: latest-1.33
-    BAZEL_VERSION: 3.4.1
-    DOCKER_VERSION: 5:28.*
-  '1.32':
-    CONFIG: '1.32'
-    GO_VERSION: 1.24.13
-    K8S_RELEASE: latest-1.32
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*


### PR DESCRIPTION
Bump Go to 1.26.2/1.25.9 for kubekins-e2e/kubekins-e2e-v2/krte

xref https://github.com/kubernetes/release/issues/4365

/assign @Verolop @cpanato @dims 
cc @kubernetes/release-engineering 