### PR TITLE
Re-add multi zone VMSS test

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -1576,6 +1576,81 @@ periodics:
     testgrid-tab-name: cloud-provider-azure-conformance-vmss-capz
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss."
+- cron: '0 20 * * *'  # Run at 20:00 UTC everyday
+  # cloud-provider-azure-conformance-multi-zone-vmss-capz runs Kubernetes conformance tests periodically on vmss with multiple availability zones.
+  name: cloud-provider-azure-conformance-multi-zone-vmss-capz
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: false
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-e2e-capz
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest"
+      - name: GINKGO_ARGS  # cloud-provider-azure config
+        # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
+        value: --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete.Grace.Period|runs.ReplicaSets.to.verify.preemption.running.path|client.go.should.negotiate|should.contain.custom.columns.for.each.resource|Network.should.set.TCP.CLOSE_WAIT.timeout|PodSecurityPolicy|In-tree.Volumes|ephemeral.should.support.expansion.of.pvcs.created.for.ephemeral.pvcs|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator --report-dir=/logs/artifacts --disable-log-dump=true
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: WORKER_MACHINE_COUNT  # CAPZ config
+        value: "3"
+      - name: CLUSTER_TEMPLATE  # CAPZ config
+        value: https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/test/ci/cluster-template-prow-machine-pool-ci-version-multi-zone.yaml
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "Standard"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: GINKGO_PARALLEL_NODES  # cloud-provider-azure config
+        value: "30"
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure
+    testgrid-tab-name: cloud-provider-azure-conformance-multi-zone-vmss-capz
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on vmss with multiple availability zones."
 - cron: '0 19 * * *'  # Run at 19:00 UTC everyday
   # cloud-provider-azure-conformance-serial-vmss-capz runs Kubernetes conformance serial tests periodically on vmss.
   name: cloud-provider-azure-conformance-serial-vmss-capz


### PR DESCRIPTION
Re-adding multi zone VMSS test that was removed in #36242. Added a new template to test this with in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6252