### PR TITLE
rightsize various prow jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-addon-provider-helm/cluster-api-addon-provider-helm-presubmits-main.yaml
@@ -191,11 +191,11 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 7
-            memory: 32Gi
+            cpu: 2
+            memory: 4Gi
           limits:
-            cpu: 7
-            memory: 32Gi
+            cpu: 2
+            memory: 4Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-addon-provider-helm
       testgrid-tab-name: caaph-pr-capi-e2e-main

--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -38,10 +38,10 @@ periodics:
           resources:
             requests:
               cpu: 6
-              memory: "28Gi"
+              memory: "16Gi"
             limits:
               cpu: 6
-              memory: "28Gi"
+              memory: "16Gi"
 
   - name: ci-kubernetes-integration-ppc64le-master
     interval: 1h

--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-s390x-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-s390x-periodics.yaml
@@ -31,10 +31,10 @@ periodics:
           resources:
             requests:
               cpu: 6
-              memory: "28Gi"
+              memory: "16Gi"
             limits:
               cpu: 6
-              memory: "28Gi"
+              memory: "16Gi"
 
   - name: ci-kubernetes-integration-master-s390x
     interval: 1h

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -541,10 +541,10 @@ presubmits:
             privileged: true
           resources:
             limits:
-              cpu: 8
+              cpu: 7
               memory: 10Gi
             requests:
-              cpu: 8
+              cpu: 7
               memory: 10Gi
   - name: pull-kubernetes-e2e-ec2-canary
     skip_branches:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -130,6 +130,13 @@ periodics:
       - files
       - --manifests=/home/prow/go/src/github.com/kubernetes/k8s.io/artifacts/
       - --confirm
+      resources:
+        limits:
+          cpu: 2
+          memory: "4Gi"
+        requests:
+          cpu: 2
+          memory: "4Gi"
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
@@ -175,10 +182,10 @@ periodics:
         # request most of one node 🚀
         requests:
           cpu: 7
-          memory: "40Gi"
+          memory: "26Gi"
         limits:
           cpu: 7
-          memory: "40Gi"
+          memory: "26Gi"
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, sig-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
@@ -258,6 +265,13 @@ periodics:
       - --log-level=debug
       - --certificate-identity-regexp=(keyless@projectsigstore.iam.gserviceaccount.com)|(krel-trust@k8s-releng-prod.iam.gserviceaccount.com)
       - --certificate-oidc-issuer=https://accounts.google.com
+      resources:
+        requests:
+          cpu: 1
+          memory: 1Gi
+        limits:
+          cpu: 1
+          memory: 1Gi
   annotations:
     testgrid-dashboards: sig-release-releng-informing
     testgrid-alert-email: release-managers+alerts@kubernetes.io
@@ -326,6 +340,13 @@ periodics:
         - --from-days=7
       args:
         - sigcheck
+      resources:
+        requests:
+          cpu: 1
+          memory: 1Gi
+        limits:
+          cpu: 1
+          memory: 1Gi
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes
@@ -363,6 +384,13 @@ periodics:
             value: 767373bbdcb8270361b96548387bf2a9ad0d48758c35
           - name: FASTLY_SERVICE_NAME
             value: dl.k8s.io
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+          limits:
+            cpu: 1
+            memory: 1Gi
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes
@@ -379,7 +407,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: downloadkubernetes
-    base_ref: main
+    base_ref: master
     path_alias: sigs.k8s.io/downloadkubernetes
   spec:
     serviceAccountName: gcb-builder
@@ -400,6 +428,13 @@ periodics:
             value: 5d7373bbdcb8270361b96548387bf2a9ad0d48758c35
           - name: FASTLY_SERVICE_NAME
             value: dl.k8s.dev
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+          limits:
+            cpu: 1
+            memory: 1Gi
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-peribolos.yaml
@@ -32,6 +32,13 @@ postsubmits:
         volumeMounts:
         - name: github
           mountPath: /etc/github
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
       volumes:
       - name: github
         secret:
@@ -72,6 +79,13 @@ periodics:
       volumeMounts:
       - name: github
         mountPath: /etc/github
+      resources:
+        limits:
+          cpu: 1
+          memory: 4Gi
+        requests:
+          cpu: 1
+          memory: 4Gi
     volumes:
     - name: github
       secret:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-apps-periodics.yaml
@@ -33,6 +33,13 @@ periodics:
       - name: github
         mountPath: /etc/github-token
         readOnly: true
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
     volumes:
     - name: github
       secret:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -18,16 +18,19 @@ postsubmits:
         - ./triage/
         - push-static
         resources:
+          limits:
+            cpu: 2
+            memory: "4Gi"
           requests:
-            memory: "1Gi"
+            memory: "4Gi"
+            cpu: 2
     annotations:
       testgrid-dashboards: sig-testing-maintenance, sig-k8s-infra-prow
       testgrid-tab-name: triage-update
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
       description: Updates the html contents for go.k8s.io/triage.
-  # TODO: Remove 'canary-' once `post-test-infra-upload-testgrid-config` job is removed.
-  - name: post-test-infra-upload-testgrid-config-canary
+  - name: post-test-infra-upload-testgrid-config
     cluster: k8s-infra-prow-build-trusted
     branches:
     - ^master$
@@ -50,8 +53,12 @@ postsubmits:
         - --update-description
         - --oneshot
         resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
           requests:
-            memory: "1Gi"
+            cpu: 1
+            memory: 1Gi
     annotations:
       testgrid-dashboards: sig-testing-maintenance, sig-k8s-infra-prow
       testgrid-tab-name: testgrid-config-update-canary
@@ -76,8 +83,12 @@ postsubmits:
         - ./metrics/web/
         - push-static
         resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
           requests:
-            memory: "256Mi"
+            cpu: 1
+            memory: 1Gi
     annotations:
       testgrid-dashboards: sig-testing-misc, sig-k8s-infra-prow
       testgrid-tab-name: metrics-dashboards-update
@@ -118,6 +129,13 @@ periodics:
       - --jq=/usr/bin/jq
       - --jobs-dir=config/jobs
       - --filter-stale-jobs
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
 
 - name: ci-test-infra-triage
   interval: 3h

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-security-trusted.yaml
@@ -21,6 +21,13 @@ periodics:
       env:
       - name: CVE_GCS_PATH
         value: "gs://k8s-cve-feed"
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
   annotations:
     testgrid-create-test-group: "true"
     testgrid-alert-email: cve-feed-maintainers@kubernetes.io

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-branchprotector.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-branchprotector.yaml
@@ -31,6 +31,13 @@ periodics:
       - name: github
         mountPath: /etc/github
         readOnly: true
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
     volumes:
     - name: github
       secret:

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -69,10 +69,10 @@ periodics:
       resources:
         limits:
           cpu: "7"
-          memory: "34Gi"
+          memory: "24Gi"
         requests:
           cpu: "7"
-          memory: "34Gi"
+          memory: "24Gi"
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -425,13 +425,21 @@ periodics:
       image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
       name: ""
+      env:
+        - name: FASTLY_SERVICE_NAME
+          value: dl.k8s.io
+        - name: FASTLY_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: fastly-purge-token
+              key: token
       resources:
         limits:
           cpu: "7"
-          memory: 34Gi
+          memory: 24Gi
         requests:
           cpu: "7"
-          memory: 34Gi
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -962,10 +970,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 28Gi
+          memory: 16Gi
         requests:
           cpu: "6"
-          memory: 28Gi
+          memory: 16Gi
       securityContext:
         allowPrivilegeEscalation: false
     securityContext:
@@ -3007,10 +3015,10 @@ presubmits:
         resources:
           limits:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
           requests:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -3041,10 +3049,10 @@ presubmits:
         resources:
           limits:
             cpu: "4"
-            memory: 36Gi
+            memory: 16Gi
           requests:
             cpu: "4"
-            memory: 36Gi
+            memory: 16Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -700,15 +700,24 @@ periodics:
       - --registry=gcr.io/k8s-staging-ci-images
       - --extra-version-markers=k8s-stable2
       image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
+      env:
+        - name: FASTLY_SERVICE_NAME
+          value: dl.k8s.io
+        - name: FASTLY_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: fastly-purge-token
+              key: token
+      # docker-in-docker needs privileged mode
       imagePullPolicy: Always
       name: ""
       resources:
         limits:
           cpu: "7"
-          memory: 34Gi
+          memory: 24Gi
         requests:
           cpu: "7"
-          memory: 34Gi
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -1237,10 +1246,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 28Gi
+          memory: 16Gi
         requests:
           cpu: "6"
-          memory: 28Gi
+          memory: 16Gi
       securityContext:
         allowPrivilegeEscalation: false
     securityContext:
@@ -1538,10 +1547,10 @@ presubmits:
         resources:
           limits:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
           requests:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -1620,10 +1629,10 @@ presubmits:
         resources:
           limits:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
           requests:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -3846,10 +3855,10 @@ presubmits:
         resources:
           limits:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
           requests:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -3880,10 +3889,10 @@ presubmits:
         resources:
           limits:
             cpu: "4"
-            memory: 36Gi
+            memory: 16Gi
           requests:
             cpu: "4"
-            memory: 36Gi
+            memory: 16Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -821,14 +821,23 @@ periodics:
       - --extra-version-markers=k8s-stable1
       image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
+      env:
+        - name: FASTLY_SERVICE_NAME
+          value: dl.k8s.io
+        - name: FASTLY_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: fastly-purge-token
+              key: token
+      # docker-in-docker needs privileged mode
       name: ""
       resources:
         limits:
           cpu: "7"
-          memory: 34Gi
+          memory: 24Gi
         requests:
           cpu: "7"
-          memory: 34Gi
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -1357,10 +1366,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 28Gi
+          memory: 16Gi
         requests:
           cpu: "6"
-          memory: 28Gi
+          memory: 16Gi
       securityContext:
         allowPrivilegeEscalation: false
     securityContext:
@@ -1658,10 +1667,10 @@ presubmits:
         resources:
           limits:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
           requests:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -1740,10 +1749,10 @@ presubmits:
         resources:
           limits:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
           requests:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
@@ -4184,10 +4193,10 @@ presubmits:
         resources:
           limits:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
           requests:
             cpu: "7"
-            memory: 43Gi
+            memory: 16Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -28,10 +28,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 28Gi
+          memory: 16Gi
         requests:
           cpu: "6"
-          memory: 28Gi
+          memory: 16Gi
       securityContext:
         allowPrivilegeEscalation: false
     securityContext:
@@ -1228,13 +1228,22 @@ periodics:
       image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
       name: ""
+      env:
+        - name: FASTLY_SERVICE_NAME
+          value: dl.k8s.io
+        - name: FASTLY_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: fastly-purge-token
+              key: token
+      # docker-in-docker needs privileged mode
       resources:
         limits:
           cpu: "7"
-          memory: 34Gi
+          memory: 24Gi
         requests:
           cpu: "7"
-          memory: 34Gi
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -5181,10 +5190,10 @@ presubmits:
         resources:
           limits:
             cpu: "4"
-            memory: 36Gi
+            memory: 16Gi
           requests:
             cpu: "4"
-            memory: 36Gi
+            memory: 16Gi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:

--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-periodic-dra.yaml
@@ -418,10 +418,10 @@ periodics:
         resources:
           requests:
             cpu: "7"
-            memory: "28Gi"
+            memory: "16Gi"
           limits:
             cpu: "7"
-            memory: "28Gi"
+            memory: "16Gi"
 
   - name: ci-kubernetes-e2e-kops-gce-5000-node-dra-with-workload-ipalias-using-cl2
     tags:
@@ -533,7 +533,7 @@ periodics:
         resources:
           requests:
             cpu: "7"
-            memory: "28Gi"
+            memory: "24Gi"
           limits:
             cpu: "7"
-            memory: "28Gi"
+            memory: "24Gi"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1219,10 +1219,10 @@ periodics:
       resources:
         requests:
           cpu: 7
-          memory: "32Gi"
+          memory: "27Gi"
         limits:
           cpu: 7
-          memory: "32Gi"
+          memory: "27Gi"
 
 # NOTE: When making changes to this job, please ensure that you also keep the original job
 # ci-kubernetes-e2e-gce-scale-performance-100 in sig-scalability-release-blocking-jobs.yaml

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -1287,7 +1287,7 @@ presubmits:
         resources:
           requests:
             cpu: 7
-            memory: "32Gi"
+            memory: "27Gi"
           limits:
             cpu: 7
-            memory: "32Gi"
+            memory: "27Gi"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -70,10 +70,10 @@ periodics:
       resources:
         requests:
           cpu: 6
-          memory: "39Gi"
+          memory: "16Gi"
         limits:
           cpu: 6
-          memory: "39Gi"
+          memory: "16Gi"
 
 # This is a sig-release-master-blocking job.
 # The frequency was cut to reduce infrastructure costs.
@@ -190,10 +190,10 @@ periodics:
       resources:
         requests:
           cpu: 7
-          memory: "32Gi"
+          memory: "27Gi"
         limits:
           cpu: 7
-          memory: "32Gi"
+          memory: "27Gi"
 
 - name: ci-kubernetes-e2e-gce-scale-performance-100
   tags:

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -114,14 +114,13 @@ presubmits:
             value: ""
           - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
             value: auto
-          # TODO: direct copy from pull-kubernetes-bazel-test, tune these
           resources:
             limits:
               cpu: 4
-              memory: "36Gi"
+              memory: "16Gi"
             requests:
               cpu: 4
-              memory: "36Gi"
+              memory: "16Gi"
 periodics:
   - interval: 1h
     name: ci-kubernetes-unit


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/pull/36121

For jobs that didn't have resources set, I used datadog to pull the current usage of the past 30 days. 

https://us5.datadoghq.com/dashboard/7yk-x38-q78/prow-builds?fromUser=true&refresh_mode=sliding&tpl_var_job_name%5B0%5D=ci-promo-tools-image-promo-canary&from_ts=1774434464596&to_ts=1777112864596&live=true

kube unit jobs have been at 16GB since 1.35, so all their permutations have been fixed