### PR TITLE
config/jobs/lambda: also skip GPU sanity test on gh200 arm64

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda.yaml
@@ -135,12 +135,14 @@ periodics:
       env:
       - name: GPU_TYPE
         value: "gpu_1x_gh200"
-      # tensorflow/tensorflow:latest-gpu and cupy/cupy:v13.3.0 (used by
-      # "Test using a Pod" and "Test using a Job" in test/e2e/node/gpu.go)
-      # are amd64-only; skip them on arm64 until upstream k/k switches to
-      # multi-arch images.
+      # test/e2e/node/gpu.go hard-codes paths that don't work on arm64:
+      #  - "Test using a Pod" -> tensorflow/tensorflow:latest-gpu (amd64-only)
+      #  - "Test using a Job" -> cupy/cupy:v13.3.0 (amd64-only)
+      #  - "Sanity test using nvidia-smi" -> apt install cuda-demo-suite-12-5
+      #    which NVIDIA only publishes for x86_64 (no package on sbsa).
+      # Skip all three on arm64 until upstream k/k fixes each.
       - name: GINKGO_SKIP
-        value: '\[Flaky\]|Test using a Pod|Test using a Job'
+        value: '\[Flaky\]|Sanity test using nvidia-smi|Test using a Pod|Test using a Job'
       args:
       - bash
       - -c


### PR DESCRIPTION
The Sanity test in test/e2e/node/gpu.go embeds `apt-get install -y cuda-demo-suite-12-5` under `set -e`. NVIDIA's CUDA apt repo publishes that package for x86_64 but not for sbsa/arm64, so the install fails, the container exits 1, and the test asserts PodSucceeded. All three [Feature:GPUDevicePlugin] tests in gpu.go have arm64-hostile hard-coded paths today; skip the sanity test too until upstream k/k addresses the script.

Root-cause evidence:

  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/Packages
  -> 0 cuda-demo-suite-* entries
  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/Packages
  -> cuda-demo-suite-12-5 present

This keeps ci-kubernetes-e2e-lambda-device-plugin-gpu-gh200 green as a smoke signal (kubelet+device-plugin boot, nvidia.com/gpu advertised) while the upstream fix is in flight.