### PR TITLE
configure ci jobs to purge fastly cache

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -41,9 +41,9 @@ periodics:
     repo: kubernetes
     base_ref: master
   labels:
-    preset-service-account: "true"
     preset-dind-enabled: "true"
   spec:
+    serviceAccountName: prow-build
     containers:
     - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
@@ -55,7 +55,14 @@ periodics:
       - --allow-dup=false
       - --bucket=k8s-release-dev
       - --registry=gcr.io/k8s-staging-ci-images
-      - --extra-version-markers=k8s-master
+      env:
+        - name: FASTLY_SERVICE_NAME
+          value: dl.k8s.io
+        - name: FASTLY_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: fastly-purge-token
+              key: token
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
@@ -86,9 +93,9 @@ periodics:
     repo: kubernetes
     base_ref: master
   labels:
-    preset-service-account: "true"
     preset-dind-enabled: "true"
   spec:
+    serviceAccountName: prow-build
     containers:
     - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
@@ -101,6 +108,14 @@ periodics:
       - --fast
       - --bucket=k8s-release-dev
       # docker-in-docker needs privileged mode
+      env:
+        - name: FASTLY_SERVICE_NAME
+          value: dl.k8s.io
+        - name: FASTLY_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: fastly-purge-token
+              key: token
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
This PR applies the Fastly krel change we have in prod to our CI jobs.

The plan is to cache markers and purge them from cache on new builds & make gs://k8s-release-dev private.

Also, k8s-master marker is not being used anywhere. https://github.com/search?q=repo%3Akubernetes%2Ftest-infra+k8s-master.txt&type=code


Do we want to move this build job to the trusted cluster? The fastly credential being used isn't sensitive as it's only read + purge(can't modify the service)


/hold