### PR TITLE
[contributor-site] Add main branch to postsubmits

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-contributor-site.yaml
+++ b/config/jobs/image-pushing/k8s-staging-contributor-site.yaml
@@ -23,6 +23,7 @@ postsubmits:
       #  - '^dependabot'
       branches:
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
This PR adds the `main` branch to the `branches` list for the `contributor-site` image pushing postsubmit job. This is part of the default branch migration from `master` to `main`.

Ref: https://github.com/kubernetes/contributor-site/issues/686