### PR TITLE
dra-driver-nvidia-gpu: add gh200 lambda presubmit and periodic

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
@@ -54,6 +54,49 @@ presubmits:
             cpu: "4"
             memory: "8Gi"
 
+  # Opt-in variant pinned to gpu_1x_gh200 (arm64). Not always_run because the
+  # GPU_TYPE="" presubmit above already runs on every PR and may land on a
+  # GH200 by chance; this job exists for explicit arm64 coverage on demand via
+  # `/test pull-dra-driver-nvidia-gpu-e2e-lambda-gpu-gh200`.
+  - name: pull-dra-driver-nvidia-gpu-e2e-lambda-gpu-gh200
+    cluster: k8s-infra-prow-build
+    optional: true
+    always_run: false
+    max_concurrency: 1
+    skip_branches:
+    - release-\d+\.\d+
+    decorate: true
+    decoration_config:
+      timeout: 2h
+    labels:
+      preset-lambda-credential: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
+    annotations:
+      testgrid-dashboards: sig-node-gpu, lambda-gpu-presubmits
+      testgrid-tab-name: pull-dra-driver-nvidia-gpu-lambda-gh200
+      description: "DRA GPU e2e tests on a Lambda Cloud gpu_1x_gh200 (arm64) instance"
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+        command:
+        - runner.sh
+        args:
+        - hack/ci/lambda/e2e-test.sh
+        env:
+        - name: GPU_TYPE
+          value: "gpu_1x_gh200"
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
+
 periodics:
 - name: ci-dra-driver-nvidia-gpu-e2e-lambda-gpu
   cluster: k8s-infra-prow-build
@@ -86,6 +129,50 @@ periodics:
       env:
       - name: GPU_TYPE
         value: ""
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"
+
+# Same 6h cadence as the GPU_TYPE="" periodic above, but pinned to
+# gpu_1x_gh200 (arm64). Cron fires at 00:30, 06:30, 12:30, 18:30 UTC --
+# maximally offset (3h) from ci-kubernetes-e2e-lambda-device-plugin-gpu-gh200
+# at "30 3,9,15,21 * * *" so the two gh200 periodics don't compete for Lambda
+# GH200 capacity.
+- name: ci-dra-driver-nvidia-gpu-e2e-lambda-gpu-gh200
+  cluster: k8s-infra-prow-build
+  cron: "30 0,6,12,18 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  labels:
+    preset-lambda-credential: "true"
+  annotations:
+    testgrid-dashboards: sig-node-gpu, lambda-gpu-periodics
+    testgrid-tab-name: ci-dra-driver-nvidia-gpu-lambda-gh200
+    description: "Periodic DRA GPU e2e tests on a Lambda Cloud gpu_1x_gh200 (arm64) instance"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: dra-driver-nvidia-gpu
+    base_ref: main
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+      command:
+      - runner.sh
+      args:
+      - hack/ci/lambda/e2e-test.sh
+      env:
+      - name: GPU_TYPE
+        value: "gpu_1x_gh200"
       resources:
         requests:
           cpu: "4"


### PR DESCRIPTION
Mirrors the ci-kubernetes-e2e-lambda-device-plugin-gpu-gh200 pattern for the DRA driver: two new jobs pinned to GPU_TYPE=gpu_1x_gh200 (arm64) alongside the existing GPU_TYPE="" (any-GPU) jobs.

- pull-dra-driver-nvidia-gpu-e2e-lambda-gpu-gh200
- ci-dra-driver-nvidia-gpu-e2e-lambda-gpu-gh200

No script changes needed: hack/ci/lambda/e2e-test.sh in the driver repo already uses lambda_download_k8s (no source build, no cross-compile), builds the driver image natively on the Lambda host, and has runtime gh200 awareness in its BATS filter tags.