### PR TITLE
Kops - Skip more grid jobs on older kops versions

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -495,7 +495,7 @@ def generate_grid():
                             continue
                     # Fixes in https://github.com/kubernetes/kops/pull/17940
                     # but not backported to earlier kops versions.
-                    if kops_version == '1.34' and (distro_short in ('deb13') and networking == 'amazon-vpc') or (distro_short in ('deb13', 'al2023', 'al2023arm64') and networking == 'cilium-eni'):
+                    if kops_version == '1.34' and (distro_short in ('deb13', 'al2023', 'al2023arm64') and networking == 'amazon-vpc') or (distro_short in ('deb13', 'al2023', 'al2023arm64') and networking == 'cilium-eni'):
                         continue
                     extra_flags = []
                     if 'arm64' in distro:

--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -497,6 +497,10 @@ def generate_grid():
                     # but not backported to earlier kops versions.
                     if kops_version == '1.34' and (distro_short in ('deb13', 'al2023', 'al2023arm64') and networking == 'amazon-vpc') or (distro_short in ('deb13', 'al2023', 'al2023arm64') and networking == 'cilium-eni'):
                         continue
+                    # Tests flake due to cilium 1.16 config issue. Fixed with cilium 1.18 in kops 1.34+
+                    # "Unable to connect to kvstore: timed out while waiting for etcd session"
+                    if kops_version in ('1.32', '1.33') and networking == 'cilium-etcd':
+                        continue
                     extra_flags = []
                     if 'arm64' in distro:
                         extra_flags.extend([


### PR DESCRIPTION
All of these are permanently failing or permanently flakey, fixed in newer kops versions but not backported. We can skip testing them until we stop testing these kops versions altogether.

Example VPC CNI failures:

https://testgrid.k8s.io/kops-distro-al2023#kops-grid-amazonvpc-al2023-k33-ko34
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-amazonvpc-al2023-k33-ko34/2046841560154247168

https://testgrid.k8s.io/kops-distro-al2023#kops-grid-amazonvpc-al2023arm64-k34-ko34
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-amazonvpc-al2023arm64-k34-ko34/2047709285915299840

Example cilium-etcd flakes:

https://testgrid.k8s.io/kops-distro-u2404#kops-grid-cilium-etcd-u2404arm64-k32-ko33
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-cilium-etcd-u2404arm64-k32-ko33/2044272689190801408

https://testgrid.k8s.io/kops-distro-al2023#kops-grid-cilium-etcd-al2023-k32-ko32
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-cilium-etcd-al2023-k32-ko32/2046747942160699392

Different tests fail each job indicating its not a problem with the test definition but with the environment.

```diff
diff --git a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
index 2ea3107127..53749db6c5 100644
--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -1,5 +1,5 @@
 # Test jobs generated by build_jobs.py (do not manually edit)
-# 2134 jobs, total of 13145 runs per week
+# 2092 jobs, total of 13103 runs per week
...
```

/cc @hakman