### PR TITLE
Fix Lambda CI for arm64 GPU instances (GH200)

### DIFF
--- a/experiment/lambda/lib/lambda-common.sh
+++ b/experiment/lambda/lib/lambda-common.sh
@@ -85,18 +85,33 @@ lambda_rsync_to() {
   rsync -a -e "ssh ${LAMBDA_SSH_OPTS[*]} -i ${LAMBDA_SSH_KEY}" "$@"
 }
 
+# Detect the Lambda instance's CPU architecture (call after lambda_launch).
+# Sets LAMBDA_ARCH to "amd64" or "arm64".
+lambda_detect_arch() {
+  local uname_m
+  uname_m=$(lambda_remote uname -m)
+  case "${uname_m}" in
+    x86_64)  LAMBDA_ARCH="amd64" ;;
+    aarch64) LAMBDA_ARCH="arm64" ;;
+    *)       LAMBDA_ARCH="amd64"; echo "WARNING: unknown arch '${uname_m}', defaulting to amd64" ;;
+  esac
+  echo "Detected Lambda instance architecture: ${LAMBDA_ARCH} (uname -m: ${uname_m})"
+}
+
 # Download k8s release binaries to a local directory
 # Usage: lambda_download_k8s /tmp/k8s-bins [version]
+# Requires: LAMBDA_ARCH set (call lambda_detect_arch first)
 lambda_download_k8s() {
   local dest="$1"
   local version="${2:-$(curl -sSfL https://dl.k8s.io/release/stable.txt)}"
+  local arch="${LAMBDA_ARCH:-amd64}"
   mkdir -p "${dest}"
   for bin in kubeadm kubelet kubectl; do
-    curl -sSfL "https://dl.k8s.io/release/${version}/bin/linux/amd64/${bin}" \
+    curl -sSfL "https://dl.k8s.io/release/${version}/bin/linux/${arch}/${bin}" \
       -o "${dest}/${bin}"
     chmod +x "${dest}/${bin}"
   done
-  echo "Downloaded k8s ${version} binaries to ${dest}"
+  echo "Downloaded k8s ${version} binaries (${arch}) to ${dest}"
 }
 
 # Collect artifacts from the Lambda instance
@@ -108,10 +123,11 @@ lambda_collect_artifacts() {
   lambda_rsync_to "ubuntu@${LAMBDA_INSTANCE_IP}:${remote_path}" "${local_path}/" || true
 }
 
-# Convenience: init everything (install CLI, create key, register cleanup, launch)
+# Convenience: init everything (install CLI, create key, register cleanup, launch, detect arch)
 lambda_init_and_launch() {
   lambda_install_cli
   lambda_create_ssh_key
   lambda_register_cleanup
   lambda_launch
+  lambda_detect_arch
 }

--- a/experiment/lambda/lib/setup-k8s-node.sh
+++ b/experiment/lambda/lib/setup-k8s-node.sh
@@ -37,11 +37,14 @@ sudo apt-get install -y -qq \
   iptables iproute2 conntrack ebtables kmod socat ethtool \
   jq rsync psmisc curl wget git
 
+# --- Detect architecture ---
+ARCH=$(uname -m | sed -e 's,x86_64,amd64,' -e 's,aarch64,arm64,')
+
 # --- CNI plugins ---
 CNI_VERSION=$(curl -s https://api.github.com/repos/containernetworking/plugins/releases/latest \
   | grep tag_name | cut -d'"' -f4)
 sudo mkdir -p /opt/cni/bin
-curl -sL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" \
+curl -sL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz" \
   | sudo tar -C /opt/cni/bin -xz
 
 # --- CNI networking ---


### PR DESCRIPTION
Lambda Cloud can provision arm64 instances (e.g., GH200 Grace Hopper). The shared Lambda CI library was hardcoding amd64 for k8s binary downloads and CNI plugin downloads, causing failures on arm64.

- lambda-common.sh: add lambda_detect_arch() which SSHs to the instance and maps uname -m to amd64/arm64. Called automatically by lambda_init_and_launch(). lambda_download_k8s() now uses LAMBDA_ARCH instead of hardcoded amd64.
- setup-k8s-node.sh: detect architecture locally via uname -m and use it for CNI plugin download URL.

Fixes: pull-dra-driver-nvidia-gpu-e2e-lambda-gpu failure on gpu_1x_gh200
Logs: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_dra-driver-nvidia-gpu/1021/pull-dra-driver-nvidia-gpu-e2e-lambda-gpu/2042933739641638912