### PR TITLE
Bump kpromo to v4.5.0-0

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -13,7 +13,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v4.4.1-0
+      - image: registry.k8s.io/artifact-promoter/kpromo:v4.5.0-0
         command:
         - /kpromo
         args:
@@ -54,7 +54,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v4.4.1-0
+      - image: registry.k8s.io/artifact-promoter/kpromo:v4.5.0-0
         command:
         - /kpromo
         args:
@@ -122,7 +122,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v4.4.1-0
+    - image: registry.k8s.io/artifact-promoter/kpromo:v4.5.0-0
       command:
       - /kpromo
       args:
@@ -159,7 +159,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v4.4.1-0
+    - image: registry.k8s.io/artifact-promoter/kpromo:v4.5.0-0
       command:
       - /kpromo
       args:
@@ -209,7 +209,7 @@ periodics:
     serviceAccountName: k8s-infra-gcr-promoter
     activeDeadlineSeconds: 7800 # 2h10m
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v4.4.1-0
+    - image: registry.k8s.io/artifact-promoter/kpromo:v4.5.0-0
       command:
       - /kpromo
       args:
@@ -319,7 +319,7 @@ periodics:
     path_alias: sigs.k8s.io/promo-tools
   spec:
     containers:
-    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.4.1-0
+    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.5.0-0
       imagePullPolicy: Always
       command:
         - /kpromo


### PR DESCRIPTION
Pin all kpromo prow jobs to `registry.k8s.io/artifact-promoter/kpromo:v4.5.0-0`.

Release: https://github.com/kubernetes-sigs/promo-tools/releases/tag/v4.5.0
Image promotion: https://github.com/kubernetes/k8s.io/pull/9430