### PR TITLE
kueue: add tas baseline and extended e2e presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -499,14 +499,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-tas-main
+    name: periodic-kueue-test-e2e-tas-baseline-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-tas-main
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-baseline-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic tas end to end tests"
+      description: "Run periodic tas baseline end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -533,7 +533,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-tas-e2e
+            - test-tas-e2e-baseline
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-tas-extended-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-extended-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic tas extended end to end tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-tas-e2e-extended
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
@@ -422,14 +422,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-tas-release-0-16
+    name: periodic-kueue-test-e2e-tas-baseline-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-tas-release-0-16
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-baseline-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic tas end to end tests"
+      description: "Run periodic tas baseline end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -456,7 +456,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-tas-e2e
+            - test-tas-e2e-baseline
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-tas-extended-release-0-16
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-extended-release-0-16
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic tas extended end to end tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.16
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-tas-e2e-extended
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -461,14 +461,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-tas-release-0-17
+    name: periodic-kueue-test-e2e-tas-baseline-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-tas-release-0-17
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-baseline-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic tas end to end tests"
+      description: "Run periodic tas baseline end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -495,7 +495,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-tas-e2e
+            - test-tas-e2e-baseline 
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-tas-extended-release-0-17
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-extended-release-0-17
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic tas extended end to end tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.17
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-tas-e2e-extended
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -495,7 +495,7 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-tas-e2e-baseline 
+            - test-tas-e2e-baseline
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -304,7 +304,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-tas-main
+    - name: pull-kueue-test-e2e-tas-baseline-main
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -313,8 +313,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-tas-main
-        description: "Run tas end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-tas-baseline-main
+        description: "Run tas baseline end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -326,13 +326,47 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
-              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
-              - test-tas-e2e
-            # docker-in-docker needs privileged mode
+              - test-tas-e2e-baseline
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-tas-extended-main
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-tas-extended-main
+        description: "Run tas extended end to end tests"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-tas-e2e-extended
             securityContext:
               privileged: true
             resources:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -326,11 +326,13 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
               - test-tas-e2e-baseline
+            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -362,11 +364,13 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
               - test-tas-e2e-extended
+            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
@@ -304,7 +304,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-tas-release-0-16
+    - name: pull-kueue-test-e2e-tas-baseline-release-0-16
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.16
@@ -313,8 +313,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-tas-release-0-16
-        description: "Run tas end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-tas-baseline-release-0-16
+        description: "Run tas baseline end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -326,13 +326,47 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
-              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
-              - test-tas-e2e
-            # docker-in-docker needs privileged mode
+              - test-tas-e2e-baseline
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-tas-extended-release-0-16
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.16
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-tas-extended-release-0-16
+        description: "Run tas extended end to end tests"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-tas-e2e-extended
             securityContext:
               privileged: true
             resources:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
@@ -326,11 +326,13 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
               - test-tas-e2e-baseline
+            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -362,11 +364,13 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
               - test-tas-e2e-extended
+            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -304,7 +304,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-tas-release-0-17
+    - name: pull-kueue-test-e2e-tas-baseline-release-0-17
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.17
@@ -313,8 +313,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-tas-release-0-17
-        description: "Run tas end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-tas-baseline-release-0-17
+        description: "Run tas baseline end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -326,13 +326,47 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
-              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
-              - test-tas-e2e
-            # docker-in-docker needs privileged mode
+              - test-tas-e2e-baseline
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-tas-extended-release-0-17
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.17
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-tas-extended-release-0-17
+        description: "Run tas extended end to end tests"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-tas-e2e-extended
             securityContext:
               privileged: true
             resources:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -326,11 +326,13 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
               - test-tas-e2e-baseline
+            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -362,11 +364,13 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
               - test-tas-e2e-extended
+            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
kueue: add tas baseline and extended e2e presubmit jobs

Part of kubernetes-sigs/kueue#11002

Adds two new presubmit jobs for the new **tas-baseline** and **tas-extended** 
e2e test targets introduced in the kueue repo.

