### PR TITLE
Kops - Skip VPC CNI + RHEL10 jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -523,14 +523,14 @@ def generate_grid():
                             # Missing support for nftables
                             # https://github.com/cloudnativelabs/kube-router/issues/2034
                             continue
+                        if networking == 'amazon-vpc':
+                            # RHEL10/Rocky10 kernels removed xt_comment and xt_conntrack modules;
+                            # the AWS VPC CNI requires these for iptables-nft SNAT rules.
+                            continue
                         # https://github.com/kubernetes/kops/issues/17915
                         extra_flags.extend([
                             "--set=cluster.spec.kubeProxy.proxyMode=nftables",
                         ])
-                        if networking == 'amazon-vpc':
-                            extra_flags.extend([
-                                "--set=cluster.spec.networking.amazonVPC.env=ENABLE_NFTABLES=true",
-                            ])
                         if 'cilium' in networking:
                             extra_flags.extend([
                                 "--set=cluster.spec.networking.cilium.enableBPFMasquerade=true",


### PR DESCRIPTION
The AWS VPC CNI plugin uses `iptables -m comment` and `-m conntrack` for SNAT chain management. RHEL 10 and Rocky 10 kernels [removed the `xt_comment` and `xt_conntrack` compatibility modules](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kops/18228/pull-kops-e2e-k8s-aws-amazonvpc/2046764642528661504/artifacts/i-055f5fa2cf87c58fb/journal.log):

```
FATAL: Module xt_comment not found in directory /lib/modules/6.12.0-124.47.1.el10_1.aarch64
FATAL: Module xt_conntrack not found in directory /lib/modules/6.12.0-124.47.1.el10_1.aarch64
```

The VPC CNI's `iptables-wrapper` correctly detects nft mode via the kubelet hint (`KUBE-IPTABLES-HINT` chain), but the IPAMD still shells out to `iptables-nft` with `-m comment`, which fails because the underlying xt_* kernel modules no longer exist. This causes all aws-node pods to CLBO.

This combination cannot work until the VPC CNI adds native nftables support that does not depend on xt_* compat modules.

I confirmed all 8 jobs being removed are in this same failure state.

/cc @hakman