### PR TITLE
Add post submit job for dra-driver-google-tpu

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-dra-driver-google-tpu.yaml
+++ b/config/jobs/image-pushing/k8s-staging-dra-driver-google-tpu.yaml
@@ -1,0 +1,24 @@
+postsubmits:
+  kubernetes-sigs/dra-driver-google-tpu:
+    - name: post-dra-driver-google-tpu-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-node-image-pushes, sig-k8s-infra-gcb
+        testgrid-alert-email: jbelamaric@google.com, mortent@google.com, troychiu@google.com
+      decorate: true
+      branches:
+        - ^main$
+        - ^release-
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20251215-d7853fe2a6
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-images
+              - --scratch-bucket=gs://k8s-staging-images-gcb
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
+              - --with-git-dir
+              - .


### PR DESCRIPTION
Following https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md to add post submit job for [dra-driver-google-tpu](https://github.com/kubernetes-sigs/dra-driver-google-tpu). I use https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-dra-driver-cpu.yaml as a reference.