### PR TITLE
[kueue] Update Kueue to golang 1.26

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -22,7 +22,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           env:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
@@ -101,7 +101,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:
@@ -139,7 +139,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:
@@ -177,7 +177,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:
@@ -215,7 +215,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
@@ -22,7 +22,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           env:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
@@ -62,7 +62,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:
@@ -100,7 +100,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:
@@ -138,7 +138,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:
@@ -176,7 +176,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -22,7 +22,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           env:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
@@ -101,7 +101,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:
@@ -139,7 +139,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:
@@ -177,7 +177,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:
@@ -215,7 +215,7 @@ periodics:
       timeout: 1h
     spec:
       containers:
-        - image: public.ecr.aws/docker/library/golang:1.25
+        - image: public.ecr.aws/docker/library/golang:1.26
           command:
             - make
           args:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -13,7 +13,7 @@ presubmits:
         description: "Run kueue unit tests"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             env:
               - name: GO_TEST_FLAGS
                 value: "-race -count 3"
@@ -43,7 +43,7 @@ presubmits:
         description: "Run kueue test-integration-baseline"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -71,7 +71,7 @@ presubmits:
         description: "Run kueue test-integration-extended"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -99,7 +99,7 @@ presubmits:
         description: "Run kueue test-multikueue-integration"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -731,7 +731,7 @@ presubmits:
         description: "Run kueue test-scheduling-perf"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -759,7 +759,7 @@ presubmits:
         description: "Run kueue test-tas-scheduling-perf"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -820,7 +820,7 @@ presubmits:
         description: "Run kueue-populator unit tests"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             env:
               - name: GO_TEST_FLAGS
                 value: "-race -count 3"
@@ -850,7 +850,7 @@ presubmits:
         description: "Run kueue-populator integration tests"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
@@ -13,7 +13,7 @@ presubmits:
         description: "Run kueue unit tests"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             env:
               - name: GO_TEST_FLAGS
                 value: "-race -count 3"
@@ -43,7 +43,7 @@ presubmits:
         description: "Run kueue test-integration-baseline"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -71,7 +71,7 @@ presubmits:
         description: "Run kueue test-integration-extended"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -99,7 +99,7 @@ presubmits:
         description: "Run kueue test-multikueue-integration"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -692,7 +692,7 @@ presubmits:
         description: "Run kueue test-scheduling-perf"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -720,7 +720,7 @@ presubmits:
         description: "Run kueue test-tas-scheduling-perf"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -781,7 +781,7 @@ presubmits:
         description: "Run kueue-populator unit tests"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             env:
               - name: GO_TEST_FLAGS
                 value: "-race -count 3"
@@ -811,7 +811,7 @@ presubmits:
         description: "Run kueue-populator integration tests"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -13,7 +13,7 @@ presubmits:
         description: "Run kueue unit tests"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             env:
               - name: GO_TEST_FLAGS
                 value: "-race -count 3"
@@ -43,7 +43,7 @@ presubmits:
         description: "Run kueue test-integration-baseline"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -71,7 +71,7 @@ presubmits:
         description: "Run kueue test-integration-extended"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -99,7 +99,7 @@ presubmits:
         description: "Run kueue test-multikueue-integration"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -730,7 +730,7 @@ presubmits:
         description: "Run kueue test-scheduling-perf"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -758,7 +758,7 @@ presubmits:
         description: "Run kueue test-tas-scheduling-perf"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
@@ -819,7 +819,7 @@ presubmits:
         description: "Run kueue-populator unit tests"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             env:
               - name: GO_TEST_FLAGS
                 value: "-race -count 3"
@@ -849,7 +849,7 @@ presubmits:
         description: "Run kueue-populator integration tests"
       spec:
         containers:
-          - image: public.ecr.aws/docker/library/golang:1.25
+          - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/kueue/issues/10712.