### PR TITLE
add large scale Kueue periodics and presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -231,6 +231,44 @@ periodics:
               cpu: "6"
               memory: "9Gi"
   - interval: 12h
+    name: periodic-kueue-test-large-scale-scheduling-perf-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-large-scale-scheduling-perf-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue test-large-scale-scheduling-perf"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.26
+          command:
+            - make
+          args:
+            - test-large-scale-performance-scheduler
+          env:
+            - name: GOMAXPROCS
+              value: "7"
+          resources:
+            requests:
+              cpu: "7"
+              memory: "26Gi"
+            limits:
+              cpu: "7"
+              memory: "26Gi"
+  - interval: 12h
     name: periodic-kueue-test-e2e-main-1-33
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -774,6 +774,34 @@ presubmits:
               limits:
                 cpu: "6"
                 memory: "9Gi"
+    - name: pull-kueue-test-large-scale-scheduling-perf-main
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-large-scale-scheduling-perf-main
+        description: "Run kueue test-large-scale-scheduling-perf"
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.26
+            command:
+              - make
+            args:
+              - test-large-scale-performance-scheduler
+            env:
+              - name: GOMAXPROCS
+                value: "7"
+            resources:
+              requests:
+                cpu: "7"
+                memory: "26Gi"
+              limits:
+                cpu: "7"
+                memory: "26Gi"
     - name: pull-kueue-populator-verify-main
       cluster: eks-prow-build-cluster
       branches:


### PR DESCRIPTION
to run the large scale performance tests in https://github.com/kubernetes-sigs/kueue/pull/10780 and to fix https://github.com/kubernetes-sigs/kueue/issues/10773 we propose a new periodic and presubmit for Kueue

https://github.com/kubernetes-sigs/kueue/pull/10780#discussion_r3194956283 is more context for the pod sizing