### PR TITLE
Add shared Lambda CI library, consolidate existing Lambda jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
@@ -1,0 +1,95 @@
+# Prow jobs for DRA GPU e2e tests on Lambda Cloud.
+#
+# These jobs test the dra-driver-nvidia-gpu repo by provisioning an ephemeral
+# Lambda GPU instance, setting up a single-node kubeadm cluster, building and
+# deploying the DRA driver from source, then running the BATS GPU test subset.
+#
+# The shared Lambda CI library (experiment/lambda/lib/) is checked out via
+# extra_refs and sourced by the driver repo's hack/ci/lambda/e2e-test.sh.
+#
+# All Docker and image builds happen on the Lambda instance, not the Prow pod,
+# so no DinD or privileged containers are needed.
+#
+# NOTE: preset-lambda-credential is defined in
+# config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml and reused here.
+
+presubmits:
+  kubernetes-sigs/dra-driver-nvidia-gpu:
+  - name: pull-dra-driver-nvidia-gpu-e2e-lambda-gpu
+    cluster: k8s-infra-prow-build
+    optional: true
+    always_run: false
+    max_concurrency: 1
+    skip_branches:
+    - release-\d+\.\d+
+    decorate: true
+    decoration_config:
+      timeout: 2h
+    labels:
+      preset-lambda-credential: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    annotations:
+      testgrid-dashboards: sig-node-gpu
+      testgrid-tab-name: pull-dra-driver-nvidia-gpu-lambda
+      description: "DRA GPU e2e tests on Lambda Cloud for dra-driver-nvidia-gpu PRs"
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+        command:
+        - runner.sh
+        args:
+        - hack/ci/lambda/e2e-test.sh
+        env:
+        - name: GPU_TYPE
+          value: ""
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
+
+periodics:
+- name: ci-dra-driver-nvidia-gpu-e2e-lambda-gpu
+  cluster: k8s-infra-prow-build
+  interval: 6h
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  labels:
+    preset-lambda-credential: "true"
+  annotations:
+    testgrid-dashboards: sig-node-gpu
+    testgrid-tab-name: ci-dra-driver-nvidia-gpu-lambda
+    description: "Periodic DRA GPU e2e tests on Lambda Cloud"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: dra-driver-nvidia-gpu
+    base_ref: main
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+      command:
+      - runner.sh
+      args:
+      - hack/ci/lambda/e2e-test.sh
+      env:
+      - name: GPU_TYPE
+        value: ""
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"

--- a/experiment/lambda/e2e-test.sh
+++ b/experiment/lambda/e2e-test.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# e2e-test.sh — orchestrates GPU e2e tests on a Lambda Cloud instance.
+# e2e-test.sh -- orchestrates GPU e2e tests on a Lambda Cloud instance.
 #
 # Must be run from a kubernetes source checkout directory.
 # Requires: LAMBDA_API_KEY_FILE, JOB_NAME, BUILD_ID, ARTIFACTS env vars.
@@ -23,44 +23,10 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR)
-GPU_TYPE="${GPU_TYPE-gpu_1x_a10}"
-GPU_ARGS=()
-if [ -n "${GPU_TYPE}" ]; then
-  GPU_ARGS=(--gpu "${GPU_TYPE}")
-fi
-SSH_KEY_NAME=$(echo -n "prow-${JOB_NAME}-${BUILD_ID}" | sha256sum | cut -c1-64)
-SSH_DIR=$(mktemp -d /tmp/lambda-ssh.XXXXXX)
-SSH_KEY="${SSH_DIR}/key"
+source "${SCRIPT_DIR}/lib/lambda-common.sh"
 
-# --- Install lambdactl ---
-GOPROXY=direct go install github.com/dims/lambdactl@latest
-
-# --- Generate ephemeral SSH key ---
-ssh-keygen -t ed25519 -f "${SSH_KEY}" -N "" -q
-SSH_KEY_ID=$(lambdactl --json ssh-keys add "${SSH_KEY_NAME}" "${SSH_KEY}.pub" | jq -r '.id')
-
-cleanup() {
-  echo "Cleaning up..."
-  [ -n "${INSTANCE_ID:-}" ] && lambdactl stop "${INSTANCE_ID}" --yes 2>/dev/null || true
-  [ -n "${SSH_KEY_ID:-}" ] && lambdactl ssh-keys rm "${SSH_KEY_ID}" 2>/dev/null || true
-  rm -rf "${SSH_DIR}"
-}
-trap cleanup EXIT
-
-# --- Launch instance (poll until capacity is available) ---
-LAUNCH_OUTPUT=$(lambdactl --json watch \
-  "${GPU_ARGS[@]}" \
-  --ssh "${SSH_KEY_NAME}" \
-  --name "${SSH_KEY_NAME}" \
-  --interval 30 \
-  --timeout 900 \
-  --wait-ssh)
-INSTANCE_IP=$(echo "${LAUNCH_OUTPUT}" | jq -r '.ip')
-INSTANCE_ID=$(echo "${LAUNCH_OUTPUT}" | jq -r '.id')
-
-remote() { ssh "${SSH_OPTS[@]}" -i "${SSH_KEY}" "ubuntu@${INSTANCE_IP}" "$@"; }
-rsync_to() { rsync -e "ssh ${SSH_OPTS[*]} -i ${SSH_KEY}" "$@"; }
+# --- Launch Lambda instance ---
+lambda_init_and_launch
 
 # --- Build k8s binaries ---
 git fetch --tags --depth 100 origin 2>/dev/null || true
@@ -68,13 +34,37 @@ make \
   WHAT="cmd/kubeadm cmd/kubelet cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/v2/ginkgo"
 
 # --- Transfer binaries to Lambda instance ---
-rsync_to _output/local/go/bin/{kubeadm,kubelet,kubectl,e2e.test,ginkgo} "ubuntu@${INSTANCE_IP}:/tmp/"
+lambda_remote mkdir -p /tmp/k8s-bins
+lambda_rsync_to _output/local/go/bin/{kubeadm,kubelet,kubectl} "ubuntu@${LAMBDA_INSTANCE_IP}:/tmp/k8s-bins/"
+lambda_rsync_to _output/local/go/bin/{e2e.test,ginkgo} "ubuntu@${LAMBDA_INSTANCE_IP}:/tmp/"
 
 # --- Set up single-node k8s cluster with GPU support ---
-remote bash -s < "${SCRIPT_DIR}/setup-cluster.sh"
+# No CDI, no Docker, no extra labels needed for device-plugin.
+lambda_remote bash -s < "${SCRIPT_DIR}/lib/setup-k8s-node.sh"
+
+# --- Deploy NVIDIA device plugin and wait for GPU capacity ---
+lambda_remote bash -s <<'EOF'
+set -eux
+export KUBECONFIG=$HOME/.kube/config
+kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.1/deployments/static/nvidia-device-plugin.yml
+kubectl -n kube-system rollout status daemonset/nvidia-device-plugin-daemonset --timeout=120s
+
+# Wait for GPU capacity to appear on the node
+for i in $(seq 1 30); do
+  GPU_COUNT=$(kubectl get nodes -o jsonpath='{.items[0].status.capacity.nvidia\.com/gpu}' 2>/dev/null || echo "0")
+  [ -z "${GPU_COUNT}" ] && GPU_COUNT="0"
+  [ "${GPU_COUNT}" != "0" ] && break
+  sleep 2
+done
+echo "GPUs detected: ${GPU_COUNT}"
+if [ "${GPU_COUNT}" = "0" ]; then
+  echo "ERROR: No GPUs detected"
+  exit 1
+fi
+EOF
 
 # --- Run GPU e2e tests ---
-remote bash -s <<TESTEOF
+lambda_remote bash -s <<TESTEOF
 set -eux
 export KUBECONFIG=\$HOME/.kube/config
 mkdir -p /tmp/gpu-test-artifacts
@@ -92,5 +82,4 @@ mkdir -p /tmp/gpu-test-artifacts
 TESTEOF
 
 # --- Collect artifacts ---
-mkdir -p "${ARTIFACTS}"
-rsync_to "ubuntu@${INSTANCE_IP}:/tmp/gpu-test-artifacts/" "${ARTIFACTS}/" || true
+lambda_collect_artifacts /tmp/gpu-test-artifacts/

--- a/experiment/lambda/lib/lambda-common.sh
+++ b/experiment/lambda/lib/lambda-common.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# lambda-common.sh -- shared functions for Lambda Cloud GPU CI jobs.
+# Source this file from project-specific e2e-test.sh scripts.
+#
+# Required env: JOB_NAME, BUILD_ID (set by Prow)
+# Optional env: GPU_TYPE (default: gpu_1x_a10, set empty to accept any)
+
+set -o errexit; set -o nounset; set -o pipefail
+
+LAMBDA_SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR)
+LAMBDA_GPU_TYPE="${GPU_TYPE-gpu_1x_a10}"
+LAMBDA_SSH_DIR=""
+LAMBDA_SSH_KEY=""
+LAMBDA_SSH_KEY_ID=""
+LAMBDA_INSTANCE_IP=""
+LAMBDA_INSTANCE_ID=""
+
+# Install lambdactl CLI
+lambda_install_cli() {
+  GOPROXY=direct go install github.com/dims/lambdactl@latest
+}
+
+# Create ephemeral SSH key and register with Lambda Cloud
+lambda_create_ssh_key() {
+  LAMBDA_SSH_DIR=$(mktemp -d /tmp/lambda-ssh.XXXXXX)
+  LAMBDA_SSH_KEY="${LAMBDA_SSH_DIR}/key"
+  local key_name
+  key_name=$(echo -n "prow-${JOB_NAME}-${BUILD_ID}" | sha256sum | cut -c1-64)
+  ssh-keygen -t ed25519 -f "${LAMBDA_SSH_KEY}" -N "" -q
+  LAMBDA_SSH_KEY_ID=$(lambdactl --json ssh-keys add "${key_name}" "${LAMBDA_SSH_KEY}.pub" | jq -r '.id')
+  export LAMBDA_SSH_KEY_NAME="${key_name}"
+}
+
+# Launch GPU instance and wait for SSH
+lambda_launch() {
+  local gpu_args=()
+  if [ -n "${LAMBDA_GPU_TYPE}" ]; then
+    gpu_args=(--gpu "${LAMBDA_GPU_TYPE}")
+  fi
+  local launch_output
+  launch_output=$(lambdactl --json watch \
+    "${gpu_args[@]}" \
+    --ssh "${LAMBDA_SSH_KEY_NAME}" \
+    --name "${LAMBDA_SSH_KEY_NAME}" \
+    --interval 30 \
+    --timeout 900 \
+    --wait-ssh)
+  LAMBDA_INSTANCE_IP=$(echo "${launch_output}" | jq -r '.ip')
+  LAMBDA_INSTANCE_ID=$(echo "${launch_output}" | jq -r '.id')
+}
+
+# Register cleanup trap (call after lambda_create_ssh_key)
+lambda_register_cleanup() {
+  trap '_lambda_cleanup' EXIT
+}
+
+_lambda_cleanup() {
+  echo "Cleaning up Lambda resources..."
+  [ -n "${LAMBDA_INSTANCE_ID:-}" ] && lambdactl stop "${LAMBDA_INSTANCE_ID}" --yes 2>/dev/null || true
+  [ -n "${LAMBDA_SSH_KEY_ID:-}" ] && lambdactl ssh-keys rm "${LAMBDA_SSH_KEY_ID}" 2>/dev/null || true
+  rm -rf "${LAMBDA_SSH_DIR}"
+}
+
+# SSH to the Lambda instance
+lambda_remote() {
+  ssh "${LAMBDA_SSH_OPTS[@]}" -i "${LAMBDA_SSH_KEY}" "ubuntu@${LAMBDA_INSTANCE_IP}" "$@"
+}
+
+# Rsync files to the Lambda instance
+lambda_rsync_to() {
+  rsync -a -e "ssh ${LAMBDA_SSH_OPTS[*]} -i ${LAMBDA_SSH_KEY}" "$@"
+}
+
+# Download k8s release binaries to a local directory
+# Usage: lambda_download_k8s /tmp/k8s-bins [version]
+lambda_download_k8s() {
+  local dest="$1"
+  local version="${2:-$(curl -sSfL https://dl.k8s.io/release/stable.txt)}"
+  mkdir -p "${dest}"
+  for bin in kubeadm kubelet kubectl; do
+    curl -sSfL "https://dl.k8s.io/release/${version}/bin/linux/amd64/${bin}" \
+      -o "${dest}/${bin}"
+    chmod +x "${dest}/${bin}"
+  done
+  echo "Downloaded k8s ${version} binaries to ${dest}"
+}
+
+# Collect artifacts from the Lambda instance
+# Usage: lambda_collect_artifacts /remote/path [/local/artifacts]
+lambda_collect_artifacts() {
+  local remote_path="$1"
+  local local_path="${2:-${ARTIFACTS}}"
+  mkdir -p "${local_path}"
+  lambda_rsync_to "ubuntu@${LAMBDA_INSTANCE_IP}:${remote_path}" "${local_path}/" || true
+}
+
+# Convenience: init everything (install CLI, create key, register cleanup, launch)
+lambda_init_and_launch() {
+  lambda_install_cli
+  lambda_create_ssh_key
+  lambda_register_cleanup
+  lambda_launch
+}

--- a/experiment/lambda/lib/setup-k8s-node.sh
+++ b/experiment/lambda/lib/setup-k8s-node.sh
@@ -13,24 +13,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# setup-cluster.sh — runs on the Lambda GPU instance via SSH.
-# Sets up a single-node kubeadm cluster with NVIDIA GPU support.
-# Expects k8s binaries (kubeadm, kubelet, kubectl) already in /tmp/.
+# setup-k8s-node.sh -- generic single-node kubeadm cluster setup for Lambda
+# GPU instances. Expects k8s binaries in /tmp/k8s-bins/.
+#
+# Base: system deps, CNI, containerd with NVIDIA runtime, kubeadm cluster.
+# Optional (controlled by env vars):
+#   ENABLE_CDI=true        -- enable CDI in containerd (required for DRA)
+#   ENABLE_DOCKER=true     -- install Docker (needed by harnesses that run in containers)
+#   NODE_LABELS="k=v,..."  -- additional node labels (e.g., nvidia.com/gpu.present=true)
+#
+# Does NOT install any GPU driver/plugin -- callers handle that.
 set -euxo pipefail
 
+ENABLE_CDI="${ENABLE_CDI:-false}"
+ENABLE_DOCKER="${ENABLE_DOCKER:-false}"
+NODE_LABELS="${NODE_LABELS:-}"
+K8S_BINS_DIR="${K8S_BINS_DIR:-/tmp/k8s-bins}"
+
+# --- System dependencies ---
 sudo apt-get update -qq
 sudo apt-get install -y -qq \
   build-essential pkg-config libseccomp-dev libseccomp2 \
   iptables iproute2 conntrack ebtables kmod socat ethtool \
-  jq rsync psmisc curl wget
+  jq rsync psmisc curl wget git
 
-# Install CNI plugins
-CNI_VERSION=$(curl -s https://api.github.com/repos/containernetworking/plugins/releases/latest | grep tag_name | cut -d'"' -f4)
+# --- CNI plugins ---
+CNI_VERSION=$(curl -s https://api.github.com/repos/containernetworking/plugins/releases/latest \
+  | grep tag_name | cut -d'"' -f4)
 sudo mkdir -p /opt/cni/bin
 curl -sL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" \
   | sudo tar -C /opt/cni/bin -xz
 
-# Configure CNI networking
+# --- CNI networking ---
 sudo mkdir -p /etc/cni/net.d
 sudo tee /etc/cni/net.d/10-containerd-net.conflist > /dev/null <<'EOF'
 {
@@ -49,22 +63,22 @@ sudo tee /etc/cni/net.d/10-containerd-net.conflist > /dev/null <<'EOF'
         "routes": [{"dst": "0.0.0.0/0"}]
       }
     },
-    {
-      "type": "portmap",
-      "capabilities": {"portMappings": true}
-    }
+    {"type": "portmap", "capabilities": {"portMappings": true}}
   ]
 }
 EOF
 
-# Configure containerd with NVIDIA runtime
+# --- Containerd with NVIDIA runtime ---
 sudo mkdir -p /etc/containerd
 sudo containerd config default | sudo tee /etc/containerd/config.toml > /dev/null
 sudo sed -i 's/SystemdCgroup = false/SystemdCgroup = true/g' /etc/containerd/config.toml
 sudo nvidia-ctk runtime configure --runtime=containerd --set-as-default
+if [ "${ENABLE_CDI}" = "true" ]; then
+  sudo sed -i 's/enable_cdi = false/enable_cdi = true/g' /etc/containerd/config.toml
+fi
 sudo systemctl restart containerd
 
-# Enable IP forwarding and bridge netfilter
+# --- Networking ---
 sudo modprobe br_netfilter
 echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
 echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward
@@ -75,11 +89,11 @@ EOF
 sudo sysctl --system
 sudo swapoff -a || true
 
-# Install k8s binaries
-sudo cp /tmp/kubeadm /tmp/kubelet /tmp/kubectl /usr/local/bin/
+# --- K8s binaries ---
+sudo cp "${K8S_BINS_DIR}"/{kubeadm,kubelet,kubectl} /usr/local/bin/
 sudo chmod +x /usr/local/bin/{kubeadm,kubelet,kubectl}
 
-# Create kubelet systemd service
+# --- Kubelet systemd service ---
 sudo tee /etc/systemd/system/kubelet.service > /dev/null <<'EOF'
 [Unit]
 Description=kubelet: The Kubernetes Node Agent
@@ -107,39 +121,45 @@ EOF
 sudo systemctl daemon-reload
 sudo systemctl enable kubelet
 
-# Initialize cluster
+# --- kubeadm init ---
 sudo kubeadm init \
   --pod-network-cidr=10.88.0.0/16 \
   --cri-socket=unix:///run/containerd/containerd.sock \
   --ignore-preflight-errors=NumCPU,Mem,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,SystemVerification,KubeletVersion
 
-# Configure kubectl
 mkdir -p "$HOME/.kube"
 sudo cp /etc/kubernetes/admin.conf "$HOME/.kube/config"
 sudo chown "$(id -u):$(id -g)" "$HOME/.kube/config"
 
-# Allow pods on control-plane
+# --- Allow scheduling on control-plane ---
 kubectl taint nodes --all node-role.kubernetes.io/control-plane-
 
-# Fix pod networking
+# --- Pod networking fix ---
 sudo iptables -I FORWARD -i cni0 -j ACCEPT
 sudo iptables -I FORWARD -o cni0 -j ACCEPT
 sudo iptables -I FORWARD -i cni0 -o cni0 -j ACCEPT
 sudo iptables -t nat -A POSTROUTING -s 10.88.0.0/16 ! -o cni0 -j MASQUERADE
 
-# Deploy NVIDIA device plugin
-kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.1/deployments/static/nvidia-device-plugin.yml
-kubectl -n kube-system rollout status daemonset/nvidia-device-plugin-daemonset --timeout=120s
+# --- Optional: node labels ---
+if [ -n "${NODE_LABELS}" ]; then
+  NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+  IFS=',' read -ra LABELS <<< "${NODE_LABELS}"
+  for label in "${LABELS[@]}"; do
+    kubectl label node "${NODE_NAME}" "${label}"
+  done
+fi
 
-# Verify GPU is visible
-for i in $(seq 1 30); do
-  GPU_COUNT=$(kubectl get nodes -o jsonpath='{.items[0].status.capacity.nvidia\.com/gpu}' 2>/dev/null || true)
-  [ -z "${GPU_COUNT}" ] && GPU_COUNT="0"
-  [ "${GPU_COUNT}" != "0" ] && break
-  sleep 2
-done
-echo "GPUs detected: ${GPU_COUNT}"
-if [ "${GPU_COUNT}" = "0" ]; then
-  echo "ERROR: No GPUs detected"
+# --- Optional: Docker ---
+if [ "${ENABLE_DOCKER}" = "true" ]; then
+  curl -fsSL https://get.docker.com | sudo sh
+  sudo usermod -aG docker ubuntu
+fi
+
+# --- Verify GPU ---
+if ! nvidia-smi -L; then
+  echo "ERROR: nvidia-smi failed -- no GPU visible"
   exit 1
 fi
+echo "GPU hardware verified: $(nvidia-smi -L | head -1)"
+
+echo "=== Lambda node setup complete ==="


### PR DESCRIPTION
Add a shared Lambda Cloud CI library and refactor the existing device-plugin Lambda jobs to use it, eliminating code duplication.

Shared library (experiment/lambda/lib/):
- lambda-common.sh: instance lifecycle, SSH, rsync, cleanup, k8s binary download, artifact collection
- setup-k8s-node.sh: generic single-node kubeadm cluster setup with NVIDIA containerd runtime. Optional env-var knobs: ENABLE_CDI, ENABLE_DOCKER, NODE_LABELS, K8S_BINS_DIR

Consolidation:
- experiment/lambda/e2e-test.sh: refactored to source lambda-common.sh (was monolithic, duplicated all lifecycle code)
- experiment/lambda/setup-cluster.sh: deleted, replaced by lib/setup-k8s-node.sh + device-plugin install inline in e2e-test.sh
- Existing Prow jobs (pull-kubernetes-e2e-lambda-device-plugin-gpu, ci-kubernetes-e2e-lambda-device-plugin-gpu) pick up the refactored script automatically via their existing test-infra extra_refs.

New Prow jobs for nvidia-dra-driver-gpu:
- pull-nvidia-dra-driver-gpu-e2e-lambda-gpu (presubmit, optional)
- ci-nvidia-dra-driver-gpu-e2e-lambda-gpu (periodic, every 6h) Both use extra_refs to check out test-infra for the shared library.