### PR TITLE
experiment/gcp-nvkind + dra-driver-nvidia-gpu Prow jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
@@ -95,10 +95,6 @@ periodics:
       args:
       - hack/ci/gcp-nvkind/e2e-test.sh
       env:
-      - name: BOSKOS_HOST
-        value: "http://boskos.test-pods.svc.cluster.local"
-      - name: BOSKOS_RESOURCE_TYPE
-        value: "gpu-project"
       - name: GCE_ZONE
         value: "us-central1-b"
       - name: GCE_MACHINE_TYPE
@@ -106,11 +102,11 @@ periodics:
       - name: GCE_ACCELERATOR
         value: "type=nvidia-tesla-t4,count=1"
       - name: GCE_IMAGE_FAMILY
-        value: "common-cu129-ubuntu-2204-nvidia-580"
+        value: "common-cu129-ubuntu-2404-nvidia-580"
       - name: GCE_IMAGE_PROJECT
         value: "deeplearning-platform-release"
       - name: K8S_VERSION
-        value: "v1.34.3"
+        value: "v1.35.3"
       - name: GPU_OPERATOR_VERSION
         value: "v26.3.1"
       - name: TESTINFRA_DIR

--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
@@ -1,0 +1,124 @@
+# DRA driver e2e on GCP + nvkind + GPU Operator.
+#
+# Each run acquires a gpu-project from Boskos, provisions a T4 GCE VM,
+# stands up a DRA-enabled kind cluster via experiment/gcp-nvkind/lib/, then
+# installs GPU Operator (minimal mode) + the DRA driver from PR source and
+# runs the Ginkgo suite under test/e2e/. All Docker work happens on the VM,
+# so the Prow pod needs neither DinD nor privileged.
+
+presubmits:
+  kubernetes-sigs/dra-driver-nvidia-gpu:
+  - name: pull-dra-driver-nvidia-gpu-e2e-gcp-nvkind
+    cluster: k8s-infra-prow-build
+    job_queue_name: gce-gpu-test
+    optional: true
+    always_run: false
+    max_concurrency: 1
+    skip_branches:
+    - release-\d+\.\d+
+    decorate: true
+    decoration_config:
+      timeout: 2h
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    annotations:
+      testgrid-dashboards: sig-node-gpu
+      testgrid-tab-name: pull-dra-driver-nvidia-gpu-gcp-nvkind
+      description: "DRA GPU e2e on GCP + nvkind + GPU Operator (optional presubmit)"
+    spec:
+      serviceAccountName: prow-build
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+        command:
+        - runner.sh
+        args:
+        - hack/ci/gcp-nvkind/e2e-test.sh
+        env:
+        - name: BOSKOS_HOST
+          value: "http://boskos.test-pods.svc.cluster.local"
+        - name: BOSKOS_RESOURCE_TYPE
+          value: "gpu-project"
+        - name: GCE_ZONE
+          value: "us-central1-b"
+        - name: GCE_MACHINE_TYPE
+          value: "n1-standard-4"
+        - name: GCE_ACCELERATOR
+          value: "type=nvidia-tesla-t4,count=1"
+        - name: GCE_IMAGE_FAMILY
+          value: "common-cu129-ubuntu-2204-nvidia-580"
+        - name: GCE_IMAGE_PROJECT
+          value: "deeplearning-platform-release"
+        - name: K8S_VERSION
+          value: "v1.34.3"
+        - name: GPU_OPERATOR_VERSION
+          value: "v26.3.1"
+        - name: TESTINFRA_DIR
+          value: "/home/prow/go/src/k8s.io/test-infra"
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
+
+periodics:
+- name: ci-dra-driver-nvidia-gpu-e2e-gcp-nvkind
+  cluster: k8s-infra-prow-build
+  job_queue_name: gce-gpu-test
+  interval: 6h
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: dra-driver-nvidia-gpu
+    base_ref: main
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  annotations:
+    testgrid-dashboards: sig-node-gpu
+    testgrid-tab-name: ci-dra-driver-nvidia-gpu-gcp-nvkind
+    description: "Periodic DRA GPU e2e on GCP + nvkind + GPU Operator"
+  spec:
+    serviceAccountName: prow-build
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+      command:
+      - runner.sh
+      args:
+      - hack/ci/gcp-nvkind/e2e-test.sh
+      env:
+      - name: BOSKOS_HOST
+        value: "http://boskos.test-pods.svc.cluster.local"
+      - name: BOSKOS_RESOURCE_TYPE
+        value: "gpu-project"
+      - name: GCE_ZONE
+        value: "us-central1-b"
+      - name: GCE_MACHINE_TYPE
+        value: "n1-standard-4"
+      - name: GCE_ACCELERATOR
+        value: "type=nvidia-tesla-t4,count=1"
+      - name: GCE_IMAGE_FAMILY
+        value: "common-cu129-ubuntu-2204-nvidia-580"
+      - name: GCE_IMAGE_PROJECT
+        value: "deeplearning-platform-release"
+      - name: K8S_VERSION
+        value: "v1.34.3"
+      - name: GPU_OPERATOR_VERSION
+        value: "v26.3.1"
+      - name: TESTINFRA_DIR
+        value: "/home/prow/go/src/k8s.io/test-infra"
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"

--- a/experiment/gcp-nvkind/README.md
+++ b/experiment/gcp-nvkind/README.md
@@ -1,0 +1,61 @@
+# experiment/gcp-nvkind
+
+Shell helpers for Prow jobs that need:
+
+1. A GCP project leased from a Boskos pool (e.g. `gpu-project`).
+2. A GCE VM with an attached NVIDIA GPU.
+3. A `kind` cluster managed by [nvkind](https://github.com/NVIDIA/nvkind)
+   so containers get GPU access via the nvidia-container-runtime.
+
+Typical callers install their own workload on top (for example a DRA driver
+plus GPU Operator, a device-plugin variant, or CDI validation tooling).
+
+## Layout
+
+```
+experiment/gcp-nvkind/
+├── README.md
+└── lib/
+    ├── boskos.sh               # boskos::acquire / heartbeat_start / release
+    ├── gce.sh                  # gce::create / ssh / scp_to / scp_from / wait_for_driver / delete
+    ├── setup-nvkind-node.sh    # on-VM: install docker+toolkit+go+kind+nvkind+helm+kubectl; create cluster
+    └── nvkind-config.yaml.tmpl # kind config: DRA feature gate + CDI containerd patch
+```
+
+## Contract
+
+- Caller sets `BOSKOS_HOST`, `BOSKOS_RESOURCE_TYPE`, `JOB_NAME`.
+- Caller's service account must have Compute IAM on the leased project.
+- Caller runs `go install sigs.k8s.io/boskos/cmd/boskosctl@latest` at job
+  start (not pre-installed in `kubekins-e2e`).
+- After `setup-nvkind-node.sh` exits, the cluster is Ready at
+  `$NVKIND_K8S_VERSION` with `KUBECONFIG=$HOME/.kube/config` on the VM.
+- These helpers install no project-specific workload — that is the caller's
+  job.
+
+## Example
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+source "${TESTINFRA_DIR}/experiment/gcp-nvkind/lib/boskos.sh"
+source "${TESTINFRA_DIR}/experiment/gcp-nvkind/lib/gce.sh"
+
+boskos::acquire
+export GCP_PROJECT="${BOSKOS_PROJECT}"
+boskos::heartbeat_start
+
+export VM_NAME="myjob-${BUILD_ID}"
+export GCE_ZONE=us-central1-b
+trap 'gce::delete; boskos::release' EXIT
+
+gce::create
+gce::wait_for_driver
+gce::scp_to "${MY_TARBALL}" /tmp/
+gce::ssh "tar -xzf /tmp/*.tgz -C /tmp/src"
+gce::ssh "NVKIND_CLUSTER_NAME=test \
+          NVKIND_K8S_VERSION=v1.34.3 \
+          NVKIND_CONFIG_PATH=/tmp/src/.../nvkind-config.yaml.tmpl \
+          bash /tmp/src/.../setup-nvkind-node.sh"
+gce::ssh "bash /tmp/install-workload.sh && bash /tmp/run-tests.sh"
+```

--- a/experiment/gcp-nvkind/lib/boskos.sh
+++ b/experiment/gcp-nvkind/lib/boskos.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# boskos.sh -- acquire / heartbeat / release a Boskos resource.
+#
+# Required env: BOSKOS_HOST, BOSKOS_RESOURCE_TYPE, JOB_NAME.
+# On success exports: BOSKOS_RESOURCE_JSON, BOSKOS_PROJECT.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# sigs.k8s.io/boskos has no tags; pin a commit SHA. Bump with a reviewable diff.
+: "${BOSKOSCTL_VERSION:=c2c6f437ca1db28863fb1cbaaa74b8ea4784483f}"
+
+boskos::install_cli() {
+  if command -v boskosctl >/dev/null 2>&1; then return 0; fi
+  echo "Installing boskosctl@${BOSKOSCTL_VERSION}..."
+  GO111MODULE=on go install "sigs.k8s.io/boskos/cmd/boskosctl@${BOSKOSCTL_VERSION}"
+  export PATH="${PATH}:$(go env GOPATH)/bin"
+}
+
+boskos::acquire() {
+  : "${BOSKOS_HOST:?BOSKOS_HOST must be set}"
+  : "${BOSKOS_RESOURCE_TYPE:?BOSKOS_RESOURCE_TYPE must be set}"
+  : "${JOB_NAME:?JOB_NAME must be set}"
+
+  boskos::install_cli
+
+  echo "Acquiring a ${BOSKOS_RESOURCE_TYPE} from ${BOSKOS_HOST}..."
+  BOSKOS_RESOURCE_JSON=$(boskosctl \
+    --server-url "${BOSKOS_HOST}" \
+    --owner-name "${JOB_NAME}" \
+    acquire \
+    --type "${BOSKOS_RESOURCE_TYPE}" \
+    --state free \
+    --target-state busy \
+    --timeout 30m)
+  BOSKOS_PROJECT=$(jq -r .name <<<"${BOSKOS_RESOURCE_JSON}")
+  export BOSKOS_RESOURCE_JSON BOSKOS_PROJECT
+  echo "Acquired project: ${BOSKOS_PROJECT}"
+}
+
+boskos::heartbeat_start() {
+  : "${BOSKOS_RESOURCE_JSON:?call boskos::acquire first}"
+  boskosctl \
+    --server-url "${BOSKOS_HOST}" \
+    --owner-name "${JOB_NAME}" \
+    heartbeat \
+    --resource "${BOSKOS_RESOURCE_JSON}" \
+    --period 30s &
+  BOSKOS_HEARTBEAT_PID=$!
+  export BOSKOS_HEARTBEAT_PID
+  echo "Heartbeat started (pid ${BOSKOS_HEARTBEAT_PID})"
+}
+
+boskos::release() {
+  if [ -n "${BOSKOS_HEARTBEAT_PID:-}" ]; then
+    kill "${BOSKOS_HEARTBEAT_PID}" 2>/dev/null || true
+    wait "${BOSKOS_HEARTBEAT_PID}" 2>/dev/null || true
+  fi
+  if [ -n "${BOSKOS_PROJECT:-}" ]; then
+    echo "Releasing project ${BOSKOS_PROJECT} back to the pool (dirty)..."
+    boskosctl \
+      --server-url "${BOSKOS_HOST}" \
+      --owner-name "${JOB_NAME}" \
+      release \
+      --name "${BOSKOS_PROJECT}" \
+      --target-state dirty || true
+  fi
+}

--- a/experiment/gcp-nvkind/lib/gce.sh
+++ b/experiment/gcp-nvkind/lib/gce.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# gce.sh -- GCE VM lifecycle: create, wait for NVIDIA driver, SSH, SCP, delete.
+#
+# Required env: GCP_PROJECT, GCE_ZONE, VM_NAME.
+# Optional env (with defaults):
+#   GCE_MACHINE_TYPE    n1-standard-4
+#   GCE_ACCELERATOR     type=nvidia-tesla-t4,count=1
+#   GCE_IMAGE_FAMILY    common-cu129-ubuntu-2204-nvidia-580
+#   GCE_IMAGE_PROJECT   deeplearning-platform-release
+#   GCE_BOOT_DISK_SIZE  100GB
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${GCE_MACHINE_TYPE:=n1-standard-4}"
+: "${GCE_ACCELERATOR:=type=nvidia-tesla-t4,count=1}"
+: "${GCE_IMAGE_FAMILY:=common-cu129-ubuntu-2204-nvidia-580}"
+: "${GCE_IMAGE_PROJECT:=deeplearning-platform-release}"
+: "${GCE_BOOT_DISK_SIZE:=100GB}"
+
+gce::create() {
+  : "${GCP_PROJECT:?GCP_PROJECT must be set}"
+  : "${GCE_ZONE:?GCE_ZONE must be set}"
+  : "${VM_NAME:?VM_NAME must be set}"
+
+  echo "Creating VM ${VM_NAME} in ${GCP_PROJECT}/${GCE_ZONE}..."
+  gcloud compute instances create "${VM_NAME}" \
+    --project="${GCP_PROJECT}" \
+    --zone="${GCE_ZONE}" \
+    --machine-type="${GCE_MACHINE_TYPE}" \
+    --accelerator="${GCE_ACCELERATOR}" \
+    --maintenance-policy=TERMINATE \
+    --image-family="${GCE_IMAGE_FAMILY}" \
+    --image-project="${GCE_IMAGE_PROJECT}" \
+    --metadata=install-nvidia-driver=True \
+    --boot-disk-size="${GCE_BOOT_DISK_SIZE}" \
+    --boot-disk-type=pd-balanced
+}
+
+gce::wait_for_driver() {
+  local deadline
+  deadline=$(( $(date +%s) + 900 ))
+  echo "Waiting for nvidia-smi to succeed on ${VM_NAME} (up to 15 min)..."
+  until gce::ssh 'nvidia-smi -L' 2>&1 | grep -q 'GPU 0'; do
+    local now
+    now=$(date +%s)
+    if [ "${now}" -gt "${deadline}" ]; then
+      echo "TIMEOUT waiting for driver on ${VM_NAME}"
+      return 1
+    fi
+    echo "  driver not ready yet ($(( (deadline - now) / 60 )) min left)"
+    sleep 15
+  done
+  echo "Driver ready: $(gce::ssh 'nvidia-smi -L' | head -1)"
+}
+
+gce::ssh() {
+  gcloud compute ssh "${VM_NAME}" \
+    --zone="${GCE_ZONE}" \
+    --project="${GCP_PROJECT}" \
+    --ssh-flag='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ServerAliveInterval=30' \
+    --command="$*"
+}
+
+gce::scp_to() {
+  # gce::scp_to LOCAL... REMOTE_PATH
+  local n=$#
+  local remote="${!n}"
+  local locals=()
+  local i
+  for ((i=1; i<n; i++)); do locals+=("${!i}"); done
+  gcloud compute scp --recurse \
+    --zone="${GCE_ZONE}" \
+    --project="${GCP_PROJECT}" \
+    "${locals[@]}" "${VM_NAME}:${remote}"
+}
+
+gce::scp_from() {
+  # gce::scp_from REMOTE_PATH LOCAL_PATH
+  gcloud compute scp --recurse \
+    --zone="${GCE_ZONE}" \
+    --project="${GCP_PROJECT}" \
+    "${VM_NAME}:$1" "$2"
+}
+
+gce::delete() {
+  if [ -n "${VM_NAME:-}" ] && [ -n "${GCE_ZONE:-}" ] && [ -n "${GCP_PROJECT:-}" ]; then
+    echo "Deleting VM ${VM_NAME}..."
+    gcloud compute instances delete "${VM_NAME}" \
+      --project="${GCP_PROJECT}" --zone="${GCE_ZONE}" \
+      --quiet 2>/dev/null || true
+  fi
+}

--- a/experiment/gcp-nvkind/lib/nvkind-config.yaml.tmpl
+++ b/experiment/gcp-nvkind/lib/nvkind-config.yaml.tmpl
@@ -1,0 +1,43 @@
+# nvkind / kind cluster config template.
+# Rendered by nvkind: `numGPUs` is provided automatically based on host GPU count.
+# Enables DynamicResourceAllocation feature gate across control-plane
+# components and kubelet, and turns on CDI in containerd.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  DynamicResourceAllocation: true
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri"]
+    enable_cdi = true
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        feature-gates: "DynamicResourceAllocation=true"
+    controllerManager:
+      extraArgs:
+        feature-gates: "DynamicResourceAllocation=true"
+    scheduler:
+      extraArgs:
+        feature-gates: "DynamicResourceAllocation=true"
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        feature-gates: "DynamicResourceAllocation=true"
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        feature-gates: "DynamicResourceAllocation=true"
+  {{- range $gpu := until numGPUs }}
+  extraMounts:
+  - hostPath: /dev/null
+    containerPath: /var/run/nvidia-container-devices/{{ $gpu }}
+  {{- end }}

--- a/experiment/gcp-nvkind/lib/setup-nvkind-node.sh
+++ b/experiment/gcp-nvkind/lib/setup-nvkind-node.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# setup-nvkind-node.sh -- run on the GCE GPU VM via SSH.
+# Installs Docker + NVIDIA toolkit config + Go + kind + nvkind + helm +
+# kubectl, then creates a DRA-enabled nvkind cluster.
+#
+# Required env: NVKIND_CONFIG_PATH (kind config template already on the VM).
+# Optional env (with defaults):
+#   NVKIND_CLUSTER_NAME  nvkind-ci
+#   NVKIND_K8S_VERSION   v1.34.3
+#   NODE_LABELS          "nvidia.com/gpu.present=true feature.node.kubernetes.io/pci-10de.present=true"
+#   GO_VERSION           1.24.2
+#   KUBECTL_VERSION      $NVKIND_K8S_VERSION
+#   NVKIND_DELETE_EXISTING  if "true", wipe+recreate if cluster exists
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+: "${NVKIND_CLUSTER_NAME:=nvkind-ci}"
+: "${NVKIND_K8S_VERSION:=v1.34.3}"
+: "${NVKIND_CONFIG_PATH:?NVKIND_CONFIG_PATH must be set}"
+: "${NODE_LABELS:=nvidia.com/gpu.present=true feature.node.kubernetes.io/pci-10de.present=true}"
+: "${GO_VERSION:=1.24.2}"
+: "${KUBECTL_VERSION:=${NVKIND_K8S_VERSION}}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Fail fast if no GPU.
+if ! nvidia-smi -L 2>/dev/null | grep -q '^GPU '; then
+  echo "ERROR: nvidia-smi reports no GPU on this host" >&2
+  exit 1
+fi
+echo "Host sees: $(nvidia-smi -L | head -1)"
+
+sudo apt-get update -qq
+sudo apt-get install -y -qq ca-certificates curl gnupg make build-essential git jq
+
+# Docker CE.
+if ! command -v docker >/dev/null 2>&1; then
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
+    sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" |
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+fi
+# Idempotent; covers the pre-installed-Docker case.
+sudo usermod -aG docker "$(id -un)"
+
+# nvidia-container-toolkit (DLVM ships it; stock Ubuntu does not).
+if ! command -v nvidia-ctk >/dev/null 2>&1; then
+  curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey |
+    sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+  curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list |
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' |
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq nvidia-container-toolkit
+fi
+
+# Toolkit config. Restart docker only if daemon.json actually changed, so
+# re-invocations don't nuke a running kind cluster.
+before=$(sudo sha256sum /etc/docker/daemon.json 2>/dev/null | awk '{print $1}' || echo none)
+sudo nvidia-ctk runtime configure --runtime=docker --set-as-default --cdi.enabled
+sudo nvidia-ctk config --set accept-nvidia-visible-devices-as-volume-mounts=true --in-place
+after=$(sudo sha256sum /etc/docker/daemon.json 2>/dev/null | awk '{print $1}' || echo none)
+if [ "${before}" != "${after}" ]; then
+  sudo systemctl restart docker
+fi
+
+# Smoke: docker can see the GPU.
+sudo docker run --rm --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all ubuntu:22.04 nvidia-smi -L
+
+# Go, kubectl, helm.
+if ! /usr/local/go/bin/go version 2>/dev/null | grep -q "${GO_VERSION}"; then
+  curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tgz
+  sudo rm -rf /usr/local/go
+  sudo tar -C /usr/local -xzf /tmp/go.tgz
+fi
+export PATH="/usr/local/go/bin:${HOME}/go/bin:${PATH}"
+
+if ! kubectl version --client 2>/dev/null | grep -q "${KUBECTL_VERSION}"; then
+  curl -fsSLo /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+  sudo install /tmp/kubectl /usr/local/bin/kubectl
+fi
+
+if ! command -v helm >/dev/null 2>&1; then
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+fi
+
+# kind (pinned to the version nvkind vendors) and nvkind. nvkind has no
+# tags; pin a commit SHA. Bump with a reviewable diff after re-validating.
+: "${NVKIND_SHA:=8bce71ec58cf12b4003758eb4e49adac53cc40f2}"
+go install sigs.k8s.io/kind@v0.31.0
+go install "github.com/NVIDIA/nvkind/cmd/nvkind@${NVKIND_SHA}"
+
+# `sg docker -c` avoids re-login after usermod -aG docker.
+if sg docker -c "kind get clusters" | grep -qx "${NVKIND_CLUSTER_NAME}"; then
+  if [ "${NVKIND_DELETE_EXISTING:-false}" = "true" ]; then
+    sg docker -c "kind delete cluster --name=${NVKIND_CLUSTER_NAME}"
+  else
+    echo "ERROR: cluster ${NVKIND_CLUSTER_NAME} exists; set NVKIND_DELETE_EXISTING=true to recreate" >&2
+    exit 1
+  fi
+fi
+
+sg docker -c "nvkind cluster create \
+  --name ${NVKIND_CLUSTER_NAME} \
+  --image kindest/node:${NVKIND_K8S_VERSION} \
+  --config-template ${NVKIND_CONFIG_PATH}"
+
+kubectl --context "kind-${NVKIND_CLUSTER_NAME}" wait \
+  --for=condition=Ready nodes --all --timeout=300s
+
+for node in $(kubectl --context "kind-${NVKIND_CLUSTER_NAME}" get nodes -l '!node-role.kubernetes.io/control-plane' -o name); do
+  # shellcheck disable=SC2086
+  kubectl --context "kind-${NVKIND_CLUSTER_NAME}" label $node $NODE_LABELS --overwrite
+done
+
+sg docker -c "nvkind cluster print-gpus --name ${NVKIND_CLUSTER_NAME}"
+echo "nvkind cluster ${NVKIND_CLUSTER_NAME} ready"


### PR DESCRIPTION
experiment/gcp-nvkind/ provides reusable shell helpers for Prow jobs that want a GCE-hosted NVIDIA GPU under a nvkind-managed kind cluster:

```
  lib/boskos.sh            acquire / heartbeat / release a Boskos resource
  lib/gce.sh               GCE VM lifecycle: create / ssh / scp / delete
  lib/setup-nvkind-node.sh on-VM install of Docker + NVIDIA toolkit + Go
                           + kind + nvkind + helm + kubectl, then create
                           a DRA-enabled kind cluster
  lib/nvkind-config.yaml.tmpl  kind config with DRA feature gate + CDI
```

nvkind and boskosctl are pinned to commit SHAs (neither project publishes tags); bumps are reviewable diffs.

config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml adds the first consumer: an optional presubmit and a 6-hour periodic for kubernetes-sigs/dra-driver-nvidia-gpu. Both source the shared lib via TESTINFRA_DIR, share the gce-gpu-test job queue for concurrency, and keep Docker work off the Prow pod (no DinD, no privileged).

https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/pull/1063 builds on this harness with a specific set of CI jobs for `dra-driver-nvidia-gpu`