### PR TITLE
config/testgrids: add nvidia dashboard group

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
@@ -25,7 +25,7 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/test-infra
     annotations:
-      testgrid-dashboards: sig-node-gpu
+      testgrid-dashboards: sig-node-gpu, nvidia-gpu, nvidia-dra, nvidia-presubmits
       testgrid-tab-name: pull-dra-driver-nvidia-gpu-gcp-nvkind
       description: "DRA GPU e2e on GCP + nvkind + GPU Operator (optional presubmit)"
     spec:
@@ -83,7 +83,7 @@ periodics:
     base_ref: master
     path_alias: k8s.io/test-infra
   annotations:
-    testgrid-dashboards: sig-node-gpu
+    testgrid-dashboards: sig-node-gpu, nvidia-gpu, nvidia-dra, nvidia-periodics
     testgrid-tab-name: ci-dra-driver-nvidia-gpu-gcp-nvkind
     description: "Periodic DRA GPU e2e on GCP + nvkind + GPU Operator"
   spec:

--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
@@ -33,7 +33,7 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/test-infra
     annotations:
-      testgrid-dashboards: sig-node-gpu, lambda-gpu-presubmits
+      testgrid-dashboards: sig-node-gpu, lambda-gpu-presubmits, nvidia-gpu, nvidia-dra, nvidia-presubmits
       testgrid-tab-name: pull-dra-driver-nvidia-gpu-lambda
       description: "DRA GPU e2e tests on Lambda Cloud for dra-driver-nvidia-gpu PRs"
     spec:
@@ -76,7 +76,7 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/test-infra
     annotations:
-      testgrid-dashboards: sig-node-gpu, lambda-gpu-presubmits
+      testgrid-dashboards: sig-node-gpu, lambda-gpu-presubmits, nvidia-gpu, nvidia-dra, nvidia-arm64, nvidia-presubmits
       testgrid-tab-name: pull-dra-driver-nvidia-gpu-lambda-gh200
       description: "DRA GPU e2e tests on a Lambda Cloud gpu_1x_gh200 (arm64) instance"
     spec:
@@ -107,7 +107,7 @@ periodics:
   labels:
     preset-lambda-credential: "true"
   annotations:
-    testgrid-dashboards: sig-node-gpu, lambda-gpu-periodics
+    testgrid-dashboards: sig-node-gpu, lambda-gpu-periodics, nvidia-gpu, nvidia-dra, nvidia-periodics
     testgrid-tab-name: ci-dra-driver-nvidia-gpu-lambda
     description: "Periodic DRA GPU e2e tests on Lambda Cloud"
   extra_refs:
@@ -151,7 +151,7 @@ periodics:
   labels:
     preset-lambda-credential: "true"
   annotations:
-    testgrid-dashboards: sig-node-gpu, lambda-gpu-periodics
+    testgrid-dashboards: sig-node-gpu, lambda-gpu-periodics, nvidia-gpu, nvidia-dra, nvidia-arm64, nvidia-periodics
     testgrid-tab-name: ci-dra-driver-nvidia-gpu-lambda-gh200
     description: "Periodic DRA GPU e2e tests on a Lambda Cloud gpu_1x_gh200 (arm64) instance"
   extra_refs:

--- a/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
@@ -25,7 +25,7 @@ presubmits:
     labels:
       preset-lambda-credential: "true"
     annotations:
-      testgrid-dashboards: sig-node-gpu, lambda-gpu-presubmits
+      testgrid-dashboards: sig-node-gpu, lambda-gpu-presubmits, nvidia-gpu, nvidia-device-plugin, nvidia-presubmits
       testgrid-tab-name: pull-lambda-device-plugin-gpu
       description: "Runs [Feature:GPUDevicePlugin] e2e tests on a Lambda Cloud GPU instance"
     decorate: true
@@ -65,7 +65,7 @@ periodics:
   labels:
     preset-lambda-credential: "true"
   annotations:
-    testgrid-dashboards: sig-node-gpu, lambda-gpu-periodics
+    testgrid-dashboards: sig-node-gpu, lambda-gpu-periodics, nvidia-gpu, nvidia-device-plugin, nvidia-periodics
     testgrid-tab-name: ci-lambda-device-plugin-gpu
     description: "Runs [Feature:GPUDevicePlugin] e2e tests on a Lambda Cloud GPU instance"
   decorate: true
@@ -111,7 +111,7 @@ periodics:
   labels:
     preset-lambda-credential: "true"
   annotations:
-    testgrid-dashboards: sig-node-gpu, lambda-gpu-periodics
+    testgrid-dashboards: sig-node-gpu, lambda-gpu-periodics, nvidia-gpu, nvidia-device-plugin, nvidia-arm64, nvidia-periodics
     testgrid-tab-name: ci-lambda-device-plugin-gpu-gh200
     description: "Runs [Feature:GPUDevicePlugin] e2e tests on a Lambda Cloud gpu_1x_gh200 (arm64) instance"
   decorate: true

--- a/config/testgrids/nvidia/OWNERS
+++ b/config/testgrids/nvidia/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+- dims
+- shivamerla

--- a/config/testgrids/nvidia/nvidia.yaml
+++ b/config/testgrids/nvidia/nvidia.yaml
@@ -1,0 +1,19 @@
+# Testgrid dashboards for Kubernetes + NVIDIA GPU integration jobs.
+
+dashboards:
+- name: nvidia-gpu              # rollup: every NVIDIA GPU job opts in
+- name: nvidia-device-plugin    # classic nvidia.com/gpu stack
+- name: nvidia-dra              # DRA stack (dra-driver-nvidia-gpu, dra-gpu)
+- name: nvidia-arm64            # arm64 coverage (GH200)
+- name: nvidia-periodics
+- name: nvidia-presubmits
+
+dashboard_groups:
+- name: nvidia
+  dashboard_names:
+  - nvidia-gpu
+  - nvidia-device-plugin
+  - nvidia-dra
+  - nvidia-arm64
+  - nvidia-periodics
+  - nvidia-presubmits

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -59,6 +59,7 @@ var (
 		"jetstack",
 		"kubevirt",
 		"lambda",
+		"nvidia",
 	}
 	orgs = []string{
 		"conformance",


### PR DESCRIPTION
Today NVIDIA GPU jobs scatter across sig-node-gpu, amazon-ec2, lambda-gpu-{periodics,presubmits}, and sig-release-*-blocking. Works for cross-SIG visibility but is poor for vendor triage: you can't tell at a glance whether a red build is device-plugin vs DRA, or amd64 vs arm64.
