### PR TITLE
chore(test): bump CAPA e2e Prow job CPU requests from 2 to 4

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-clusterclass.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-clusterclass.yaml
@@ -36,10 +36,10 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-main.yaml
@@ -39,10 +39,10 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -88,10 +88,10 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-k8s-infra-canaries
@@ -133,10 +133,10 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -182,10 +182,10 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
           limits:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -246,9 +246,9 @@ periodics:
             # these are both a bit below peak usage during build
             # this is mostly for building kubernetes
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-2.10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-2.10.yaml
@@ -39,10 +39,10 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -88,10 +88,10 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-k8s-infra-canaries
@@ -133,10 +133,10 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -182,10 +182,10 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
           limits:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -246,9 +246,9 @@ periodics:
             # these are both a bit below peak usage during build
             # this is mostly for building kubernetes
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-2.11.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-2.11.yaml
@@ -39,10 +39,10 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -88,10 +88,10 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-k8s-infra-canaries
@@ -133,10 +133,10 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -182,10 +182,10 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
           limits:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -246,9 +246,9 @@ periodics:
             # these are both a bit below peak usage during build
             # this is mostly for building kubernetes
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-2.9.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics-release-2.9.yaml
@@ -39,10 +39,10 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -88,10 +88,10 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-k8s-infra-canaries
@@ -133,10 +133,10 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -182,10 +182,10 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
           limits:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -246,9 +246,9 @@ periodics:
             # these are both a bit below peak usage during build
             # this is mostly for building kubernetes
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -38,10 +38,10 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                cpu: 2
+                cpu: 4
                 memory: "9Gi"
               limits:
-                cpu: 2
+                cpu: 4
                 memory: "9Gi"
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -83,10 +83,10 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                cpu: 2
+                cpu: 4
                 memory: "9Gi"
               limits:
-                cpu: 2
+                cpu: 4
                 memory: "9Gi"
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -129,10 +129,10 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                cpu: 2
+                cpu: 4
                 memory: "9Gi"
               limits:
-                cpu: 2
+                cpu: 4
                 memory: "9Gi"
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-clusterclass.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-clusterclass.yaml
@@ -38,10 +38,10 @@ presubmits:
               privileged: true
             resources:
               requests:
-                cpu: 2
+                cpu: 4
                 memory: "9Gi"
               limits:
-                cpu: 2
+                cpu: 4
                 memory: "9Gi"
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-main.yaml
@@ -196,9 +196,9 @@ presubmits:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
               memory: "9Gi"
-              cpu: 2
+              cpu: 4
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -243,10 +243,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -294,10 +294,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -339,10 +339,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -384,10 +384,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -431,10 +431,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.10.yaml
@@ -196,9 +196,9 @@ presubmits:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
               memory: "9Gi"
-              cpu: 2
+              cpu: 4
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -243,10 +243,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -294,10 +294,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -339,10 +339,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -384,10 +384,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -431,10 +431,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.11.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.11.yaml
@@ -196,9 +196,9 @@ presubmits:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
               memory: "9Gi"
-              cpu: 2
+              cpu: 4
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -243,10 +243,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -294,10 +294,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -339,10 +339,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -384,10 +384,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -431,10 +431,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.9.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.9.yaml
@@ -196,9 +196,9 @@ presubmits:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
               memory: "9Gi"
-              cpu: 2
+              cpu: 4
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -243,10 +243,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -294,10 +294,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -339,10 +339,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -384,10 +384,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -431,10 +431,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/templates/cluster-api-provider-aws-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/templates/cluster-api-provider-aws-periodics.yaml.tpl
@@ -38,10 +38,10 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -87,10 +87,10 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-k8s-infra-canaries
@@ -132,10 +132,10 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
         limits:
-          cpu: 2
+          cpu: 4
           memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -181,10 +181,10 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
           limits:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -245,9 +245,9 @@ periodics:
             # these are both a bit below peak usage during build
             # this is mostly for building kubernetes
             memory: "9Gi"
-            cpu: 2
+            cpu: 4
           limits:
-            cpu: 2
+            cpu: 4
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/templates/cluster-api-provider-aws-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/templates/cluster-api-provider-aws-presubmits.yaml.tpl
@@ -195,9 +195,9 @@ presubmits:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
               memory: "9Gi"
-              cpu: 2
+              cpu: 4
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -243,10 +243,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -295,10 +295,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -340,10 +340,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -385,10 +385,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -432,10 +432,10 @@ presubmits:
             privileged: true
           resources:
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -480,10 +480,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
             limits:
-              cpu: 2
+              cpu: 4
               memory: "9Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws


### PR DESCRIPTION
Increase CPU requests/limits from 2 to 4 for all CAPA e2e, conformance, and EKS Prow jobs (presubmits, postsubmits, and periodics).

This allows Ginkgo's -p flag to auto-detect more parallel nodes, projected to reduce e2e wall-clock time by ~40-45% based on analysis of recent CI runs. This aligns CAPA with cluster-api-provider-gcp (4 CPUs) and cluster-api-provider-azure (4-6 CPUs).