### PR TITLE
Add node conformance periodic job for release-1.36

### DIFF
--- a/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
+++ b/config/jobs/kubernetes/sig-node/k8s-release-branches.yaml
@@ -155,3 +155,55 @@ periodics:
     testgrid-tab-name: node-conformance-release-1.35
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: Node conformance tests in release branch 1.35
+- name: ci-kubernetes-node-release-branch-1-36
+  cluster: k8s-infra-prow-build
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 240m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.36
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+        command:
+        - runner.sh
+        args:
+          - kubetest2
+          - noop
+          - --test=node
+          - --
+          - --repo-root=.
+          - --gcp-zone=us-central1-a
+          - --parallelism=8
+          - --focus-regex=\[NodeConformance\]
+          - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]
+          - '--test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.36.yaml
+          - --timeout=180m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+  annotations:
+    testgrid-dashboards: sig-node-release-blocking
+    testgrid-tab-name: node-conformance-release-1.36
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
+    description: Node conformance tests in release branch 1.36

--- a/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.36.yaml
+++ b/jobs/e2e_node/containerd/k8s-release-branches/image-config-1.36.yaml
@@ -1,0 +1,5 @@
+images:
+  cos-dev:
+    image_family: cos-125-lts
+    project: cos-cloud
+    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml"


### PR DESCRIPTION
Add ci-kubernetes-node-release-branch-1-36 periodic job and
corresponding image config, mirroring the existing 1.35 job
configuration.

Changes:
- Add periodic job entry in k8s-release-branches.yaml targeting
  release-1.36 branch
- Add image-config-1.36.yaml using cos-125-lts

/sig node
/area test

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).