### PR TITLE
sig-scalability/sig-scalability-presubmit-jobs: set CL2_INFORMER_RUN_ON_CONTROL_PLANE

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -1222,6 +1222,8 @@ presubmits:
         env:
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
           value: "true"
+        - name: CL2_INFORMER_RUN_ON_CONTROL_PLANE
+          value: "true"
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
           value: "21474836480"
         - name: CL2_EXECSERVICE_CPU_REQUESTS


### PR DESCRIPTION
for now only for `pull-perf-tests-gce-master-scale-performance-5000`, after testing i will add it to the remaining CI jobs.


xref: https://github.com/kubernetes/perf-tests/pull/3982