### PR TITLE
Skip eviction test on Hyper-V Windows CI job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -400,7 +400,7 @@ periodics:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
           - name: GINKGO_SKIP
-            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|\[Alpha\]|\[FeatureGate:SchedulerAsyncPreemption\]|\[Beta\]
+            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|\[Alpha\]|\[FeatureGate:SchedulerAsyncPreemption\]|\[Beta\]|should.evict.a.pod.when.a.node.experiences.memory.pressure
           - name: NODE_FEATURE_GATES
             value: "WindowsGracefulNodeShutdown=true"
   annotations:


### PR DESCRIPTION
## What this PR does

Adds `should.evict.a.pod.when.a.node.experiences.memory.pressure` to the `GINKGO_SKIP` for the `ci-kubernetes-e2e-capz-master-windows-hyperv-serial-slow` job.

## Why

Hyper-V containers run inside lightweight utility VMs (UVMs) with dynamic memory. The eviction test uses `testlimit.exe` to exhaust memory and trigger kubelet eviction, but under Hyper-V:

1. `testlimit.exe` allocates memory **inside the UVM**, not on the host
2. The kubelet monitors **host-level** memory via `win32_OperatingSystem.FreePhysicalMemory`
3. The UVM's balloon driver reclaims pages within the VM boundary
4. Host memory pressure is never triggered → eviction never fires → test times out

This is a fundamental architectural limitation of Hyper-V isolation, not a bug. The test passes on process-isolation (non-HV) Windows clusters.

A complementary code-level skip has been proposed upstream: kubernetes/kubernetes#138597

## Which jobs are affected

Only `ci-kubernetes-e2e-capz-master-windows-hyperv-serial-slow` — the non-HV serial-slow job is unchanged.

/sig windows
/area test
/cc @daschott @jayunit100 @marosset