### PR TITLE
Cleanup K8S `<= 1.31` dashboards for Gardener

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -77,36 +77,6 @@ dashboards:
     - name: Gardener, v1.32 Alibaba Cloud
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud
       test_group_name: ci-gardener-e2e-conformance-alicloud-v1.32
-    - name: Gardener, v1.31 AWS
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
-      test_group_name: ci-gardener-e2e-conformance-aws-v1.31
-    - name: Gardener, v1.31 GCE
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
-      test_group_name: ci-gardener-e2e-conformance-gce-v1.31
-    - name: Gardener, v1.31 OpenStack
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack
-      test_group_name: ci-gardener-e2e-conformance-openstack-v1.31
-    - name: Gardener, v1.31 Azure
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
-      test_group_name: ci-gardener-e2e-conformance-azure-v1.31
-    - name: Gardener, v1.31 Alibaba Cloud
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud
-      test_group_name: ci-gardener-e2e-conformance-alicloud-v1.31
-    - name: Gardener, v1.30 AWS
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
-      test_group_name: ci-gardener-e2e-conformance-aws-v1.30
-    - name: Gardener, v1.30 GCE
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
-      test_group_name: ci-gardener-e2e-conformance-gce-v1.30
-    - name: Gardener, v1.30 OpenStack
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack
-      test_group_name: ci-gardener-e2e-conformance-openstack-v1.30
-    - name: Gardener, v1.30 Azure
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
-      test_group_name: ci-gardener-e2e-conformance-azure-v1.30
-    - name: Gardener, v1.30 Alibaba Cloud
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud
-      test_group_name: ci-gardener-e2e-conformance-alicloud-v1.30
 
 - name: conformance-apisnoop
 - name: conformance-ec2
@@ -218,56 +188,6 @@ dashboards:
     - name: Gardener, v1.32 Alibaba Cloud
       description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud
       test_group_name: ci-gardener-e2e-conformance-alicloud-v1.32
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.31 AWS
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
-      test_group_name: ci-gardener-e2e-conformance-aws-v1.31
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.31 GCE
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
-      test_group_name: ci-gardener-e2e-conformance-gce-v1.31
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.31 OpenStack
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack
-      test_group_name: ci-gardener-e2e-conformance-openstack-v1.31
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.31 Azure
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
-      test_group_name: ci-gardener-e2e-conformance-azure-v1.31
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.31 Alibaba Cloud
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud
-      test_group_name: ci-gardener-e2e-conformance-alicloud-v1.31
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.30 AWS
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Amazon Web Services (AWS)
-      test_group_name: ci-gardener-e2e-conformance-aws-v1.30
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.30 GCE
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Google Cloud Engine (GCE)
-      test_group_name: ci-gardener-e2e-conformance-gce-v1.30
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.30 OpenStack
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Openstack
-      test_group_name: ci-gardener-e2e-conformance-openstack-v1.30
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.30 Azure
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Microsoft Azure
-      test_group_name: ci-gardener-e2e-conformance-azure-v1.30
-      alert_options:
-        alert_mail_to_addresses: gardener-oq@listserv.sap.com
-    - name: Gardener, v1.30 Alibaba Cloud
-      description: Runs conformance tests on a Kubernetes cluster provided by Gardener (https://github.com/gardener/gardener) on Alibaba Cloud
-      test_group_name: ci-gardener-e2e-conformance-alicloud-v1.30
       alert_options:
         alert_mail_to_addresses: gardener-oq@listserv.sap.com
 
@@ -392,56 +312,6 @@ test_groups:
   disable_prowjob_analysis: true
 - name: ci-gardener-e2e-conformance-alicloud-v1.32
   gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-alicloud-v1.32
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-aws-v1.31
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.31
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-gce-v1.31
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-gce-v1.31
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-openstack-v1.31
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-openstack-v1.31
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-azure-v1.31
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-azure-v1.31
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-alicloud-v1.31
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-alicloud-v1.31
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-aws-v1.30
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-aws-v1.30
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-gce-v1.30
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-gce-v1.30
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-openstack-v1.30
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-openstack-v1.30
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-azure-v1.30
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-azure-v1.30
-  alert_stale_results_hours: 168
-  num_failures_to_alert: 1
-  disable_prowjob_analysis: true
-- name: ci-gardener-e2e-conformance-alicloud-v1.30
-  gcs_prefix: k8s-conformance-gardener/ci-gardener-e2e-conformance-alicloud-v1.30
   alert_stale_results_hours: 168
   num_failures_to_alert: 1
   disable_prowjob_analysis: true


### PR DESCRIPTION
/kind cleanup

Gardener no longer supports Kubernetes `v1.30` and `v1.31`.
This PR cleans up the related Gardener dashboards.

/cc @ialidzhikov