### PR TITLE
Bump the number of consecutive failures.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -228,7 +228,7 @@ periodics:
     testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, kops-misc
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com, release-team@kubernetes.io
     description: "Uses kubetest2 to run k8s.io/perf-tests/run-e2e.sh against a 100-node cluster created with kops"
-    testgrid-num-failures-to-alert: '2'
+    testgrid-num-failures-to-alert: '8'
     testgrid-tab-name: gce-master-scale-performance-100
   spec:
     serviceAccountName: prow-build


### PR DESCRIPTION
The goal is to avoid alerting on transient issues as the K8s Scalability oncaller is not likely to look at them before they become obsolete, hence the alerts just create unnecessary toil.

Sample case: alert for 5 failures on 2026-04-20, picked up only on 2026-04-22, around 50 executions later.