### PR TITLE
Update promo-tools CI to Go 1.26

### DIFF
--- a/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
+++ b/config/jobs/kubernetes-sigs/promo-tools/promo-tools.yaml
@@ -73,7 +73,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.26-trixie
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
Updates the `pull-cip-verify` job image from `releng-ci:latest-go1.25-trixie` to `releng-ci:latest-go1.26-trixie`.

Required for kubernetes-sigs/promo-tools#1827 which bumps k8s.io/apimachinery to v0.36.0 (requires Go 1.26).