### PR TITLE
secrets-store-sync-controller: run push-images on ./VERSION change

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-secrets-store-sync.yaml
+++ b/config/jobs/image-pushing/k8s-staging-secrets-store-sync.yaml
@@ -11,7 +11,7 @@ postsubmits:
         testgrid-dashboards: sig-auth-secrets-store-sync-controller, sig-k8s-infra-gcb
       decorate: true
       # we only need to run if necessary (e.g.: the version was bumped)
-      run_if_changed: 'docker/Makefile'
+      run_if_changed: 'VERSION'
       # this causes the job to only run on the master branch. Remove it if your
       # job makes sense on every branch (unless it's setting a `latest` tag it
       # probably does).


### PR DESCRIPTION
Depends on https://github.com/kubernetes-sigs/secrets-store-sync-controller/pull/205

cc @aramase 