### PR TITLE
Set GOWORK to off for kube-agentic-networking `make test|verify`

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-agentic-networking/kube-agentic-networking-config.yaml
+++ b/config/jobs/kubernetes-sigs/kube-agentic-networking/kube-agentic-networking-config.yaml
@@ -21,6 +21,9 @@ presubmits:
         args:
           - make
           - verify
+        env:
+        - name: "GOWORK"
+          value: "off"
         # docker-in-docker needs privileged mode.
         securityContext:
           privileged: true
@@ -52,6 +55,9 @@ presubmits:
           args:
             - make
             - test
+          env:
+          - name: "GOWORK"
+            value: "off"
           # docker-in-docker needs privileged mode.
           securityContext:
             privileged: true


### PR DESCRIPTION
This should fix the test failure on https://github.com/kubernetes-sigs/kube-agentic-networking/pull/263.

https://github.com/kubernetes-sigs/kube-agentic-networking includes two modules:

* The main module at the root (.).
* A separate module for tests (./tests).