### PR TITLE
Update runner.sh to display ip6table_nat module not found as warning

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -62,7 +62,9 @@ EOF
     sysctl net.ipv6.conf.all.disable_ipv6=0
     sysctl net.ipv6.conf.all.forwarding=1
     # enable ipv6 iptables
-    modprobe -v ip6table_nat
+    if ! modprobe ip6table_nat 2>/dev/null; then
+      echo "INFO: Could not load ip6table_nat. This is expected on some kernel versions and can usually be ignored."
+    fi
 
     # Fix ulimit issue
     sed -i 's|ulimit -Hn|ulimit -n|' /etc/init.d/docker || true


### PR DESCRIPTION
modprobe: FATAL: Module ip6table_nat not found error occurring during Prow job environment initialization.
This error message is non-blocking but creates log noise.

This pull request update the FATAL message to WARNING for clear logging.


Tracking bug: b/503065060