### PR TITLE
use an available 1.36 image tag instead of a non-existent 1.36 image tag

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -23,7 +23,7 @@ periodics:
       - name: KUBE_TIMEOUT
         value: -timeout=300s
       - name: KUBE_RACE
-      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -61,7 +61,7 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
-      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -119,7 +119,7 @@ periodics:
           --test=ginkgo -- --test-package-dir ci --test-package-marker $MARKER_VERSION --focus-regex='\[Conformance\]'
       command:
       - runner.sh
-      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -163,7 +163,7 @@ periodics:
         \; --test-package-marker=$MARKER_VERSION \; --focus-regex='\[Conformance\]'
       command:
       - runner.sh
-      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -224,7 +224,7 @@ periodics:
       - runner.sh
       - kubetest2
       - gce
-      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -271,7 +271,7 @@ periodics:
         value: Conformance && !Slow && !Disruptive && !Flaky
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -363,7 +363,7 @@ periodics:
         wait "${GINKGO_E2E_PID}"
       command:
       - runner.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -490,7 +490,7 @@ periodics:
         wait "${GINKGO_E2E_PID}"
       command:
       - runner.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -617,7 +617,7 @@ periodics:
         wait "${GINKGO_E2E_PID}"
       command:
       - runner.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -744,7 +744,7 @@ periodics:
         wait "${GINKGO_E2E_PID}"
       command:
       - runner.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -789,7 +789,7 @@ periodics:
         # and to debug potential cross-test interactions.
         make WHAT="cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
         make test WHAT=./test/e2e_dra FULL_LOG=y KUBE_PRUNE_JUNIT_TESTS=false KUBE_TIMEOUT=-timeout=30m KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -851,7 +851,7 @@ periodics:
         value: /go
       - name: KUBE_SSH_USER
         value: core
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -906,7 +906,7 @@ periodics:
       - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
       command:
       - runner.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -964,7 +964,7 @@ periodics:
       - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
       command:
       - runner.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1012,7 +1012,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1057,7 +1057,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1099,7 +1099,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1143,7 +1143,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1187,7 +1187,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1302,7 +1302,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1399,7 +1399,7 @@ periodics:
         value: gce
       - name: BOSKOS_RESOURCE_TYPE
         value: scalability-project
-      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1441,7 +1441,7 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
-      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1478,7 +1478,7 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
-      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1516,7 +1516,7 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
-      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1561,7 +1561,7 @@ periodics:
         value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1608,7 +1608,7 @@ periodics:
         value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1640,7 +1640,7 @@ periodics:
     - command:
       - make
       - test
-      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1687,7 +1687,7 @@ periodics:
         value: /workspace/k8s.io/kubernetes
       - name: TYPECHECK_SERIAL
         value: "true"
-      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1738,7 +1738,7 @@ periodics:
       - env
       - KUBERNETES_VERSION=latest-1.36
       - ./capz/run-capz-e2e.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       name: ""
       resources:
         limits:
@@ -1772,7 +1772,7 @@ presubmits:
         env:
         - name: GOFLAGS
           value: -tags=fieldsv1string
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -1807,7 +1807,7 @@ presubmits:
         env:
         - name: GOFLAGS
           value: -tags=fieldsv1string
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -1847,7 +1847,7 @@ presubmits:
           value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -1890,7 +1890,7 @@ presubmits:
           value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -1922,7 +1922,7 @@ presubmits:
         - ./../test-infra/experiment/dependencies/update-dependencies-and-run-tests.sh
         - --test-mode
         - unit
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -1970,7 +1970,7 @@ presubmits:
           value: "true"
         - name: GO_VERSION
           value: devel
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2004,7 +2004,7 @@ presubmits:
         env:
         - name: GO_VERSION
           value: devel
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2058,7 +2058,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2107,7 +2107,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2160,7 +2160,7 @@ presubmits:
         env:
         - name: BOOTSTRAP_FETCH_TEST_INFRA
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2218,7 +2218,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2271,7 +2271,7 @@ presubmits:
             --parallel=30
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2328,7 +2328,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2382,7 +2382,7 @@ presubmits:
             --parallel=1
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2437,7 +2437,7 @@ presubmits:
             --parallel=1
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2489,7 +2489,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2540,7 +2540,7 @@ presubmits:
         - runner.sh
         - kubetest2
         - gce
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2625,7 +2625,7 @@ presubmits:
           wait "${GINKGO_E2E_PID}"
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2722,7 +2722,7 @@ presubmits:
           value: -race
         - name: KUBE_CGO_OVERRIDES
           value: kube-apiserver kube-controller-manager kube-scheduler
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2818,7 +2818,7 @@ presubmits:
           value: -race
         - name: KUBE_CGO_OVERRIDES
           value: kube-apiserver kube-controller-manager kube-scheduler
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -2952,7 +2952,7 @@ presubmits:
           wait "${GINKGO_E2E_PID}"
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3086,7 +3086,7 @@ presubmits:
           wait "${GINKGO_E2E_PID}"
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3220,7 +3220,7 @@ presubmits:
           wait "${GINKGO_E2E_PID}"
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3261,7 +3261,7 @@ presubmits:
           # and to debug potential cross-test interactions.
           make WHAT="cmd/kube-apiserver cmd/kube-scheduler cmd/kube-controller-manager cmd/kube-proxy cmd/kubelet"
           make test WHAT=./test/e2e_dra FULL_LOG=y KUBE_PRUNE_JUNIT_TESTS=false KUBE_TIMEOUT=-timeout=30m KUBETEST_IN_DOCKER=true CONTAINER_RUNTIME_ENDPOINT=/var/run/docker/containerd/containerd.sock KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/linux/amd64" KUBERNETES_SERVER_CACHE_DIR=/tmp/cache-dir
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3320,7 +3320,7 @@ presubmits:
           value: /go
         - name: KUBE_SSH_USER
           value: core
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3378,7 +3378,7 @@ presubmits:
           value: /go
         - name: KUBE_SSH_USER
           value: core
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3429,7 +3429,7 @@ presubmits:
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3483,7 +3483,7 @@ presubmits:
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3535,7 +3535,7 @@ presubmits:
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3591,7 +3591,7 @@ presubmits:
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3642,7 +3642,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3690,7 +3690,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3732,7 +3732,7 @@ presubmits:
           value: aws-instance.yaml
         - name: TEST_ARGS
           value: --kubelet-flags="--cgroup-driver=systemd"
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3782,7 +3782,7 @@ presubmits:
           value: aws-instance-arm64.yaml
         - name: TEST_ARGS
           value: --kubelet-flags="--cgroup-driver=systemd"
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3834,7 +3834,7 @@ presubmits:
           value: aws-instance-arm64-serial.yaml
         - name: TEST_ARGS
           value: --kubelet-flags="--cgroup-driver=systemd"
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3892,7 +3892,7 @@ presubmits:
         env:
         - name: GOPATH
           value: /go
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3942,7 +3942,7 @@ presubmits:
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -3987,7 +3987,7 @@ presubmits:
           value: \[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:DynamicResourceAllocation\]|\[Feature:PodLevelResources\]
         - name: TEST_ARGS
           value: --kubelet-flags="--cgroup-driver=systemd"
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4035,7 +4035,7 @@ presubmits:
   #       command:
   #       - runner.sh
   #       - /workspace/scenarios/kubernetes_e2e.py
-  #       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+  #       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
   #       name: ""
   #       resources:
   #         limits:
@@ -4116,7 +4116,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4202,7 +4202,7 @@ presubmits:
           value: gce
         - name: BOSKOS_RESOURCE_TYPE
           value: scalability-project
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4282,7 +4282,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4356,7 +4356,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4410,7 +4410,7 @@ presubmits:
             --parallel=1 # [Feature:SELinux] tests include serial ones
         command:
         - runner.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4444,7 +4444,7 @@ presubmits:
           value: "8"
         - name: KUBE_TIMEOUT
           value: -timeout=30m
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4477,7 +4477,7 @@ presubmits:
           value: 1.26.2
         - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
           value: auto
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4516,7 +4516,7 @@ presubmits:
           value: ipv6
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4548,7 +4548,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: main
         resources:
           limits:
@@ -4576,7 +4576,7 @@ presubmits:
         - ./hack/jenkins/test-integration-dockerized.sh
         command:
         - runner.sh
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4612,7 +4612,7 @@ presubmits:
           value: -timeout=30m
         - name: KUBE_RACE
           value: -race
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4645,7 +4645,7 @@ presubmits:
           value: 1.26.2
         - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
           value: auto
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4682,7 +4682,7 @@ presubmits:
           value: 'Feature: isEmpty && !Slow && !Disruptive && !Flaky'
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4724,7 +4724,7 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: ipv6
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4762,7 +4762,7 @@ presubmits:
           value: '{"AllAlpha":false,"AllBeta":false}'
         - name: RUNTIME_CONFIG
           value: '{"api/alpha":"false", "api/beta":"false"}'
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4801,7 +4801,7 @@ presubmits:
           value: '{"api/alpha":"false", "api/beta":"false"}'
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4845,7 +4845,7 @@ presubmits:
             && !Disruptive && !Flaky'
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4890,7 +4890,7 @@ presubmits:
           value: 'Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky'
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4934,7 +4934,7 @@ presubmits:
           value: Conformance && !Deprecated && !Slow && !Disruptive && !Flaky
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -4978,7 +4978,7 @@ presubmits:
             && !Flaky'
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -5023,7 +5023,7 @@ presubmits:
           value: 'Feature: isEmpty && !Deprecated && !Slow && !Disruptive && !Flaky'
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -5068,7 +5068,7 @@ presubmits:
           value: Conformance && !Deprecated && !Slow && !Disruptive && !Flaky
         - name: PARALLEL
           value: "true"
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -5117,7 +5117,7 @@ presubmits:
           value: -race
         - name: KUBE_CGO_OVERRIDES
           value: kube-apiserver kube-controller-manager kube-scheduler
-        image: gcr.io/k8s-staging-test-infra/krte:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/krte:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -5143,7 +5143,7 @@ presubmits:
       - command:
         - make
         - test
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -5177,7 +5177,7 @@ presubmits:
           value: 1.26.2
         - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
           value: auto
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -5208,7 +5208,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: main
         resources:
           limits:
@@ -5243,7 +5243,7 @@ presubmits:
           value: release-1.36
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         imagePullPolicy: Always
         name: ""
         resources:
@@ -5281,7 +5281,7 @@ presubmits:
           value: release-1.36
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         imagePullPolicy: Always
         name: ""
         resources:
@@ -5309,7 +5309,7 @@ presubmits:
         - WHAT=golangci-lint-pr-hints
         command:
         - make
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -5357,7 +5357,7 @@ presubmits:
         - env
         - KUBERNETES_VERSION=latest-1.36
         - ./capz/run-capz-e2e.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -5429,7 +5429,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:
@@ -5501,7 +5501,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
         name: ""
         resources:
           limits:


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/issues/34675

all jobs are currently failing, e.g. https://testgrid.k8s.io/sig-release-1.36-blocking#kind-ipv6-1.36