### PR TITLE
update golang to 1.26 for lws presubmits on main

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -41,7 +41,7 @@ presubmits:
       description: "Run lws integration tests"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         command:
         - make
         args:
@@ -253,7 +253,7 @@ presubmits:
       description: "Run lws verify checks"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         command:
         - make
         args:


### PR DESCRIPTION
Bump the golang builder image from `1.25` to `1.26` for the lws `pull-lws-test-integration-main` and `pull-lws-verify-main` presubmits, to match the Go upgrade in the lws repo.

This mirrors the same change done for jobset in https://github.com/kubernetes/test-infra/pull/36879, and pairs with https://github.com/kubernetes-sigs/lws/pull/827, which bumps Go to 1.26 in kubernetes-sigs/lws.

/sig testing
/area jobs
/cc @Edwinhr716