### PR TITLE
Add periodic job for contributor-site Hugo modules update

### DIFF
--- a/config/jobs/kubernetes/contributor-site/OWNERS
+++ b/config/jobs/kubernetes/contributor-site/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-contributor-experience-leads
+labels:
+  - sig/contributor-experience
+  - area/prow

--- a/config/jobs/kubernetes/contributor-site/contributor-site-periodics.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-periodics.yaml
@@ -1,0 +1,29 @@
+periodics:
+- name: ci-contributor-site-update-hugo-modules
+  interval: 168h # Weekly
+  annotations:
+    testgrid-dashboards: sig-contribex-contributor-website
+    testgrid-tab-name: ci-contributor-site-update-hugo-modules
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: contributor-site
+    base_ref: master
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+      command:
+      - runner.sh
+      args:
+      - ./hack/update-hugo-modules.sh
+      env:
+      - name: GITHUB_TOKEN_PATH
+        value: /etc/github-token/oauth
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github-token
+        readOnly: true
+    volumes:
+    - name: github
+      secret:
+        secretName: k8s-ci-robot-github-token

--- a/config/jobs/kubernetes/contributor-site/contributor-site-periodics.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-periodics.yaml
@@ -4,6 +4,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-contribex-contributor-website
     testgrid-tab-name: ci-contributor-site-update-hugo-modules
+  cluster: k8s-infra-prow-build-trusted
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -11,7 +12,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/contributor-site/contributor-site-periodics.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-periodics.yaml
@@ -12,7 +12,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/contributor-site/contributor-site-periodics.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-periodics.yaml
@@ -1,9 +1,11 @@
 periodics:
 - name: ci-contributor-site-update-hugo-modules
-  interval: 168h # Weekly
+  interval: 24h # Daily
   annotations:
     testgrid-dashboards: sig-contribex-contributor-website
     testgrid-tab-name: ci-contributor-site-update-hugo-modules
+    testgrid-alert-email: sig-contribex-leads@kubernetes.io
+    testgrid-num-failures-to-alert: "1"
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
@@ -6,7 +6,6 @@ presubmits:
       testgrid-dashboards: sig-contribex-contributor-website
       testgrid-tab-name: pull-contributor-site-validate-hugo-modules
     decorate: true
-    always_run: true
     run_if_changed: '^(go\.mod|go\.sum|hugo\.yaml|hack/update-hugo-modules\.sh|Dockerfile|netlify\.toml)$'
     branches:
     - ^master$

--- a/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
@@ -17,3 +17,10 @@ presubmits:
         args:
         - ./hack/update-hugo-modules.sh
         - --dry-run
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi

--- a/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-images/contributor-site/k8s-contrib-site-hugo:latest
+      - image: us-central1-docker.pkg.dev/k8s-staging-images/contributor-site/k8s-contrib-site-hugo:v0.133.0-7f658d63039e
         command:
         - bash
         args:

--- a/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
@@ -1,0 +1,19 @@
+presubmits:
+  kubernetes/contributor-site:
+  - name: pull-contributor-site-validate-hugo-modules
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-contribex-contributor-website
+      testgrid-tab-name: pull-contributor-site-validate-hugo-modules
+    decorate: true
+    always_run: true
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        command:
+        - runner.sh
+        args:
+        - ./hack/update-hugo-modules.sh
+        - --dry-run

--- a/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
@@ -11,16 +11,19 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
+      - image: us-central1-docker.pkg.dev/k8s-staging-images/contributor-site/k8s-contrib-site-hugo:latest
         command:
-        - runner.sh
+        - bash
         args:
         - ./hack/update-hugo-modules.sh
         - --dry-run
+        env:
+        - name: GOMODCACHE
+          value: /tmp/gomod
         resources:
           limits:
-            cpu: 200m
-            memory: 256Mi
+            cpu: "1"
+            memory: 1Gi
           requests:
-            cpu: 200m
-            memory: 256Mi
+            cpu: "1"
+            memory: 1Gi

--- a/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
@@ -7,6 +7,7 @@ presubmits:
       testgrid-tab-name: pull-contributor-site-validate-hugo-modules
     decorate: true
     always_run: true
+    run_if_changed: '^(go\.mod|go\.sum|hugo\.yaml|hack/update-hugo-modules\.sh|Dockerfile|netlify\.toml)$'
     branches:
     - ^master$
     spec:

--- a/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
+++ b/config/jobs/kubernetes/contributor-site/contributor-site-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-images/contributor-site/k8s-contrib-site-hugo:v0.133.0-7f658d63039e
+      - image: us-central1-docker.pkg.dev/k8s-staging-images/contributor-site/k8s-contrib-site-hugo:v20260504-5ae63b7
         command:
         - bash
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-contributor-site-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-contributor-site-periodics.yaml
@@ -14,7 +14,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-images/contributor-site/k8s-contrib-site-hugo:v0.133.0-7f658d63039e
+    - image: us-central1-docker.pkg.dev/k8s-staging-images/contributor-site/k8s-contrib-site-hugo:v20260504-5ae63b7
       command:
       - bash
       args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-contributor-site-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-contributor-site-periodics.yaml
@@ -14,7 +14,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-images/contributor-site/k8s-contrib-site-hugo:latest
+    - image: us-central1-docker.pkg.dev/k8s-staging-images/contributor-site/k8s-contrib-site-hugo:v0.133.0-7f658d63039e
       command:
       - bash
       args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-contributor-site-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-contributor-site-periodics.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: ci-contributor-site-update-hugo-modules
-  interval: 24h # Daily
+  interval: 24h
   annotations:
     testgrid-dashboards: sig-contribex-contributor-website
     testgrid-tab-name: ci-contributor-site-update-hugo-modules
@@ -14,25 +14,27 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260410-1226423a7b-master
+    - image: us-central1-docker.pkg.dev/k8s-staging-images/contributor-site/k8s-contrib-site-hugo:latest
       command:
-      - runner.sh
+      - bash
       args:
       - ./hack/update-hugo-modules.sh
       env:
       - name: GITHUB_TOKEN_PATH
         value: /etc/github-token/oauth
+      - name: GOMODCACHE
+        value: /tmp/gomod
       volumeMounts:
       - name: github
         mountPath: /etc/github-token
         readOnly: true
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: "1"
+          memory: 1Gi
         requests:
-          cpu: 200m
-          memory: 256Mi
+          cpu: "1"
+          memory: 1Gi
     volumes:
     - name: github
       secret:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-contributor-site-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-contributor-site-periodics.yaml
@@ -5,7 +5,7 @@ periodics:
     testgrid-dashboards: sig-contribex-contributor-website
     testgrid-tab-name: ci-contributor-site-update-hugo-modules
     testgrid-alert-email: sig-contribex-leads@kubernetes.io
-    testgrid-num-failures-to-alert: "1"
+    testgrid-num-failures-to-alert: "3"
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   extra_refs:
@@ -26,6 +26,13 @@ periodics:
       - name: github
         mountPath: /etc/github-token
         readOnly: true
+      resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
+        requests:
+          cpu: 200m
+          memory: 256Mi
     volumes:
     - name: github
       secret:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-contributor-site-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-contributor-site-periodics.yaml
@@ -21,7 +21,7 @@ periodics:
       - ./hack/update-hugo-modules.sh
       env:
       - name: GITHUB_TOKEN_PATH
-        value: /etc/github-token/oauth
+        value: /etc/github-token/token
       - name: GOMODCACHE
         value: /tmp/gomod
       volumeMounts:
@@ -38,4 +38,4 @@ periodics:
     volumes:
     - name: github
       secret:
-        secretName: k8s-ci-robot-github-token
+        secretName: k8s-infra-ci-robot-github-token

--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -45,3 +45,8 @@ prefixes:
     repo: "https://github.com/kubernetes-sigs/apisnoop"
     summarise: false
     consistentImages: false
+  - name: "k8s-staging-images contributor-site"
+    prefix: "us-central1-docker.pkg.dev/k8s-staging-images/contributor-site"
+    repo: "https://github.com/kubernetes/contributor-site"
+    summarise: false
+    consistentImages: false


### PR DESCRIPTION
This PR adds periodic and presubmit Prow jobs for `kubernetes/contributor-site`.

- **Periodic Job**: Updates Hugo modules daily and opens a PR (`interval: 24h`; deduped via pr-creator `matchTitle`).
- **Presubmit Job**: Validates Hugo module updates on PRs to ensure no breaking changes. Runs only when files affecting modules change (`run_if_changed`).

This replaces the previous GitHub Actions proposal in kubernetes/contributor-site#647.

Depends-on: kubernetes/contributor-site#647
/sig contributor-experience
/area prow
/kind feature