### PR TITLE
Resize memory for test pods and worker nodes in ppc conformance jobs

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -112,10 +112,10 @@ periodics:
           resources:
             requests:
               cpu: 2
-              memory: "14Gi"
+              memory: "8Gi"
             limits:
               cpu: 2
-              memory: "14Gi"
+              memory: "8Gi"
           command:
             - runner.sh
           args:
@@ -131,7 +131,7 @@ periodics:
               make install-deployer-tf
 
               export TF_VAR_powervs_system_type=s1022
-              kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
+              kubetest2 tf --powervs-image-name CentOS-Stream-10 \
                 --powervs-ssh-key k8s-prow-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
                 --workers-count 2 --cluster-name conformance-$(date +%s) \

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -876,7 +876,7 @@ periodics:
         make install-deployer-tf
 
         export TF_VAR_powervs_system_type=s1022
-        kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
+        kubetest2 tf --powervs-image-name CentOS-Stream-10 \
           --powervs-ssh-key k8s-prow-sshkey \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \
           --workers-count 2 --cluster-name conformance-$(date +%s) \
@@ -892,10 +892,10 @@ periodics:
       resources:
         limits:
           cpu: "2"
-          memory: 14Gi
+          memory: 8Gi
         requests:
           cpu: "2"
-          memory: 14Gi
+          memory: 8Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1151,7 +1151,7 @@ periodics:
         make install-deployer-tf
 
         export TF_VAR_powervs_system_type=s1022
-        kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
+        kubetest2 tf --powervs-image-name CentOS-Stream-10 \
           --powervs-ssh-key k8s-prow-sshkey \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \
           --workers-count 2 --cluster-name conformance-$(date +%s) \
@@ -1167,10 +1167,10 @@ periodics:
       resources:
         limits:
           cpu: "2"
-          memory: 14Gi
+          memory: 8Gi
         requests:
           cpu: "2"
-          memory: 14Gi
+          memory: 8Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -1271,7 +1271,7 @@ periodics:
         make install-deployer-tf
 
         export TF_VAR_powervs_system_type=s1022
-        kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
+        kubetest2 tf --powervs-image-name CentOS-Stream-10 \
           --powervs-ssh-key k8s-prow-sshkey \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \
           --workers-count 2 --cluster-name conformance-$(date +%s) \
@@ -1287,10 +1287,10 @@ periodics:
       resources:
         limits:
           cpu: "2"
-          memory: 14Gi
+          memory: 8Gi
         requests:
           cpu: "2"
-          memory: 14Gi
+          memory: 8Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -107,7 +107,7 @@ periodics:
         make install-deployer-tf
 
         export TF_VAR_powervs_system_type=s1022
-        kubetest2 tf --powervs-image-name CentOS-Stream-10 --powervs-memory 32 \
+        kubetest2 tf --powervs-image-name CentOS-Stream-10 \
           --powervs-ssh-key k8s-prow-sshkey \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \
           --workers-count 2 --cluster-name conformance-$(date +%s) \
@@ -123,10 +123,10 @@ periodics:
       resources:
         limits:
           cpu: "2"
-          memory: 14Gi
+          memory: 8Gi
         requests:
           cpu: "2"
-          memory: 14Gi
+          memory: 8Gi
       securityContext:
         privileged: true
 - annotations:


### PR DESCRIPTION
The reduced memory values are sufficient, as confirmed by test runs.