### PR TITLE
ss sync-controller: fix kind version tags

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-sync-controller/secrets-store-sync-controller-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-sync-controller/secrets-store-sync-controller-config.yaml
@@ -170,7 +170,7 @@ presubmits:
           privileged: true
         env:
         - name: KIND_NODE_IMAGE_VERSION
-          value: 1.34.3
+          value: v1.34.3
         resources:
           requests:
             cpu: "4"
@@ -210,7 +210,7 @@ presubmits:
           privileged: true
         env:
         - name: KIND_NODE_IMAGE_VERSION
-          value: 1.35.1
+          value: v1.35.1
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
Accidentally omitted the `v` from version in the last PR after I've experimented with YAML anchors, sorry about that :facepalm: 

/assign @aramase 