### PR TITLE
Add BATS_TARGET for a10 x86 GPU tests

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
@@ -46,6 +46,8 @@ presubmits:
         env:
         - name: GPU_TYPE
           value: "gpu_1x_a10"
+        - name: BATS_TARGET
+          value: "tests-gpu-a10"
         resources:
           requests:
             cpu: "4"
@@ -129,6 +131,8 @@ periodics:
       env:
       - name: GPU_TYPE
         value: "gpu_1x_a10"
+      - name: BATS_TARGET
+        value: "tests-gpu-a10"
       resources:
         requests:
           cpu: "4"


### PR DESCRIPTION
Update the x86 Lambda jobs for `dra-driver-nvidia-gpu` to use `BATS_TARGET=tests-gpu-a10`. This keeps the pinned A10 lane deterministic by running the stable A10-safe subset without DynMIG. 

