### PR TITLE
config/jobs/dra-driver-nvidia-gpu: pin gcp-nvkind periodic to a published kindest/node tag

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
@@ -106,7 +106,7 @@ periodics:
       - name: GCE_IMAGE_PROJECT
         value: "deeplearning-platform-release"
       - name: K8S_VERSION
-        value: "v1.35.3"
+        value: "v1.35.1"
       - name: GPU_OPERATOR_VERSION
         value: "v26.3.1"
       - name: TESTINFRA_DIR


### PR DESCRIPTION
Docker Hub only has v1.35.0 (2025-12-18) and v1.35.1 (2026-02-14) published for the 1.35 line -- kindest/node images lag kubernetes patch releases because the kind maintainers publish on their own cadence.