### PR TITLE
Add jobset release-0.12 presubmit and periodic jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-12.yaml
@@ -1,0 +1,190 @@
+periodics:
+  - interval: 12h
+    name: periodic-jobset-test-unit-release-0-12
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: release-0.12
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-periodics
+      testgrid-tab-name: periodic-jobset-test-unit-release-0-12
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset unit tests on release 0.12"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        env:
+        - name: GO_TEST_FLAGS
+          value: "-race -count 3"
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-integration-release-0-12
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: release-0.12
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-periodics
+      testgrid-tab-name: periodic-jobset-test-integration-release-0-12
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset integration tests on release 0.12"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: public.ecr.aws/docker/library/golang:1.25
+        command:
+        - make
+        args:
+        - test-integration
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-release-0-12-1-33
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: release-0.12
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-periodics
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-12-1-33
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.33 on release 0.12"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        env:
+        - name: E2E_KIND_VERSION
+          value: kindest/node:v1.33.1
+        - name: BUILDER_IMAGE
+          value: public.ecr.aws/docker/library/golang:1.25
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-release-0-12-1-34
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: release-0.12
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-periodics
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-12-1-34
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.34 on release 0.12"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        env:
+        - name: E2E_KIND_VERSION
+          value: kindest/node:v1.34.0
+        - name: BUILDER_IMAGE
+          value: public.ecr.aws/docker/library/golang:1.25
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-release-0-12-1-35
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: release-0.12
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-periodics
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-12-1-35
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.35 on release 0.12"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        env:
+        - name: E2E_KIND_VERSION
+          value: kindest/node:v1.35.0
+        - name: BUILDER_IMAGE
+          value: public.ecr.aws/docker/library/golang:1.25
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-12.yaml
@@ -1,0 +1,197 @@
+presubmits:
+  kubernetes-sigs/jobset:
+  - name: pull-jobset-test-unit-release-0-12
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^release-0.12
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      description: "Run jobset unit tests"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        env:
+        - name: GO_TEST_FLAGS
+          value: "-race -count 3"
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi
+  - name: pull-jobset-test-integration-release-0-12
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^release-0.12
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      description: "Run jobset integration tests"
+    spec:
+      containers:
+      - image: public.ecr.aws/docker/library/golang:1.25
+        command:
+        - make
+        args:
+        - test-integration
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi
+  - name: pull-jobset-test-e2e-release-0-12-1-33
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^release-0.12
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      description: "Run jobset end to end tests for Kubernetes 1.33"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.33.1
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.25
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+  - name: pull-jobset-test-e2e-release-0-12-1-34
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^release-0.12
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      description: "Run jobset end to end tests for Kubernetes 1.34"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.34.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.25
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+  - name: pull-jobset-test-e2e-release-0-12-1-35
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^release-0.12
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      description: "Run jobset end to end tests for Kubernetes 1.35"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.35.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.25
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+  - name: pull-jobset-verify-release-0-12
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^release-0.12
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      description: "Run jobset verify checks"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260316-e86cefa561-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - verify
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi


### PR DESCRIPTION
Add Prow job configurations for the jobset release-0.12 branch,
mirroring the existing release-0.11 setup.

Jobs added:

Presubmits (6 jobs on `^release-0.12`):
- Unit tests
- Integration tests
- E2E tests for Kubernetes 1.33, 1.34, 1.35
- Verify checks

Periodics (5 jobs, 12h interval on `release-0.12`):
- Unit tests
- Integration tests
- E2E tests for Kubernetes 1.33, 1.34, 1.35

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).