### PR TITLE
periodics: revert skip_cloning for ci-kubernetes-cross-canary

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -31,8 +31,6 @@ periodics:
     cluster: k8s-infra-aks-prow-build
     interval: 2h
     decorate: true
-    decoration_config:
-      skip_cloning: true
     extra_refs:
       - org: kubernetes
         repo: kubernetes


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

[#36825](https://github.com/kubernetes/test-infra/pull/36825) added `skip_cloning: true` to many periodics. Most of those jobs run fine, but [`ci-kubernetes-cross-canary`](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-cross-canary) has been broken on every trigger since the change rolled out. 24 of the 24 most recent prowjobs (the full retention window in `prowjobs.js`, covering 2026-05-08 14:51 to 2026-05-10 13:03 UTC) are in `state=error`:

> Pod can not be created: create pod test-pods/<uuid> in cluster k8s-infra-aks-prow-build: Pod \"<uuid>\" is invalid: spec.initContainers[0].image: Required value

The job runs on the `k8s-infra-aks-prow-build` cluster, which has a per-cluster decoration override in [`config/prow/config.yaml`](https://github.com/kubernetes/test-infra/blob/master/config/prow/config.yaml) setting `gcs_credentials_secret: \"\"`. The combination of that override plus `skip_cloning: true` plus `extra_refs` from `kubernetes/kubernetes` causes the prow-controller-manager to generate a pod where the first init container has no `image` set, and the AKS API server rejects the pod.

The job-history page does not show this because pod-create errors never write GCS artifacts. It looks frozen at 2026-05-07 14:44 UTC, which was the last successful run, roughly 90 minutes before #36825 merged.

The other 28 jobs touched by #36825 keep their `skip_cloning` improvement. The other 3 jobs running on the same AKS cluster (`ci-k8s-infra-aks-build-cluster`, `ci-kubernetes-verify-master-canary`, `ci-kubernetes-e2e-kind-ipv6-canary`) do not set `skip_cloning` and are unaffected.

**Which issue(s) this PR fixes**:

(none filed yet)

**Special notes for your reviewer**:

Sample failed prowjob: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-cross-canary/2053460969023082496

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/cc @pohly @upodroid
/sig k8s-infra
/area prow