### PR TITLE
Add presubmit job to kubernetes-sigs/scheduler-library

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-library/OWNERS
+++ b/config/jobs/kubernetes-sigs/scheduler-library/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - dom4ha
+  - macsko
+  - sanposhiho

--- a/config/jobs/kubernetes-sigs/scheduler-library/scheduler-library-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-library/scheduler-library-presubmits-main.yaml
@@ -1,0 +1,28 @@
+# sigs.k8s.io/scheduler-library presubmits
+presubmits:
+  kubernetes-sigs/scheduler-library:
+  - name: pull-scheduler-library-verify-main
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-library
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-scheduler-library-verify-main
+    branches:
+    - ^main$
+    always_run: true
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+        resources:
+          requests:
+            memory: "2Gi"
+            cpu: "2"
+          limits:
+            memory: "2Gi"
+            cpu: "2"
+        command:
+        - runner.sh
+        args:
+        - make
+        - verify


### PR DESCRIPTION
Requires https://github.com/kubernetes-sigs/scheduler-library/pull/1 to be merged first.