### PR TITLE
Enable Lambda DRA GPU presubmit to run on all PRs

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
@@ -18,7 +18,7 @@ presubmits:
   - name: pull-dra-driver-nvidia-gpu-e2e-lambda-gpu
     cluster: k8s-infra-prow-build
     optional: true
-    always_run: false
+    always_run: true
     max_concurrency: 1
     skip_branches:
     - release-\d+\.\d+


### PR DESCRIPTION
Change pull-dra-driver-nvidia-gpu-e2e-lambda-gpu to always_run: true so every PR to dra-driver-nvidia-gpu gets GPU e2e test coverage on Lambda Cloud. Keep optional: true so a failure does not block merges (Lambda GPU capacity is not guaranteed).

xref: https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1013

/hold we need hold for `dra-driver-nvidia-gpu/pull/1013` to land first.

