### PR TITLE
Add prow job for conformance test for kube-agentic-networking projec

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-agentic-networking/kube-agentic-networking-config.yaml
+++ b/config/jobs/kubernetes-sigs/kube-agentic-networking/kube-agentic-networking-config.yaml
@@ -93,3 +93,34 @@ presubmits:
             requests:
               cpu: 4
               memory: 8Gi
+  - name: pull-kube-agentic-networking-gateway-api-conformance
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-network-kube-agentic-networking
+      testgrid-tab-name: gateway-api-conformance
+    labels:
+      preset-kind-volume-mounts: "true"
+      preset-dind-enabled: "true"
+    decorate: true
+    path_alias: sigs.k8s.io/kube-agentic-networking
+    always_run: true
+    skip_report: false
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260504-c27e3ff179-master
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-gateway-api-conformance
+          # docker-in-docker needs privileged mode.
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 4
+              memory: 8Gi
+            requests:
+              cpu: 4
+              memory: 8Gi


### PR DESCRIPTION
The `test-conformance` rule is added in https://github.com/kubernetes-sigs/kube-agentic-networking/pull/263.

/hold https://github.com/kubernetes-sigs/kube-agentic-networking/pull/263 needs to be merged first.