### PR TITLE
Bump CAPZ ref in azure-scalability job to release-1.24

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
@@ -17,7 +17,7 @@ periodics:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.24
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     - org: kubernetes-sigs
       repo: cloud-provider-azure


### PR DESCRIPTION
The `ci-kubernetes-e2e-azure-scalability` periodic (testgrid: [`azure-master-scalability-100`](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#azure-master-scalability-100)) has been failing for ~2 weeks. The control plane VM's cloud-init aborts at `kubeadm init`:

```
error: featureGates: Invalid value: {"ControlPlaneKubeletLocalMode":true}: ControlPlaneKubeletLocalMode is not a valid feature name.
```

**Root cause:** the job tests CAPZ `release-1.21` against Kubernetes `master` (now v1.36). CAPZ release-1.21 pins CAPI v1.10.9, where KCP unconditionally injects the `ControlPlaneKubeletLocalMode=true` feature gate for K8s ≥ 1.31 (kubernetes-sigs/cluster-api#10947). In K8s v1.36 this feature gate graduated to GA and was removed from kubeadm, so passing it became a hard error.

CAPI fixed this in kubernetes-sigs/cluster-api#13177 (main) and backported to release-1.12 in kubernetes-sigs/cluster-api#13211 — but not to release-1.10 / release-1.11. CAPZ `release-1.24` uses CAPI v1.13.1 which contains the fix, so bumping the job's `base_ref` unblocks the lane.

/sig cluster-lifecycle
/area provider/azure
/cc @nojnhuh @willie-yao
