### PR TITLE
add skip_checkout to periodics which don't need source code

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -14,6 +14,8 @@ periodics:
     repo: apisnoop
     base_ref: main
     path_alias: sigs.k8s.io/apisnoop
+  decoration_config:
+    skip_cloning: true
   spec:
     containers:
     - name: apisnoop-gate

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -538,6 +538,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 260m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -580,6 +581,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 260m
+    skip_cloning: true
   spec:
     containers:
     - command:

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -13,6 +13,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 8h40m0s
+    skip_cloning: true
   interval: 12h
   labels:
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -1039,6 +1039,7 @@ periodics:
     path_alias: k8s.io/test-infra
   decoration_config:
     timeout: 4h
+    skip_cloning: true
   spec:
     serviceAccountName: node-e2e-tests
     containers:

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -57,6 +57,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 1h45m0s
+    skip_cloning: true
   # Same as in other release-blocking jobs. If we want to save resources, then we should
   # run some of those less often. This job is the only one which matches a blocking presubmit,
   # so we want to know about problems as quickly as reasonably possible.

--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -31,6 +31,8 @@ periodics:
     cluster: k8s-infra-aks-prow-build
     interval: 2h
     decorate: true
+    decoration_config:
+      skip_cloning: true
     extra_refs:
       - org: kubernetes
         repo: kubernetes

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -367,6 +367,8 @@ periodics:
   name: ci-fast-forward
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: release
@@ -408,6 +410,8 @@ periodics:
     testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: verify-image-signatures
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes-sigs
     repo: promo-tools

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -4,6 +4,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -64,6 +66,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -115,6 +119,8 @@ periodics:
   interval: 10m
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -170,6 +176,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -244,6 +252,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -439,6 +449,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -513,6 +525,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -585,6 +599,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -659,6 +675,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -731,6 +749,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -791,6 +811,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -854,6 +876,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -918,6 +942,8 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org
@@ -984,6 +1010,8 @@ periodics:
   labels:
     preset-service-account: "true"
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-triage-robot-retester.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-triage-robot-retester.yaml
@@ -3,6 +3,8 @@ periodics:
   interval: 20m  # Retest at most 1 PR per 20m, which should not DOS the queue.
   cluster: k8s-infra-prow-build-trusted
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: org

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -130,6 +130,7 @@ periodics:
     path_alias: k8s.io/test-infra
   decoration_config:
     timeout: 3h
+    skip_cloning: true
   max_concurrency: 1
   annotations:
     testgrid-num-failures-to-alert: '18'

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-label-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-label-sync.yaml
@@ -5,6 +5,8 @@ periodics:
   labels:
     app: label-sync
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: test-infra

--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -191,6 +191,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 340m
+    skip_cloning: true
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master

--- a/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
@@ -351,6 +351,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 80m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -395,6 +396,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 60m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -438,6 +440,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 80m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -481,6 +484,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -520,6 +524,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 80m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -564,6 +569,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 80m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -608,6 +614,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -648,6 +655,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 340m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -691,6 +699,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 340m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -733,6 +742,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 200m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -774,6 +784,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 70m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -817,6 +828,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -860,6 +872,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -908,6 +921,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -946,6 +960,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -986,6 +1001,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 520m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -1026,6 +1042,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 520m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -1068,6 +1085,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
+    skip_cloning: true
   spec:
     containers:
     - command:

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -416,6 +416,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 70m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -460,6 +461,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 70m
+    skip_cloning: true
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
@@ -864,6 +866,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 70m
+    skip_cloning: true
   spec:
     containers:
     - command:

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -20,6 +20,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
+      skip_cloning: true
     extra_refs:
     - org: kubernetes
       repo: kubernetes
@@ -114,6 +115,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
+      skip_cloning: true
     extra_refs:
     - org: kubernetes
       repo: kubernetes
@@ -228,6 +230,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
+      skip_cloning: true
     extra_refs:
     - org: kubernetes
       repo: kubernetes
@@ -360,6 +363,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
+      skip_cloning: true
     extra_refs:
     - org: kubernetes
       repo: kubernetes
@@ -492,6 +496,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
+      skip_cloning: true
     extra_refs:
     - org: kubernetes
       repo: kubernetes

--- a/config/jobs/kubernetes/sig-node/dra.generate.conf
+++ b/config/jobs/kubernetes/sig-node/dra.generate.conf
@@ -22,7 +22,7 @@ e2e_node_timeout = 60m
 # Values > 0 enable version skew testing with an older kubelet version.
 kubelet_skew = 0
 # Can be set to non-empty for jobs which need extra refs.
-need_kubernetes_repo = true
+need_kubernetes_repo =
 need_test_infra_repo =
 need_containerd_repo =
 
@@ -100,12 +100,14 @@ description = Runs integration tests for DRA which need some additional setup in
 use_dind = true
 use_dind_cdi = true
 job_type = integration
+need_kubernetes_repo = true
 cluster = eks-prow-build-cluster
 run_if_changed = /(dra|e2e_dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 
 # This job runs the node e2e tests for DRA with CRI-O
 [node-crio-dra]
 job_type = node
+need_kubernetes_repo = true
 need_test_infra_repo = true
 description = Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O
 image_config_file = /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config.yaml
@@ -115,6 +117,7 @@ release_informing = true
 # This job adds all alpha and beta feature gates to node-crio-dra and runs all DRA tests which can work in that configuration.
 [node-crio-dra-alpha-beta-features]
 job_type = node
+need_kubernetes_repo = true
 need_test_infra_repo = true
 all_features = true
 description = Runs all E2E node tests for Dynamic Resource Allocation features with CRI-O and with all feature gates enabled (including non-DRA feature gates)
@@ -124,6 +127,7 @@ inject_ssh_public_key = true
 # This job runs the same tests as ci-node-crio-dra with Containerd 1.7 runtime
 [node-e2e-containerd-1-7-dra]
 job_type = node
+need_kubernetes_repo = true
 need_test_infra_repo = true
 description = Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 1.7
 image_config_file = /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
@@ -133,6 +137,7 @@ run_if_changed = (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resour
 # This job runs the same tests as ci-node-crio-dra with Containerd 2.0 runtime
 [node-e2e-containerd-2-0-dra]
 job_type = node
+need_kubernetes_repo = true
 need_test_infra_repo = true
 need_containerd_repo = true
 description = Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 2.1
@@ -154,6 +159,7 @@ image_config_file = /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-
 # This job adds all alpha and beta feature gates to node-e2e-containerd-2-0-dra and runs all DRA tests which can work in that configuration.
 [node-e2e-containerd-2-0-dra-alpha-beta-features]
 job_type = node
+need_kubernetes_repo = true
 need_test_infra_repo = true
 need_containerd_repo = true
 all_features = true

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -62,12 +62,15 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: {{timeout}}
+      {%- if ci and not need_kubernetes_repo and not need_test_infra_repo and not need_containerd_repo %}
+      skip_cloning: true
+      {%- endif %}
     {%- if not ci %}
     path_alias: k8s.io/kubernetes
     {%- endif %}
-    {%- if ci and need_kubernetes_repo or need_test_infra_repo or need_containerd_repo %}
+    {%- if ci or need_test_infra_repo or need_containerd_repo %}
     extra_refs:
-    {%- if ci and need_kubernetes_repo %}
+    {%- if ci %}
     - org: kubernetes
       repo: kubernetes
       base_ref: master

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -57,6 +57,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 1h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.33
     org: kubernetes
@@ -980,6 +981,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.33
     org: kubernetes
@@ -1027,6 +1029,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.33
     org: kubernetes
@@ -1071,6 +1074,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.33
     org: kubernetes
@@ -1113,6 +1117,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 11h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.33
     org: kubernetes
@@ -1157,6 +1162,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h50m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.33
     org: kubernetes

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -57,6 +57,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 1h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.34
     org: kubernetes
@@ -1255,6 +1256,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.34
     org: kubernetes
@@ -1302,6 +1304,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.34
     org: kubernetes
@@ -1346,6 +1349,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.34
     org: kubernetes
@@ -1388,6 +1392,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 11h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.34
     org: kubernetes
@@ -1432,6 +1437,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h50m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.34
     org: kubernetes

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -1375,6 +1375,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.35
     org: kubernetes
@@ -1422,6 +1423,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.35
     org: kubernetes
@@ -1466,6 +1468,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.35
     org: kubernetes
@@ -1508,6 +1511,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 11h20m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.35
     org: kubernetes
@@ -1552,6 +1556,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h50m0s
+    skip_cloning: true
   extra_refs:
   - base_ref: release-1.35
     org: kubernetes

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -289,6 +289,7 @@ periodics:
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
+    skip_cloning: true
     timeout: 1h30m0s
   extra_refs:
   - base_ref: release-1.36
@@ -381,6 +382,7 @@ periodics:
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
+    skip_cloning: true
     timeout: 1h30m0s
   extra_refs:
   - base_ref: release-1.36
@@ -508,6 +510,7 @@ periodics:
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
+    skip_cloning: true
     timeout: 1h30m0s
   extra_refs:
   - base_ref: release-1.36
@@ -635,6 +638,7 @@ periodics:
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
+    skip_cloning: true
     timeout: 1h30m0s
   extra_refs:
   - base_ref: release-1.36

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -7,6 +7,8 @@ periodics:
     preset-aws-ssh: "true"
     preset-aws-credential-boskos-scale-001-kops: "true"
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: test-infra

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -19,6 +19,7 @@ periodics:
   job_queue_name: "5k-gce-scale-test" # DON'T REMOVE THIS
   decoration_config:
     timeout: 270m
+    skip_cloning: true
   annotations:
     testgrid-num-failures-to-alert: '2'
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com, release-team@kubernetes.io

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -298,6 +298,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 150m
+    skip_cloning: true
   spec:
     containers:
     - command:
@@ -344,6 +345,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 150m
+    skip_cloning: true
   spec:
     containers:
     - command:

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -6,6 +6,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -66,6 +66,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 240m
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -7,6 +7,8 @@ periodics:
     preset-aws-ssh: "true"
     preset-aws-credential-aws-shared-testing: "true"
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: test-infra
@@ -42,6 +44,8 @@ periodics:
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
   decorate: true
+  decoration_config:
+    skip_cloning: true
   extra_refs:
   - org: kubernetes
     repo: test-infra

--- a/releng/Makefile
+++ b/releng/Makefile
@@ -14,6 +14,7 @@
 
 REPO_ROOT:=${CURDIR}/..
 BIN_DIR:=$(REPO_ROOT)/_bin
+SHELL=bash
 
 all: prepare-release-branch
 


### PR DESCRIPTION
0712a63a added extra_refs to all periodics which didn't check out source code because that adds the following labels to the Prow pod:
    
- prow.k8s.io/refs.base_ref
- prow.k8s.io/refs.org
- prow.k8s.io/refs.repo
    
Those labels are needed by the dashboards at monitoring-gke.prow.k8s.io.
    
However, checking out source code that isn't needed by the job slows them down     (~ 1 minute), causes more network traffic, and adds the risk that jobs fail     when cloning fails. In addition, we then have two sources for which revision     got tested (source code checkout and whatever the job itself wrote), which     might not be in sync.
    
Adding `skip_checkout` avoids the overhead and should avoid the problem with     two revisions because the branch reference never gets resolved.
    
This commit was created by:

- changing the dra job configuration so that only jobs which need
  k/k checked out have need_kubernetes_repo=true (the previous approach)
  and then adding the repo anyway with skip_cloning for CI jobs
- adding skip_checkout on top of the 0712a63a commit in all places where
  extra_refs were added
- rebasing onto master
- resolving conflicts:
  - 1.32.yaml was removed, 1.36.yaml added => re-generated 1.36.yaml to sync
    with updated jobs on master
  - generated.yaml removed in b9bc949f90224441a647dca662989e2ff2e8216a =>
    manually fixed all jobs added in that commit (more than just
    ci-kubernetes-e2e-gce-cos-k8sbeta-alphafeatures and ci-kubernetes-e2e-gce-cos-k8sbeta-default!)
  - some concurrent changes in other files
 
Conflicts:
- config/jobs/kubernetes/generated/generated.yaml
- config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
- config/jobs/kubernetes/sig-release/release-branch-jobs/1.32.yaml
- config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
- config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml

For `make -C releng prepare-release-branch` to work I had to fix the default shell.

/assign @BenTheElder @upodroid 