### PR TITLE
Fix arm64 cross-compilation in Lambda GPU CI

### DIFF
--- a/experiment/lambda/e2e-test.sh
+++ b/experiment/lambda/e2e-test.sh
@@ -31,12 +31,13 @@ lambda_init_and_launch
 # --- Build k8s binaries ---
 git fetch --tags --depth 100 origin 2>/dev/null || true
 make \
-  WHAT="cmd/kubeadm cmd/kubelet cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/v2/ginkgo"
+  WHAT="cmd/kubeadm cmd/kubelet cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/v2/ginkgo" \
+  KUBE_BUILD_PLATFORMS="linux/${LAMBDA_ARCH}"
 
 # --- Transfer binaries to Lambda instance ---
 lambda_remote mkdir -p /tmp/k8s-bins
-lambda_rsync_to _output/local/go/bin/{kubeadm,kubelet,kubectl} "ubuntu@${LAMBDA_INSTANCE_IP}:/tmp/k8s-bins/"
-lambda_rsync_to _output/local/go/bin/{e2e.test,ginkgo} "ubuntu@${LAMBDA_INSTANCE_IP}:/tmp/"
+lambda_rsync_to _output/local/bin/linux/${LAMBDA_ARCH}/{kubeadm,kubelet,kubectl} "ubuntu@${LAMBDA_INSTANCE_IP}:/tmp/k8s-bins/"
+lambda_rsync_to _output/local/bin/linux/${LAMBDA_ARCH}/{e2e.test,ginkgo} "ubuntu@${LAMBDA_INSTANCE_IP}:/tmp/"
 
 # --- Set up single-node k8s cluster with GPU support ---
 # No CDI, no Docker, no extra labels needed for device-plugin.


### PR DESCRIPTION
The make command was building binaries for the host platform (amd64), so when Lambda provisions an arm64 instance (e.g. GH200) the amd64 ELF binaries fail to execute.

Two fixes:
1. Pass KUBE_BUILD_PLATFORMS="linux/${LAMBDA_ARCH}" to make so binaries are built for the target architecture.
2. Update rsync source paths from _output/local/go/bin/ (a symlink that always resolves to the host platform) to the explicit platform- qualified path _output/local/bin/linux/${LAMBDA_ARCH}/, which works correctly for both native and cross-compilation.