### PR TITLE
Add kubekins-e2e-v2 variants for v1.36

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -10,6 +10,12 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:28.*
+  '1.36':
+    CONFIG: '1.36'
+    GO_VERSION: 1.26.2
+    K8S_RELEASE: latest-1.36
+    BAZEL_VERSION: 3.4.1
+    DOCKER_VERSION: 5:28.*
   '1.35':
     CONFIG: '1.35'
     GO_VERSION: 1.25.9


### PR DESCRIPTION
add kubekins variants for v1.36 (similar to https://github.com/kubernetes/test-infra/pull/36002)

/hold

cc @xmudrii @dims