### PR TITLE
Align the release blocking test with exemplar pod

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1160,15 +1160,8 @@ periodics:
         value: "8"
       - name: CL2_EXECSERVICE_MEMORY_REQUESTS
         value: "16Gi"
-      # Migrating from resource from payload to realistic pod. Taget 1.5GB pod resource.
       - name: CL2_REALISTIC_POD
         value: "true"
-      - name: CL2_DAEMONSET_POD_PAYLOAD_SIZE
-        value: "6000"
-      - name: CL2_STATEFULSET_POD_PAYLOAD_SIZE
-        value: "6000"
-      - name: CL2_JOB_POD_PAYLOAD_SIZE
-        value: "6000"
       #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -453,18 +453,11 @@ presubmits:
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
           value: "21474836480"
         - name: CL2_EXECSERVICE_CPU_REQUESTS
-          value: "4"
+          value: "8"
         - name: CL2_EXECSERVICE_MEMORY_REQUESTS
-          value: "8Gi"
-        # Override for 1.5GB pod resource size
-        - name: CL2_DAEMONSET_POD_PAYLOAD_SIZE
-          value: "6000"
-        - name: CL2_DEPLOYMENT_POD_PAYLOAD_SIZE
-          value: "6000"
-        - name: CL2_STATEFULSET_POD_PAYLOAD_SIZE
-          value: "6000"
-        - name: CL2_JOB_POD_PAYLOAD_SIZE
-          value: "6000"
+          value: "16Gi"
+        - name: CL2_REALISTIC_POD
+          value: "true"
         #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
         - name: KUBE_SSH_KEY_PATH
           value: /etc/ssh-key-secret/ssh-private
@@ -1225,19 +1218,11 @@ presubmits:
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
           value: "21474836480"
         - name: CL2_EXECSERVICE_CPU_REQUESTS
-          value: "4"
+          value: "8"
         - name: CL2_EXECSERVICE_MEMORY_REQUESTS
-          value: "8Gi"
-        # Override for 1.5GB pod resource size
-        - name: CL2_DAEMONSET_POD_PAYLOAD_SIZE
-          value: "6000"
-        - name: CL2_DEPLOYMENT_POD_PAYLOAD_SIZE
-          value: "6000"
-        - name: CL2_STATEFULSET_POD_PAYLOAD_SIZE
-          value: "6000"
-        - name: CL2_JOB_POD_PAYLOAD_SIZE
-          value: "6000"
-        #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
+          value: "16Gi"
+        - name: CL2_REALISTIC_POD
+          value: "true"
         - name: KUBE_SSH_KEY_PATH
           value: /etc/ssh-key-secret/ssh-private
         - name: KUBE_SSH_USER

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -128,19 +128,11 @@ periodics:
       - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
         value: "21474836480"
       - name: CL2_EXECSERVICE_CPU_REQUESTS
-        value: "4"
+        value: "8"
       - name: CL2_EXECSERVICE_MEMORY_REQUESTS
-        value: "8Gi"
-      # Override for 1.5GB pod resource size
-      - name: CL2_DAEMONSET_POD_PAYLOAD_SIZE
-        value: "6000"
-      - name: CL2_DEPLOYMENT_POD_PAYLOAD_SIZE
-        value: "6000"
-      - name: CL2_STATEFULSET_POD_PAYLOAD_SIZE
-        value: "6000"
-      - name: CL2_JOB_POD_PAYLOAD_SIZE
-        value: "6000"
-      #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
+        value: "16Gi"
+      - name: CL2_REALISTIC_POD
+        value: "true"
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
       - name: KUBE_SSH_USER


### PR DESCRIPTION
Followup from https://github.com/kubernetes/test-infra/pull/36400
Part of https://github.com/kubernetes/kubernetes/issues/138415

Introducing exemplar pod to 5k test had the following impact on 5k tests:

|                                                                                                                                                                                                                               | Before   | After |
| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------- |
| Pod Size                                                                                                                                                                                                                      | 10.15 KB | 10.29 KB (+1.4%)          |
| Pod Resource Size                                                                                                                                                                                                             | 1571 MB  | 1601 MB (+2%)             |
| Number of Writes in Scheduling Cycle                                                                                                                                                                                          | 4        | 8                         |
| Managed Fields Overhead                                                                                                                                                                                                       | 20.6%    | 48.80%                    |
| [API Server Memory](https://perf-dash.k8s.io/#/?jobname=gce-5000Nodes-1.5GB-pods&metriccategoryname=E2E&metricname=LoadResources&PodName=kube-apiserver-control-plane-us-east1-b%2Fkube-apiserver&Resource=memory)            | 53.6 GB  | 61 GB (+14%)              |
| [API Server CPU](https://perf-dash.k8s.io/#/?jobname=gce-5000Nodes-1.5GB-pods&metriccategoryname=E2E&metricname=LoadResources&PodName=kube-apiserver-control-plane-us-east1-b%2Fkube-apiserver&Resource=cpu)            | 38 cores  | 47.5 (+25%)              |
| [KCM Memory](https://perf-dash.k8s.io/#/?jobname=gce-5000Nodes-1.5GB-pods&metriccategoryname=E2E&metricname=LoadResources&PodName=kube-controller-manager-control-plane-us-east1-b%2Fkube-controller-manager&Resource=memory) | 9.3 GB   | 11.9 GB (+28%)            |
| [Scheduler Memory](https://perf-dash.k8s.io/#/?jobname=gce-5000Nodes-1.5GB-pods&metriccategoryname=E2E&metricname=LoadResources&PodName=kube-scheduler-control-plane-us-east1-b%2Fkube-scheduler&Resource=memory)             | 7.6 GB   | 10.0 GB (+31.6%)           |
| [Etcd events memory](https://perf-dash.k8s.io/#/?jobname=gce-5000Nodes-1.5GB-pods&metriccategoryname=E2E&metricname=LoadResources&PodName=etcd-manager-events-control-plane-us-east1-b%2Fetcd-manager&Resource=memory) | 2.3GB  | 3.3GB (+43%)     |
| Pod Shape | <img width="507" height="494" alt="Image" src="https://github.com/user-attachments/assets/e0f929e1-157e-4a34-a23f-140c79b766f3" /> | <img width="516" height="521" alt="Image" src="https://github.com/user-attachments/assets/cde6327b-7be0-4255-aad4-a641567f68e8" />| 


Only one issue that happen was with events https://github.com/kubernetes/perf-tests/pull/3976 after resolving it we had 4 consecutive passes on resource-size experimental test for 5k. 
<img width="1178" height="364" alt="image" src="https://github.com/user-attachments/assets/59a134c9-9878-4391-b5c6-8b1cd1faa626" />

/cc @wojtek-t @mborsz