### PR TITLE
experiment/lambda: install aarch64 cross-gcc when cross-compiling

### DIFF
--- a/experiment/lambda/e2e-test.sh
+++ b/experiment/lambda/e2e-test.sh
@@ -29,6 +29,13 @@ source "${SCRIPT_DIR}/lib/lambda-common.sh"
 lambda_init_and_launch
 
 # --- Build k8s binaries ---
+# Install the arm64 cross-compile toolchain when targeting arm64 from an
+# amd64 build host. kubelet's cgo code paths cannot be compiled with
+# CGO_ENABLED=0, so we need a real cross-gcc.
+if [ "${LAMBDA_ARCH}" = "arm64" ] && ! command -v aarch64-linux-gnu-gcc >/dev/null 2>&1; then
+  echo "Installing aarch64 cross-compile toolchain..."
+  apt-get update -qq && apt-get install -y -qq gcc-aarch64-linux-gnu
+fi
 git fetch --tags --depth 100 origin 2>/dev/null || true
 make \
   WHAT="cmd/kubeadm cmd/kubelet cmd/kubectl test/e2e/e2e.test vendor/github.com/onsi/ginkgo/v2/ginkgo" \


### PR DESCRIPTION
ci-kubernetes-e2e-lambda-device-plugin-gpu-gh200 runs on the amd64 kubekins-e2e Prow container but targets a gpu_1x_gh200 (arm64) Lambda instance, so the make invocation cross-compiles k8s binaries for linux/arm64. kubelet's cgo code paths require a real C compiler, and the container image does not ship gcc-aarch64-linux-gnu, so cgo fails with:

snippet from [log](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-lambda-device-plugin-gpu-gh200/2045706652379779072):
```
  cgo: C compiler "aarch64-linux-gnu-gcc" not found
```