### PR TITLE
Kops - Use BPF for calico+cilium on nftables distros

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -517,7 +517,7 @@ def generate_grid():
                         extra_flags.extend([
                             "--topology=public",
                         ])
-                    if 'rhel10' in distro:
+                    if 'rhel10' in distro or 'rocky10' in distro:
                         # https://github.com/kubernetes/kops/issues/17915
                         extra_flags.extend([
                             "--set=cluster.spec.kubeProxy.proxyMode=nftables",
@@ -525,6 +525,14 @@ def generate_grid():
                         if networking == 'amazon-vpc':
                             extra_flags.extend([
                                 "--set=cluster.spec.networking.amazonVPC.env=ENABLE_NFTABLES=true",
+                            ])
+                        if 'cilium' in networking:
+                            extra_flags.extend([
+                                "--set=cluster.spec.networking.cilium.enableBPFMasquerade=true",
+                            ])
+                        if networking == 'calico':
+                            extra_flags.extend([
+                                "--set=cluster.spec.networking.calico.bpfEnabled=true",
                             ])
                     results.append(
                         build_test(cloud="aws",
@@ -558,6 +566,19 @@ def generate_grid():
                         extra_flags.extend([
                             "--set=cluster.spec.cloudProvider.gce.useStartupScript=true"
                         ])
+                    if 'rhel10' in distro or 'rocky10' in distro:
+                        # https://github.com/kubernetes/kops/issues/17915
+                        extra_flags.extend([
+                            "--set=cluster.spec.kubeProxy.proxyMode=nftables",
+                        ])
+                        if 'cilium' in networking:
+                            extra_flags.extend([
+                                "--set=cluster.spec.networking.cilium.enableBPFMasquerade=true",
+                            ])
+                        if networking == 'calico':
+                            extra_flags.extend([
+                                "--set=cluster.spec.networking.calico.bpfEnabled=true",
+                            ])
                     results.append(
                         build_test(cloud="gce",
                                    runs_per_day=2,
@@ -1406,6 +1427,10 @@ def generate_distros():
                 "--node-size=m6g.large",
                 "--control-plane-size=m6g.large"
             ])
+        if 'rhel10' in distro or 'rocky10' in distro:
+            extra_flags.extend([
+                "--set=cluster.spec.networking.cilium.enableBPFMasquerade=true",
+            ])
         results.append(
             build_test(distro=distro_short,
                        networking='cilium',
@@ -1433,6 +1458,11 @@ def generate_presubmits_distros():
                 "--node-size=m6g.large",
                 "--control-plane-size=m6g.large"
             ])
+        cilium_extra_flags = list(extra_flags)
+        if 'rhel10' in distro or 'rocky10' in distro:
+            cilium_extra_flags.extend([
+                "--set=cluster.spec.networking.cilium.enableBPFMasquerade=true",
+            ])
         results.append(
             presubmit_test(
                 distro=distro_short,
@@ -1441,7 +1471,7 @@ def generate_presubmits_distros():
                 kops_channel='alpha',
                 name=f"pull-kops-aws-distro-{distro}",
                 tab_name=f"e2e-aws-{distro}",
-                extra_flags=extra_flags,
+                extra_flags=cilium_extra_flags,
                 always_run=False,
             )
         )
@@ -1472,6 +1502,11 @@ def generate_presubmits_distros():
             extra_flags.extend([
                 "--set=cluster.spec.cloudProvider.gce.useStartupScript=true"
             ])
+        cilium_extra_flags = list(extra_flags)
+        if 'rhel10' in distro or 'rocky10' in distro:
+            cilium_extra_flags.extend([
+                "--set=cluster.spec.networking.cilium.enableBPFMasquerade=true",
+            ])
         results.append(
             presubmit_test(
                 cloud="gce",
@@ -1481,7 +1516,7 @@ def generate_presubmits_distros():
                 kops_channel='alpha',
                 name=f"pull-kops-gce-distro-{distro}",
                 tab_name=f"e2e-gce-{distro}",
-                extra_flags=extra_flags,
+                extra_flags=cilium_extra_flags,
                 always_run=False,
             )
         )

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -786,7 +786,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-rhel9
 
-# {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-distro-rhel10arm64
   cron: '9 3-23/8 * * *'
   labels:
@@ -816,7 +816,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260217-arm64-0-Hourly2-GP3' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260217-arm64-0-Hourly2-GP3' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -843,7 +843,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: rhel10arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -917,7 +917,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-rocky9
 
-# {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-distro-rocky10arm64
   cron: '31 5-23/8 * * *'
   labels:
@@ -947,7 +947,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -974,7 +974,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: rocky10arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -1619,7 +1619,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-aws-kindnet-rhel9
 
-  # {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-aws-distro-rhel10arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1650,7 +1650,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260217-arm64-0-Hourly2-GP3' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260217-arm64-0-Hourly2-GP3' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1679,7 +1679,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: rhel10arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -1889,7 +1889,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-aws-kindnet-rocky9
 
-  # {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-aws-distro-rocky10arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1920,7 +1920,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1949,7 +1949,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: rocky10arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -4199,7 +4199,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-gce-ipalias-ubuntuminimal2404arm64
 
-  # {"cloud": "gce", "distro": "rhel10", "extra_flags": "--gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "gce", "distro": "rhel10", "extra_flags": "--gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-gce-distro-rhel10
     cluster: k8s-infra-prow-build
     branches:
@@ -4230,7 +4230,7 @@ presubmits:
             --up --build --down \
             --cloud-provider=gce \
             --admin-access=0.0.0.0/0 \
-            --create-args="--image='rhel-cloud/rhel-10-v20260310' --channel=alpha --networking=cilium --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+            --create-args="--image='rhel-cloud/rhel-10-v20260310' --channel=alpha --networking=cilium --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -4259,7 +4259,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: gce
       test.kops.k8s.io/distro: rhel10
-      test.kops.k8s.io/extra_flags: --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true
+      test.kops.k8s.io/extra_flags: --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -4335,7 +4335,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-gce-ipalias-rhel10
 
-  # {"cloud": "gce", "distro": "rocky10arm64", "extra_flags": "--gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "gce", "distro": "rocky10arm64", "extra_flags": "--gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-gce-distro-rocky10arm64
     cluster: k8s-infra-prow-build
     branches:
@@ -4366,7 +4366,7 @@ presubmits:
             --up --build --down \
             --cloud-provider=gce \
             --admin-access=0.0.0.0/0 \
-            --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260313' --channel=alpha --networking=cilium --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+            --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260313' --channel=alpha --networking=cilium --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -4395,7 +4395,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: gce
       test.kops.k8s.io/distro: rocky10arm64
-      test.kops.k8s.io/extra_flags: --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true
+      test.kops.k8s.io/extra_flags: --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -4471,7 +4471,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-gce-ipalias-rocky10arm64
 
-  # {"cloud": "gce", "distro": "rocky10", "extra_flags": "--gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "gce", "distro": "rocky10", "extra_flags": "--gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-gce-distro-rocky10
     cluster: k8s-infra-prow-build
     branches:
@@ -4502,7 +4502,7 @@ presubmits:
             --up --build --down \
             --cloud-provider=gce \
             --admin-access=0.0.0.0/0 \
-            --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260313' --channel=alpha --networking=cilium --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+            --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260313' --channel=alpha --networking=cilium --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -4531,7 +4531,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: gce
       test.kops.k8s.io/distro: rocky10
-      test.kops.k8s.io/extra_flags: --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true
+      test.kops.k8s.io/extra_flags: --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium


### PR DESCRIPTION
followup to https://github.com/kubernetes/kops/pull/18179

We're still seeing clusters fail to validate when using RHEL10 and calico/cilium:

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-grid-calico-rhel10arm64-k33/2041267262635118592/artifacts/cluster-info/kube-system/calico-node-n6fzd/calico-node.log

```
2026-04-06 21:58:31.953 [INFO][39112] felix/int_dataplane.go 866: Failed to remove BPF connect-time load balancer, ignoring. error=error querying cgroup 11 : no such file or directory
error querying cgroup 15 : no such file or directory
error querying cgroup 20 : no such file or directory
error querying cgroup 10 : no such file or directory
error querying cgroup 14 : no such file or directory
error querying cgroup 19 : no such file or directory
2026-04-06 21:58:32.300 [INFO][39112] felix/int_dataplane.go 2955: File /var/lib/calico/bpf_ct_map_size does not exist
2026-04-06 21:58:32.300 [INFO][39112] felix/ipsets.go 179: Queueing IP set for creation family="inet" setID="all-ipam-pools" setType="hash:net"
2026-04-06 21:58:32.300 [INFO][39112] felix/ipsets.go 179: Queueing IP set for creation family="inet" setID="masq-ipam-pools" setType="hash:net"
2026-04-06 21:58:32.300 [INFO][39112] felix/int_dataplane.go 1129: IPIP enabled, starting thread to keep tunnel configuration in sync.
2026-04-06 21:58:32.301 [INFO][39112] felix/int_dataplane.go 1369: Registering to report health.
2026-04-06 21:58:32.304 [INFO][39112] felix/route_mgr.go 479: Tunnel device thread started. device="tunl0" ipVersion=0x4 mtu=8981 tunnelDevice="tunl0" wait=10s xsumBroken=false
2026-04-06 21:58:32.304 [INFO][39112] felix/int_dataplane.go 2471: attempted to modprobe nf_conntrack_proto_sctp error=exit status 1 output=""
2026-04-06 21:58:32.304 [INFO][39112] felix/int_dataplane.go 2474: Making sure IPv4 forwarding is enabled.
```

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-aws-distro-rhel10arm64/2043406219795763200/artifacts/cluster-info/kube-system/cilium-gkhlw/cilium-agent.log

`time=2026-04-12T19:34:12.916555953Z level=error msg="iptables rules full reconciliation failed, will retry another one later" module=agent.datapath.iptables error="failed to install rules: cannot install static proxy rules: unable to run 'iptables -t raw -A CILIUM_PRE_raw -m mark --mark 0x00000200/0x00000f00 -m comment --comment cilium: NOTRACK for proxy traffic -j CT --notrack' iptables command: exit status 4 stderr=\"Warning: Extension mark revision 0 not supported, missing kernel module?\\nWarning: Extension comment revision 0 not supported, missing kernel module?\\nWarning: Extension CT revision 0 not supported, missing kernel module?\\niptables v1.8.8 (nf_tables):  RULE_APPEND failed (No such file or directory): rule in chain CILIUM_PRE_raw\\n\""`

Both CNIs were still trying to use iptables. Rather than load `nft_compat`, lets set these cluster spec fields to use bpf instead of iptables. Eventually we should consider setting these fields by default for new clusters.

should fix the majority of these jobs: https://storage.googleapis.com/k8s-metrics/failures-latest.html?include=kops.*%28rhel10%7Crocky10%29&sort=name&asc=1

I'll look into the remaining CNIs in the next batch of fixes.

Written with assistance from Opus 4.6.

/cc @hakman