### PR TITLE
Kops - Skip kuberouter jobs for nftables distros

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -467,6 +467,7 @@ def presubmit_test(branch='master',
 ############################
 # kops-periodics-grid.yaml #
 ############################
+# pylint: disable=too-many-statements
 def generate_grid():
     results = []
     # pylint: disable=too-many-nested-blocks
@@ -518,6 +519,10 @@ def generate_grid():
                             "--topology=public",
                         ])
                     if 'rhel10' in distro or 'rocky10' in distro:
+                        if networking == 'kuberouter':
+                            # Missing support for nftables
+                            # https://github.com/cloudnativelabs/kube-router/issues/2034
+                            continue
                         # https://github.com/kubernetes/kops/issues/17915
                         extra_flags.extend([
                             "--set=cluster.spec.kubeProxy.proxyMode=nftables",


### PR DESCRIPTION
Kuberouter doesn't have support for nftables: https://github.com/cloudnativelabs/kube-router/issues/2034 so skip jobs for distros that dont have iptables

/cc @hakman