### PR TITLE
kubeadm: bump unavailable v1.36 kubekins image tags

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.35
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.35
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -161,7 +161,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.34
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -205,7 +205,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-dryrun.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-dryrun.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.35
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.35
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -161,7 +161,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.34
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -205,7 +205,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-encryption-algorithm.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-encryption-algorithm.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-ca.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.35
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.35
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -161,7 +161,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.34
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -205,7 +205,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.35
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.35
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -161,7 +161,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.34
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -205,7 +205,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kubelet-x-on-y.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -161,7 +161,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -205,7 +205,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -249,7 +249,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -293,7 +293,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.35
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.35
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -337,7 +337,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.35
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.35
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -381,7 +381,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.34
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-rootless.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-super-admin.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-super-admin.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.35
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.35
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -161,7 +161,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.34
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.35
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.35
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.34
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -161,7 +161,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -29,7 +29,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -73,7 +73,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.36
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.36
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.35
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.35
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -161,7 +161,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.34
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -205,7 +205,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-1.33
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
@@ -21,7 +21,7 @@ periodics:
       - runner.sh
       args:
       - ./tests/e2e/manifests/verify_manifest_lists.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       resources:
         limits:
           memory: "9000Mi"


### PR DESCRIPTION
/assign @neolit123 @carlory 

Fixes https://github.com/kubernetes/kubeadm/issues/3303