### PR TITLE
CAPZ: bump k8s pinned versions

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -209,7 +209,7 @@ periodics:
           - name: GINKGO_FOCUS
             value: "API Version Upgrade"
           - name: KUBERNETES_VERSION
-            value: "v1.30.3"
+            value: "v1.33.10"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -294,7 +294,7 @@ periodics:
         - name: GINKGO_SKIP
           value: \[Managed Kubernetes\]|\[WINDOWS\]|\[KubeRay\]
         - name: KUBERNETES_VERSION
-          value: v1.33.9 # TODO: Remove this once v1.33.10 artifacts are published for Flatcar and RKE2 tests
+          value: v1.35.3 # Pin to previous patch until Flatcar and RKE2 publish v1.35.4 artifacts
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -145,7 +145,7 @@ presubmits:
           - name: GINKGO_SKIP
             value: \[KubeRay\]
           - name: KUBERNETES_VERSION
-            value: v1.33.9 # TODO: Remove this once v1.33.10 artifacts are published for Flatcar and RKE2 tests
+            value: v1.35.3 # Pin to previous patch until Flatcar and RKE2 publish v1.35.4 artifacts
         resources:
           limits:
             cpu: 4

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-release-v1beta1.yaml
@@ -118,7 +118,7 @@ presubmits:
             - name: GINKGO_FOCUS
               value: "API Version Upgrade"
             - name: KUBERNETES_VERSION
-              value: "v1.30.3"
+              value: "v1.33.10"
           resources:
             limits:
               cpu: 6


### PR DESCRIPTION
This moves kubernetes test versions forward in sync with kubernetes-sigs/cluster-api-provider-azure#6245, and moves off of k8s v1.30 which went out of support in June 2025.