### PR TITLE
config/jobs/dra-driver-nvidia-gpu: run gh200 and gcp-nvkind presubmits on every PR

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
@@ -12,7 +12,7 @@ presubmits:
     cluster: k8s-infra-prow-build
     job_queue_name: gce-gpu-test
     optional: true
-    always_run: false
+    always_run: true
     max_concurrency: 1
     skip_branches:
     - release-\d+\.\d+

--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
@@ -54,14 +54,14 @@ presubmits:
             cpu: "4"
             memory: "8Gi"
 
-  # Opt-in variant pinned to gpu_1x_gh200 (arm64). Not always_run because the
-  # GPU_TYPE="" presubmit above already runs on every PR and may land on a
-  # GH200 by chance; this job exists for explicit arm64 coverage on demand via
-  # `/test pull-dra-driver-nvidia-gpu-e2e-lambda-gpu-gh200`.
+  # Variant pinned to gpu_1x_gh200 (arm64). Runs on every PR to guarantee
+  # arm64 coverage; the GPU_TYPE="" presubmit above picks whatever instance
+  # type Lambda has spare and rarely lands on gh200 in practice. Kept
+  # optional so a gh200 stockout or arm64-only flake doesn't gate merges.
   - name: pull-dra-driver-nvidia-gpu-e2e-lambda-gpu-gh200
     cluster: k8s-infra-prow-build
     optional: true
-    always_run: false
+    always_run: true
     max_concurrency: 1
     skip_branches:
     - release-\d+\.\d+


### PR DESCRIPTION
Flip both optional presubmits from `always_run: false` to `always_run: true`:

  - `pull-dra-driver-nvidia-gpu-e2e-gcp-nvkind`    (GCE T4 via Boskos)
  - `pull-dra-driver-nvidia-gpu-e2e-lambda-gpu-gh200`  (Lambda gpu_1x_gh200, arm64)

Every PR now gets both the GCP/GPU-Operator path and the arm64 Lambda path by default, instead of depending on the GPU_TYPE="" lambda job happening to land on a gh200 (almost never) or on a maintainer remembering to /test the jobs by hand.

- https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-dra-driver-nvidia-gpu-e2e-lambda-gpu-gh200
- https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-dra-driver-nvidia-gpu-e2e-gcp-nvkind

Both stay optional: true, so a Boskos shortage, Lambda gh200 stockout, or arm64-only flake does not gate merges while these paths stabilize.