### PR TITLE
capz: add k8s 1.35 -> 1.36 upgrade job, remove 1.31 -> 1.32

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main-upgrades.yaml
@@ -1,54 +1,5 @@
 periodics:
 
-- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-31-1-32-main
-  cluster: eks-prow-build-cluster
-  minimum_interval: 24h
-  decorate: true
-  decoration_config:
-    timeout: 4h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-community: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-  spec:
-    serviceAccountName: azure
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.32
-      args:
-        - runner.sh
-        - "./scripts/ci-e2e.sh"
-      env:
-        - name: KUBERNETES_VERSION_UPGRADE_FROM
-          value: "stable-1.31"
-        - name: KUBERNETES_VERSION_UPGRADE_TO
-          value: "stable-1.32"
-        - name: GINKGO_FOCUS
-          value: "\\[K8s-Upgrade\\]"
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        limits:
-          cpu: 4
-          memory: 9Gi
-        requests:
-          cpu: 4
-          memory: 9Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capi-periodic-upgrade-main-1-31-1-32
-    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: "Runs Kubernetes upgrade tests from v1.31 to v1.32 on CAPZ main branch"
-
 - name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-32-1-33-main
   cluster: eks-prow-build-cluster
   minimum_interval: 24h
@@ -195,3 +146,52 @@ periodics:
     testgrid-tab-name: capi-periodic-upgrade-main-1-34-1-35
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
     description: "Runs Kubernetes upgrade tests from v1.34 to v1.35 on CAPZ main branch"
+
+- name: periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-35-1-36-main
+  cluster: eks-prow-build-cluster
+  minimum_interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.32
+      args:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      env:
+        - name: KUBERNETES_VERSION_UPGRADE_FROM
+          value: "stable-1.35"
+        - name: KUBERNETES_VERSION_UPGRADE_TO
+          value: "stable-1.36"
+        - name: GINKGO_FOCUS
+          value: "\\[K8s-Upgrade\\]"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capi-periodic-upgrade-main-1-35-1-36
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: "Runs Kubernetes upgrade tests from v1.35 to v1.36 on CAPZ main branch"


### PR DESCRIPTION
Adds a new CAPZ periodic upgrade job for Kubernetes 1.35 -> 1.36 and removes the older 1.31 -> 1.32 job, following the existing pattern in this file.

/sig cluster-lifecycle
/area provider/azure