### PR TITLE
Kops - Enable Prefix Delegation for Cilium ENI jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -62,6 +62,15 @@ AMAZON_VPC_ENV_FLAGS = [
     "--set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10",
 ]
 
+# Common flags applied to every Cilium ENI job. Mirrors the AWS VPC CNI
+# tuning above: enable IPv4 prefix delegation and raise per-node IP
+# watermarks so a t3.large doesn't run out of pod IPs under --parallel=25.
+CILIUM_ENI_EXTRA_CONFIG_FLAGS = [
+    "--set=cluster.spec.networking.cilium.extraConfig=aws-enable-prefix-delegation=true",
+    "--set=cluster.spec.networking.cilium.extraConfig=ipam-min-allocate=80",
+    "--set=cluster.spec.networking.cilium.extraConfig=ipam-pre-allocate=10",
+]
+
 loader = jinja2.FileSystemLoader(searchpath=os.path.join(script_dir, "templates"))
 
 # A helper function to construct the URLs to our marker files
@@ -536,6 +545,9 @@ def generate_grid():
                         extra_flags = ['--node-size=t3.large']
                     if networking == 'amazon-vpc':
                         extra_flags.extend(AMAZON_VPC_ENV_FLAGS)
+                    # extraConfig field added in kops 1.34; older versions reject the --set.
+                    if networking == 'cilium-eni' and kops_version not in ('1.32', '1.33'):
+                        extra_flags.extend(CILIUM_ENI_EXTRA_CONFIG_FLAGS)
                     if networking == 'kubenet':
                         extra_flags.extend([
                             "--topology=public",
@@ -1563,6 +1575,8 @@ def generate_network_plugins():
             extra_flags = ['--node-size=t3.large']
             if plugin in ['amazon-vpc']:
                 extra_flags += AMAZON_VPC_ENV_FLAGS
+            if plugin == 'cilium-eni':
+                extra_flags += CILIUM_ENI_EXTRA_CONFIG_FLAGS
             if plugin == 'calico':
                 extra_flags.extend([
                     "--set=cluster.spec.networking.calico.wireguardEnabled=false",
@@ -2023,6 +2037,8 @@ def generate_presubmits_network_plugins():
             ]
             if plugin == 'amazonvpc':
                 aws_extra_flags.extend(AMAZON_VPC_ENV_FLAGS)
+            if plugin == 'cilium-eni':
+                aws_extra_flags.extend(CILIUM_ENI_EXTRA_CONFIG_FLAGS)
             if plugin == 'calico':
                 aws_extra_flags.extend([
                     "--set=cluster.spec.networking.calico.wireguardEnabled=false",

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -656,7 +656,7 @@ periodics:
     testgrid-days-of-results: '35'
     testgrid-tab-name: kops-gce-cni-cilium-etcd
 
-# {"cloud": "aws", "distro": "u2404", "extra_flags": "--node-size=t3.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
+# {"cloud": "aws", "distro": "u2404", "extra_flags": "--node-size=t3.large --set=cluster.spec.networking.cilium.extraConfig=aws-enable-prefix-delegation=true --set=cluster.spec.networking.cilium.extraConfig=ipam-min-allocate=80 --set=cluster.spec.networking.cilium.extraConfig=ipam-pre-allocate=10", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium-eni"}
 - name: e2e-kops-aws-cni-cilium-eni
   cron: '13 5-23/8 * * *'
   labels:
@@ -686,7 +686,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260424' --channel=alpha --networking=cilium-eni --node-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260424' --channel=alpha --networking=cilium-eni --node-size=t3.large --set=cluster.spec.networking.cilium.extraConfig=aws-enable-prefix-delegation=true --set=cluster.spec.networking.cilium.extraConfig=ipam-min-allocate=80 --set=cluster.spec.networking.cilium.extraConfig=ipam-pre-allocate=10" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -713,7 +713,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404
-    test.kops.k8s.io/extra_flags: --node-size=t3.large
+    test.kops.k8s.io/extra_flags: --node-size=t3.large --set=cluster.spec.networking.cilium.extraConfig=aws-enable-prefix-delegation=true --set=cluster.spec.networking.cilium.extraConfig=ipam-min-allocate=80 --set=cluster.spec.networking.cilium.extraConfig=ipam-pre-allocate=10
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -824,7 +824,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-gce-cni-cilium-etcd
 
-  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--control-plane-size=c6g.large --node-size=t4g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium-eni"}
+  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--control-plane-size=c6g.large --node-size=t4g.large --set=cluster.spec.networking.cilium.extraConfig=aws-enable-prefix-delegation=true --set=cluster.spec.networking.cilium.extraConfig=ipam-min-allocate=80 --set=cluster.spec.networking.cilium.extraConfig=ipam-pre-allocate=10", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium-eni"}
   - name: pull-kops-e2e-cni-cilium-eni
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -856,7 +856,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260424' --channel=alpha --networking=cilium-eni --control-plane-size=c6g.large --node-size=t4g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260424' --channel=alpha --networking=cilium-eni --control-plane-size=c6g.large --node-size=t4g.large --set=cluster.spec.networking.cilium.extraConfig=aws-enable-prefix-delegation=true --set=cluster.spec.networking.cilium.extraConfig=ipam-min-allocate=80 --set=cluster.spec.networking.cilium.extraConfig=ipam-pre-allocate=10" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -885,7 +885,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2404arm64
-      test.kops.k8s.io/extra_flags: --control-plane-size=c6g.large --node-size=t4g.large
+      test.kops.k8s.io/extra_flags: --control-plane-size=c6g.large --node-size=t4g.large --set=cluster.spec.networking.cilium.extraConfig=aws-enable-prefix-delegation=true --set=cluster.spec.networking.cilium.extraConfig=ipam-min-allocate=80 --set=cluster.spec.networking.cilium.extraConfig=ipam-pre-allocate=10
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium-eni


### PR DESCRIPTION
Followup to https://github.com/kubernetes/kops/pull/18285

Mirror AMAZON_VPC_ENV_FLAGS for cilium-eni: without prefix delegation a t3.large only gets ~33 secondary IPs and e2e jobs flake on pod-IP exhaustion at --parallel=25.

cluster.spec.networking.cilium.extraConfig was added to kops in https://github.com/kubernetes/kops/pull/18285 and backported to 1.35/1.34, so exclude 1.32/1.33.

The network-plugins periodic and presubmit sites are master-only and need no gate.

/cc @hakman 

Assisted by Opus 4.7
