### PR TITLE
Add Kubernetes 1.36 Kind e2e jobs for jobset

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -188,3 +188,43 @@ periodics:
             requests:
               cpu: 3
               memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-main-1-36
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: main
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset, sig-apps-jobset-periodics
+      testgrid-tab-name: periodic-jobset-test-e2e-main-1-36
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.36"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.36.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.26
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-11.yaml
@@ -188,3 +188,43 @@ periodics:
           requests:
             cpu: 3
             memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-release-0-11-1-36
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: release-0.11
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-periodics
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-11-1-36
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.36 on release 0.11"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        env:
+        - name: E2E_KIND_VERSION
+          value: kindest/node:v1.36.0
+        - name: BUILDER_IMAGE
+          value: public.ecr.aws/docker/library/golang:1.25
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -170,6 +170,43 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-jobset-test-e2e-main-1-36
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^main
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      testgrid-tab-name: pull-jobset-test-e2e-main-1-36
+      description: "Run jobset end to end tests for Kubernetes 1.36"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.36.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.26
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-jobset-verify-main
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-11.yaml
@@ -165,6 +165,42 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-jobset-test-e2e-release-0-11-1-36
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^release-0.11
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      description: "Run jobset end to end tests for Kubernetes 1.36"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.36.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.25
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-jobset-verify-release-0-11
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
Add presubmit and periodic e2e test jobs using
kindest/node:v1.36.0 for both main and release-0.11
branches. Main branch uses golang 1.26, release-0.11
uses golang 1.25.

Jobs added:
- pull-jobset-test-e2e-main-1-36
- periodic-jobset-test-e2e-main-1-36
- pull-jobset-test-e2e-release-0-11-1-36
- periodic-jobset-test-e2e-release-0-11-1-36

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).