### PR TITLE
Generate 1.36 testgrid jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -4131,7 +4131,7 @@ presubmits:
     branches:
     - release-1.36
     cluster: k8s-infra-prow-build
-    context: pull-kubernetes-e2e-gce-1.36-scale-performance-100
+    context: pull-kubernetes-e2e-gce-master-scale-performance-100
     decorate: true
     decoration_config:
       timeout: 2h0m0s

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -1,0 +1,5513 @@
+periodics:
+- annotations:
+    fork-per-release-cron: 0 1/6 * * *, 0 5 * * *, 0 6 * * *, 0 7 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
+    testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics, sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-unit-ppc64le-1.36
+  cluster: k8s-infra-ppc64le-prow-build
+  cron: 0 3/2 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  name: ci-kubernetes-unit-ppc64le-1-36
+  spec:
+    containers:
+    - command:
+      - make
+      - test
+      env:
+      - name: KUBE_TIMEOUT
+        value: -timeout=300s
+      - name: KUBE_RACE
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "6"
+          memory: 28Gi
+        requests:
+          cpu: "6"
+          memory: 28Gi
+      securityContext:
+        allowPrivilegeEscalation: false
+    securityContext:
+      runAsGroup: 2010
+      runAsUser: 2001
+- annotations:
+    fork-per-release-cron: 0 1/6 * * *, 0 2 * * *, 0 4 * * *, 0 6 * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
+    testgrid-dashboards: ibm-ppc64le-k8s, ibm-ppc64le-periodics, sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-integration-ppc64le-1.36
+  cluster: k8s-infra-ppc64le-prow-build
+  cron: 0 0/2 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  name: ci-kubernetes-integration-ppc64le-1-36
+  spec:
+    containers:
+    - args:
+      - ./hack/jenkins/test-integration-dockerized.sh
+      command:
+      - runner.sh
+      env:
+      - name: SHORT
+        value: --short=false
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "6"
+          memory: 20Gi
+        requests:
+          cpu: "6"
+          memory: 20Gi
+      securityContext:
+        privileged: true
+- annotations:
+    fork-per-release-cron: 20 0-23/4 * * *, 30 1-23/4 * * *, 40 4-23/4 * * *, 50 2-23/4
+      * * *
+    testgrid-alert-email: sig-cloud-provider-ibm-ppc64le-alerts@kubernetes.io
+    testgrid-dashboards: ibm-ppc64le-e2e, ibm-ppc64le-k8s, conformance-ppc64le, ibm-k8s-e2e,
+      sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: ci-kubernetes-ppc64le-conformance-latest-1.36
+  cluster: k8s-infra-ppc64le-prow-build
+  cron: 10 3-23/4 * * *
+  decorate: true
+  decoration_config:
+    timeout: 5h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    repo: provider-ibmcloud-test-infra
+    workdir: true
+  labels:
+    preset-ibmcloud-cred: "true"
+  name: ci-kubernetes-ppc64le-conformance-latest-1-36
+  spec:
+    containers:
+    - args:
+      - bash
+      - -c
+      - |
+        set -o xtrace
+        MARKER_VERSION=latest-1.36.txt;
+        # Fetch build version only once
+        K8S_BUILD_VERSION=$(curl -Ls https://dl.k8s.io/ci/$MARKER_VERSION);
+
+        #Setup of kubetest2 tf deployer
+        make install-deployer-tf
+
+        export TF_VAR_powervs_system_type=s1022
+        kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
+          --powervs-ssh-key k8s-prow-sshkey \
+          --ssh-private-key /etc/secret-volume/ssh-privatekey \
+          --workers-count 2 --cluster-name conformance-$(date +%s) \
+          --up --down --auto-approve --retry-on-tf-failure 3 \
+          --break-kubetest-on-upfail true --ignore-destroy-errors \
+          --build-version $K8S_BUILD_VERSION \
+          --release-marker $K8S_BUILD_VERSION \
+          --test=ginkgo -- --test-package-dir ci --test-package-marker $MARKER_VERSION --focus-regex='\[Conformance\]'
+      command:
+      - runner.sh
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 14Gi
+        requests:
+          cpu: "2"
+          memory: 14Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: release-team@kubernetes.io
+    testgrid-alert-stale-results-hours: "24"
+    testgrid-dashboards: sig-release-1.36-blocking, conformance-all, conformance-gce
+    testgrid-num-columns-recent: "3"
+    testgrid-num-failures-to-alert: "1"
+    testgrid-tab-name: Conformance - GCE - 1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h30m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 3h
+  labels:
+    preset-dind-enabled: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-gce-conformance-latest-1-36
+  spec:
+    containers:
+    - args:
+      - /bin/bash
+      - -c
+      - set -o errexit; set -o nounset; set -o pipefail; set -o xtrace; MARKER_VERSION=latest-1.36.txt;
+        kubetest2 gce \; --v=9 \; --legacy-mode \; --up \; --down \; --kubernetes-version=https://dl.k8s.io/ci/$MARKER_VERSION
+        \; --test=ginkgo \; -- \; --test-package-url=https://dl.k8s.io \; --test-package-dir=ci
+        \; --test-package-marker=$MARKER_VERSION \; --focus-regex='\[Conformance\]'
+      command:
+      - runner.sh
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 14Gi
+        requests:
+          cpu: "4"
+          memory: 14Gi
+      securityContext:
+        privileged: true
+- annotations:
+    fork-per-release-cron: 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *, 0 14-23/24
+      * * *
+    testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com, release-team@kubernetes.io,
+      sig-node-ci+testgrid@kubernetes.io
+    testgrid-alert-stale-results-hours: "24"
+    testgrid-dashboards: sig-release-1.36-blocking, google-gce, sig-node-gpu, sig-node-containerd
+    testgrid-num-failures-to-alert: "6"
+    testgrid-tab-name: gce-device-plugin-gpu-1.36
+  cluster: k8s-infra-prow-build
+  cron: 0 0-23/2 * * *
+  decorate: true
+  decoration_config:
+    timeout: 1h20m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  job_queue_name: gce-gpu-test
+  labels:
+    preset-k8s-ssh: "true"
+  name: ci-kubernetes-e2e-gce-device-plugin-gpu-1-36
+  spec:
+    containers:
+    - args:
+      - --v=9
+      - --legacy-mode
+      - --up
+      - --down
+      - --node-size=n1-standard-2
+      - --num-nodes=2
+      - --gcp-zone=us-central1-b
+      - --boskos-resource-type=gpu-project
+      - --node-accelerators=type=nvidia-tesla-t4,count=2
+      - --env=KUBE_CLUSTER_INITIALIZATION_TIMEOUT=900
+      - --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt
+      - --test=ginkgo
+      - --
+      - --provider=gce
+      - --test-package-url=https://dl.k8s.io
+      - --test-package-dir=ci
+      - --test-args=--minStartupPods=8
+      - --test-package-marker=latest-1.36.txt
+      - --focus-regex=\[Feature:GPUDevicePlugin\]
+      - --timeout=60m
+      command:
+      - runner.sh
+      - kubetest2
+      - gce
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+    serviceAccountName: prow-build
+- annotations:
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-alert-email: bentheelder@google.com,siarkowicz@google.com,patrick.ohly@intel.com
+    testgrid-dashboards: sig-instrumentation-tests, sig-testing-kind, sig-release-job-config-errors
+    testgrid-num-columns-recent: "6"
+    testgrid-tab-name: kind-json-logging-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h30m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  name: ci-kubernetes-kind-e2e-json-logging-1-36
+  spec:
+    containers:
+    - command:
+      - wrapper.sh
+      - bash
+      - -c
+      - |
+        curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && curl -sSL https://github.com/kubernetes/test-infra/raw/master/experiment/kind-logs-e2e-k8s.sh >$(which e2e-k8s.sh) && chmod u+x $(which e2e-k8s.sh) && e2e-k8s.sh
+      env:
+      - name: CLUSTER_LOG_FORMAT
+        value: json
+      - name: KIND_CLUSTER_LOG_LEVEL
+        value: "6"
+      - name: LABEL_FILTER
+        value: Conformance && !Slow && !Disruptive && !Flaky
+      - name: PARALLEL
+        value: "true"
+      image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "7"
+          memory: 9Gi
+        requests:
+          cpu: "7"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-1.36-informing
+    testgrid-tab-name: ci-kind-dra
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+    workdir: true
+  interval: 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+  name: ci-kind-dra-1-36
+  spec:
+    containers:
+    - args:
+      - /bin/bash
+      - -xce
+      - |
+        set -o pipefail
+        # A CI job uses pre-built release artifacts and pulls necessary source files from GitHub.
+        revision=$(curl --fail --silent --show-error --location https://dl.k8s.io/ci/latest-1.36.txt)
+        # Report what was tested.
+        echo "{\"revision\":\"$revision\"}" >"${ARTIFACTS}/metadata.json"
+        # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
+        hash=${revision/*+/}
+        kind_yaml_cmd=(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
+        kind_node_source="https://dl.k8s.io/ci/$revision/kubernetes-server-linux-amd64.tar.gz"
+        major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+        minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+        features=( )
+        curl --fail --silent --show-error --location "https://dl.k8s.io/ci/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
+        ginkgo=kubernetes/test/bin/ginkgo
+        e2e_test=kubernetes/test/bin/e2e.test
+        # The latest kind is assumed to work also for older release branches, should this job get forked.
+        curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+        kind build node-image --image=dra/node:latest "${kind_node_source}"
+        GINKGO_E2E_PID=
+        trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+        trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+        # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
+        # and adding something at the end.
+        (
+            ${kind_yaml_cmd[@]}
+
+            # Additional features are not in kind.yaml, but they can be added at the end.
+            for feature in ${features[@]}; do echo "  ${feature}: true"; done
+        ) >/tmp/kind.yaml
+
+        # Add or extend kubeadmConfigPatches with a ClusterConfiguration which causes etcd to use /tmp
+        # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+        # kind.yaml may or may not have a `kubeadmConfigPatches`, so we have to be
+        # careful.
+        if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
+            echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
+        fi
+        sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+        mkdir -p "${ARTIFACTS}/kind"
+        cp /tmp/kind.yaml "${ARTIFACTS}/kind"
+        cat /tmp/kind.yaml
+
+        kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+        atexit () {
+            kind export logs "${ARTIFACTS}/kind"
+            kind delete cluster
+        }
+        trap atexit EXIT
+
+        KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+        GINKGO_E2E_PID=$!
+        wait "${GINKGO_E2E_PID}"
+      command:
+      - runner.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-job-config-errors
+    testgrid-tab-name: ci-kind-dra-n-1
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+    workdir: true
+  interval: 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+  name: ci-kind-dra-n-1-1-36
+  spec:
+    containers:
+    - args:
+      - /bin/bash
+      - -xce
+      - |
+        set -o pipefail
+        # A CI job uses pre-built release artifacts and pulls necessary source files from GitHub.
+        revision=$(curl --fail --silent --show-error --location https://dl.k8s.io/ci/latest-1.36.txt)
+        # Report what was tested.
+        echo "{\"revision\":\"$revision\"}" >"${ARTIFACTS}/metadata.json"
+        # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
+        hash=${revision/*+/}
+        kind_yaml_cmd=(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
+        kind_node_source="https://dl.k8s.io/ci/$revision/kubernetes-server-linux-amd64.tar.gz"
+        major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+        minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+        features=( )
+        curl --fail --silent --show-error --location "https://dl.k8s.io/ci/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
+        ginkgo=kubernetes/test/bin/ginkgo
+        e2e_test=kubernetes/test/bin/e2e.test
+        # The latest kind is assumed to work also for older release branches, should this job get forked.
+        curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+        kind build node-image --image=dra/node:latest "${kind_node_source}"
+        GINKGO_E2E_PID=
+        trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+        trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+        # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
+        # and adding something at the end.
+        (
+            ${kind_yaml_cmd[@]}
+
+            # Additional features are not in kind.yaml, but they can be added at the end.
+            for feature in ${features[@]}; do echo "  ${feature}: true"; done
+        ) >/tmp/kind.yaml
+
+        # Add or extend kubeadmConfigPatches with a ClusterConfiguration which causes etcd to use /tmp
+        # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+        # kind.yaml may or may not have a `kubeadmConfigPatches`, so we have to be
+        # careful.
+        if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
+            echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
+        fi
+        sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+        mkdir -p "${ARTIFACTS}/kind"
+        cp /tmp/kind.yaml "${ARTIFACTS}/kind"
+        cat /tmp/kind.yaml
+
+        kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+        atexit () {
+            kind export logs "${ARTIFACTS}/kind"
+            kind delete cluster
+        }
+        trap atexit EXIT
+
+        # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
+        # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
+        previous_minor=$((minor - 1))
+        if [[ $revision == *alpha.0* ]]; then
+            : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
+            previous_minor=$((previous_minor - 1))
+        fi
+        # Test with the most recent CI build, doesn't even need to be released yet.
+        # We want to know if those are broken.
+        previous=$(curl --silent -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
+        curl --silent -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
+        chmod a+rx /tmp/kubelet
+        /tmp/kubelet --version
+        worker_nodes=$(kind get nodes | grep worker)
+        for n in $worker_nodes; do
+            docker cp /tmp/kubelet $n:/usr/bin/kubelet
+            # DRAExtendedResource has been available since 1.34.
+            # We can do version-skew testing against Kubernetes >= 1.36
+            # where it is on by default, but only if we enable it
+            # explicitly for older kubelets.
+            if [[ $previous_minor -ge 34 ]]; then
+                docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                # Verify, intentionally not with --quiet.
+                docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                docker exec $n systemctl daemon-reload
+            fi
+            docker exec $n systemctl restart kubelet
+        done
+
+        # Running tests which only cover control plane behavior are not useful
+        # in a kubelet version skew job. We can filter them out by including
+        # only tests which have the DynamicResourceAllocation feature because
+        # only those cover kubelet behavior.
+        kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
+
+        KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+        GINKGO_E2E_PID=$!
+        wait "${GINKGO_E2E_PID}"
+      command:
+      - runner.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-job-config-errors
+    testgrid-tab-name: ci-kind-dra-n-2
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+    workdir: true
+  interval: 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+  name: ci-kind-dra-n-2-1-36
+  spec:
+    containers:
+    - args:
+      - /bin/bash
+      - -xce
+      - |
+        set -o pipefail
+        # A CI job uses pre-built release artifacts and pulls necessary source files from GitHub.
+        revision=$(curl --fail --silent --show-error --location https://dl.k8s.io/ci/latest-1.36.txt)
+        # Report what was tested.
+        echo "{\"revision\":\"$revision\"}" >"${ARTIFACTS}/metadata.json"
+        # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
+        hash=${revision/*+/}
+        kind_yaml_cmd=(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
+        kind_node_source="https://dl.k8s.io/ci/$revision/kubernetes-server-linux-amd64.tar.gz"
+        major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+        minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+        features=( )
+        curl --fail --silent --show-error --location "https://dl.k8s.io/ci/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
+        ginkgo=kubernetes/test/bin/ginkgo
+        e2e_test=kubernetes/test/bin/e2e.test
+        # The latest kind is assumed to work also for older release branches, should this job get forked.
+        curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+        kind build node-image --image=dra/node:latest "${kind_node_source}"
+        GINKGO_E2E_PID=
+        trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+        trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+        # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
+        # and adding something at the end.
+        (
+            ${kind_yaml_cmd[@]}
+
+            # Additional features are not in kind.yaml, but they can be added at the end.
+            for feature in ${features[@]}; do echo "  ${feature}: true"; done
+        ) >/tmp/kind.yaml
+
+        # Add or extend kubeadmConfigPatches with a ClusterConfiguration which causes etcd to use /tmp
+        # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+        # kind.yaml may or may not have a `kubeadmConfigPatches`, so we have to be
+        # careful.
+        if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
+            echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
+        fi
+        sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+        mkdir -p "${ARTIFACTS}/kind"
+        cp /tmp/kind.yaml "${ARTIFACTS}/kind"
+        cat /tmp/kind.yaml
+
+        kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+        atexit () {
+            kind export logs "${ARTIFACTS}/kind"
+            kind delete cluster
+        }
+        trap atexit EXIT
+
+        # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
+        # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
+        previous_minor=$((minor - 2))
+        if [[ $revision == *alpha.0* ]]; then
+            : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
+            previous_minor=$((previous_minor - 1))
+        fi
+        # Test with the most recent CI build, doesn't even need to be released yet.
+        # We want to know if those are broken.
+        previous=$(curl --silent -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
+        curl --silent -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
+        chmod a+rx /tmp/kubelet
+        /tmp/kubelet --version
+        worker_nodes=$(kind get nodes | grep worker)
+        for n in $worker_nodes; do
+            docker cp /tmp/kubelet $n:/usr/bin/kubelet
+            # DRAExtendedResource has been available since 1.34.
+            # We can do version-skew testing against Kubernetes >= 1.36
+            # where it is on by default, but only if we enable it
+            # explicitly for older kubelets.
+            if [[ $previous_minor -ge 34 ]]; then
+                docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                # Verify, intentionally not with --quiet.
+                docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                docker exec $n systemctl daemon-reload
+            fi
+            docker exec $n systemctl restart kubelet
+        done
+
+        # Running tests which only cover control plane behavior are not useful
+        # in a kubelet version skew job. We can filter them out by including
+        # only tests which have the DynamicResourceAllocation feature because
+        # only those cover kubelet behavior.
+        kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
+
+        KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+        GINKGO_E2E_PID=$!
+        wait "${GINKGO_E2E_PID}"
+      command:
+      - runner.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-job-config-errors
+    testgrid-tab-name: ci-kind-dra-n-3
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+    workdir: true
+  interval: 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+  name: ci-kind-dra-n-3-1-36
+  spec:
+    containers:
+    - args:
+      - /bin/bash
+      - -xce
+      - |
+        set -o pipefail
+        # A CI job uses pre-built release artifacts and pulls necessary source files from GitHub.
+        revision=$(curl --fail --silent --show-error --location https://dl.k8s.io/ci/latest-1.36.txt)
+        # Report what was tested.
+        echo "{\"revision\":\"$revision\"}" >"${ARTIFACTS}/metadata.json"
+        # git hash from e.g. v1.33.0-alpha.1.161+e62ce1c9db2dad
+        hash=${revision/*+/}
+        kind_yaml_cmd=(curl --fail --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/$hash/test/e2e/dra/kind.yaml")
+        kind_node_source="https://dl.k8s.io/ci/$revision/kubernetes-server-linux-amd64.tar.gz"
+        major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+        minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+        features=( )
+        curl --fail --silent --show-error --location "https://dl.k8s.io/ci/$revision/kubernetes-test-linux-amd64.tar.gz" | tar zxvf -
+        ginkgo=kubernetes/test/bin/ginkgo
+        e2e_test=kubernetes/test/bin/e2e.test
+        # The latest kind is assumed to work also for older release branches, should this job get forked.
+        curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+        kind build node-image --image=dra/node:latest "${kind_node_source}"
+        GINKGO_E2E_PID=
+        trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+        trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+        # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
+        # and adding something at the end.
+        (
+            ${kind_yaml_cmd[@]}
+
+            # Additional features are not in kind.yaml, but they can be added at the end.
+            for feature in ${features[@]}; do echo "  ${feature}: true"; done
+        ) >/tmp/kind.yaml
+
+        # Add or extend kubeadmConfigPatches with a ClusterConfiguration which causes etcd to use /tmp
+        # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+        # kind.yaml may or may not have a `kubeadmConfigPatches`, so we have to be
+        # careful.
+        if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
+            echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
+        fi
+        sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+        mkdir -p "${ARTIFACTS}/kind"
+        cp /tmp/kind.yaml "${ARTIFACTS}/kind"
+        cat /tmp/kind.yaml
+
+        kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+        atexit () {
+            kind export logs "${ARTIFACTS}/kind"
+            kind delete cluster
+        }
+        trap atexit EXIT
+
+        # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
+        # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
+        previous_minor=$((minor - 3))
+        if [[ $revision == *alpha.0* ]]; then
+            : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
+            previous_minor=$((previous_minor - 1))
+        fi
+        # Test with the most recent CI build, doesn't even need to be released yet.
+        # We want to know if those are broken.
+        previous=$(curl --silent -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
+        curl --silent -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
+        chmod a+rx /tmp/kubelet
+        /tmp/kubelet --version
+        worker_nodes=$(kind get nodes | grep worker)
+        for n in $worker_nodes; do
+            docker cp /tmp/kubelet $n:/usr/bin/kubelet
+            # DRAExtendedResource has been available since 1.34.
+            # We can do version-skew testing against Kubernetes >= 1.36
+            # where it is on by default, but only if we enable it
+            # explicitly for older kubelets.
+            if [[ $previous_minor -ge 34 ]]; then
+                docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                # Verify, intentionally not with --quiet.
+                docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                docker exec $n systemctl daemon-reload
+            fi
+            docker exec $n systemctl restart kubelet
+        done
+
+        # Running tests which only cover control plane behavior are not useful
+        # in a kubelet version skew job. We can filter them out by including
+        # only tests which have the DynamicResourceAllocation feature because
+        # only those cover kubelet behavior.
+        kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
+
+        KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+        GINKGO_E2E_PID=$!
+        wait "${GINKGO_E2E_PID}"
+      command:
+      - runner.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-job-config-errors
+    testgrid-tab-name: ci-dra-integration
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+    workdir: true
+  interval: 24h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+  name: ci-dra-integration-1-36
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /bin/bash
+      - -xce
+      - |
+        # test/e2e_dra is a Go unit test with a dependency on local-up-cluster.sh
+        # and the the control plane binaries.
+        # We can run it via "make test" to get a JUnit file from gotestsum.
+        # The full log output gets enabled to see progress while the test runs
+        # and to debug potential cross-test interactions.
+        make WHAT="cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
+        make test WHAT=./test/e2e_dra FULL_LOG=y KUBE_PRUNE_JUNIT_TESTS=false KUBE_TIMEOUT=-timeout=30m KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o, sig-release-1.36-informing
+    testgrid-tab-name: ci-node-crio-dra
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+    workdir: true
+  - base_ref: master
+    org: kubernetes
+    path_alias: k8s.io/test-infra
+    repo: test-infra
+  interval: 24h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-node-crio-dra-1-36
+  spec:
+    containers:
+    - args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-central1-b
+      - --parallelism=1
+      - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation } &&
+        !Flaky'
+      - --timeout=60m
+      - --skip-regex=
+      - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio
+        --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true
+        --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service"
+        --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config.yaml
+      command:
+      - runner.sh
+      env:
+      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+        value: "1"
+      - name: GOPATH
+        value: /go
+      - name: KUBE_SSH_USER
+        value: core
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-containerd,
+      sig-release-1.36-informing
+    testgrid-tab-name: ci-node-e2e-containerd-1-7-dra
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+    workdir: true
+  - base_ref: master
+    org: kubernetes
+    path_alias: k8s.io/test-infra
+    repo: test-infra
+  interval: 24h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-node-e2e-containerd-1-7-dra-1-36
+  spec:
+    containers:
+    - args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-central1-b
+      - --parallelism=1
+      - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation } &&
+        !Flaky'
+      - --timeout=60m
+      - --skip-regex=
+      - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+        --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file=
+        --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
+        --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service"
+        --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+      command:
+      - runner.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
+    testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-containerd,
+      sig-release-1.36-informing
+    testgrid-tab-name: ci-node-e2e-containerd-2-0-dra
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h30m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+    workdir: true
+  - base_ref: master
+    org: kubernetes
+    path_alias: k8s.io/test-infra
+    repo: test-infra
+  - base_ref: release/2.1
+    org: containerd
+    repo: containerd
+  interval: 24h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-node-e2e-containerd-2-0-dra-1-36
+  spec:
+    containers:
+    - args:
+      - kubetest2
+      - noop
+      - --test=node
+      - --
+      - --repo-root=.
+      - --gcp-zone=us-central1-b
+      - --parallelism=1
+      - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation } &&
+        !Flaky'
+      - --timeout=60m
+      - --skip-regex=
+      - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+        --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file=
+        --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
+        --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service"
+        --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+      - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
+      command:
+      - runner.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    fork-per-release-generic-suffix: "true"
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-alert-email: release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-blocking
+    testgrid-tab-name: gce-cos-alphafeatures-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 3h20m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 1h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-cos-alphafeatures-beta
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --provider=gce
+      - --gcp-region=us-central1
+      - --gcp-node-image=gci
+      - --extract=ci/latest-1.36
+      - --timeout=180m
+      - --env=ENABLE_POD_PRIORITY=true
+      - --env=KUBE_FEATURE_GATES=AllAlpha=true,AllBeta=true,EventedPLEG=false
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+      - --runtime-config=api/all=true
+      - --test_args=--ginkgo.focus=\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|SidecarContainers|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking
+        --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Example)\]|IPv6|csi-hostpath-v0
+        --minStartupPods=8
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi
+- annotations:
+    fork-per-release-generic-suffix: "true"
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-alert-email: release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-blocking
+    testgrid-tab-name: gce-cos-default-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h20m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 1h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-cos-default-beta
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --provider=gce
+      - --gcp-region=us-central1
+      - --gcp-node-image=gci
+      - --extract=ci/latest-1.36
+      - --timeout=120m
+      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+        --minStartupPods=8
+      - --ginkgo-parallel=30
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+- annotations:
+    fork-per-release-generic-suffix: "true"
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-alert-email: release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-blocking
+    testgrid-tab-name: gce-cos-reboot-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 3h20m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 1h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-cos-reboot-beta
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --provider=gce
+      - --gcp-region=us-central1
+      - --gcp-node-image=gci
+      - --extract=ci/latest-1.36
+      - --timeout=180m
+      - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi
+- annotations:
+    fork-per-release-generic-suffix: "true"
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-dashboards: sig-release-1.36-informing
+    testgrid-num-failures-to-alert: "6"
+    testgrid-tab-name: gce-cos-serial-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 11h20m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 1h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-cos-serial-beta
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --provider=gce
+      - --gcp-region=us-central1
+      - --gcp-node-image=gci
+      - --extract=ci/latest-1.36
+      - --timeout=660m
+      - --ginkgo-parallel=1
+      - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\]
+        --minStartupPods=8
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi
+- annotations:
+    fork-per-release-generic-suffix: "true"
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-dashboards: sig-release-1.36-informing
+    testgrid-num-failures-to-alert: "6"
+    testgrid-tab-name: gce-cos-slow-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 2h50m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 1h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-e2e-gce-cos-slow-beta
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --provider=gce
+      - --gcp-region=us-central1
+      - --gcp-node-image=gci
+      - --extract=ci/latest-1.36
+      - --timeout=150m
+      - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\]
+        --minStartupPods=8
+      - --ginkgo-parallel=30
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 6Gi
+- annotations:
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-blocking, sig-release-releng-blocking
+    testgrid-tab-name: build-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    repo: kubernetes
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-build-1-36
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes
+      slug: release-managers
+  spec:
+    containers:
+    - command:
+      - wrapper.sh
+      - /krel
+      - ci-build
+      - --configure-docker
+      - --allow-dup=false
+      - --bucket=k8s-release-dev
+      - --registry=gcr.io/k8s-staging-ci-images
+      - --extra-version-markers=k8s-beta
+      image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        limits:
+          cpu: "7"
+          memory: 34Gi
+        requests:
+          cpu: "7"
+          memory: 34Gi
+      securityContext:
+        privileged: true
+- annotations:
+    fork-per-release-cron: 0 7 * * *, 0 13 * * *, 0 17 * * *, 0 21 * * *
+    testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
+    testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: kubemark-1.36-500
+  cluster: k8s-infra-prow-build
+  cron: 0 3 * * *
+  decorate: true
+  decoration_config:
+    timeout: 2h0m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/perf-tests
+    repo: perf-tests
+  labels:
+    preset-dind-enabled: "true"
+    preset-e2e-kubemark-common: "true"
+    preset-e2e-scalability-periodics: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-kubemark-500-gce-1-36
+  spec:
+    containers:
+    - args:
+      - --cluster=kubemark-500
+      - --extract=ci/latest-1.36
+      - --gcp-master-size=n2-standard-4
+      - --gcp-node-image=gci
+      - --gcp-node-size=e2-standard-8
+      - --gcp-nodes=8
+      - --gcp-project-type=scalability-project
+      - --gcp-zone=us-east1-b
+      - --kubemark
+      - --kubemark-nodes=500
+      - --kubemark-master-size=n2-standard-16
+      - --metadata-sources=cl2-metadata.json
+      - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=160 --max-mutating-requests-inflight=0
+        --profiling --contention-profiling
+      - --provider=gce
+      - --test=false
+      - --test_args=--ginkgo.focus=xxxx
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=500
+      - --test-cmd-args=--provider=kubemark
+      - --test-cmd-args=--report-dir=$(ARTIFACTS)
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testconfig=testing/huge-service/config.yaml
+      - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+      - --test-cmd-args=--testoverrides=./testing/overrides/kubemark_500_nodes.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=100m
+      - --use-logexporter
+      - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 8Gi
+        requests:
+          cpu: "2"
+          memory: 8Gi
+      securityContext:
+        privileged: true
+  tags:
+  - 'perfDashPrefix: kubemark-500Nodes-1.36'
+  - 'perfDashJobType: performance'
+- annotations:
+    fork-per-release-cron: 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *, 0 8-20/24
+      * * *
+    testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com,
+      release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-blocking, sig-scalability-gce, kops-misc
+    testgrid-num-failures-to-alert: "2"
+    testgrid-tab-name: gce-1.36-scale-performance-100
+  cluster: k8s-infra-prow-build
+  cron: 0 */6 * * *
+  decorate: true
+  decoration_config:
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/perf-tests
+    repo: perf-tests
+  - base_ref: master
+    org: kubernetes
+    path_alias: k8s.io/kops
+    repo: kops
+    workdir: true
+  labels:
+    preset-k8s-ssh: "true"
+  name: ci-kubernetes-e2e-gce-scale-performance-100-1-36
+  spec:
+    containers:
+    - args:
+      - ./tests/e2e/scenarios/scalability/run-test.sh
+      command:
+      - runner.sh
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/ssh-key-secret/ssh-private
+      - name: KUBE_SSH_USER
+        value: prow
+      - name: GOPATH
+        value: /home/prow/go
+      - name: KUBERNETES_VERSION
+        value: "1.36"
+      - name: CNI_PLUGIN
+        value: gce
+      - name: KUBE_NODE_COUNT
+        value: "100"
+      - name: CL2_LOAD_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_DELETE_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_RATE_LIMIT_POD_CREATION
+        value: "false"
+      - name: NODE_MODE
+        value: master
+      - name: KUBE_PROXY_MODE
+        value: nftables
+      - name: CONTROL_PLANE_COUNT
+        value: "1"
+      - name: CONTROL_PLANE_SIZE
+        value: c4-standard-32
+      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+        value: "true"
+      - name: CL2_ENABLE_DNS_PROGRAMMING
+        value: "true"
+      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+        value: "true"
+      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+        value: "99.5"
+      - name: CL2_ALLOWED_SLOW_API_CALLS
+        value: "1"
+      - name: ENABLE_PROMETHEUS_SERVER
+        value: "true"
+      - name: TEAR_DOWN_PROMETHEUS_SERVER
+        value: "false"
+      - name: PROMETHEUS_PVC_STORAGE_CLASS
+        value: ssd-csi
+      - name: CLOUD_PROVIDER
+        value: gce
+      - name: BOSKOS_RESOURCE_TYPE
+        value: scalability-project
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 6Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      securityContext:
+        privileged: true
+    serviceAccountName: prow-build
+  tags:
+  - 'perfDashPrefix: gce-100Nodes-1.36'
+  - 'perfDashJobType: performance'
+  - 'perfDashBuildsCount: 500'
+- annotations:
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-alert-email: release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-blocking
+    testgrid-tab-name: cmd-1.36
+  cluster: eks-prow-build-cluster
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 2h
+  labels:
+    preset-dind-enabled: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-cmd-1-36
+  spec:
+    containers:
+    - args:
+      - ./hack/jenkins/test-cmd-dockerized.sh
+      command:
+      - runner.sh
+      env:
+      - name: SHORT
+        value: --short=false
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "6"
+          memory: 20Gi
+        requests:
+          cpu: "6"
+          memory: 20Gi
+      securityContext:
+        privileged: true
+- annotations:
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-alert-email: release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-blocking
+    testgrid-tab-name: integration-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 2h
+  labels:
+    preset-dind-enabled: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-integration-1-36
+  spec:
+    containers:
+    - args:
+      - ./hack/jenkins/test-integration-dockerized.sh
+      command:
+      - runner.sh
+      env:
+      - name: SHORT
+        value: --short=false
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "6"
+          memory: 20Gi
+        requests:
+          cpu: "6"
+          memory: 20Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+- annotations:
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-alert-email: release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-blocking
+    testgrid-tab-name: integration-arm64-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 2h
+  labels:
+    preset-dind-enabled: "true"
+  name: ci-kubernetes-integration-arm64-1-36
+  spec:
+    containers:
+    - args:
+      - ./hack/jenkins/test-integration-dockerized.sh
+      command:
+      - runner.sh
+      env:
+      - name: SHORT
+        value: --short=false
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "6"
+          memory: 20Gi
+        requests:
+          cpu: "6"
+          memory: 20Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      kubernetes.io/arch: arm64
+- annotations:
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-blocking, sig-testing-kind
+    testgrid-num-columns-recent: "6"
+    testgrid-tab-name: kind-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+  name: ci-kubernetes-e2e-kind-1-36
+  spec:
+    containers:
+    - command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz -
+        -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+      - name: LABEL_FILTER
+        value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
+      - name: PARALLEL
+        value: "true"
+      image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "7"
+          memory: 9Gi
+        requests:
+          cpu: "7"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+- annotations:
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-blocking, sig-testing-kind
+    testgrid-num-columns-recent: "6"
+    testgrid-tab-name: kind-ipv6-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+  name: ci-kubernetes-e2e-kind-ipv6-1-36
+  spec:
+    containers:
+    - command:
+      - wrapper.sh
+      - bash
+      - -c
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz -
+        -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+      - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+        value: "true"
+      - name: IP_FAMILY
+        value: ipv6
+      - name: LABEL_FILTER
+        value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
+      - name: PARALLEL
+        value: "true"
+      image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "7"
+          memory: 9Gi
+        requests:
+          cpu: "7"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, release-team@kubernetes.io
+    testgrid-alert-stale-results-hours: "24"
+    testgrid-create-test-group: "true"
+    testgrid-dashboards: sig-release-1.36-blocking
+    testgrid-days-of-results: "1"
+    testgrid-num-failures-to-alert: "3"
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 1h
+  name: ci-kubernetes-unit-1-36
+  spec:
+    containers:
+    - command:
+      - make
+      - test
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "7"
+          memory: 16Gi
+        requests:
+          cpu: "7"
+          memory: 16Gi
+      securityContext:
+        allowPrivilegeEscalation: false
+    securityContext:
+      runAsGroup: 2010
+      runAsUser: 2001
+- annotations:
+    fork-per-release-periodic-interval: 2h 6h 24h
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, release-managers+alerts@kubernetes.io,
+      release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-blocking
+    testgrid-tab-name: verify-1.36
+  cluster: k8s-infra-prow-build
+  decorate: true
+  extra_refs:
+  - base_ref: release-1.36
+    org: kubernetes
+    path_alias: k8s.io/kubernetes
+    repo: kubernetes
+  interval: 2h
+  labels:
+    preset-dind-enabled: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-verify-1-36
+  spec:
+    containers:
+    - args:
+      - ./hack/jenkins/verify-dockerized.sh
+      command:
+      - runner.sh
+      env:
+      - name: EXCLUDE_READONLY_PACKAGE
+        value: "y"
+      - name: KUBE_VERIFY_GIT_BRANCH
+        value: release-1.36
+      - name: REPO_DIR
+        value: /workspace/k8s.io/kubernetes
+      - name: TYPECHECK_SERIAL
+        value: "true"
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        limits:
+          cpu: "7"
+          memory: 24Gi
+        requests:
+          cpu: "7"
+          memory: 24Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io,
+      release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-informing, sig-windows-master-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-1.36
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    repo: cluster-api-provider-azure
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+    workdir: true
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    repo: cloud-provider-azure
+  interval: 3h
+  labels:
+    preset-azure-community: "true"
+    preset-capz-containerd-2-0-latest: "true"
+    preset-capz-windows-2022: "true"
+    preset-capz-windows-common: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  name: ci-kubernetes-e2e-capz-master-windows-1-36
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - env
+      - KUBERNETES_VERSION=latest-1.36
+      - ./capz/run-capz-e2e.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 9Gi
+        requests:
+          cpu: "2"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+    serviceAccountName: azure
+postsubmits: {}
+presubmits:
+  kubernetes/kubernetes:
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-unit-fieldsv1string
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    name: pull-kubernetes-unit-fieldsv1string
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - make
+        - test
+        env:
+        - name: GOFLAGS
+          value: -tags=fieldsv1string
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 16Gi
+          requests:
+            cpu: "7"
+            memory: 16Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsGroup: 2010
+        runAsUser: 2001
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-integration-fieldsv1string
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration-fieldsv1string
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-integration-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: GOFLAGS
+          value: -tags=fieldsv1string
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 20Gi
+          requests:
+            cpu: "7"
+            memory: 20Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-fieldsv1string
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind-fieldsv1string
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: GOFLAGS
+          value: -tags=fieldsv1string
+        - name: LABEL_FILTER
+          value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-dependencies
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind-dependencies
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - ./../test-infra/experiment/dependencies/update-dependencies-and-run-tests.sh
+          --test-mode kind
+        env:
+        - name: LABEL_FILTER
+          value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-unit-dependencies
+    decorate: true
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    name: pull-kubernetes-e2e-unit-dependencies
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./../test-infra/experiment/dependencies/update-dependencies-and-run-tests.sh
+        - --test-mode
+        - unit
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 16Gi
+          requests:
+            cpu: "7"
+            memory: 16Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsGroup: 2010
+        runAsUser: 2001
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-golang-tip
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind-golang-tip
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: LABEL_FILTER
+          value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
+        - name: PARALLEL
+          value: "true"
+        - name: GO_VERSION
+          value: devel
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-unit-golang-tip
+    decorate: true
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    name: pull-kubernetes-e2e-unit-golang-tip
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - make
+        - test
+        env:
+        - name: GO_VERSION
+          value: devel
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 16Gi
+          requests:
+            cpu: "7"
+            memory: 16Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsGroup: 2010
+        runAsUser: 2001
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gci-gce
+    decorate: true
+    decoration_config:
+      timeout: 2h20m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gci-gce
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --check-leaked-resources
+        - --build=quick
+        - --gcp-node-image=gci
+        - --gcp-region=us-central1
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHCACHE_CONSISTENCY_CHECKER=true
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=120m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce-cos
+    decorate: true
+    decoration_config:
+      timeout: 1h45m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce-cos
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --gcp-node-image=gci
+        - --gcp-region=us-central1
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHCACHE_CONSISTENCY_CHECKER=true
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce-cos-canary
+    decorate: true
+    decoration_config:
+      timeout: 1h45m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce-cos-canary
+    path_alias: k8s.io/kubernetes
+    skip_report: true
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --gcp-node-image=gci
+        - --gcp-region=us-central1
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHCACHE_CONSISTENCY_CHECKER=true
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        env:
+        - name: BOOTSTRAP_FETCH_TEST_INFRA
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce
+    decorate: true
+    decoration_config:
+      timeout: 1h45m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.1.0
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.3.0
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+        - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
+        - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_IMAGE_FAMILY=ubuntu-2404-lts-amd64
+        - --env=KUBE_GCE_IMAGE_PROJECT=ubuntu-os-cloud
+        - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
+        - --gcp-master-image=ubuntu
+        - --gcp-node-image=ubuntu
+        - --gcp-region=us-central1
+        - --ginkgo-parallel=25
+        - --provider=gce
+        - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHLIST_INCONSISTENCY_DETECTOR=true
+        - --env=ENABLE_KUBE_WATCHCACHE_CONSISTENCY_CHECKER=true
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 20Gi
+          requests:
+            cpu: "7"
+            memory: 20Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce-canary
+    decorate: true
+    decoration_config:
+      timeout: 1h50m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kops
+      repo: kops
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+    name: pull-kubernetes-e2e-gce-canary
+    optional: true
+    path_alias: k8s.io/kubernetes
+    skip_report: true
+    spec:
+      containers:
+      - args:
+        - bash
+        - -c
+        - |
+          ARGS="--set=spec.containerd.runc.version=1.1.12 --set=spec.packages=nfs-common --set=spec.containerd.version=1.7.13"
+          make -C $GOPATH/src/k8s.io/kops test-e2e-install
+          kubetest2 kops -v=6 --cloud-provider=gce --up --down --build \
+            --build-kubernetes=true --target-build-arch=linux/amd64 \
+            --admin-access=0.0.0.0/0 \
+            --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
+            --create-args "$ARGS --networking=kubenet --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true" \
+            --test=kops \
+            -- \
+            --ginkgo-args="--debug" \
+            --skip-regex="\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[KubeUp\]" \
+            --timeout=80m \
+            --use-built-binaries=true \
+            --parallel=30
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: k8s-kops-test
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce-serial
+    decorate: true
+    decoration_config:
+      timeout: 8h40m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce-serial
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v2.1.0
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.3.0
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+        - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
+        - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_IMAGE_FAMILY=ubuntu-2404-lts-amd64
+        - --env=KUBE_GCE_IMAGE_PROJECT=ubuntu-os-cloud
+        - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
+        - --gcp-master-image=ubuntu
+        - --gcp-node-image=ubuntu
+        - --gcp-region=us-central1
+        - --ginkgo-parallel=1
+        - --provider=gce
+        - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=500m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce-serial-canary
+    decorate: true
+    decoration_config:
+      timeout: 8h50m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kops
+      repo: kops
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-storage-e2e-service-account: "true"
+    name: pull-kubernetes-e2e-gce-serial-canary
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - bash
+        - -c
+        - |
+          ARGS="--set=spec.containerd.runc.version=1.1.12  --set=spec.packages=nfs-common --set=spec.containerd.version=1.7.13"
+          make -C $GOPATH/src/k8s.io/kops test-e2e-install
+          kubetest2 kops -v=6 --cloud-provider=gce --up --down --build \
+            --build-kubernetes=true --target-build-arch=linux/amd64 \
+            --admin-access=0.0.0.0/0 \
+            --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
+            --create-args "$ARGS --node-count=3 --networking=kubenet --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true" \
+            --test=kops \
+            -- \
+            --test-args="-test.timeout=800m --num-nodes=3 --master-os-distro=ubuntu --node-os-distro=ubuntu" \
+            --focus-regex="\[Serial\]" \
+            --skip-regex="\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[KubeUp\]" \
+            --timeout=500m \
+            --use-built-binaries=true \
+            --parallel=1
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: k8s-kops-test
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce-disruptive-canary
+    decorate: true
+    decoration_config:
+      timeout: 10h30m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kops
+      repo: kops
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-storage-e2e-service-account: "true"
+    name: pull-kubernetes-e2e-gce-disruptive-canary
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - bash
+        - -c
+        - |
+          ARGS="--set=spec.containerd.runc.version=1.1.12  --set=spec.packages=nfs-common --set=spec.containerd.version=1.7.13"
+          make -C $GOPATH/src/k8s.io/kops test-e2e-install
+          kubetest2 kops -v=6 --cloud-provider=gce --up --down --build \
+            --build-kubernetes=true --target-build-arch=linux/amd64 \
+            --admin-access=0.0.0.0/0 \
+            --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
+            --create-args "$ARGS --node-count=3 --networking=kubenet --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true" \
+            --test=kops \
+            -- \
+            --test-args="-test.timeout=600m --num-nodes=3 --master-os-distro=ubuntu --node-os-distro=ubuntu" \
+            --focus-regex="\[Disruptive\]" \
+            --skip-regex="\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[KubeUp\]" \
+            --timeout=500m \
+            --use-built-binaries=true \
+            --parallel=1
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: k8s-kops-test
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-e2e-gce-cloud-provider-disabled
+    decorate: true
+    decoration_config:
+      timeout: 2h0m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-e2e-gce-cloud-provider-disabled
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --env=CLOUD_PROVIDER_FLAG=external
+        - --env=ENABLE_AUTH_PROVIDER_GCP=true
+        - --gcp-master-image=gci
+        - --gcp-node-image=gci
+        - --gcp-nodes=4
+        - --gcp-region=us-central1
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce-device-plugin-gpu
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    job_queue_name: gce-gpu-test
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+    max_concurrency: 5
+    name: pull-kubernetes-e2e-gce-device-plugin-gpu
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --v=9
+        - --legacy-mode
+        - --build
+        - --up
+        - --down
+        - --node-size=n1-standard-2
+        - --num-nodes=2
+        - --gcp-zone=us-central1-b
+        - --env=KUBE_CLUSTER_INITIALIZATION_TIMEOUT=900
+        - --boskos-resource-type=gpu-project
+        - --node-accelerators=type=nvidia-tesla-t4,count=2
+        - --test=ginkgo
+        - --
+        - --provider=gce
+        - --use-built-binaries=true
+        - --test-args=--minStartupPods=8
+        - --focus-regex=\[Feature:GPUDevicePlugin\]
+        command:
+        - runner.sh
+        - kubetest2
+        - gce
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 14Gi
+          requests:
+            cpu: "6"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: prow-build
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-kind-dra
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-kind-dra
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+    spec:
+      containers:
+      - args:
+        - /bin/bash
+        - -xce
+        - |
+          set -o pipefail
+          # A presubmit job uses the checked out and merged source code.
+          revision=$(git describe --tags)
+          kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
+          kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+          features=( )
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
+          ginkgo=_output/bin/ginkgo
+          e2e_test=_output/bin/e2e.test
+          # The latest kind is assumed to work also for older release branches, should this job get forked.
+          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          kind build node-image --image=dra/node:latest "${kind_node_source}"
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
+          # and adding something at the end.
+          (
+              ${kind_yaml_cmd[@]}
+
+              # Additional features are not in kind.yaml, but they can be added at the end.
+              for feature in ${features[@]}; do echo "  ${feature}: true"; done
+          ) >/tmp/kind.yaml
+
+          # Add or extend kubeadmConfigPatches with a ClusterConfiguration which causes etcd to use /tmp
+          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+          # kind.yaml may or may not have a `kubeadmConfigPatches`, so we have to be
+          # careful.
+          if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
+              echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
+          fi
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
+          cat /tmp/kind.yaml
+
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          atexit () {
+              kind export logs "${ARTIFACTS}/kind"
+              kind delete cluster
+          }
+          trap atexit EXIT
+
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-kind-dra-all
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-kind-dra-all
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+    spec:
+      containers:
+      - args:
+        - /bin/bash
+        - -xce
+        - |
+          set -o pipefail
+          # A presubmit job uses the checked out and merged source code.
+          revision=$(git describe --tags)
+          kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
+          kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+          # Which DRA features exist can change over time.
+          features=( $( grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/' ) )
+          # These extra features are dependencies for some DRA features but only
+          # valid for Kubernetes 1.35+. Additional features here should not
+          # affect behavior of tests that don't require them.
+          if ((major >= 1 && minor - 0 >= 35)); then
+            features+=('GenericWorkload')
+          fi
+          : "Enabling DRA feature(s): ${features[*]}."
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
+          ginkgo=_output/bin/ginkgo
+          e2e_test=_output/bin/e2e.test
+          # The latest kind is assumed to work also for older release branches, should this job get forked.
+          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          kind build node-image --image=dra/node:latest "${kind_node_source}"
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
+          # and adding something at the end.
+          (
+              ${kind_yaml_cmd[@]}
+
+              # Additional features are not in kind.yaml, but they can be added at the end.
+              for feature in ${features[@]}; do echo "  ${feature}: true"; done
+          ) >/tmp/kind.yaml
+
+          # Add or extend kubeadmConfigPatches with a ClusterConfiguration which causes etcd to use /tmp
+          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+          # kind.yaml may or may not have a `kubeadmConfigPatches`, so we have to be
+          # careful.
+          if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
+              echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
+          fi
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
+          cat /tmp/kind.yaml
+
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          atexit () {
+              kind export logs "${ARTIFACTS}/kind"
+              kind delete cluster
+          }
+          trap atexit EXIT
+
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
+        command:
+        - runner.sh
+        env:
+        - name: KUBE_RACE
+          value: -race
+        - name: KUBE_CGO_OVERRIDES
+          value: kube-apiserver kube-controller-manager kube-scheduler
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 12Gi
+          requests:
+            cpu: "2"
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-kind-dra-all-slow
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-kind-dra-all-slow
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - /bin/bash
+        - -xce
+        - |
+          set -o pipefail
+          # A presubmit job uses the checked out and merged source code.
+          revision=$(git describe --tags)
+          kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
+          kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+          # Which DRA features exist can change over time.
+          features=( $( grep '"DRA' pkg/features/kube_features.go | sed 's/.*"\(.*\)"/\1/' ) )
+          # These extra features are dependencies for some DRA features but only
+          # valid for Kubernetes 1.35+. Additional features here should not
+          # affect behavior of tests that don't require them.
+          if ((major >= 1 && minor - 0 >= 35)); then
+            features+=('GenericWorkload')
+          fi
+          : "Enabling DRA feature(s): ${features[*]}."
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
+          ginkgo=_output/bin/ginkgo
+          e2e_test=_output/bin/e2e.test
+          # The latest kind is assumed to work also for older release branches, should this job get forked.
+          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          kind build node-image --image=dra/node:latest "${kind_node_source}"
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
+          # and adding something at the end.
+          (
+              ${kind_yaml_cmd[@]}
+
+              # Additional features are not in kind.yaml, but they can be added at the end.
+              for feature in ${features[@]}; do echo "  ${feature}: true"; done
+          ) >/tmp/kind.yaml
+
+          # Add or extend kubeadmConfigPatches with a ClusterConfiguration which causes etcd to use /tmp
+          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+          # kind.yaml may or may not have a `kubeadmConfigPatches`, so we have to be
+          # careful.
+          if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
+              echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
+          fi
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
+          cat /tmp/kind.yaml
+
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          atexit () {
+              kind export logs "${ARTIFACTS}/kind"
+              kind delete cluster
+          }
+          trap atexit EXIT
+
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
+        command:
+        - runner.sh
+        env:
+        - name: KUBE_RACE
+          value: -race
+        - name: KUBE_CGO_OVERRIDES
+          value: kube-apiserver kube-controller-manager kube-scheduler
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 12Gi
+          requests:
+            cpu: "2"
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-kind-dra-n-1
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-kind-dra-n-1
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+    spec:
+      containers:
+      - args:
+        - /bin/bash
+        - -xce
+        - |
+          set -o pipefail
+          # A presubmit job uses the checked out and merged source code.
+          revision=$(git describe --tags)
+          kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
+          kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+          features=( )
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
+          ginkgo=_output/bin/ginkgo
+          e2e_test=_output/bin/e2e.test
+          # The latest kind is assumed to work also for older release branches, should this job get forked.
+          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          kind build node-image --image=dra/node:latest "${kind_node_source}"
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
+          # and adding something at the end.
+          (
+              ${kind_yaml_cmd[@]}
+
+              # Additional features are not in kind.yaml, but they can be added at the end.
+              for feature in ${features[@]}; do echo "  ${feature}: true"; done
+          ) >/tmp/kind.yaml
+
+          # Add or extend kubeadmConfigPatches with a ClusterConfiguration which causes etcd to use /tmp
+          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+          # kind.yaml may or may not have a `kubeadmConfigPatches`, so we have to be
+          # careful.
+          if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
+              echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
+          fi
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
+          cat /tmp/kind.yaml
+
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          atexit () {
+              kind export logs "${ARTIFACTS}/kind"
+              kind delete cluster
+          }
+          trap atexit EXIT
+
+          # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
+          # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
+          previous_minor=$((minor - 1))
+          if [[ $revision == *alpha.0* ]]; then
+              : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
+              previous_minor=$((previous_minor - 1))
+          fi
+          # Test with the stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
+          # Ask curl to append the HTTP status code after the response body (-w ' %{http_code}').
+          # Then parse the output using Bash parameter expansion:
+          #   ${response% *}  → everything before the last space (the body)
+          #   ${response##* } → everything after the last space (the HTTP code)
+          response=$(curl --silent -w ' %{http_code}' -L "https://dl.k8s.io/release/stable-$major.$previous_minor.txt" )
+          previous="${response% *}"
+          status="${response##* }"
+          if [ "$status" == 404 ] ; then
+              # if stable doesn't exist - use latest
+              response=$(curl --silent -w ' %{http_code}' -L "https://dl.k8s.io/release/latest-$major.$previous_minor.txt" )
+              previous="${response% *}"
+              status="${response##* }"
+          fi
+          if [ "$status" -ne 200 ] ; then
+              echo "error: unable to get release $major.$previous_minor info, HTTP status: $status, response: $previous"
+              exit 1
+          fi
+          curl --silent -L "https://dl.k8s.io/release/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
+          chmod a+rx /tmp/kubelet
+          /tmp/kubelet --version
+          worker_nodes=$(kind get nodes | grep worker)
+          for n in $worker_nodes; do
+              docker cp /tmp/kubelet $n:/usr/bin/kubelet
+              # DRAExtendedResource has been available since 1.34.
+              # We can do version-skew testing against Kubernetes >= 1.36
+              # where it is on by default, but only if we enable it
+              # explicitly for older kubelets.
+              if [[ $previous_minor -ge 34 ]]; then
+                  docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                  # Verify, intentionally not with --quiet.
+                  docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                  docker exec $n systemctl daemon-reload
+              fi
+              docker exec $n systemctl restart kubelet
+          done
+
+          # Running tests which only cover control plane behavior are not useful
+          # in a kubelet version skew job. We can filter them out by including
+          # only tests which have the DynamicResourceAllocation feature because
+          # only those cover kubelet behavior.
+          kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
+
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-kind-dra-n-2
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-kind-dra-n-2
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+    spec:
+      containers:
+      - args:
+        - /bin/bash
+        - -xce
+        - |
+          set -o pipefail
+          # A presubmit job uses the checked out and merged source code.
+          revision=$(git describe --tags)
+          kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
+          kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+          features=( )
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
+          ginkgo=_output/bin/ginkgo
+          e2e_test=_output/bin/e2e.test
+          # The latest kind is assumed to work also for older release branches, should this job get forked.
+          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          kind build node-image --image=dra/node:latest "${kind_node_source}"
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
+          # and adding something at the end.
+          (
+              ${kind_yaml_cmd[@]}
+
+              # Additional features are not in kind.yaml, but they can be added at the end.
+              for feature in ${features[@]}; do echo "  ${feature}: true"; done
+          ) >/tmp/kind.yaml
+
+          # Add or extend kubeadmConfigPatches with a ClusterConfiguration which causes etcd to use /tmp
+          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+          # kind.yaml may or may not have a `kubeadmConfigPatches`, so we have to be
+          # careful.
+          if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
+              echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
+          fi
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
+          cat /tmp/kind.yaml
+
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          atexit () {
+              kind export logs "${ARTIFACTS}/kind"
+              kind delete cluster
+          }
+          trap atexit EXIT
+
+          # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
+          # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
+          previous_minor=$((minor - 2))
+          if [[ $revision == *alpha.0* ]]; then
+              : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
+              previous_minor=$((previous_minor - 1))
+          fi
+          # Test with the stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
+          # Ask curl to append the HTTP status code after the response body (-w ' %{http_code}').
+          # Then parse the output using Bash parameter expansion:
+          #   ${response% *}  → everything before the last space (the body)
+          #   ${response##* } → everything after the last space (the HTTP code)
+          response=$(curl --silent -w ' %{http_code}' -L "https://dl.k8s.io/release/stable-$major.$previous_minor.txt" )
+          previous="${response% *}"
+          status="${response##* }"
+          if [ "$status" == 404 ] ; then
+              # if stable doesn't exist - use latest
+              response=$(curl --silent -w ' %{http_code}' -L "https://dl.k8s.io/release/latest-$major.$previous_minor.txt" )
+              previous="${response% *}"
+              status="${response##* }"
+          fi
+          if [ "$status" -ne 200 ] ; then
+              echo "error: unable to get release $major.$previous_minor info, HTTP status: $status, response: $previous"
+              exit 1
+          fi
+          curl --silent -L "https://dl.k8s.io/release/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
+          chmod a+rx /tmp/kubelet
+          /tmp/kubelet --version
+          worker_nodes=$(kind get nodes | grep worker)
+          for n in $worker_nodes; do
+              docker cp /tmp/kubelet $n:/usr/bin/kubelet
+              # DRAExtendedResource has been available since 1.34.
+              # We can do version-skew testing against Kubernetes >= 1.36
+              # where it is on by default, but only if we enable it
+              # explicitly for older kubelets.
+              if [[ $previous_minor -ge 34 ]]; then
+                  docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                  # Verify, intentionally not with --quiet.
+                  docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                  docker exec $n systemctl daemon-reload
+              fi
+              docker exec $n systemctl restart kubelet
+          done
+
+          # Running tests which only cover control plane behavior are not useful
+          # in a kubelet version skew job. We can filter them out by including
+          # only tests which have the DynamicResourceAllocation feature because
+          # only those cover kubelet behavior.
+          kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
+
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-kind-dra-n-3
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-kind-dra-n-3
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+    spec:
+      containers:
+      - args:
+        - /bin/bash
+        - -xce
+        - |
+          set -o pipefail
+          # A presubmit job uses the checked out and merged source code.
+          revision=$(git describe --tags)
+          kind_yaml_cmd=(cat test/e2e/dra/kind.yaml)
+          kind_node_source=.
+          major=$(echo "$revision" | sed -e 's/^v\([0-9]*\).*/\1/')
+          minor=$(echo "$revision" | sed -e 's/^v[0-9]*\.\([0-9]*\).*/\1/')
+          features=( )
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
+          ginkgo=_output/bin/ginkgo
+          e2e_test=_output/bin/e2e.test
+          # The latest kind is assumed to work also for older release branches, should this job get forked.
+          curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
+          kind build node-image --image=dra/node:latest "${kind_node_source}"
+          GINKGO_E2E_PID=
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
+          # and adding something at the end.
+          (
+              ${kind_yaml_cmd[@]}
+
+              # Additional features are not in kind.yaml, but they can be added at the end.
+              for feature in ${features[@]}; do echo "  ${feature}: true"; done
+          ) >/tmp/kind.yaml
+
+          # Add or extend kubeadmConfigPatches with a ClusterConfiguration which causes etcd to use /tmp
+          # (https://github.com/kubernetes-sigs/kind/issues/845#issuecomment-1261248420).
+          # kind.yaml may or may not have a `kubeadmConfigPatches`, so we have to be
+          # careful.
+          if ! grep -q '^kubeadmConfigPatches:$' /tmp/kind.yaml; then
+              echo "kubeadmConfigPatches:" >>/tmp/kind.yaml
+          fi
+          sed -i -e '/^kubeadmConfigPatches:$/a\' -e '  - |\n    kind: ClusterConfiguration\n    etcd:\n      local:\n        dataDir: /tmp/etcd\n' /tmp/kind.yaml
+
+          mkdir -p "${ARTIFACTS}/kind"
+          cp /tmp/kind.yaml "${ARTIFACTS}/kind"
+          cat /tmp/kind.yaml
+
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          atexit () {
+              kind export logs "${ARTIFACTS}/kind"
+              kind delete cluster
+          }
+          trap atexit EXIT
+
+          # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
+          # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
+          previous_minor=$((minor - 3))
+          if [[ $revision == *alpha.0* ]]; then
+              : Treating alpha.0 like previous release because it already gets set on the master branch during code freeze and/or is too similar to the previous release to justify a change in what the jobs test against.
+              previous_minor=$((previous_minor - 1))
+          fi
+          # Test with the stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
+          # Ask curl to append the HTTP status code after the response body (-w ' %{http_code}').
+          # Then parse the output using Bash parameter expansion:
+          #   ${response% *}  → everything before the last space (the body)
+          #   ${response##* } → everything after the last space (the HTTP code)
+          response=$(curl --silent -w ' %{http_code}' -L "https://dl.k8s.io/release/stable-$major.$previous_minor.txt" )
+          previous="${response% *}"
+          status="${response##* }"
+          if [ "$status" == 404 ] ; then
+              # if stable doesn't exist - use latest
+              response=$(curl --silent -w ' %{http_code}' -L "https://dl.k8s.io/release/latest-$major.$previous_minor.txt" )
+              previous="${response% *}"
+              status="${response##* }"
+          fi
+          if [ "$status" -ne 200 ] ; then
+              echo "error: unable to get release $major.$previous_minor info, HTTP status: $status, response: $previous"
+              exit 1
+          fi
+          curl --silent -L "https://dl.k8s.io/release/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
+          chmod a+rx /tmp/kubelet
+          /tmp/kubelet --version
+          worker_nodes=$(kind get nodes | grep worker)
+          for n in $worker_nodes; do
+              docker cp /tmp/kubelet $n:/usr/bin/kubelet
+              # DRAExtendedResource has been available since 1.34.
+              # We can do version-skew testing against Kubernetes >= 1.36
+              # where it is on by default, but only if we enable it
+              # explicitly for older kubelets.
+              if [[ $previous_minor -ge 34 ]]; then
+                  docker exec $n sed -i -e 's/\(KUBELET_EXTRA_ARGS=.*\)/\1 --feature-gates=DRAExtendedResource=true/' /etc/default/kubelet
+                  # Verify, intentionally not with --quiet.
+                  docker exec $n cat /etc/default/kubelet | grep DRAExtendedResource=true
+                  docker exec $n systemctl daemon-reload
+              fi
+              docker exec $n systemctl restart kubelet
+          done
+
+          # Running tests which only cover control plane behavior are not useful
+          # in a kubelet version skew job. We can filter them out by including
+          # only tests which have the DynamicResourceAllocation feature because
+          # only those cover kubelet behavior.
+          kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
+
+          KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+          GINKGO_E2E_PID=$!
+          wait "${GINKGO_E2E_PID}"
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-dra-integration
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-dra-integration
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: /(dra|e2e_dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - /bin/bash
+        - -xce
+        - |
+          # test/e2e_dra is a Go unit test with a dependency on local-up-cluster.sh
+          # and the the control plane binaries.
+          # We can run it via "make test" to get a JUnit file from gotestsum.
+          # The full log output gets enabled to see progress while the test runs
+          # and to debug potential cross-test interactions.
+          make WHAT="cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
+          make test WHAT=./test/e2e_dra FULL_LOG=y KUBE_PRUNE_JUNIT_TESTS=false KUBE_TIMEOUT=-timeout=30m KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-node-crio-dra
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-node-crio-dra
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=1
+        - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation }
+          && !Flaky && !Slow'
+        - --timeout=60m
+        - --skip-regex=
+        - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock
+          --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file=
+          --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
+          --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service"
+          --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config.yaml
+        command:
+        - runner.sh
+        env:
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
+        - name: GOPATH
+          value: /go
+        - name: KUBE_SSH_USER
+          value: core
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-node-crio-dra-alpha-beta-features
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-node-crio-dra-alpha-beta-features
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=1
+        - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault,DynamicResourceAllocation
+          } && !Flaky && !Slow'
+        - --timeout=60m
+        - --skip-regex=
+        - '--test-args=--feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false
+          --service-feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false --runtime-config=api/alpha=true,api/beta=true
+          --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio
+          --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true
+          --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service"
+          --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config.yaml
+        command:
+        - runner.sh
+        env:
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
+        - name: GOPATH
+          value: /go
+        - name: KUBE_SSH_USER
+          value: core
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-node-e2e-containerd-1-7-dra
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-node-e2e-containerd-1-7-dra
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resourceslice/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_).*\.(go|yaml)
+    spec:
+      containers:
+      - args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=1
+        - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation }
+          && !Flaky && !Slow'
+        - --timeout=60m
+        - --skip-regex=
+        - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+          --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file=
+          --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
+          --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service"
+          --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-node-e2e-containerd-2-0-dra
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    - base_ref: release/2.1
+      org: containerd
+      repo: containerd
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-node-e2e-containerd-2-0-dra
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resourceslice/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_).*\.(go|yaml)
+    spec:
+      containers:
+      - args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=1
+        - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation }
+          && !Flaky && !Slow'
+        - --timeout=60m
+        - --skip-regex=
+        - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+          --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file=
+          --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
+          --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service"
+          --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-node-e2e-containerd-1-7-dra-alpha-beta-features
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-node-e2e-containerd-1-7-dra-alpha-beta-features
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=1
+        - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault,DynamicResourceAllocation
+          } && !Flaky && !Slow'
+        - --timeout=60m
+        - --skip-regex=
+        - '--test-args=--feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false
+          --service-feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false --runtime-config=api/alpha=true,api/beta=true
+          --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+          --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file=
+          --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
+          --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service"
+          --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-node-e2e-containerd-2-0-dra-alpha-beta-features
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    - base_ref: release/2.1
+      org: containerd
+      repo: containerd
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-node-e2e-containerd-2-0-dra-alpha-beta-features
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resourceslice/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_).*\.(go|yaml)
+    spec:
+      containers:
+      - args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=1
+        - '--label-filter=DRA && Feature: isSubsetOf { OffByDefault,DynamicResourceAllocation
+          } && !Flaky && !Slow'
+        - --timeout=60m
+        - --skip-regex=
+        - '--test-args=--feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false
+          --service-feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false --runtime-config=api/alpha=true,api/beta=true
+          --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock
+          --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file=
+          --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
+          --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service"
+          --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-containerd-gce
+    decorate: true
+    decoration_config:
+      timeout: 1h45m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-containerd-gce
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --cluster=
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+        - --gcp-node-image=gci
+        - --gcp-zone=us-central1-b
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 6Gi
+          requests:
+            cpu: "4"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-node-e2e-containerd
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    max_concurrency: 12
+    name: pull-kubernetes-node-e2e-containerd
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --deployment=node
+        - --gcp-zone=us-central1-b
+        - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock
+          --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file=
+          --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
+          --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\":
+          \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+        - --node-tests=true
+        - --provider=gce
+        - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
+        - --timeout=65m
+        - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 6Gi
+          requests:
+            cpu: "4"
+            memory: 6Gi
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-node-e2e-containerd-ec2
+    decorate: true
+    extra_refs:
+    - base_ref: main
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+      repo: provider-aws-test-infra
+      workdir: true
+    labels:
+      preset-e2e-containerd-ec2: "true"
+    max_concurrency: 50
+    name: pull-kubernetes-node-e2e-containerd-ec2
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - hack/make-rules/test-e2e-node.sh
+        command:
+        - runner.sh
+        env:
+        - name: FOCUS
+          value: NodeConformance
+        - name: IMAGE_CONFIG_DIR
+          value: config
+        - name: IMAGE_CONFIG_FILE
+          value: aws-instance.yaml
+        - name: TEST_ARGS
+          value: --kubelet-flags="--cgroup-driver=systemd"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 6Gi
+          requests:
+            cpu: "4"
+            memory: 6Gi
+      serviceAccountName: node-e2e-tests
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-node-arm64-e2e-containerd-ec2
+    decorate: true
+    decoration_config:
+      timeout: 4h0m0s
+    extra_refs:
+    - base_ref: main
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+      repo: provider-aws-test-infra
+      workdir: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-e2e-containerd-ec2: "true"
+    max_concurrency: 50
+    name: pull-kubernetes-node-arm64-e2e-containerd-ec2
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - hack/make-rules/test-e2e-node.sh
+        command:
+        - runner.sh
+        env:
+        - name: FOCUS
+          value: NodeConformance
+        - name: USE_DOCKERIZED_BUILD
+          value: "true"
+        - name: TARGET_BUILD_ARCH
+          value: linux/arm64
+        - name: IMAGE_CONFIG_DIR
+          value: config
+        - name: IMAGE_CONFIG_FILE
+          value: aws-instance-arm64.yaml
+        - name: TEST_ARGS
+          value: --kubelet-flags="--cgroup-driver=systemd"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 10Gi
+          requests:
+            cpu: "7"
+            memory: 10Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: node-e2e-tests
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-node-arm64-e2e-containerd-serial-ec2
+    decorate: true
+    extra_refs:
+    - base_ref: main
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+      repo: provider-aws-test-infra
+      workdir: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-e2e-containerd-ec2: "true"
+    max_concurrency: 50
+    name: pull-kubernetes-node-arm64-e2e-containerd-serial-ec2
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - hack/make-rules/test-e2e-node.sh
+        command:
+        - runner.sh
+        env:
+        - name: FOCUS
+          value: \[Serial\]
+        - name: SKIP
+          value: \[Flaky\]|\[Slow\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+        - name: USE_DOCKERIZED_BUILD
+          value: "true"
+        - name: TARGET_BUILD_ARCH
+          value: linux/arm64
+        - name: IMAGE_CONFIG_DIR
+          value: config
+        - name: IMAGE_CONFIG_FILE
+          value: aws-instance-arm64-serial.yaml
+        - name: TEST_ARGS
+          value: --kubelet-flags="--cgroup-driver=systemd"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 10Gi
+          requests:
+            cpu: "7"
+            memory: 10Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: node-e2e-tests
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-node-arm64-ubuntu-serial-gce
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-node-arm64-ubuntu-serial-gce
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-a
+        - --parallelism=1
+        - --focus-regex=\[Serial\]
+        - --use-dockerized-build=true
+        - --target-build-arch=linux/arm64
+        - --skip-regex=\[Flaky\]|\[Slow\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:NodeSwap\]|\[Feature:HugePages\]|\[Feature:PodLevelResources\]
+        - '--test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock
+          --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file=
+          --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
+          --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\":
+          \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/arm/image-config-serial.yaml
+        - --timeout=180m
+        command:
+        - runner.sh
+        env:
+        - name: GOPATH
+          value: /go
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 6Gi
+          requests:
+            cpu: "4"
+            memory: 6Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-node-e2e-containerd-kubetest2
+    decorate: true
+    decoration_config:
+      timeout: 1h5m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/test-infra
+      repo: test-infra
+    labels:
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-node-e2e-containerd-kubetest2
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=8
+        - --focus-regex=\[NodeConformance\]
+        - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
+        - '--test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock
+          --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file=
+          --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/
+          --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\":
+          \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 6Gi
+          requests:
+            cpu: "4"
+            memory: 6Gi
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-node-e2e-containerd-serial-ec2
+    decorate: true
+    extra_refs:
+    - base_ref: main
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/provider-aws-test-infra
+      repo: provider-aws-test-infra
+      workdir: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-e2e-containerd-ec2: "true"
+    max_concurrency: 50
+    name: pull-kubernetes-node-e2e-containerd-serial-ec2
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - hack/make-rules/test-e2e-node.sh
+        command:
+        - runner.sh
+        env:
+        - name: FOCUS
+          value: \[Serial\]
+        - name: IMAGE_CONFIG_DIR
+          value: config
+        - name: IMAGE_CONFIG_FILE
+          value: aws-instance-serial.yaml
+        - name: SKIP
+          value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:PodLevelResources\]
+        - name: TEST_ARGS
+          value: --kubelet-flags="--cgroup-driver=systemd"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 10Gi
+          requests:
+            cpu: "7"
+            memory: 10Gi
+      serviceAccountName: node-e2e-tests
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce-cos-serial
+    decorate: true
+    decoration_config:
+      timeout: 11h20m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce-cos-serial
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --check-leaked-resources
+        - --provider=gce
+        - --gcp-region=us-central1
+        - --gcp-node-image=gci
+        - --timeout=660m
+        - --ginkgo-parallel=1
+        - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\]
+          --minStartupPods=8
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce-100-performance
+    decorate: true
+    decoration_config:
+      timeout: 2h0m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/perf-tests
+      repo: perf-tests
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-e2e-scalability-common: "true"
+      preset-e2e-scalability-presubmits: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    max_concurrency: 12
+    name: pull-kubernetes-e2e-gce-100-performance
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --cluster=
+        - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
+        - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0
+          --profiling --contention-profiling
+        - --env=KUBE_COS_INSTALL_CONTAINERD_VERSION=v2.1.5
+        - --env=KUBE_COS_INSTALL_RUNC_VERSION=v1.3.4
+        - --flush-mem-after-build=true
+        - --gcp-node-image=gci
+        - --gcp-nodes=100
+        - --gcp-project-type=scalability-project
+        - --gcp-zone=us-east1-b
+        - --provider=gce
+        - --tear-down-previous
+        - --env=CL2_ENABLE_DNS_PROGRAMMING=true
+        - --env=CL2_SCHEDULER_THROUGHPUT_THRESHOLD=0
+        - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true
+        - --env=CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD=99.5
+        - --test=false
+        - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+        - --test-cmd-args=cluster-loader2
+        - --test-cmd-args=--nodes=100
+        - --test-cmd-args=--provider=gce
+        - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
+        - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
+        - --test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true
+        - --test-cmd-args=--prometheus-scrape-kubelets=true
+        - --test-cmd-args=--prometheus-scrape-node-exporter
+        - --test-cmd-args=--report-dir=$(ARTIFACTS)
+        - --test-cmd-args=--testconfig=testing/load/config.yaml
+        - --test-cmd-args=--testconfig=testing/huge-service/config.yaml
+        - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
+        - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+        - --test-cmd-args=--testoverrides=./testing/overrides/load_throughput.yaml
+        - --test-cmd-name=ClusterLoaderV2
+        - --timeout=100m
+        - --use-logexporter
+        - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 14Gi
+          requests:
+            cpu: "6"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce-1.36-scale-performance-100
+    decorate: true
+    decoration_config:
+      timeout: 2h0m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kops
+      repo: kops
+      workdir: true
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/perf-tests
+      repo: perf-tests
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+    max_concurrency: 3
+    name: pull-kubernetes-e2e-gce-master-scale-performance-100
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./tests/e2e/scenarios/scalability/run-test.sh
+        command:
+        - runner.sh
+        env:
+        - name: KUBE_SSH_KEY_PATH
+          value: /etc/ssh-key-secret/ssh-private
+        - name: KUBE_SSH_USER
+          value: prow
+        - name: GOPATH
+          value: /home/prow/go
+        - name: CNI_PLUGIN
+          value: gce
+        - name: KUBE_NODE_COUNT
+          value: "100"
+        - name: CL2_LOAD_TEST_THROUGHPUT
+          value: "50"
+        - name: CL2_DELETE_TEST_THROUGHPUT
+          value: "50"
+        - name: CL2_RATE_LIMIT_POD_CREATION
+          value: "false"
+        - name: NODE_MODE
+          value: master
+        - name: KUBE_PROXY_MODE
+          value: nftables
+        - name: CONTROL_PLANE_COUNT
+          value: "1"
+        - name: CONTROL_PLANE_SIZE
+          value: c4-standard-32
+        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+          value: "true"
+        - name: CL2_ENABLE_DNS_PROGRAMMING
+          value: "true"
+        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+          value: "true"
+        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+          value: "99.5"
+        - name: CL2_ALLOWED_SLOW_API_CALLS
+          value: "1"
+        - name: ENABLE_PROMETHEUS_SERVER
+          value: "true"
+        - name: TEAR_DOWN_PROMETHEUS_SERVER
+          value: "false"
+        - name: PROMETHEUS_PVC_STORAGE_CLASS
+          value: ssd-csi
+        - name: CLOUD_PROVIDER
+          value: gce
+        - name: BOSKOS_RESOURCE_TYPE
+          value: scalability-project
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 16Gi
+          requests:
+            cpu: "5"
+            memory: 16Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: prow-build
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-kubemark-e2e-gce-big
+    decorate: true
+    decoration_config:
+      timeout: 2h0m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/perf-tests
+      repo: perf-tests
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-e2e-kubemark-common: "true"
+      preset-e2e-scalability-presubmits: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    max_concurrency: 12
+    name: pull-kubernetes-kubemark-e2e-gce-big
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --cluster=
+        - --flush-mem-after-build=true
+        - --gcp-master-size=n2-standard-4
+        - --gcp-node-size=e2-standard-8
+        - --gcp-nodes=7
+        - --gcp-project-type=scalability-project
+        - --gcp-zone=us-east1-b
+        - --kubemark
+        - --kubemark-nodes=500
+        - --kubemark-master-size=n2-standard-16
+        - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=160 --max-mutating-requests-inflight=0
+          --profiling --contention-profiling
+        - --provider=gce
+        - --tear-down-previous
+        - --test=false
+        - --test_args=--ginkgo.focus=xxxx
+        - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+        - --test-cmd-args=cluster-loader2
+        - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
+        - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
+        - --test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true
+        - --test-cmd-args=--nodes=500
+        - --test-cmd-args=--provider=kubemark
+        - --test-cmd-args=--report-dir=$(ARTIFACTS)
+        - --test-cmd-args=--testconfig=testing/load/config.yaml
+        - --test-cmd-args=--testconfig=testing/huge-service/config.yaml
+        - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
+        - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
+        - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+        - --test-cmd-args=--testoverrides=./testing/overrides/kubemark_500_nodes.yaml
+        - --test-cmd-name=ClusterLoaderV2
+        - --timeout=100m
+        - --use-logexporter
+        - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 16Gi
+          requests:
+            cpu: "6"
+            memory: 16Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-kubemark-e2e-gce-scale
+    decorate: true
+    decoration_config:
+      timeout: 18h20m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/perf-tests
+      repo: perf-tests
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-e2e-kubemark-common: "true"
+      preset-e2e-kubemark-gce-scale: "true"
+      preset-e2e-scalability-presubmits: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    max_concurrency: 1
+    name: pull-kubernetes-kubemark-e2e-gce-scale
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - --build=quick
+        - --cluster=
+        - --flush-mem-after-build=true
+        - --gcp-node-size=e2-standard-8
+        - --gcp-nodes=84
+        - --gcp-project-type=scalability-project
+        - --gcp-zone=us-east1-b
+        - --kubemark
+        - --kubemark-nodes=5000
+        - --kubemark-master-size=n2-standard-64
+        - --provider=gce
+        - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=640 --max-mutating-requests-inflight=0
+          --profiling --contention-profiling
+        - --test=false
+        - --test_args=--ginkgo.focus=xxxx
+        - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+        - --test-cmd-args=cluster-loader2
+        - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
+        - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
+        - --test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true
+        - --test-cmd-args=--nodes=5000
+        - --test-cmd-args=--provider=kubemark
+        - --test-cmd-args=--report-dir=$(ARTIFACTS)
+        - --test-cmd-args=--testconfig=testing/load/config.yaml
+        - --test-cmd-args=--testconfig=testing/huge-service/config.yaml
+        - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
+        - --test-cmd-name=ClusterLoaderV2
+        - --timeout=1080m
+        - --use-logexporter
+        - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 16Gi
+          requests:
+            cpu: "6"
+            memory: 16Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-gce-storage-selinux
+    decorate: true
+    decoration_config:
+      timeout: 2h30m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/kops
+      repo: kops
+    labels:
+      preset-dind-enabled: "true"
+      preset-k8s-ssh: "true"
+    name: pull-kubernetes-e2e-gce-storage-selinux
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - bash
+        - -xc
+        - |
+          make -C $GOPATH/src/k8s.io/kops test-e2e-install
+          kubetest2 kops -v=6 --cloud-provider=gce --up --down --build --env=KOPS_FEATURE_FLAGS=SELinuxMount \
+            --build-kubernetes=true --target-build-arch=linux/amd64 \
+            --admin-access=0.0.0.0/0 \
+            --kubernetes-feature-gates=SELinuxMount,SELinuxChangePolicy \
+            --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt \
+            --create-args "--image='rhel-cloud/rhel-9-v20240815' --channel=alpha --networking=cilium --set=cluster.spec.containerd.selinuxEnabled=true --set=cluster.spec.kubeControllerManager.controllers='*' --set=cluster.spec.kubeControllerManager.controllers=selinux-warning-controller --gce-service-account=default --set=spec.nodeProblemDetector.enabled=true --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+            --test=kops \
+            -- \
+            --ginkgo-args="--debug -v" \
+            --test-args="--master-os-distro=custom --node-os-distro=custom" \
+            --timeout=120m \
+            --focus-regex="\[Feature:SELinux\]" \
+            --skip-regex="\[Feature:Volumes\]|\[Driver:.nfs\]|\[Driver:.nfs3\]|\[Driver:.local\]|\[Feature:SELinuxMountReadWriteOncePodOnly\]" \
+            --use-built-binaries=true \
+            --parallel=1 # [Feature:SELinux] tests include serial ones
+        command:
+        - runner.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 14Gi
+          requests:
+            cpu: "4"
+            memory: 14Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: k8s-kops-test
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-cmd
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-cmd
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-cmd-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
+          value: "8"
+        - name: KUBE_TIMEOUT
+          value: -timeout=30m
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 20Gi
+          requests:
+            cpu: "7"
+            memory: 20Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-cmd-go-compatibility
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-cmd-go-compatibility
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-cmd-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: GO_VERSION
+          value: 1.26.2
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 15Gi
+          requests:
+            cpu: "6"
+            memory: 15Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-conformance-kind-ipv6-parallel
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    max_concurrency: 8
+    name: pull-kubernetes-conformance-kind-ipv6-parallel
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
+        - name: IP_FAMILY
+          value: ipv6
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
+          requests:
+            cpu: "4"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-dependencies
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-dependencies
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - make
+        - verify
+        command:
+        - runner.sh
+        env:
+        - name: WHAT
+          value: external-dependencies-version vendor vendor-licenses
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: main
+        resources:
+          limits:
+            cpu: "2"
+            memory: 1288490188800m
+          requests:
+            cpu: "2"
+            memory: 1288490188800m
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-integration
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-integration-dockerized.sh
+        command:
+        - runner.sh
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 20Gi
+          requests:
+            cpu: "7"
+            memory: 20Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-integration-race
+    decorate: true
+    decoration_config:
+      timeout: 1h30m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration-race
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-integration-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: KUBE_TIMEOUT
+          value: -timeout=30m
+        - name: KUBE_RACE
+          value: -race
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 20Gi
+          requests:
+            cpu: "7"
+            memory: 20Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-integration-go-compatibility
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration-go-compatibility
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-integration-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: GO_VERSION
+          value: 1.26.2
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "6"
+            memory: 15Gi
+          requests:
+            cpu: "6"
+            memory: 15Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: LABEL_FILTER
+          value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-ipv6
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind-ipv6
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: LABEL_FILTER
+          value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
+        - name: PARALLEL
+          value: "true"
+        - name: DOCKER_IN_DOCKER_IPV6_ENABLED
+          value: "true"
+        - name: IP_FAMILY
+          value: ipv6
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-conformance-kind-ga-only
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 2h20m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-conformance-kind-ga-only
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":false,"AllBeta":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/alpha":"false", "api/beta":"false"}'
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9Gi
+          requests:
+            cpu: "4"
+            memory: 9Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-conformance-kind-ga-only-parallel
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-conformance-kind-ga-only-parallel
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":false,"AllBeta":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/alpha":"false", "api/beta":"false"}'
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9Gi
+          requests:
+            cpu: "4"
+            memory: 9Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-beta-features
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind-beta-features
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: ^pkg/features/
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"AllBeta":true}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/beta":"true", "api/ga":"true"}'
+        - name: LABEL_FILTER
+          value: 'Feature: isSubsetOf OffByDefault && !Alpha && !Deprecated && !Slow
+            && !Disruptive && !Flaky'
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-beta-enabled
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind-beta-enabled
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: ^pkg/features/
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"AllBeta":true}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/beta":"true", "api/ga":"true"}'
+        - name: FOCUS
+        - name: SKIP
+        - name: LABEL_FILTER
+          value: 'Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky'
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-beta-enabled-conformance
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind-beta-enabled-conformance
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"AllBeta":true}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/beta":"true", "api/ga":"true"}'
+        - name: FOCUS
+        - name: SKIP
+        - name: LABEL_FILTER
+          value: Conformance && !Deprecated && !Slow && !Disruptive && !Flaky
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-alpha-beta-features
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind-alpha-beta-features
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: ^pkg/features/
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/all":"true"}'
+        - name: LABEL_FILTER
+          value: 'Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive
+            && !Flaky'
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-alpha-beta-enabled
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind-alpha-beta-enabled
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: ^pkg/features/
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/all":"true"}'
+        - name: FOCUS
+        - name: SKIP
+        - name: LABEL_FILTER
+          value: 'Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky'
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-alpha-beta-enabled-conformance
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h0m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind-alpha-beta-enabled-conformance
+    optional: true
+    path_alias: k8s.io/kubernetes
+    run_if_changed: ^pkg/features/
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz
+          - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/all":"true"}'
+        - name: FOCUS
+        - name: SKIP
+        - name: LABEL_FILTER
+          value: Conformance && !Deprecated && !Slow && !Disruptive && !Flaky
+        - name: PARALLEL
+          value: "true"
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 9000Mi
+          requests:
+            cpu: "7"
+            memory: 9000Mi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-e2e-kind-alpha-beta-features-race
+    decorate: true
+    decoration_config:
+      grace_period: 15m0s
+      timeout: 1h40m0s
+    labels:
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-e2e-kind-alpha-beta-features-race
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - wrapper.sh
+        - bash
+        - -c
+        - |
+          curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && curl -sSL https://github.com/kubernetes/test-infra/raw/master/experiment/kind-race-e2e-k8s.sh >/tmp/kind-race-e2e-k8s.sh && chmod u+x /tmp/kind-race-e2e-k8s.sh && /tmp/kind-race-e2e-k8s.sh
+        env:
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/all":"true"}'
+        - name: LABEL_FILTER
+          value: 'Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive
+            && !Flaky'
+        - name: PARALLEL
+          value: "true"
+        - name: KUBE_E2E_TEST_ARGS
+          value: -logcheck-data-races
+        - name: KUBE_RACE
+          value: -race
+        - name: KUBE_CGO_OVERRIDES
+          value: kube-apiserver kube-controller-manager kube-scheduler
+        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 16Gi
+          requests:
+            cpu: "7"
+            memory: 16Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-unit
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    name: pull-kubernetes-unit
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - make
+        - test
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 16Gi
+          requests:
+            cpu: "7"
+            memory: 16Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsGroup: 2010
+        runAsUser: 2001
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-unit-go-compatibility
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    name: pull-kubernetes-unit-go-compatibility
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - make
+        - test
+        env:
+        - name: GO_VERSION
+          value: 1.26.2
+        - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
+          value: auto
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "4"
+            memory: 36Gi
+          requests:
+            cpu: "4"
+            memory: 36Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsGroup: 2010
+        runAsUser: 2001
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-typecheck
+    decorate: true
+    name: pull-kubernetes-typecheck
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - verify
+        command:
+        - make
+        env:
+        - name: WHAT
+          value: typecheck
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: main
+        resources:
+          limits:
+            cpu: "5"
+            memory: 19Gi
+          requests:
+            cpu: "5"
+            memory: 19Gi
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-update
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-update
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/update-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: EXCLUDE_TYPECHECK
+          value: "y"
+        - name: EXCLUDE_GODEP
+          value: "y"
+        - name: KUBE_VERIFY_GIT_BRANCH
+          value: release-1.36
+        - name: REPO_DIR
+          value: /workspace/k8s.io/kubernetes
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 12Gi
+          requests:
+            cpu: "7"
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-kubernetes-verify
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-verify
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/verify-dockerized.sh
+        command:
+        - runner.sh
+        env:
+        - name: EXCLUDE_TYPECHECK
+          value: "y"
+        - name: EXCLUDE_GODEP
+          value: "y"
+        - name: KUBE_VERIFY_GIT_BRANCH
+          value: release-1.36
+        - name: REPO_DIR
+          value: /workspace/k8s.io/kubernetes
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          limits:
+            cpu: "7"
+            memory: 24Gi
+          requests:
+            cpu: "7"
+            memory: 24Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-linter-hints
+    decorate: true
+    name: pull-kubernetes-linter-hints
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - verify
+        - WHAT=golangci-lint-pr-hints
+        command:
+        - make
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "5"
+            memory: 12Gi
+          requests:
+            cpu: "5"
+            memory: 12Gi
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: eks-prow-build-cluster
+    context: pull-kubernetes-e2e-capz-windows
+    decorate: true
+    decoration_config:
+      timeout: 2h30m0s
+    extra_refs:
+    - base_ref: main
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      repo: cluster-api-provider-azure
+    - base_ref: master
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      repo: cloud-provider-azure
+    - base_ref: master
+      org: kubernetes-sigs
+      path_alias: k8s.io/windows-testing
+      repo: windows-testing
+      workdir: true
+    labels:
+      preset-azure-community: "true"
+      preset-capz-containerd-2-0-latest: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-windows-common-pull: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    name: pull-kubernetes-e2e-capz-windows
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - env
+        - KUBERNETES_VERSION=latest-1.36
+        - ./capz/run-capz-e2e.sh
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 9Gi
+          requests:
+            cpu: "2"
+            memory: 9Gi
+        securityContext:
+          privileged: true
+      serviceAccountName: azure
+  kubernetes/perf-tests:
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-perf-tests-clusterloader2
+    decorate: true
+    decoration_config:
+      timeout: 2h0m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-e2e-scalability-common: "true"
+      preset-e2e-scalability-presubmits: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    max_concurrency: 3
+    name: pull-perf-tests-clusterloader2
+    path_alias: k8s.io/perf-tests
+    run_if_changed: ^clusterloader2/.*$
+    spec:
+      containers:
+      - args:
+        - --cluster=
+        - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
+        - --extract=ci/latest
+        - --gcp-nodes=100
+        - --gcp-project-type=scalability-project
+        - --gcp-zone=us-east1-b
+        - --provider=gce
+        - --tear-down-previous
+        - --env=CL2_ENABLE_DNS_PROGRAMMING=true
+        - --env=CL2_SCHEDULER_THROUGHPUT_THRESHOLD=0
+        - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true
+        - --env=CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD=99.5
+        - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0
+          --profiling --contention-profiling
+        - --test=false
+        - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+        - --test-cmd-args=cluster-loader2
+        - --test-cmd-args=--nodes=100
+        - --test-cmd-args=--prometheus-scrape-node-exporter
+        - --test-cmd-args=--provider=gce
+        - --test-cmd-args=--report-dir=$(ARTIFACTS)
+        - --test-cmd-args=--testconfig=testing/load/config.yaml
+        - --test-cmd-args=--testconfig=testing/huge-service/config.yaml
+        - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
+        - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
+        - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+        - --test-cmd-args=--testoverrides=./testing/overrides/load_throughput.yaml
+        - --test-cmd-name=ClusterLoaderV2
+        - --timeout=100m
+        - --use-logexporter
+        - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+  - always_run: false
+    branches:
+    - release-1.36
+    cluster: k8s-infra-prow-build
+    context: pull-perf-tests-clusterloader2-kubemark
+    decorate: true
+    decoration_config:
+      timeout: 2h0m0s
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      path_alias: k8s.io/release
+      repo: release
+    labels:
+      preset-dind-enabled: "true"
+      preset-e2e-kubemark-common: "true"
+      preset-e2e-scalability-presubmits: "true"
+      preset-k8s-ssh: "true"
+      preset-service-account: "true"
+    max_concurrency: 3
+    name: pull-perf-tests-clusterloader2-kubemark
+    path_alias: k8s.io/perf-tests
+    run_if_changed: ^clusterloader2/.*$
+    spec:
+      containers:
+      - args:
+        - --cluster=
+        - --extract=ci/latest
+        - --gcp-master-size=n2-standard-2
+        - --gcp-node-size=e2-standard-4
+        - --gcp-nodes=4
+        - --gcp-project-type=scalability-project
+        - --gcp-zone=us-east1-b
+        - --kubemark
+        - --kubemark-nodes=100
+        - --kubemark-master-size=n2-standard-8
+        - --env=KUBEMARK_APISERVER_TEST_ARGS=--max-requests-inflight=80 --max-mutating-requests-inflight=0
+          --profiling --contention-profiling
+        - --provider=gce
+        - --tear-down-previous
+        - --test=false
+        - --test_args=--ginkgo.focus=xxxx
+        - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+        - --test-cmd-args=cluster-loader2
+        - --test-cmd-args=--nodes=100
+        - --test-cmd-args=--prometheus-scrape-node-exporter
+        - --test-cmd-args=--provider=kubemark
+        - --env=CL2_ENABLE_DNS_PROGRAMMING=true
+        - --env=CL2_ENABLE_API_AVAILABILITY_MEASUREMENT=true
+        - --test-cmd-args=--report-dir=$(ARTIFACTS)
+        - --test-cmd-args=--testconfig=testing/load/config.yaml
+        - --test-cmd-args=--testconfig=testing/huge-service/config.yaml
+        - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
+        - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
+        - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+        - --test-cmd-args=--testoverrides=./testing/overrides/kubemark_load_throughput.yaml
+        - --test-cmd-name=ClusterLoaderV2
+        - --timeout=100m
+        - --use-logexporter
+        - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        name: ""
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "2"
+            memory: 6Gi
+        securityContext:
+          privileged: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -3997,54 +3997,55 @@ presubmits:
             cpu: "7"
             memory: 10Gi
       serviceAccountName: node-e2e-tests
-  - always_run: false
-    branches:
-    - release-1.36
-    cluster: k8s-infra-prow-build
-    context: pull-kubernetes-e2e-gce-cos-serial
-    decorate: true
-    decoration_config:
-      timeout: 11h20m0s
-    extra_refs:
-    - base_ref: master
-      org: kubernetes
-      path_alias: k8s.io/release
-      repo: release
-    labels:
-      preset-dind-enabled: "true"
-      preset-k8s-ssh: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
-      preset-service-account: "true"
-    name: pull-kubernetes-e2e-gce-cos-serial
-    optional: true
-    path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-      - args:
-        - --build=quick
-        - --check-leaked-resources
-        - --provider=gce
-        - --gcp-region=us-central1
-        - --gcp-node-image=gci
-        - --timeout=660m
-        - --ginkgo-parallel=1
-        - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\]
-          --minStartupPods=8
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
-        name: ""
-        resources:
-          limits:
-            cpu: "4"
-            memory: 14Gi
-          requests:
-            cpu: "4"
-            memory: 14Gi
-        securityContext:
-          privileged: true
+  # TODO Clean this up later
+  # - always_run: false
+  #   branches:
+  #   - release-1.36
+  #   cluster: k8s-infra-prow-build
+  #   context: pull-kubernetes-e2e-gce-cos-serial
+  #   decorate: true
+  #   decoration_config:
+  #     timeout: 11h20m0s
+  #   extra_refs:
+  #   - base_ref: master
+  #     org: kubernetes
+  #     path_alias: k8s.io/release
+  #     repo: release
+  #   labels:
+  #     preset-dind-enabled: "true"
+  #     preset-k8s-ssh: "true"
+  #     preset-pull-kubernetes-e2e: "true"
+  #     preset-pull-kubernetes-e2e-gce: "true"
+  #     preset-service-account: "true"
+  #   name: pull-kubernetes-e2e-gce-cos-serial
+  #   optional: true
+  #   path_alias: k8s.io/kubernetes
+  #   spec:
+  #     containers:
+  #     - args:
+  #       - --build=quick
+  #       - --check-leaked-resources
+  #       - --provider=gce
+  #       - --gcp-region=us-central1
+  #       - --gcp-node-image=gci
+  #       - --timeout=660m
+  #       - --ginkgo-parallel=1
+  #       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]|\[sig-cloud-provider-gcp\]
+  #         --minStartupPods=8
+  #       command:
+  #       - runner.sh
+  #       - /workspace/scenarios/kubernetes_e2e.py
+  #       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+  #       name: ""
+  #       resources:
+  #         limits:
+  #           cpu: "4"
+  #           memory: 14Gi
+  #         requests:
+  #           cpu: "4"
+  #           memory: 14Gi
+  #       securityContext:
+  #         privileged: true
   - always_run: false
     branches:
     - release-1.36

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -285,7 +285,7 @@ periodics:
 - annotations:
     testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
     testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-1.36-informing
-    testgrid-tab-name: ci-kind-dra
+    testgrid-tab-name: ci-kind-dra-1-36
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -377,7 +377,7 @@ periodics:
 - annotations:
     testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-job-config-errors
-    testgrid-tab-name: ci-kind-dra-n-1
+    testgrid-tab-name: ci-kind-dra-n-1-1-36
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -504,7 +504,7 @@ periodics:
 - annotations:
     testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-job-config-errors
-    testgrid-tab-name: ci-kind-dra-n-2
+    testgrid-tab-name: ci-kind-dra-n-2-1-36
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -631,7 +631,7 @@ periodics:
 - annotations:
     testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-job-config-errors
-    testgrid-tab-name: ci-kind-dra-n-3
+    testgrid-tab-name: ci-kind-dra-n-3-1-36
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -758,7 +758,7 @@ periodics:
 - annotations:
     testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
     testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-release-job-config-errors
-    testgrid-tab-name: ci-dra-integration
+    testgrid-tab-name: ci-dra-integration-1-36
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -803,7 +803,7 @@ periodics:
 - annotations:
     testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
     testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-cri-o, sig-release-1.36-informing
-    testgrid-tab-name: ci-node-crio-dra
+    testgrid-tab-name: ci-node-crio-dra-1-36
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
@@ -864,7 +864,7 @@ periodics:
     testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
     testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-containerd,
       sig-release-1.36-informing
-    testgrid-tab-name: ci-node-e2e-containerd-1-7-dra
+    testgrid-tab-name: ci-node-e2e-containerd-1-7-dra-1-36
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
@@ -919,7 +919,7 @@ periodics:
     testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
     testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-containerd,
       sig-release-1.36-informing
-    testgrid-tab-name: ci-node-e2e-containerd-2-0-dra
+    testgrid-tab-name: ci-node-e2e-containerd-2-0-dra-1-36
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:

--- a/config/testgrids/kubernetes/sig-release/config.yaml
+++ b/config/testgrids/kubernetes/sig-release/config.yaml
@@ -5,6 +5,8 @@ dashboard_groups:
   dashboard_names:
   - sig-release-master-blocking
   - sig-release-master-informing
+  - sig-release-1.36-blocking
+  - sig-release-1.36-informing
   - sig-release-1.35-blocking
   - sig-release-1.35-informing
   - sig-release-1.34-blocking
@@ -25,6 +27,8 @@ dashboard_groups:
 dashboards:
 - name: sig-release-master-blocking
 - name: sig-release-master-informing
+- name: sig-release-1.36-blocking
+- name: sig-release-1.36-informing
 - name: sig-release-1.35-blocking
 - name: sig-release-1.35-informing
 - name: sig-release-1.34-blocking

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -1213,10 +1213,12 @@ func TestKubernetesReleaseBlockingJobsCIPolicy(t *testing.T) {
 
 	// TODO: finish eliminating this list and remove the known-failures logic
 	knownFailures := map[string]bool{
+		"ci-kubernetes-e2e-gce-cos-alphafeatures-beta":    false,
 		"ci-kubernetes-e2e-gce-cos-alphafeatures-master":  false,
 		"ci-kubernetes-e2e-gce-cos-alphafeatures-stable1": false,
 		"ci-kubernetes-e2e-gce-cos-alphafeatures-stable2": false,
 		"ci-kubernetes-e2e-gce-cos-alphafeatures-stable3": false,
+		"ci-kubernetes-e2e-gce-cos-reboot-beta":           false,
 		"ci-kubernetes-e2e-gce-cos-reboot-master":         false,
 		"ci-kubernetes-e2e-gce-cos-reboot-stable1":        false,
 		"ci-kubernetes-e2e-gce-cos-reboot-stable2":        false,

--- a/config/tests/jobs/policy/presubmit-jobs.yaml
+++ b/config/tests/jobs/policy/presubmit-jobs.yaml
@@ -41,6 +41,10 @@ optional_and_run_if_changed:
         - release-1.35
       run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
     - name: pull-kubernetes-dra-integration
+      branches:
+        - release-1.36
+      run_if_changed: /(dra|e2e_dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+    - name: pull-kubernetes-dra-integration
       skip_branches:
         - release-\d+\.\d+
       run_if_changed: /(dra|e2e_dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
@@ -113,6 +117,10 @@ optional_and_run_if_changed:
         - release-1.35
       run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
     - name: pull-kubernetes-kind-dra
+      branches:
+        - release-1.36
+      run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+    - name: pull-kubernetes-kind-dra
       skip_branches:
         - release-\d+\.\d+
       run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
@@ -129,6 +137,10 @@ optional_and_run_if_changed:
         - release-1.35
       run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
     - name: pull-kubernetes-kind-dra-all
+      branches:
+        - release-1.36
+      run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+    - name: pull-kubernetes-kind-dra-all
       skip_branches:
         - release-\d+\.\d+
       run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
@@ -141,6 +153,10 @@ optional_and_run_if_changed:
         - release-1.35
       run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
     - name: pull-kubernetes-kind-dra-n-1
+      branches:
+        - release-1.36
+      run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+    - name: pull-kubernetes-kind-dra-n-1
       skip_branches:
         - release-\d+\.\d+
       run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
@@ -152,6 +168,10 @@ optional_and_run_if_changed:
       branches:
         - release-1.35
       run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+    - name: pull-kubernetes-kind-dra-n-2
+      branches:
+        - release-1.36
+      run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
     - name: pull-kubernetes-kind-dra-n-2
       skip_branches:
         - release-\d+\.\d+
@@ -160,6 +180,10 @@ optional_and_run_if_changed:
       branches:
         - release-1.35
       run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|pkg/apis/resource|api/resource)/.*\.(go|yaml)
+    - name: pull-kubernetes-kind-dra-n-3
+      branches:
+        - release-1.36
+      run_if_changed: /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
     - name: pull-kubernetes-kind-dra-n-3
       skip_branches:
         - release-\d+\.\d+


### PR DESCRIPTION
/hold

Generate testgrid jobs for v1.35 (similar to https://github.com/kubernetes/test-infra/pull/36018)

An overview of added jobs and intervals:

```bash
# yq -o=json './config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml' | jq -c '.periodics | sort_by(.interval[1:2], .interval, .name) | .[] | if has("interval") then {"interval": .interval, "fork-per-release-periodic-interval": .annotations["fork-per-release-periodic-interval"], "name": .name} else {"cron": .cron, "fork-per-release-cron": .annotations["fork-per-release-cron"], "name": .name} end'

{"cron":"0 0-23/2 * * *","fork-per-release-cron":"0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *, 0 14-23/24 * * *","name":"ci-kubernetes-e2e-gce-device-plugin-gpu-1-36"}
{"cron":"0 */6 * * *","fork-per-release-cron":"0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *, 0 8-20/24 * * *","name":"ci-kubernetes-e2e-gce-scale-performance-100-1-36"}
{"cron":"0 0/2 * * *","fork-per-release-cron":"0 1/6 * * *, 0 2 * * *, 0 4 * * *, 0 6 * * *","name":"ci-kubernetes-integration-ppc64le-1-36"}
{"cron":"0 3 * * *","fork-per-release-cron":"0 7 * * *, 0 13 * * *, 0 17 * * *, 0 21 * * *","name":"ci-kubernetes-kubemark-500-gce-1-36"}
{"cron":"10 3-23/4 * * *","fork-per-release-cron":"20 0-23/4 * * *, 30 1-23/4 * * *, 40 4-23/4 * * *, 50 2-23/4 * * *","name":"ci-kubernetes-ppc64le-conformance-latest-1-36"}
{"cron":"0 3/2 * * *","fork-per-release-cron":"0 1/6 * * *, 0 5 * * *, 0 6 * * *, 0 7 * * *","name":"ci-kubernetes-unit-ppc64le-1-36"}
{"interval":"24h","fork-per-release-periodic-interval":null,"name":"ci-dra-integration-1-36"}
{"interval":"24h","fork-per-release-periodic-interval":null,"name":"ci-kind-dra-1-36"}
{"interval":"24h","fork-per-release-periodic-interval":null,"name":"ci-kind-dra-n-1-1-36"}
{"interval":"24h","fork-per-release-periodic-interval":null,"name":"ci-kind-dra-n-2-1-36"}
{"interval":"24h","fork-per-release-periodic-interval":null,"name":"ci-kind-dra-n-3-1-36"}
{"interval":"24h","fork-per-release-periodic-interval":null,"name":"ci-node-crio-dra-1-36"}
{"interval":"24h","fork-per-release-periodic-interval":null,"name":"ci-node-e2e-containerd-1-7-dra-1-36"}
{"interval":"24h","fork-per-release-periodic-interval":null,"name":"ci-node-e2e-containerd-2-0-dra-1-36"}
{"interval":"1h","fork-per-release-periodic-interval":null,"name":"ci-kubernetes-build-1-36"}
{"interval":"1h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-e2e-gce-cos-alphafeatures-beta"}
{"interval":"1h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-e2e-gce-cos-default-beta"}
{"interval":"1h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-e2e-gce-cos-reboot-beta"}
{"interval":"1h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-e2e-gce-cos-serial-beta"}
{"interval":"1h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-e2e-gce-cos-slow-beta"}
{"interval":"1h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-e2e-kind-1-36"}
{"interval":"1h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-e2e-kind-ipv6-1-36"}
{"interval":"1h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-kind-e2e-json-logging-1-36"}
{"interval":"1h","fork-per-release-periodic-interval":null,"name":"ci-kubernetes-unit-1-36"}
{"interval":"2h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-cmd-1-36"}
{"interval":"2h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-integration-1-36"}
{"interval":"2h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-integration-arm64-1-36"}
{"interval":"2h","fork-per-release-periodic-interval":"2h 6h 24h","name":"ci-kubernetes-verify-1-36"}
{"interval":"3h","fork-per-release-periodic-interval":null,"name":"ci-kubernetes-e2e-capz-master-windows-1-36"}
{"interval":"3h","fork-per-release-periodic-interval":null,"name":"ci-kubernetes-gce-conformance-latest-1-36"}
```

cc: @dims @xmudrii 