### PR TITLE
Increase memory for capg build and test periodics to fix OOM

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
@@ -21,10 +21,10 @@ periodics:
           resources:
             limits:
               cpu: 4
-              memory: 6Gi
+              memory: 8Gi
             requests:
               cpu: 4
-              memory: 6Gi
+              memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: capg-build-main
@@ -52,10 +52,10 @@ periodics:
           resources:
             limits:
               cpu: 4
-              memory: 6Gi
+              memory: 8Gi
             requests:
               cpu: 4
-              memory: 6Gi
+              memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: capg-test-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-10.yaml
@@ -21,10 +21,10 @@ periodics:
       resources:
         limits:
           cpu: 4
-          memory: 4Gi
+          memory: 8Gi
         requests:
           cpu: 4
-          memory: 4Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: capg-build-release-1-10
@@ -52,10 +52,10 @@ periodics:
       resources:
         limits:
           cpu: 4
-          memory: 4Gi
+          memory: 8Gi
         requests:
           cpu: 4
-          memory: 4Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: capg-test-release-1-10

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-11.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-11.yaml
@@ -52,10 +52,10 @@ periodics:
       resources:
         limits:
           cpu: 4
-          memory: 4Gi
+          memory: 8Gi
         requests:
           cpu: 4
-          memory: 4Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: capg-test-release-1-11

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-11.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-release-1-11.yaml
@@ -21,10 +21,10 @@ periodics:
       resources:
         limits:
           cpu: 4
-          memory: 4Gi
+          memory: 8Gi
         requests:
           cpu: 4
-          memory: 4Gi
+          memory: 8Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: capg-build-release-1-11


### PR DESCRIPTION
Bump memory requests/limits to 8Gi for the following jobs to fix OOM kills:
- `periodic-cluster-api-provider-gcp-build-release-1-11` (4Gi → 8Gi)
- `periodic-cluster-api-provider-gcp-test-release-1-11` (4Gi → 8Gi)
- `periodic-cluster-api-provider-gcp-build-release-1-10` (4Gi → 8Gi)
- `periodic-cluster-api-provider-gcp-test-release-1-10` (4Gi → 8Gi)
- `periodic-cluster-api-provider-gcp-build-main` (6Gi → 8Gi)
- `periodic-cluster-api-provider-gcp-test-main` (6Gi → 8Gi)