### PR TITLE
images: drop GO_VERSION from cloudbuild.yaml, clarify GO_VERSION

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -21,8 +21,9 @@ FROM debian:bookworm
 # arg that specifies the image name (for debugging)
 ARG IMAGE_ARG
 
-# arg that specifies the go version to install.
-# empty value specifies the latest version.
+# Overrides the Go version to install.
+# Unset GO_VERSION means we will respect .go-version in the kubernetes repo
+# based on K8S_BRANCH.
 ARG GO_VERSION
 # which Kubernetes branch we're building for
 ARG K8S_BRANCH=master

--- a/images/krte/cloudbuild.yaml
+++ b/images/krte/cloudbuild.yaml
@@ -4,7 +4,6 @@ steps:
     args:
     - build
     - --tag=gcr.io/$PROJECT_ID/krte:$_GIT_TAG-$_CONFIG
-    - --build-arg=GO_VERSION=$_GO_VERSION
     - --build-arg=K8S_BRANCH=$_K8S_BRANCH
     - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/krte:$_GIT_TAG-$_CONFIG
     - .
@@ -18,7 +17,6 @@ steps:
 substitutions:
   _GIT_TAG: '12345'
   _CONFIG: master
-  _GO_VERSION: 1.26.1
   _K8S_BRANCH: master
 options:
   substitution_option: ALLOW_LOOSE

--- a/images/kubekins-e2e-v2/Dockerfile
+++ b/images/kubekins-e2e-v2/Dockerfile
@@ -148,7 +148,10 @@ RUN rm -f $(which kubectl) && \
     export KUBECTL_VERSION=$(curl --retry 6 --retry-connrefused -fsSL https://dl.k8s.io/release/${K8S_RELEASE}.txt) && \
     wget -q https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl -O /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
-# install go
+# Install go
+# Overrides the Go version to install.
+# Unset GO_VERSION means we will respect .go-version in the kubernetes repo
+# based on K8S_BRANCH.
 ARG GO_VERSION
 ARG K8S_BRANCH
 RUN if [ -z "${GO_VERSION}" ]; then \

--- a/images/kubekins-e2e-v2/cloudbuild.yaml
+++ b/images/kubekins-e2e-v2/cloudbuild.yaml
@@ -8,7 +8,6 @@ steps:
     - --build-arg=IMAGE_ARG=$_REGISTRY/kubekins-e2e:$_GIT_TAG-$_CONFIG
     - --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
     - --build-arg=CFSSL_VERSION=$_CFSSL_VERSION
-    - --build-arg=GO_VERSION=$_GO_VERSION
     - --build-arg=K8S_RELEASE=$_K8S_RELEASE
     - --build-arg=K8S_BRANCH=$_K8S_BRANCH
     - --build-arg=KIND_VERSION=$_KIND_VERSION
@@ -23,7 +22,6 @@ substitutions:
   _CFSSL_VERSION: 1.6.5
   _CONFIG: master
   _GIT_TAG: '12345'
-  _GO_VERSION: 1.13.5
   _K8S_RELEASE: stable
   _K8S_BRANCH: master
   _KIND_VERSION: '0.31.0'

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -61,7 +61,10 @@ RUN rm -f $(which kubectl) && \
     wget https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
-# install go
+# Install go
+# Overrides the Go version to install.
+# Unset GO_VERSION means we will respect .go-version in the kubernetes repo
+# based on K8S_BRANCH.
 ARG GO_VERSION
 ARG K8S_BRANCH
 RUN if [ -z "${GO_VERSION}" ]; then \

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -19,7 +19,6 @@ steps:
     - --tag=gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG
     - --build-arg=BAZEL_VERSION_ARG=$_BAZEL_VERSION
     - --build-arg=CFSSL_VERSION=$_CFSSL_VERSION
-    - --build-arg=GO_VERSION=$_GO_VERSION
     - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG
     - --build-arg=K8S_RELEASE=$_K8S_RELEASE
     - --build-arg=K8S_BRANCH=$_K8S_BRANCH
@@ -42,7 +41,6 @@ substitutions:
   _CFSSL_VERSION: R1.2
   _CONFIG: master
   _GIT_TAG: '12345'
-  _GO_VERSION: 1.13.5
   _K8S_RELEASE: stable
   _K8S_BRANCH: master
   _KIND_VERSION: ''


### PR DESCRIPTION
Should fix #36811 

I wasn't able to easily test the cloudbuilds locally, so I had mimicked with a docker build.
But the cloudbuild still sets GO_VERSION, which now has bad default fallback.

Removing that, so the logic to use K8S_BRANCH .go-version takes over (As in my local build testing previously)