### PR TITLE
fix sig-scheduling testgrid board

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-descheduler.yaml
+++ b/config/jobs/image-pushing/k8s-staging-descheduler.yaml
@@ -15,7 +15,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         # This is the name of some testgrid dashboard to report to.
-        testgrid-dashboards: sig-scheduling, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-scheduling-descheduler, sig-k8s-infra-gcb
       decorate: true
       branches:
         - ^master$

--- a/config/jobs/image-pushing/k8s-staging-kueue.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kueue.yaml
@@ -3,7 +3,7 @@ postsubmits:
     - name: post-kueue-push-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-scheduling, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-scheduling-kueue, sig-k8s-infra-gcb
       decorate: true
       branches:
         - ^main$

--- a/config/jobs/image-pushing/k8s-staging-kwok.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kwok.yaml
@@ -5,7 +5,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
-        testgrid-dashboards: sig-scheduling, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-scheduling-kwok, sig-k8s-infra-gcb
       decorate: true
       branches:
         - ^main$

--- a/config/jobs/image-pushing/k8s-staging-sched-simulator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sched-simulator.yaml
@@ -8,7 +8,7 @@ postsubmits:
       annotations:
         # This is the name of some testgrid dashboard to report to.
         # If this is the first one for your sig, you may need to create one
-        testgrid-dashboards: sig-scheduling, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-scheduling-simulator, sig-k8s-infra-gcb
       decorate: true
       # this causes the job to only run on the master branch. Remove it if your
       # job makes sense on every branch (unless it's setting a `latest` tag it

--- a/config/jobs/image-pushing/k8s-staging-scheduler-plugins.yaml
+++ b/config/jobs/image-pushing/k8s-staging-scheduler-plugins.yaml
@@ -7,7 +7,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         # This is the name of some testgrid dashboard to report to.
-        testgrid-dashboards: sig-scheduling, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-scheduling-scheduler-plugins, sig-k8s-infra-gcb
       decorate: true
       branches:
         - ^master$

--- a/config/jobs/image-pushing/k8s-staging-wasm-scheduler.yaml
+++ b/config/jobs/image-pushing/k8s-staging-wasm-scheduler.yaml
@@ -8,7 +8,7 @@ postsubmits:
       annotations:
         # This is the name of some testgrid dashboard to report to.
         # If this is the first one for your sig, you may need to create one
-        testgrid-dashboards: sig-scheduling, sig-k8s-infra-gcb
+        testgrid-dashboards: sig-scheduling-wasm-extensions, sig-k8s-infra-gcb
       decorate: true
       # this causes the job to only run on the main branch. Remove it if your
       # job makes sense on every branch (unless it's setting a `latest` tag it

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.32.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.32.yaml
@@ -70,7 +70,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-32-1-32
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.32-1.32
     decorate: true
     decoration_config:
@@ -109,7 +109,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-32-1-31
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.32-1.31
     decorate: true
     decoration_config:
@@ -148,7 +148,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-32-1-30
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.32-1.30
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.33.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.33.yaml
@@ -70,7 +70,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-33-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.33-1.33
     decorate: true
     decoration_config:
@@ -109,7 +109,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-33-1-32
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.33-1.32
     decorate: true
     decoration_config:
@@ -148,7 +148,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-33-1-31
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.33-1.31
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.34.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.34.yaml
@@ -70,7 +70,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-34-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.34-1.34
     decorate: true
     decoration_config:
@@ -109,7 +109,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-34-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.34-1.33
     decorate: true
     decoration_config:
@@ -148,7 +148,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-34-1-32
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.34-1.32
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.35.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits-release-1.35.yaml
@@ -70,7 +70,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-35-1-35
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.35-1.35
     decorate: true
     decoration_config:
@@ -109,7 +109,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-35-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.35-1.34
     decorate: true
     decoration_config:
@@ -148,7 +148,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-release-1-35-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-release-1.35-1.33
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-capacity/cluster-capacity-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-master-1-35
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.35
     decorate: true
     decoration_config:
@@ -109,7 +109,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-master-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.34
     decorate: true
     decoration_config:
@@ -148,7 +148,7 @@ presubmits:
   - name: pull-cluster-capacity-test-e2e-k8s-master-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-cluster-capacity
       testgrid-tab-name: pull-cluster-capacity-test-e2e-k8s-master-1.33
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -4,7 +4,7 @@ presubmits:
   - name: pull-descheduler-verify-master
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-verify-master
     decorate: true
     decoration_config:
@@ -31,7 +31,7 @@ presubmits:
   - name: pull-descheduler-verify-build-master
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-verify-build-master
     decorate: true
     decoration_config:
@@ -58,7 +58,7 @@ presubmits:
   - name: pull-descheduler-unit-test-master-master
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-unit-test-master
     decorate: true
     decoration_config:
@@ -86,7 +86,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-master-1-35
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.35
     decorate: true
     decoration_config:
@@ -124,7 +124,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-master-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.34
     decorate: true
     decoration_config:
@@ -162,7 +162,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-master-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-master-1.33
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.33.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.33.yaml
@@ -4,7 +4,7 @@ presubmits:
   - name: pull-descheduler-verify-release-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-verify-release-1.33
     decorate: true
     decoration_config:
@@ -31,7 +31,7 @@ presubmits:
   - name: pull-descheduler-verify-build-release-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-verify-build-release-1.33
     decorate: true
     decoration_config:
@@ -58,7 +58,7 @@ presubmits:
   - name: pull-descheduler-unit-test-release-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-unit-test-release-1.33
     decorate: true
     decoration_config:
@@ -86,7 +86,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-release-1-33-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-33-1.33
     decorate: true
     decoration_config:
@@ -124,7 +124,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-release-1-33-1-32
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-33-1.32
     decorate: true
     decoration_config:
@@ -162,7 +162,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-release-1-33-1-31
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-33-1.31
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.34.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.34.yaml
@@ -4,7 +4,7 @@ presubmits:
   - name: pull-descheduler-verify-release-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-verify-release-1.34
     decorate: true
     decoration_config:
@@ -31,7 +31,7 @@ presubmits:
   - name: pull-descheduler-verify-build-release-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-verify-build-release-1.34
     decorate: true
     decoration_config:
@@ -58,7 +58,7 @@ presubmits:
   - name: pull-descheduler-unit-test-release-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-unit-test-release-1.34
     decorate: true
     decoration_config:
@@ -86,7 +86,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-release-1-34-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-34-1.34
     decorate: true
     decoration_config:
@@ -124,7 +124,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-release-1-34-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-34-1.33
     decorate: true
     decoration_config:
@@ -162,7 +162,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-release-1-34-1-32
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-34-1.32
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.35.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.35.yaml
@@ -4,7 +4,7 @@ presubmits:
   - name: pull-descheduler-verify-release-1-35
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-verify-release-1.35
     decorate: true
     decoration_config:
@@ -31,7 +31,7 @@ presubmits:
   - name: pull-descheduler-verify-build-release-1-35
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-verify-build-release-1.35
     decorate: true
     decoration_config:
@@ -58,7 +58,7 @@ presubmits:
   - name: pull-descheduler-unit-test-release-1-35
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-unit-test-release-1.35
     decorate: true
     decoration_config:
@@ -86,7 +86,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-release-1-35-1-35
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-35-1.35
     decorate: true
     decoration_config:
@@ -124,7 +124,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-release-1-35-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-35-1.34
     decorate: true
     decoration_config:
@@ -162,7 +162,7 @@ presubmits:
   - name: pull-descheduler-test-e2e-k8s-release-1-35-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-descheduler, sig-scheduling-descheduler-presubmits
       testgrid-tab-name: pull-descheduler-test-e2e-k8s-release-1-35-1.33
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
@@ -4,7 +4,7 @@ presubmits:
   - name: pull-kube-scheduler-simulator-backend-lint
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-simulator
       testgrid-tab-name: pull-kube-scheduler-simulator-backend-lint
     decorate: true
     path_alias: sigs.k8s.io/kube-scheduler-simulator
@@ -32,7 +32,7 @@ presubmits:
   - name: pull-kube-scheduler-simulator-frontend-lint
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-simulator
       testgrid-tab-name: pull-kube-scheduler-simulator-frontend-lint
     decorate: true
     path_alias: sigs.k8s.io/kube-scheduler-simulator

--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-test-backend.yaml
@@ -4,7 +4,7 @@ presubmits:
   - name: pull-kube-scheduler-simulator-backend-unit-test
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-simulator
       testgrid-tab-name: pull-kube-scheduler-simulator-backend-unit-test
     decorate: true
     path_alias: sigs.k8s.io/kube-scheduler-simulator

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -3,7 +3,7 @@ periodics:
     name: periodic-kueue-test-unit-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-unit-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -43,7 +43,7 @@ periodics:
     name: periodic-kueue-verify-website-links-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-verify-website-links-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -82,7 +82,7 @@ periodics:
     name: periodic-kueue-test-integration-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-integration-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -120,7 +120,7 @@ periodics:
     name: periodic-kueue-test-integration-multikueue-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-integration-multikueue-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -158,7 +158,7 @@ periodics:
     name: periodic-kueue-test-scheduling-perf-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-scheduling-perf-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -196,7 +196,7 @@ periodics:
     name: periodic-kueue-test-tas-scheduling-perf-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-tas-scheduling-perf-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -272,7 +272,7 @@ periodics:
     name: periodic-kueue-test-e2e-main-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-main-1-33
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -318,7 +318,7 @@ periodics:
     name: periodic-kueue-test-e2e-main-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-main-1-34
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -364,7 +364,7 @@ periodics:
     name: periodic-kueue-test-e2e-main-1-35
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-main-1-35
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -410,7 +410,7 @@ periodics:
     name: periodic-kueue-test-e2e-multikueue-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -456,7 +456,7 @@ periodics:
     name: periodic-kueue-test-e2e-multikueue-sequential-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-sequential-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -502,7 +502,7 @@ periodics:
     name: periodic-kueue-test-e2e-tas-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-tas-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -548,8 +548,7 @@ periodics:
     name: periodic-kueue-test-e2e-sequential-baseline-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-sequential-baseline-main
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic sequential baseline end to end tests"
@@ -595,7 +594,7 @@ periodics:
     name: periodic-kueue-test-e2e-sequential-extended-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-sequential-extended-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -641,7 +640,7 @@ periodics:
     name: periodic-kueue-test-e2e-certmanager-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-certmanager-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -687,7 +686,7 @@ periodics:
     name: periodic-kueue-test-e2e-dra-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-dra-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -733,7 +732,7 @@ periodics:
     name: periodic-kueue-test-e2e-multikueue-dra-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-dra-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -779,7 +778,7 @@ periodics:
     name: periodic-kueue-test-e2e-k8s-main-was
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-k8s-main-was
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -821,7 +820,7 @@ periodics:
     name: periodic-kueue-test-e2e-kueueviz-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-kueueviz-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
@@ -3,7 +3,7 @@ periodics:
     name: periodic-kueue-test-unit-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-unit-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -43,7 +43,7 @@ periodics:
     name: periodic-kueue-test-integration-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-integration-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -81,7 +81,7 @@ periodics:
     name: periodic-kueue-test-integration-multikueue-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-integration-multikueue-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -119,7 +119,7 @@ periodics:
     name: periodic-kueue-test-scheduling-perf-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-scheduling-perf-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -157,7 +157,7 @@ periodics:
     name: periodic-kueue-test-tas-scheduling-perf-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-tas-scheduling-perf-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -195,7 +195,7 @@ periodics:
     name: periodic-kueue-test-e2e-release-0-16-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-release-0-16-1-33
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -241,7 +241,7 @@ periodics:
     name: periodic-kueue-test-e2e-release-0-16-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-release-0-16-1-34
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -287,7 +287,7 @@ periodics:
     name: periodic-kueue-test-e2e-release-0-16-1-35
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-release-0-16-1-35
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -333,7 +333,7 @@ periodics:
     name: periodic-kueue-test-e2e-multikueue-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -379,7 +379,7 @@ periodics:
     name: periodic-kueue-test-e2e-multikueue-sequential-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-sequential-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -425,7 +425,7 @@ periodics:
     name: periodic-kueue-test-e2e-tas-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-tas-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -471,8 +471,7 @@ periodics:
     name: periodic-kueue-test-e2e-sequential-baseline-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-sequential-baseline-release-0-16
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic sequential baseline end to end tests"
@@ -563,7 +562,7 @@ periodics:
     name: periodic-kueue-test-e2e-certmanager-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-certmanager-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -609,7 +608,7 @@ periodics:
     name: periodic-kueue-test-e2e-dra-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-dra-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -655,7 +654,7 @@ periodics:
     name: periodic-kueue-test-e2e-kueueviz-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-kueueviz-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -3,7 +3,7 @@ periodics:
     name: periodic-kueue-test-unit-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-unit-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -43,7 +43,7 @@ periodics:
     name: periodic-kueue-verify-website-links-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-verify-website-links-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -82,7 +82,7 @@ periodics:
     name: periodic-kueue-test-integration-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-integration-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -120,7 +120,7 @@ periodics:
     name: periodic-kueue-test-integration-multikueue-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-integration-multikueue-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -158,7 +158,7 @@ periodics:
     name: periodic-kueue-test-scheduling-perf-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-scheduling-perf-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -196,7 +196,7 @@ periodics:
     name: periodic-kueue-test-tas-scheduling-perf-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-tas-scheduling-perf-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -234,7 +234,7 @@ periodics:
     name: periodic-kueue-test-e2e-release-0-17-1-33
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-release-0-17-1-33
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -280,7 +280,7 @@ periodics:
     name: periodic-kueue-test-e2e-release-0-17-1-34
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-release-0-17-1-34
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -326,7 +326,7 @@ periodics:
     name: periodic-kueue-test-e2e-release-0-17-1-35
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-release-0-17-1-35
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -372,7 +372,7 @@ periodics:
     name: periodic-kueue-test-e2e-multikueue-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -418,7 +418,7 @@ periodics:
     name: periodic-kueue-test-e2e-multikueue-sequential-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-sequential-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -464,7 +464,7 @@ periodics:
     name: periodic-kueue-test-e2e-tas-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-tas-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -510,8 +510,7 @@ periodics:
     name: periodic-kueue-test-e2e-sequential-baseline-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-sequential-baseline-release-0-17
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run periodic sequential baseline end to end tests"
@@ -602,7 +601,7 @@ periodics:
     name: periodic-kueue-test-e2e-certmanager-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-certmanager-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -648,7 +647,7 @@ periodics:
     name: periodic-kueue-test-e2e-dra-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-dra-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -694,7 +693,7 @@ periodics:
     name: periodic-kueue-test-e2e-multikueue-dra-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-dra-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -740,7 +739,7 @@ periodics:
     name: periodic-kueue-test-e2e-k8s-release-0-17-was
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-k8s-release-0-17-was
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
@@ -782,7 +781,7 @@ periodics:
     name: periodic-kueue-test-e2e-kueueviz-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-test-e2e-kueueviz-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-main.yaml
@@ -3,8 +3,7 @@ periodics:
     name: periodic-kueue-build-s390x-ppc64le-main
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-build-s390x-ppc64le-main
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: "Run s390x & power periodic job to build kueue image"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.15.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.15.yaml
@@ -3,7 +3,7 @@ periodics:
     name: periodic-kueue-build-s390x-ppc64le-release-0-15
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-build-s390x-ppc64le-release-0-15
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.16.yaml
@@ -3,7 +3,7 @@ periodics:
     name: periodic-kueue-build-s390x-ppc64le-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-periodics
       testgrid-tab-name: periodic-kueue-build-s390x-ppc64le-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -8,7 +8,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-unit-main
         description: "Run kueue unit tests"
       spec:
@@ -38,7 +38,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-integration-baseline-main
         description: "Run kueue test-integration-baseline"
       spec:
@@ -66,7 +66,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-integration-extended-main
         description: "Run kueue test-integration-extended"
       spec:
@@ -94,7 +94,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-integration-multikueue-main
         description: "Run kueue test-multikueue-integration"
       spec:
@@ -122,7 +122,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-main-1-33
         description: "Run kueue end to end tests for Kubernetes 1.33"
       labels:
@@ -160,7 +160,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-main-1-34
         description: "Run kueue end to end tests for Kubernetes 1.34"
       labels:
@@ -198,7 +198,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-main-1-35
         description: "Run kueue end to end tests for Kubernetes 1.35"
       labels:
@@ -236,7 +236,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-main
         description: "Run multikueue end to end tests"
       labels:
@@ -274,7 +274,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-sequential-main
         description: "Run multikueue sequential end to end tests"
       labels:
@@ -312,7 +312,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-tas-main
         description: "Run tas end to end tests"
       labels:
@@ -350,8 +350,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-          testgrid-dashboards: sig-scheduling
-          testgrid-tab-name: pull-kueue-test-e2e-sequential-baseline-main
+          testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
           description: "Run sequential baseline end to end tests"
       labels:
           preset-dind-enabled: "true"
@@ -427,7 +426,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-certmanager-main
         description: "Run cert-manager end to end tests"
       labels:
@@ -465,7 +464,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-dra-main
         description: "Run DRA end to end tests"
       labels:
@@ -503,7 +502,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-dra-main
         description: "Run MultiKueue DRA end to end tests"
       labels:
@@ -541,7 +540,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-kueueviz-main
         description: "Run kueueviz end to end tests"
       labels:
@@ -579,7 +578,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-upgrade-main
         description: "Run kueue upgrade end to end tests"
       labels:
@@ -617,7 +616,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-certmanager-upgrade-main
         description: "Run kueue upgrade with cert-manager end to end tests"
       labels:
@@ -655,7 +654,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-verify-main
         description: "Run kueue verify checks"
       labels:
@@ -688,7 +687,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-build-image-main
         description: "Build container image of kueue"
       labels:
@@ -726,7 +725,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-scheduling-perf-main
         description: "Run kueue test-scheduling-perf"
       spec:
@@ -754,7 +753,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-tas-scheduling-perf-main
         description: "Run kueue test-tas-scheduling-perf"
       spec:
@@ -782,7 +781,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-verify-main
         description: "Run kueue-populator verify checks"
       labels:
@@ -815,7 +814,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-test-unit-main
         description: "Run kueue-populator unit tests"
       spec:
@@ -845,7 +844,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-test-integration-main
         description: "Run kueue-populator integration tests"
       spec:
@@ -873,7 +872,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-test-e2e-main
         description: "Run kueue-populator end to end tests"
       labels:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
@@ -8,7 +8,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-unit-release-0-16
         description: "Run kueue unit tests"
       spec:
@@ -38,7 +38,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-integration-baseline-release-0-16
         description: "Run kueue test-integration-baseline"
       spec:
@@ -66,7 +66,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-integration-extended-release-0-16
         description: "Run kueue test-integration-extended"
       spec:
@@ -94,7 +94,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-integration-multikueue-release-0-16
         description: "Run kueue test-multikueue-integration"
       spec:
@@ -122,7 +122,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-release-0-16-1-33
         description: "Run kueue end to end tests for Kubernetes 1.33"
       labels:
@@ -160,7 +160,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-release-0-16-1-34
         description: "Run kueue end to end tests for Kubernetes 1.34"
       labels:
@@ -198,7 +198,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-release-0-16-1-35
         description: "Run kueue end to end tests for Kubernetes 1.35"
       labels:
@@ -236,7 +236,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-release-0-16
         description: "Run multikueue end to end tests"
       labels:
@@ -274,7 +274,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-sequential-release-0-16
         description: "Run multikueue sequential end to end tests"
       labels:
@@ -312,7 +312,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-tas-release-0-16
         description: "Run tas end to end tests"
       labels:
@@ -350,8 +350,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-sequential-baseline-release-0-16
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         description: "Run sequential baseline end to end tests"
       labels:
         preset-dind-enabled: "true"
@@ -426,7 +425,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-certmanager-release-0-16
         description: "Run cert-manager end to end tests"
       labels:
@@ -464,7 +463,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-dra-release-0-16
         description: "Run DRA end to end tests"
       labels:
@@ -502,7 +501,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-kueueviz-release-0-16
         description: "Run kueueviz end to end tests"
       labels:
@@ -540,7 +539,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-upgrade-release-0-16
         description: "Run kueue upgrade end to end tests"
       labels:
@@ -578,7 +577,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-certmanager-upgrade-release-0-16
         description: "Run kueue upgrade with cert-manager end to end tests"
       labels:
@@ -616,7 +615,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-verify-release-0-16
         description: "Run kueue verify checks"
       labels:
@@ -649,7 +648,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-build-image-release-0-16
         description: "Build container image of kueue"
       labels:
@@ -687,7 +686,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-scheduling-perf-release-0-16
         description: "Run kueue test-scheduling-perf"
       spec:
@@ -715,7 +714,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-tas-scheduling-perf-release-0-16
         description: "Run kueue test-tas-scheduling-perf"
       spec:
@@ -743,7 +742,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-verify-release-0-16
         description: "Run kueue-populator verify checks"
       labels:
@@ -776,7 +775,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-test-unit-release-0-16
         description: "Run kueue-populator unit tests"
       spec:
@@ -806,7 +805,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-test-integration-release-0-16
         description: "Run kueue-populator integration tests"
       spec:
@@ -834,7 +833,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-test-e2e-release-0-16
         description: "Run kueue-populator end to end tests"
       labels:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -8,7 +8,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-unit-release-0-17
         description: "Run kueue unit tests"
       spec:
@@ -38,7 +38,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-integration-baseline-release-0-17
         description: "Run kueue test-integration-baseline"
       spec:
@@ -66,7 +66,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-integration-extended-release-0-17
         description: "Run kueue test-integration-extended"
       spec:
@@ -94,7 +94,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-integration-multikueue-release-0-17
         description: "Run kueue test-multikueue-integration"
       spec:
@@ -122,7 +122,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-release-0-17-1-33
         description: "Run kueue end to end tests for Kubernetes 1.33"
       labels:
@@ -160,7 +160,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-release-0-17-1-34
         description: "Run kueue end to end tests for Kubernetes 1.34"
       labels:
@@ -198,7 +198,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-release-0-17-1-35
         description: "Run kueue end to end tests for Kubernetes 1.35"
       labels:
@@ -236,7 +236,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-release-0-17
         description: "Run multikueue end to end tests"
       labels:
@@ -274,7 +274,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-sequential-release-0-17
         description: "Run multikueue sequential end to end tests"
       labels:
@@ -312,7 +312,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-tas-release-0-17
         description: "Run tas end to end tests"
       labels:
@@ -350,8 +350,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-sequential-baseline-release-0-17
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         description: "Run sequential baseline end to end tests"
       labels:
         preset-dind-enabled: "true"
@@ -426,7 +425,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-certmanager-release-0-17
         description: "Run cert-manager end to end tests"
       labels:
@@ -464,7 +463,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-dra-release-0-17
         description: "Run DRA end to end tests"
       labels:
@@ -502,7 +501,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-dra-release-0-17
         description: "Run MultiKueue DRA end to end tests"
       labels:
@@ -540,7 +539,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-kueueviz-release-0-17
         description: "Run kueueviz end to end tests"
       labels:
@@ -578,7 +577,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-upgrade-release-0-17
         description: "Run kueue upgrade end to end tests"
       labels:
@@ -616,7 +615,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-e2e-certmanager-upgrade-release-0-17
         description: "Run kueue upgrade with cert-manager end to end tests"
       labels:
@@ -654,7 +653,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-verify-release-0-17
         description: "Run kueue verify checks"
       labels:
@@ -687,7 +686,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-build-image-release-0-17
         description: "Build container image of kueue"
       labels:
@@ -725,7 +724,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-scheduling-perf-release-0-17
         description: "Run kueue test-scheduling-perf"
       spec:
@@ -753,7 +752,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-test-tas-scheduling-perf-release-0-17
         description: "Run kueue test-tas-scheduling-perf"
       spec:
@@ -781,7 +780,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-verify-release-0-17
         description: "Run kueue-populator verify checks"
       labels:
@@ -814,7 +813,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-test-unit-release-0-17
         description: "Run kueue-populator unit tests"
       spec:
@@ -844,7 +843,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-test-integration-release-0-17
         description: "Run kueue-populator integration tests"
       spec:
@@ -872,7 +871,7 @@ presubmits:
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-        testgrid-dashboards: sig-scheduling
+        testgrid-dashboards: sig-scheduling-kueue, sig-scheduling-kueue-presubmits
         testgrid-tab-name: pull-kueue-populator-test-e2e-release-0-17
         description: "Run kueue-populator end to end tests"
       labels:

--- a/config/jobs/kubernetes-sigs/kwok/kwok-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kwok/kwok-presubmits-main.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/kwok
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kwok, sig-scheduling-kwok-presubmits
       testgrid-tab-name: pull-kwok-verify-main
     branches:
     - ^main$
@@ -31,7 +31,7 @@ presubmits:
     path_alias: sigs.k8s.io/kwok
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kwok, sig-scheduling-kwok-presubmits
       testgrid-tab-name: pull-kwok-build-main
     branches:
     - ^main$
@@ -56,7 +56,7 @@ presubmits:
     path_alias: sigs.k8s.io/kwok
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kwok, sig-scheduling-kwok-presubmits
       testgrid-tab-name: pull-kwok-unit-test-main
     branches:
     - ^main$
@@ -81,7 +81,7 @@ presubmits:
     path_alias: sigs.k8s.io/kwok
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-kwok, sig-scheduling-kwok-presubmits
       testgrid-tab-name: pull-kwok-e2e-test-main
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/scheduler-library/scheduler-library-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-library/scheduler-library-presubmits-main.yaml
@@ -6,7 +6,7 @@ presubmits:
     path_alias: sigs.k8s.io/scheduler-library
     cluster: eks-prow-build-cluster
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-scheduler-library
       testgrid-tab-name: pull-scheduler-library-verify-main
     branches:
     - ^main$

--- a/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
+++ b/config/jobs/kubernetes/sig-scheduling/sig-scheduling-config.yaml
@@ -42,8 +42,7 @@ periodics:
           cpu: 4
           memory: 9Gi
   annotations:
-    testgrid-dashboards: sig-scheduling
-    testgrid-tab-name: sig-scheduling-kind, multizone
+    testgrid-dashboards: sig-scheduling-kind
     description: Runs tests against a Multizone Kubernetes in Docker cluster
     testgrid-alert-email: antonio.ojea.garcia@gmail.com, acondor@google.com
 
@@ -65,7 +64,7 @@ presubmits:
     always_run: false
     optional: true
     annotations:
-      testgrid-dashboards: sig-scheduling
+      testgrid-dashboards: sig-scheduling-presubmits
       testgrid-tab-name: scheduler-perf
       testgrid-alert-email: sig-scheduling-alerts@kubernetes.io
     decorate: true

--- a/config/testgrids/kubernetes/sig-api-machinery/config.yaml
+++ b/config/testgrids/kubernetes/sig-api-machinery/config.yaml
@@ -1,7 +1,8 @@
 dashboard_groups:
 - name: sig-api-machinery
   dashboard_names:
-    - sig-api-machinery-gce-gke
+    - sig-api-machinery-gce
+    - sig-api-machinery-kind
     - sig-api-machinery-gengo
     - sig-api-machinery-kube-storage-version-migrator
     - sig-api-machinery-structured-merge-diff
@@ -11,7 +12,7 @@ dashboard_groups:
     - sig-api-machinery-fieldsv1string
 
 dashboards:
-- name: sig-api-machinery-gce-gke
+- name: sig-api-machinery-gce
   dashboard_tab:
     - name: gce
       test_group_name: ci-kubernetes-e2e-gci-gce
@@ -33,6 +34,12 @@ dashboards:
       test_group_name: ci-kubernetes-e2e-gci-gce-serial
       base_options: include-filter-by-regex=sig-api-machinery
       description: apimachinery gce serial e2e tests for master branch
+- name: sig-api-machinery-kind
+  dashboard_tab:
+    - name: kind
+      test_group_name: ci-kubernetes-e2e-kind
+      base_options: include-filter-by-regex=sig-api-machinery
+      description: apimachinery kind e2e tests for master branch
 - name: sig-api-machinery-kube-storage-version-migrator
 - name: sig-api-machinery-structured-merge-diff
 - name: sig-api-machinery-kubebuilder
@@ -40,3 +47,5 @@ dashboards:
 - name: sig-api-machinery-network-proxy
 - name: sig-api-machinery-emulated-version
 - name: sig-api-machinery-fieldsv1string
+
+

--- a/config/testgrids/kubernetes/sig-scheduling/config.yaml
+++ b/config/testgrids/kubernetes/sig-scheduling/config.yaml
@@ -1,5 +1,24 @@
-dashboards:
+dashboard_groups:
 - name: sig-scheduling
+  dashboard_names:
+    - sig-scheduling-presubmits
+    - sig-scheduling-gce
+    - sig-scheduling-kind
+    - sig-scheduling-kueue
+    - sig-scheduling-kueue-periodics
+    - sig-scheduling-kueue-presubmits
+    - sig-scheduling-kwok
+    - sig-scheduling-kwok-presubmits
+    - sig-scheduling-descheduler
+    - sig-scheduling-descheduler-presubmits
+    - sig-scheduling-scheduler-plugins
+    - sig-scheduling-simulator
+    - sig-scheduling-wasm-extensions
+    - sig-scheduling-cluster-capacity
+    - sig-scheduling-scheduler-library
+
+dashboards:
+- name: sig-scheduling-gce
   dashboard_tab:
     - name: gce
       test_group_name: ci-kubernetes-e2e-gci-gce
@@ -13,3 +32,22 @@ dashboards:
       test_group_name: ci-kubernetes-e2e-gci-gce-serial
       base_options: include-filter-by-regex=sig-scheduling
       description: scheduling gce serial e2e tests for master branch
+-  name: sig-scheduling-kind
+   dashboard_tab:
+     - name: kind
+       test_group_name: ci-kubernetes-e2e-kind
+       base_options: include-filter-by-regex=sig-scheduling
+       description: scheduling kind e2e tests for master branch
+- name: sig-scheduling-presubmits
+- name: sig-scheduling-kueue
+- name: sig-scheduling-kueue-periodics
+- name: sig-scheduling-kueue-presubmits
+- name: sig-scheduling-kwok
+- name: sig-scheduling-kwok-presubmits
+- name: sig-scheduling-descheduler
+- name: sig-scheduling-descheduler-presubmits
+- name: sig-scheduling-scheduler-plugins
+- name: sig-scheduling-simulator
+- name: sig-scheduling-wasm-extensions
+- name: sig-scheduling-cluster-capacity
+- name: sig-scheduling-scheduler-library


### PR DESCRIPTION
The sig-scheduling board is not configured correctly. All the jobs are attached directly to the main group.

https://testgrid.k8s.io/sig-scheduling

This PR fixes this problem.