### PR TITLE
dranet: trigger post-dranet-image on semver tags

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-dranet.yaml
+++ b/config/jobs/image-pushing/k8s-staging-dranet.yaml
@@ -1,10 +1,10 @@
 postsubmits:
   kubernetes-sigs/dranet:
     - name: post-dranet-image
-      skip_branches:
-        # do not run on dependabot branches, these exist prior to merge
-        # only merged code should trigger these jobs
-        - '^dependabot'
+      branches:
+        - ^main$
+        # Build semver tags, too
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-network-dranet, sig-k8s-infra-gcb


### PR DESCRIPTION
Extend the post-dranet-image job to also trigger on semver tags. Related to https://github.com/kubernetes-sigs/dranet/issues/140.
/hold