### PR TITLE
Add top-level lambda TestGrid dashboard group

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
@@ -33,7 +33,7 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/test-infra
     annotations:
-      testgrid-dashboards: sig-node-gpu
+      testgrid-dashboards: sig-node-gpu, lambda-gpu-presubmits
       testgrid-tab-name: pull-dra-driver-nvidia-gpu-lambda
       description: "DRA GPU e2e tests on Lambda Cloud for dra-driver-nvidia-gpu PRs"
     spec:
@@ -64,7 +64,7 @@ periodics:
   labels:
     preset-lambda-credential: "true"
   annotations:
-    testgrid-dashboards: sig-node-gpu
+    testgrid-dashboards: sig-node-gpu, lambda-gpu-periodics
     testgrid-tab-name: ci-dra-driver-nvidia-gpu-lambda
     description: "Periodic DRA GPU e2e tests on Lambda Cloud"
   extra_refs:

--- a/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
@@ -25,7 +25,7 @@ presubmits:
     labels:
       preset-lambda-credential: "true"
     annotations:
-      testgrid-dashboards: sig-node-gpu
+      testgrid-dashboards: sig-node-gpu, lambda-gpu-presubmits
       testgrid-tab-name: pull-lambda-device-plugin-gpu
       description: "Runs [Feature:GPUDevicePlugin] e2e tests on a Lambda Cloud GPU instance"
     decorate: true
@@ -65,7 +65,7 @@ periodics:
   labels:
     preset-lambda-credential: "true"
   annotations:
-    testgrid-dashboards: sig-node-gpu
+    testgrid-dashboards: sig-node-gpu, lambda-gpu-periodics
     testgrid-tab-name: ci-lambda-device-plugin-gpu
     description: "Runs [Feature:GPUDevicePlugin] e2e tests on a Lambda Cloud GPU instance"
   decorate: true

--- a/config/testgrids/lambda/lambda.yaml
+++ b/config/testgrids/lambda/lambda.yaml
@@ -1,0 +1,15 @@
+#
+# Start dashboards
+#
+dashboards:
+- name: lambda-gpu-periodics
+- name: lambda-gpu-presubmits
+
+#
+# Start dashboard groups
+#
+dashboard_groups:
+- name: lambda
+  dashboard_names:
+  - lambda-gpu-periodics
+  - lambda-gpu-presubmits

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -58,6 +58,7 @@ var (
 		"gardener",
 		"jetstack",
 		"kubevirt",
+		"lambda",
 	}
 	orgs = []string{
 		"conformance",


### PR DESCRIPTION
Add a top-level **lambda** TestGrid dashboard group (mirroring the existing **amazon** pattern) to give Lambda Cloud GPU CI jobs their own home in TestGrid.

- **New file:** `config/testgrids/lambda/lambda.yaml` — defines the `lambda` dashboard group with two sub-dashboards:
  - `lambda-gpu-periodics`
  - `lambda-gpu-presubmits`
- **Updated annotations** on all four Lambda jobs to appear on both `sig-node-gpu` (existing) and the new lambda dashboards

Hierarchy:
```
lambda (dashboard group)
├── lambda-gpu-periodics
│   ├── ci-lambda-device-plugin-gpu           (kubernetes/kubernetes, every 6h)
│   └── ci-dra-driver-nvidia-gpu-lambda       (kubernetes-sigs/dra-driver-nvidia-gpu, every 6h)
└── lambda-gpu-presubmits
    ├── pull-lambda-device-plugin-gpu          (kubernetes/kubernetes PRs)
    └── pull-dra-driver-nvidia-gpu-lambda      (kubernetes-sigs/dra-driver-nvidia-gpu PRs)
```