### PR TITLE
sig-scalability: update pull-kubernetes-gce-master-scale-performance-5000 

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -448,6 +448,24 @@ presubmits:
         securityContext:
           privileged: true
         env:
+        - name: CL2_ENABLE_INFORMER_LATENCY_TEST
+          value: "true"
+        - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
+          value: "21474836480"
+        - name: CL2_EXECSERVICE_CPU_REQUESTS
+          value: "4"
+        - name: CL2_EXECSERVICE_MEMORY_REQUESTS
+          value: "8Gi"
+        # Override for 1.5GB pod resource size
+        - name: CL2_DAEMONSET_POD_PAYLOAD_SIZE
+          value: "6000"
+        - name: CL2_DEPLOYMENT_POD_PAYLOAD_SIZE
+          value: "6000"
+        - name: CL2_STATEFULSET_POD_PAYLOAD_SIZE
+          value: "6000"
+        - name: CL2_JOB_POD_PAYLOAD_SIZE
+          value: "6000"
+        #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
         - name: KUBE_SSH_KEY_PATH
           value: /etc/ssh-key-secret/ssh-private
         - name: KUBE_SSH_USER
@@ -470,6 +488,8 @@ presubmits:
           value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-96"
+        - name: ADDONS_NODE_SIZE
+          value: "c3-standard-44"
         - name: KUBE_PROXY_MODE
           value: "nftables"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
@@ -495,10 +515,10 @@ presubmits:
         resources:
           requests:
             cpu: 7
-            memory: 25Gi
+            memory: "32Gi"
           limits:
             cpu: 7
-            memory: 25Gi
+            memory: "32Gi"
 
   kubernetes/perf-tests:
   - name: pull-perf-tests-benchmark-kube-dns


### PR DESCRIPTION
`pull-kubernetes-gce-master-scale-performance-5000` job now matches `pull-perf-tests-gce-master-scale-performance-5000`


note sure how to test the updated job.