### PR TITLE
Update vsphere-csi-driver.yaml to increase the memory limits

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -190,10 +190,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 8Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: vmware-presubmits-vsphere-csi-driver
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com


### PR DESCRIPTION
Update vsphere-csi-driver.yaml to increase the memory limits as facing OOM issue while build.

Ref PR: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/3954

Failed Job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_vsphere-csi-driver/3954/pull-vsphere-csi-driver-build/2053762905836359680
