### PR TITLE
Add CL2_INFORMER_RUN_ON_CONTROL_PLANE

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1154,6 +1154,8 @@ periodics:
       env:
       - name: CL2_ENABLE_INFORMER_LATENCY_TEST
         value: "true"
+      - name: CL2_INFORMER_RUN_ON_CONTROL_PLANE
+        value: "true"
       - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
         value: "21474836480"
       - name: CL2_EXECSERVICE_CPU_REQUESTS


### PR DESCRIPTION
This is a continuation of https://github.com/kubernetes/test-infra/pull/36899 which added this option to `pull-perf-tests-gce-master-scale-performance-5000`

This PR add the option to `ci-kubernetes-e2e-gce-scale-resource-size`.