### PR TITLE
config/jobs/lambda: skip amd64-only GPU tests on arm64 GH200

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
@@ -135,6 +135,12 @@ periodics:
       env:
       - name: GPU_TYPE
         value: "gpu_1x_gh200"
+      # tensorflow/tensorflow:latest-gpu and cupy/cupy:v13.3.0 (used by
+      # "Test using a Pod" and "Test using a Job" in test/e2e/node/gpu.go)
+      # are amd64-only; skip them on arm64 until upstream k/k switches to
+      # multi-arch images.
+      - name: GINKGO_SKIP
+        value: '\[Flaky\]|Test using a Pod|Test using a Job'
       args:
       - bash
       - -c

--- a/experiment/lambda/e2e-test.sh
+++ b/experiment/lambda/e2e-test.sh
@@ -72,6 +72,10 @@ fi
 EOF
 
 # --- Run GPU e2e tests ---
+# Default skip pattern; jobs may override via the GINKGO_SKIP env var
+# (e.g. the gh200 periodic skips the two [Feature:GPUDevicePlugin] tests
+# whose container images are amd64-only).
+GINKGO_SKIP="${GINKGO_SKIP:-\\[Flaky\\]}"
 lambda_remote bash -s <<TESTEOF
 set -eux
 export KUBECONFIG=\$HOME/.kube/config
@@ -79,7 +83,7 @@ mkdir -p /tmp/gpu-test-artifacts
 /tmp/ginkgo \
   -timeout=60m \
   -focus="\[Feature:GPUDevicePlugin\]" \
-  -skip="\[Flaky\]" \
+  -skip="${GINKGO_SKIP}" \
   -v \
   /tmp/e2e.test \
   -- \


### PR DESCRIPTION
Two of the three [Feature:GPUDevicePlugin] tests in test/e2e/node/gpu.go hard-code container images that are only published for linux/amd64:

  - "Test using a Pod" -> tensorflow/tensorflow:latest-gpu
  - "Test using a Job" -> cupy/cupy:v13.3.0

Both fail on arm64 with "no matching manifest for linux/arm64". The sanity test is fine (nvidia/cuda:12.5.0-devel-ubuntu22.04 is multi-arch), and upstream's only skip gate is
SkipUnlessProviderIs("aws","gce"), which does not filter by arch.