### PR TITLE
Update milestone applier for k/website dev-1.37 release branch

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -617,7 +617,7 @@ milestone_applier:
   kubernetes-sigs/boskos:
     master: v1.23
   kubernetes/website:
-    dev-1.36: 1.36
+    dev-1.37: 1.37
   kubernetes/node-problem-detector:
     main: v1.36
     release-1.35: v1.35


### PR DESCRIPTION
Update the k/website applier for the `dev-1.37` branch to automatically apply the 1.37 milestone for PRs created against `dev-1.37` branch

/hold for review from @kubernetes/sig-docs-leads 