### PR TITLE
Kops - Skip ENIs on certain distros with older kops versions

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -510,6 +510,10 @@ def generate_grid():
                     # "Unable to connect to kvstore: timed out while waiting for etcd session"
                     if kops_version in ('1.32', '1.33') and networking == 'cilium-etcd':
                         continue
+                    # Fixes in https://github.com/kubernetes/kops/pull/18269
+                    # but not backported to earlier kops versions
+                    if kops_version in ('1.32', '1.33', '1.34') and networking in ('amazon-vpc', 'cilium-eni') and distro_short in ('deb11', 'rhel9'):
+                        continue
                     extra_flags = []
                     if 'arm64' in distro:
                         extra_flags.extend([


### PR DESCRIPTION
We're not backporting this any older than 1.35, so skip the known-failing jobs in 1.34 and earlier

/cc @hakman 