### PR TITLE
Add 'main' branch to contributor-site staging image job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-contributor-site.yaml
+++ b/config/jobs/image-pushing/k8s-staging-contributor-site.yaml
@@ -23,6 +23,7 @@ postsubmits:
       #  - '^dependabot'
       branches:
         - ^master$
+        - ^main$
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
This PR adds the `main` branch to the `post-contributor-site-push-image-k8s-contrib-site-hugo` job.

The `kubernetes/contributor-site` repository is migrating its default branch from `master` to `main`. Adding `main` to the branches list ensures that images continue to be pushed during and after the transition.

Tracking issue: kubernetes/contributor-site#686.