### PR TITLE
Use k8s-infra-prow-build cluster for arm presubmit tests

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
@@ -40,7 +40,7 @@ presubmits:
             cpu: 4
             memory: 8Gi
   - name: pull-dra-driver-cpu-e2e-device-mode-individual-arm64
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -116,7 +116,7 @@ presubmits:
             cpu: 4
             memory: 8Gi
   - name: pull-dra-driver-cpu-e2e-device-mode-grouped-arm64
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
The current arm tests run on `eks-prow-build-cluster` and fail with 

> There are no nodes that your pod can schedule to - check your requests, tolerations, and node selectors ((combined from similar events): 0/46 nodes are available: 3 node(s) had untolerated taint {node-group: stable}, 43 node(s) didn't match Pod's node affinity/selector. preemption: 0/46 nodes are available: 46 Preemption is not helpful for scheduling.)


Using `k8s-infra-prow-build cluster` is a common pattern I noticed for other arm tests in the repo. We can probably use the same cluster for AMD tests too to keep it consistent, but we can make that change in a separate PR if necessary.  
