### PR TITLE
Skip ExternalTrafficPolicy short-circuit test in cloud-provider-azure multi-zone-vmss-capz job

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -1626,7 +1626,7 @@ periodics:
         value: "latest"
       - name: GINKGO_ARGS  # cloud-provider-azure config
         # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
-        value: --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete.Grace.Period|runs.ReplicaSets.to.verify.preemption.running.path|client.go.should.negotiate|should.contain.custom.columns.for.each.resource|Network.should.set.TCP.CLOSE_WAIT.timeout|PodSecurityPolicy|In-tree.Volumes|ephemeral.should.support.expansion.of.pvcs.created.for.ephemeral.pvcs|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator --report-dir=/logs/artifacts --disable-log-dump=true
+        value: --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete.Grace.Period|runs.ReplicaSets.to.verify.preemption.running.path|client.go.should.negotiate|should.contain.custom.columns.for.each.resource|Network.should.set.TCP.CLOSE_WAIT.timeout|PodSecurityPolicy|In-tree.Volumes|ephemeral.should.support.expansion.of.pvcs.created.for.ephemeral.pvcs|should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
         value: "1"
       - name: WORKER_MACHINE_COUNT  # CAPZ config


### PR DESCRIPTION
The `cloud-provider-azure-conformance-multi-zone-vmss-capz` job is failing on
 `[sig-network] Services should implement NodePort and HealthCheckNodePort correctly when ExternalTrafficPolicy changes`.
 
 The test asserts that source IP is preserved through kube-proxy's
 `externalTrafficPolicy=Local` short-circuit path, which is incompatible with
 CAPZ's default Calico VXLAN encapsulation (the source IP gets rewritten to the
 node's `vxlan.calico` tunnel address).
 
 Only this job is affected because it uses `WORKER_MACHINE_COUNT: "3"`; the test
 requires ≥3 schedulable workers and is skipped automatically elsewhere.
 
 Refs: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/9863, https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6252