### PR TITLE
kind: fix pull-kind-verify broken by deleted -experimental image tag

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20241125-b4ea3e27a6-experimental
+      - image: gcr.io/k8s-staging-test-infra/krte:v20260427-56a97dfac3-master
         command:
         - wrapper.sh
         - make


### PR DESCRIPTION
Fixes `pull-kind-verify`, which has been 100% `ABORTED` on every PR
because the container image it references was deleted.

The `-experimental` krte image variant was intentionally dropped in
November 2024 (commit `c68390e455`, "drop unused -experimental images
variant"). After that, no new `-experimental` tags were published, the
old tag `v20241125-b4ea3e27a6-experimental` was eventually GC'd from
GCR, and the auto-bumper silently skipped this job (nothing to bump to).

Switch to the same `-master` tag already used by every other
`pull-kind-*` job in this file (lines 13, 36, 96, 142, 189, 234).

/cc @BenTheElder @aojea @stmcginnis 
/sig testing
/kind bug