### PR TITLE
Update the Prow postsubmit job for the kubernetes-sigs/dra-driver-nvidia-gpu to trigger image builds on merges and tags

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-dra-driver-nvidia-gpu.yaml
+++ b/config/jobs/image-pushing/k8s-staging-dra-driver-nvidia-gpu.yaml
@@ -1,6 +1,6 @@
 postsubmits:
-  kubernetes-sigs/nvidia-dra-driver-gpu:
-  - name: post-nvidia-dra-driver-gpu-push-images
+  kubernetes-sigs/dra-driver-nvidia-gpu:
+  - name: post-dra-driver-nvidia-gpu-push-images
     cluster: k8s-infra-prow-build-trusted
     annotations:
       testgrid-dashboards: sig-node-image-pushes, sig-k8s-infra-gcb


### PR DESCRIPTION

* Previously the repo was called 'nvidia-dra-driver-gpu' which got renamed to 'dra-driver-nvidia-gpu'
* This change is to update the post submit job config accordingly