### PR TITLE
Try increasing Control Plane's capacity for job ci-kubernetes-ppc64le-e2e-slow-kubetest2 to minimize API server pressure under load

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -365,6 +365,7 @@ periodics:
               make install-deployer-tf
 
               export TF_VAR_powervs_system_type=s1022
+              export TF_VAR_controlplane_powervs_processors=1
               kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \


### PR DESCRIPTION
Test by name `[sig-storage] CSI Mock volume attach When CSIDriver AttachRequired changes from true to false should cleanup VolumeAttachment properly [Slow]` has been flaking often on ppc job. -> [Triage Link](https://storage.googleapis.com/k8s-triage/index.html?pr=1&test=SI%20Mock%20volume%20attach%20When%20CSIDriver%20AttachRequired%20changes%20from%20true%20to%20false%20should%20cleanup%20VolumeAttachment%20properly&xjob=e2e-kops)
```
{ failed [FAILED] Failed to delete VolumeAttachment: error waiting volume attachment csi-e85e84554be6a7bcbdbcd557fbd390c62ca2ee03194c777f01d12c34c5e70971 to terminate: client rate limiter Wait returned an error: context deadline exceeded: error waiting volume attachment csi-e85e84554be6a7bcbdbcd557fbd390c62ca2ee03194c777f01d12c34c5e70971 to terminate: client rate limiter Wait returned an error: context deadline exceeded
In [It] at: k8s.io/kubernetes/test/e2e/storage/csimock/csi_attach_volume.go:158 @ 04/08/26 21:13:19.716
}
```

Since this is **only happening on the ppc64le, not on x86** slow job and **not reproducible locally** (even when running related CSI tests together), this looks more like API pressure under load rather than a CSI functional issue.

Hence trying to improve control plane capacity and see if API server is able to handle the requests without throwing the above error.