### PR TITLE
[WIP] Update LWS Kubernetes 1.35 e2e image build

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -163,7 +163,9 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260205-38cfa9523f-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.35.0
+              value: kindest/node:v1.35.4
+            - name: E2E_KIND_BUILD_NODE_IMAGE_VERSION
+              value: v1.35.4
           command:
             - runner.sh
           args:


### PR DESCRIPTION
## Summary
- Update the LWS Kubernetes 1.35 presubmit to use Kubernetes v1.35.4.
- Set E2E_KIND_BUILD_NODE_IMAGE_VERSION so the job builds the missing Kind node image locally.

## Context
This follows the expected setup from https://github.com/kubernetes-sigs/lws/pull/752 because kindest/node:v1.35.4 is not published.

## Testing
- Parsed config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml with Python yaml.safe_load.

/hold