### PR TITLE
Fix TLS and network robustness for Lambda GPU CI

### DIFF
--- a/experiment/lambda/e2e-test.sh
+++ b/experiment/lambda/e2e-test.sh
@@ -43,10 +43,17 @@ lambda_rsync_to _output/local/go/bin/{e2e.test,ginkgo} "ubuntu@${LAMBDA_INSTANCE
 lambda_remote bash -s < "${SCRIPT_DIR}/lib/setup-k8s-node.sh"
 
 # --- Deploy NVIDIA device plugin and wait for GPU capacity ---
+# Download manifest on Prow side (reliable network) and transfer to Lambda instance.
+# This avoids TLS issues on some Lambda instances when fetching from raw.githubusercontent.com.
+DEVICE_PLUGIN_MANIFEST="/tmp/nvidia-device-plugin.yml"
+curl -sSfL -o "${DEVICE_PLUGIN_MANIFEST}" \
+  https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.1/deployments/static/nvidia-device-plugin.yml
+lambda_rsync_to "${DEVICE_PLUGIN_MANIFEST}" "ubuntu@${LAMBDA_INSTANCE_IP}:/tmp/"
+
 lambda_remote bash -s <<'EOF'
 set -eux
 export KUBECONFIG=$HOME/.kube/config
-kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.1/deployments/static/nvidia-device-plugin.yml
+kubectl apply -f /tmp/nvidia-device-plugin.yml
 kubectl -n kube-system rollout status daemonset/nvidia-device-plugin-daemonset --timeout=120s
 
 # Wait for GPU capacity to appear on the node

--- a/experiment/lambda/lib/lambda-common.sh
+++ b/experiment/lambda/lib/lambda-common.sh
@@ -86,9 +86,18 @@ lambda_remote() {
   ssh "${LAMBDA_SSH_OPTS[@]}" -i "${LAMBDA_SSH_KEY}" "ubuntu@${LAMBDA_INSTANCE_IP}" "$@"
 }
 
-# Rsync files to the Lambda instance
+# Rsync files to the Lambda instance (with retry for transient SSH failures)
 lambda_rsync_to() {
-  rsync -a -e "ssh ${LAMBDA_SSH_OPTS[*]} -i ${LAMBDA_SSH_KEY}" "$@"
+  local attempt
+  for attempt in 1 2 3; do
+    if rsync -a -e "ssh ${LAMBDA_SSH_OPTS[*]} -i ${LAMBDA_SSH_KEY}" "$@"; then
+      return 0
+    fi
+    echo "rsync attempt ${attempt} failed, retrying in 5s..." >&2
+    sleep 5
+  done
+  echo "rsync failed after 3 attempts" >&2
+  return 1
 }
 
 # Detect the Lambda instance's CPU architecture (call after lambda_launch).


### PR DESCRIPTION
Download the NVIDIA device plugin manifest on the Prow runner side (which has reliable TLS) instead of fetching it from within the Lambda instance via kubectl, avoiding x509 certificate errors on some Lambda instances. Also add retry logic (3 attempts, 5s backoff) to lambda_rsync_to() to handle transient SSH connection resets.