### PR TITLE
[contributor-site] Remove master branch from postsubmits

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-contributor-site.yaml
+++ b/config/jobs/image-pushing/k8s-staging-contributor-site.yaml
@@ -22,7 +22,6 @@ postsubmits:
       #  # only merged code should trigger these jobs
       #  - '^dependabot'
       branches:
-        - ^master$
         - ^main$
       spec:
         serviceAccountName: gcb-builder


### PR DESCRIPTION
This PR removes the `master` branch from the `branches` list for the `contributor-site` image pushing postsubmit job.

**NOTE: This should only be merged AFTER the branch rename (Phase 2) is complete.**

Depends on: https://github.com/kubernetes/test-infra/pull/36931
Part of https://github.com/kubernetes/contributor-site/issues/686