### PR TITLE
Build images from new node-local-dns repo

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-dns.yaml
+++ b/config/jobs/image-pushing/k8s-staging-dns.yaml
@@ -23,3 +23,26 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-dns-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+  kubernetes-sigs/node-local-dns:
+    - name: node-local-dns-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        # this is the name of some testgrid dashboard to report to.
+        testgrid-dashboards: sig-network-dns, sig-k8s-infra-gcb
+      decorate: true
+      # match on regex '^\d+\.\d+\.\d+$' to trigger job on new tags
+      branches:
+        - ^master$
+        - ^\d+\.\d+\.\d+$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20251215-d7853fe2a6
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+              - --project=k8s-staging-images
+              - --scratch-bucket=gs://k8s-staging-images-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .


### PR DESCRIPTION
https://github.com/kubernetes/dns is being deprecated; the node-local-dns images should be built from https://github.com/kubernetes-sigs/node-local-dns now. (https://github.com/kubernetes/kubernetes/issues/137556)

For simplicity, we're preserving the existing image names, so this should just be a matter of (a) build from node-local-dns, (b) update k/dns to stop building the node-local-dns image so the two repos don't fight over it. It may be best to merge (b) first, but we shouldn't do that until we know we're ready to merge (a)?

(I've never worked with this stuff, so I don't know if this PR is correct.)

cc @bowei 