### PR TITLE
config: enable skip-review for kubernetes-sigs/provider-aws-test-infra

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -798,6 +798,20 @@ tide:
     - kubernetes/k8s.io
     - kubernetes/test-infra
   - repos:
+    - kubernetes-sigs/provider-aws-test-infra
+    labels: # provider-aws-test-infra-admins team gates the skip-review label via plugins.yaml restricted_labels
+    - skip-review
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+  - repos:
     - kubernetes-sigs/cloud-provider-azure
     labels:
     - lgtm

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -241,6 +241,10 @@ label:
         - sig-storage-leads
         - sig-testing-leads
         - sig-windows-leads
+    kubernetes-sigs/provider-aws-test-infra:
+      - label: skip-review
+        allowed_teams:
+        - provider-aws-test-infra-admins
 
 lgtm:
 - repos:

--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -27,6 +27,7 @@
 - [Labels that apply to kubernetes-sigs/krew, for both issues and PRs](#labels-that-apply-to-kubernetes-sigskrew-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/kubespray, only for PRs](#labels-that-apply-to-kubernetes-sigskubespray-only-for-prs)
 - [Labels that apply to kubernetes-sigs/promo-tools, for both issues and PRs](#labels-that-apply-to-kubernetes-sigspromo-tools-for-both-issues-and-prs)
+- [Labels that apply to kubernetes-sigs/provider-aws-test-infra, only for PRs](#labels-that-apply-to-kubernetes-sigsprovider-aws-test-infra-only-for-prs)
 - [Labels that apply to kubernetes-sigs/prow, for both issues and PRs](#labels-that-apply-to-kubernetes-sigsprow-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/autoscaler, for both issues and PRs](#labels-that-apply-to-kubernetesautoscaler-for-both-issues-and-prs)
 - [Labels that apply to kubernetes/autoscaler, only for PRs](#labels-that-apply-to-kubernetesautoscaler-only-for-prs)
@@ -404,6 +405,12 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="area/artifacts" href="#area/artifacts">`area/artifacts`</a> | Issues or PRs related to the hosting of release artifacts for subprojects| anyone |  [label](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/label) |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
+
+## Labels that apply to kubernetes-sigs/provider-aws-test-infra, only for PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="skip-review" href="#skip-review">`skip-review`</a> | Indicates a PR is trusted, used by tide for auto-merging PRs.| provider-aws-test-infra-admins | |
 
 ## Labels that apply to kubernetes-sigs/prow, for both issues and PRs
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -2508,6 +2508,13 @@ repos:
           - name: area/release-infra
         target: both
         addedBy: label
+  kubernetes-sigs/provider-aws-test-infra:
+    labels:
+      - color: 0ffa16
+        description: Indicates a PR is trusted, used by tide for auto-merging PRs.
+        name: skip-review
+        target: prs
+        addedBy: provider-aws-test-infra-admins
   kubernetes-sigs/prow:
     labels:
       - color: 0052cc


### PR DESCRIPTION
Adds a Tide query that auto-merges PRs labeled `skip-review` (and `cncf-cla: yes`) on kubernetes-sigs/provider-aws-test-infra.

Restricts the skip-review label to the `provider-aws-test-infra-admins` GitHub team via the label plugin, and registers the label in label_sync as well.