### PR TITLE
Skip GracefulNodeShutdown test on Hyper-V Windows CI job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -400,7 +400,7 @@ periodics:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
           - name: GINKGO_SKIP
-            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|\[Alpha\]|\[FeatureGate:SchedulerAsyncPreemption\]|\[Beta\]|should.evict.a.pod.when.a.node.experiences.memory.pressure
+            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|\[Alpha\]|\[FeatureGate:SchedulerAsyncPreemption\]|\[Beta\]|should.evict.a.pod.when.a.node.experiences.memory.pressure|should.be.able.to.gracefully.shutdown.pods.with.various.grace.periods
           - name: NODE_FEATURE_GATES
             value: "WindowsGracefulNodeShutdown=true"
   annotations:


### PR DESCRIPTION
## What this PR does

Adds `should.be.able.to.gracefully.shutdown.pods.with.various.grace.periods` to the `GINKGO_SKIP` for the `ci-kubernetes-e2e-capz-master-windows-hyperv-serial-slow` job.

## Why

The GracefulNodeShutdown test reboots the Windows node to validate graceful pod termination. Under Hyper-V isolation, the node recovery takes significantly longer due to UVM cleanup and re-creation. This causes:

1. The shutdown test itself to exceed its timeout
2. Cascading failures in all subsequent tests — after the node reboots, `GetReadySchedulableNodes` temporarily returns 0 nodes, causing every following test to fail with "no schedulable nodes"

This was confirmed by analyzing 5 consecutive CI runs where GracefulNodeShutdown failure at ~22:27 triggered cascading failures for all tests from ~22:35 onward.

## Which jobs are affected

Only `ci-kubernetes-e2e-capz-master-windows-hyperv-serial-slow` — the non-HV serial-slow job is unchanged.

Follow-up to #36903 (eviction skip, merged).

/sig windows
/area test
/cc @daschott @jayunit100 @marosset