### PR TITLE
Revert the CPU capacity increase from #36780

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -365,7 +365,6 @@ periodics:
               make install-deployer-tf
 
               export TF_VAR_powervs_system_type=s1022
-              export TF_VAR_controlplane_powervs_processors=1
               kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
                 --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \


### PR DESCRIPTION
The increase in the CPU capacity didn't affect the flake rate of the testcase, other approaches may be required to mitigate the flakey nature of `[sig-storage] CSI Mock volume attach When CSIDriver AttachRequired changes from true to false should cleanup VolumeAttachment properly [Slow]`