### PR TITLE
kubespray: switch image-builder presubmit from rootless BuildKit to Dind

### DIFF
--- a/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
     always_run: false
     skip_report: false
     decorate: true
+    labels:
+      preset-dind-enabled: "true"
     spec:
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260504-c27e3ff179-master
@@ -41,34 +43,21 @@ presubmits:
         - -ceu
         - |
           apt-get update
-          apt-get install -y --no-install-recommends qemu-utils uidmap fuse-overlayfs rootlesskit slirp4netns ca-certificates curl
+
+          # Use Docker-in-Docker for this presubmit for now.
+          # The rootless BuildKit path is currently blocked on eks-prow-build
+          # because user namespaces are not available in that environment.
+          # Keep the Kubespray-side BuildKit support, but validate this lane with Docker for now.
+          # Tracking issue for the future rootless/userns path:
+          # https://github.com/kubernetes/k8s.io/issues/9433
+          apt-get install -y --no-install-recommends qemu-utils
           python3 -m pip install --no-cache-dir --break-system-packages ansible-core
           ansible-galaxy collection install community.general -p /usr/share/ansible/collections
-          buildkit_arch="$(dpkg --print-architecture)"
-          curl -fsSL "https://github.com/moby/buildkit/releases/download/v0.25.1/buildkit-v0.25.1.linux-${buildkit_arch}.tar.gz" -o /tmp/buildkit.tgz
-          tar -C /usr/local -xzf /tmp/buildkit.tgz
-          curl -fsSL "https://raw.githubusercontent.com/moby/buildkit/v0.25.1/examples/buildctl-daemonless/buildctl-daemonless.sh" -o /usr/local/bin/buildctl-daemonless.sh
-          chmod +x /usr/local/bin/buildctl-daemonless.sh
+          make -C test-infra/image-builder validate-single-docker image_name=ubuntu-2404
 
-          # Run BuildKit rootless as a non-root user.
-          if ! id -u prowbuilder >/dev/null 2>&1; then
-            useradd -m -s /bin/bash prowbuilder
-          fi
-          prowbuilder_uid="$(id -u prowbuilder)"
-          prowbuilder_home="$(getent passwd prowbuilder | cut -d: -f6)"
-          grep -q '^prowbuilder:' /etc/subuid || echo 'prowbuilder:100000:65536' >> /etc/subuid
-          grep -q '^prowbuilder:' /etc/subgid || echo 'prowbuilder:100000:65536' >> /etc/subgid
-          install -d -m 700 -o prowbuilder -g prowbuilder "/run/user/${prowbuilder_uid}"
-          install -d -m 700 -o prowbuilder -g prowbuilder "${prowbuilder_home}/.local/share/buildkit"
-          install -d -m 700 -o prowbuilder -g prowbuilder "${prowbuilder_home}/.local/tmp"
-          chown -R prowbuilder:prowbuilder /home/prow/go/src/github.com/kubernetes-sigs/kubespray
-
-          if [ "$(cat /proc/sys/user/max_user_namespaces 2>/dev/null || echo 0)" = "0" ]; then
-            echo "user namespaces are disabled on this node; rootless BuildKit cannot run" >&2
-            exit 1
-          fi
-
-          su -s /bin/bash -c "export HOME=${prowbuilder_home}; export XDG_RUNTIME_DIR=/run/user/${prowbuilder_uid}; export TMPDIR=${prowbuilder_home}/.local/tmp; export BUILDKITD_FLAGS='--rootless --oci-worker-no-process-sandbox --oci-worker-snapshotter=native'; make -C test-infra/image-builder validate-single image_name=ubuntu-2404" prowbuilder
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
## What this PR does

This PR switches the Kubespray `test-infra/image-builder` presubmit from the rootless BuildKit validation path to `dind` based validation.

The earlier rootless BuildKit approach is currently blocked on the `eks-prow-build` lane because user namespaces are disabled on the node environment (`user.max_user_namespaces=0`), so the presubmit cannot run rootless there today.

`dind` is the practical short-term path for keeping real image-build validation in Prow.


## Context

Related Kubespray work:
- https://github.com/kubernetes-sigs/kubespray/pull/13212

Tracking issue for the future rootless/user-namespace path:
- https://github.com/kubernetes/k8s.io/issues/9433