### PR TITLE
jobs/sig-cloud-provider: retire ci-kubernetes-soak-gci-gce-stable4

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -497,44 +497,6 @@ periodics:
         requests:
           cpu: "2"
           memory: 6Gi
-- annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: soak-gci-gce-1.12
-  cluster: k8s-infra-prow-build
-  decorate: true
-  decoration_config:
-    timeout: 23h40m0s
-  interval: 12h
-  labels:
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-  name: ci-kubernetes-soak-gci-gce-stable4
-  spec:
-    containers:
-    - args:
-      - --down=false
-      - --env=DOCKER_TEST_LOG_LEVEL=--log-level=warn
-      - --extract=ci/k8s-stable4
-      - --gcp-node-image=gci
-      - --gcp-region=us-central1
-      - --provider=gce
-      - --soak
-      - --test_args=--ginkgo.skip=\[Driver:.gcepd\]|\[Disruptive\]|\[Flaky\]|\[Feature:([^L].*|L[^o].*|Lo[^a].*|Loa[^d].*)\]
-        --clean-start=true --minStartupPods=8
-      - --timeout=1400m
-      - --up=false
-      command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
-      name: ""
-      resources:
-        limits:
-          cpu: "2"
-          memory: 6Gi
-        requests:
-          cpu: "2"
-          memory: 6Gi
 postsubmits: null
 presubmits:
   kubernetes/kubernetes:


### PR DESCRIPTION
The k8s-stable4 release channel no longer exists (HTTP 404 on extract), causing 30 consistent build failures. Remove the job; stable1 through stable3 continue to cover the supported release branches.