### PR TITLE
Increase execservice resources to prevent OOMs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1157,9 +1157,9 @@ periodics:
       - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
         value: "21474836480"
       - name: CL2_EXECSERVICE_CPU_REQUESTS
-        value: "4"
+        value: "8"
       - name: CL2_EXECSERVICE_MEMORY_REQUESTS
-        value: "8Gi"
+        value: "16Gi"
       # Migrating from resource from payload to realistic pod. Taget 1.5GB pod resource.
       - name: CL2_REALISTIC_POD
         value: "true"


### PR DESCRIPTION
Prevent `api_availability_measurement.go:83] execservice issue: problem with RunCommand(): output="", err=signal: killed` from https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/2046635450986139648

Part of https://github.com/kubernetes/kubernetes/issues/138415