### PR TITLE
move dra-driver-cpu arm64 jobs to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
@@ -40,7 +40,7 @@ presubmits:
             cpu: 4
             memory: 8Gi
   - name: pull-dra-driver-cpu-e2e-device-mode-individual-arm64
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
@@ -116,7 +116,7 @@ presubmits:
             cpu: 4
             memory: 8Gi
   - name: pull-dra-driver-cpu-e2e-device-mode-grouped-arm64
-    cluster: eks-prow-build-cluster
+    cluster: k8s-infra-prow-build
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
Migrate pull-dra-driver-cpu-e2e-device-mode-*-arm64 presubmit jobs from `eks-prow-build-cluster `to `k8s-infra-prow-build,` which has ARM nodes available. The EKS cluster does not have ARM nodes, causing these jobs to fail.

~~Confirmed ARM node availability on `k8s-infra-prow-build` on the prow Slack channel (thanks @upodroid).~~
Confirmed that there is no ARM node on the EKS (thanks @upodroid) and switching to `k8s-infra-prow-build` as I can see from other projects like minikube and containerd using the same cluster for ARM based tests/builds.

Fixes: https://github.com/kubernetes-sigs/dra-driver-cpu/issues/120
