### PR TITLE
Add postsubmit job to build kubetest2-tf from provider-ibmcloud-test-infra repo

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-postsubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-postsubmits.yaml
@@ -1,0 +1,49 @@
+postsubmits:
+  kubernetes-sigs/provider-ibmcloud-test-infra:
+  - name: post-provider-ibmcloud-test-infra-kubetest2-tf-build-push
+    cluster: k8s-infra-ppc64le-prow-build
+    decorate: true
+    branches:
+    - ^main$
+    run_if_changed: 'kubetest2-tf'
+    annotations:
+      testgrid-dashboards: ibm-ppc64le-postsubmits
+      testgrid-tab-name: post-provider-ibmcloud-test-infra-kubetest2-tf-build-push
+      description: Build and push kubetest2-tf binary when repo provider-ibmcloud-test-infra has merge to main
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+          set -o xtrace
+
+          echo "Building kubetest2-tf deployer..."
+          make build-deployer-tf
+
+          echo "Pushing kubetest2-tf binary to IBM Cloud COS..."
+          cd kubetest2-tf
+          make push-to-cos WHAT=kubetest2-tf \
+            COS_SERVICE_CREDENTIALS_PATH=/etc/secret/service-credentials
+          echo "Build and push completed successfully!"
+        volumeMounts:
+        - name: service-credentials
+          mountPath: /etc/secret
+          readOnly: true
+        resources:
+          requests:
+            cpu: 1
+            memory: 2Gi
+          limits:
+            cpu: 2
+            memory: 4Gi
+      volumes:
+      - name: service-credentials
+        secret:
+          secretName: k8s-ppc-artifacts-svc-creds

--- a/config/testgrids/ibm/config.yaml
+++ b/config/testgrids/ibm/config.yaml
@@ -5,6 +5,7 @@ dashboard_groups:
     - ibm-ppc64le-node-e2e
     - ibm-ppc64le-periodics
     - ibm-ppc64le-presubmits
+    - ibm-ppc64le-postsubmits
     - ibm-ppc64le-k8s
     - ibm-ppc64le-etcd
     - ibm-cluster-api
@@ -19,6 +20,7 @@ dashboards:
 - name: ibm-ppc64le-node-e2e
 - name: ibm-ppc64le-periodics
 - name: ibm-ppc64le-presubmits
+- name: ibm-ppc64le-postsubmits
 - name: ibm-ppc64le-k8s
 - name: ibm-ppc64le-etcd
 - name: ibm-cluster-api


### PR DESCRIPTION
This postsubmit job would build and push `kubetest2-tf` binary to IBM S3 COS bucket whenever there is a change in https://github.com/kubernetes-sigs/provider-ibmcloud-test-infra repo.
This will be used by jobs running at https://testgrid.k8s.io/ibm-ppc64le-e2e 