### PR TITLE
Add presubmit jobs tests and linting for sig-security tool srctl 

### DIFF
--- a/config/jobs/kubernetes/sig-security/srctl-tests.yaml
+++ b/config/jobs/kubernetes/sig-security/srctl-tests.yaml
@@ -1,0 +1,56 @@
+---
+presubmits:
+  kubernetes/sig-security:
+    - name: pull-sig-security-srctl-tests
+      cluster: eks-prow-build-cluster
+      annotations:
+        testgrid-dashboards: sig-security-srctl
+        testgrid-create-test-group: "true"
+        description: Run unit tests for srctl
+      run_if_changed: "^sig-security-tooling/srctl/"
+      branches:
+        - main
+      decorate: true
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.25@sha256:ed520ab5bed37ce887012c050ced60f7d52dfcd212e3dc6fdd8951e9c4e25c1a
+            command: ['go']
+            workingDir: sig-security-tooling/srctl 
+            args: ['test', '-v', '-cover', './...']
+            resources:
+              limits:
+                cpu: 1
+                memory: "256Mi"
+              requests:
+                cpu: 1
+                memory: "256Mi"
+
+    - name: pull-sig-security-srctl-lint
+      cluster: eks-prow-build-cluster
+      annotations:
+        testgrid-dashboards: sig-security-srctl
+        testgrid-create-test-group: "true"
+        description: Run linters for srctl
+      run_if_changed: "^sig-security-tooling/srctl/"
+      branches:
+        - main
+      decorate: true
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.25@sha256:ed520ab5bed37ce887012c050ced60f7d52dfcd212e3dc6fdd8951e9c4e25c1a
+            command:
+              - /bin/bash
+              - -c
+              - |
+                set -euo pipefail
+                cd sig-security-tooling/srctl
+                go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+                export PATH=$PATH:$(go env GOPATH)/bin
+                golangci-lint run ./...
+            resources:
+              limits:
+                cpu: 1
+                memory: "512Mi"
+              requests:
+                cpu: 1
+                memory: "512Mi"


### PR DESCRIPTION
Issue: [tooling: run tests and linters with prow for srctl #175
](https://github.com/kubernetes/sig-security/issues/175)

Assignment details: In the recent sig-security tooling meeting it was decided this issue was being re-assigned so it would get done and I would take this issue on if bleon-ethical did not express interest to pick it back up by today. I am a little early but if Benjamin comes on help would certainly be appreciated. Closing this PR should close [PR #36409](https://github.com/kubernetes/test-infra/pull/36409), [PR #36431](https://github.com/kubernetes/test-infra/pull/36431), and the above issue.

Work Done:
- created two presubmit jobs for when sig-security/sig-security-tooling/srctl dir is changed
- the official golang docker image mirrored on the aws public ecr registry was used
- the golang image was sha pinned to version 1.25
- golangci-lint was setup from source using go install

Special Note: The ecr golang image was used instead of the e2e kubekins image because that image is way oversized for the tasks here of running a few small golang unit tests and running a linting tool and the ecr doesn't impose the rate limiting problems that docker hub does on the kubernetes project. Oversized images mean more code surface for vulnerabilities as well as more resources to both fetch and use the image. The long term concern with this requiring manual image updating currently as the generic image auto-bumper won't work with this though a tool can be developed for this purpose and the manual work is very minimal.

Work Not Done:
- I have not test up a local prow testing environment yet so while I am confident the yaml is valid and the jobs seem to match up with existing jobs, until I do that I can't be 100% confident in the jobs.

I am leaving this a draft right now considering the lack of a testing run yet but the jobs should be good I think and review would be appreciated.

/assign