### PR TITLE
etcd: increase etcd periodics memory limits for main tests to avoid OOMs

### DIFF
--- a/config/jobs/etcd/etcd-periodics.yaml
+++ b/config/jobs/etcd/etcd-periodics.yaml
@@ -289,10 +289,10 @@ periodics:
       resources:
         requests:
           cpu: "7"
-          memory: "14Gi"
+          memory: "20Gi"
         limits:
           cpu: "7"
-          memory: "14Gi"
+          memory: "20Gi"
       # fuse needs privileged mode
       securityContext:
         privileged: true
@@ -335,10 +335,10 @@ periodics:
       resources:
         requests:
           cpu: "7"
-          memory: "14Gi"
+          memory: "20Gi"
         limits:
           cpu: "7"
-          memory: "14Gi"
+          memory: "20Gi"
       # fuse needs privileged mode
       securityContext:
         privileged: true
@@ -381,10 +381,10 @@ periodics:
       resources:
         requests:
           cpu: "7"
-          memory: "14Gi"
+          memory: "20Gi"
         limits:
           cpu: "7"
-          memory: "14Gi"
+          memory: "20Gi"
       # fuse needs privileged mode
       securityContext:
         privileged: true
@@ -425,10 +425,10 @@ periodics:
       resources:
         requests:
           cpu: "7"
-          memory: "14Gi"
+          memory: "20Gi"
         limits:
           cpu: "7"
-          memory: "14Gi"
+          memory: "20Gi"
       # fuse needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
We recently found that the test jobs in the etcd project failed due to OOM kills.  So, we would like to scale up the test infra to accommodate the needs by these jobs.

> Job execution failed: Job pod was OOM killed by the cluster.

- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-robustness-main-amd64/2043047351408398336 
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-robustness-main-amd64/2045584093046902784 
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-robustness-main-amd64/2043772134588682240 
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-robustness-main-arm64/2046148737453002752 
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-robustness-main-arm64/2046873521044328448 

cc @serathius  @ivanvc 