### PR TITLE
label_sync: quote numeric-looking hex colors, add regression test

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -773,7 +773,7 @@ repos:
         name: area/vertical-pod-autoscaler/prometheus
         target: both
         addedBy: label
-      - color: 5319e7
+      - color: "5319e7"
         description: Issues or PRs related to the Addon Resizer component
         name: area/addon-resizer
         target: both
@@ -979,7 +979,7 @@ repos:
         target: issues
         prowPlugin: label
         addedBy: Release enhancements team ONLY
-      - color: 108737
+      - color: "108737"
         description: Denotes an enhancement issue is actively being tracked by the Release Team
         name: tracked/yes
         target: issues

--- a/label_sync/main_test.go
+++ b/label_sync/main_test.go
@@ -19,6 +19,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -26,6 +28,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.yaml.in/yaml/v2"
 	"sigs.k8s.io/prow/pkg/github"
 )
 
@@ -584,5 +587,61 @@ func TestSyncOrgs(t *testing.T) {
 				t.Errorf("syncOrgs() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestLabelsYAMLColors verifies that every "color" scalar in labels.yaml is
+// unmarshaled as a Go string (i.e. the YAML scalar was tagged !!str) and
+// matches the 6-digit hex format GitHub accepts.
+//
+// Without the string check, an unquoted scalar like `color: 5319e7` is
+// resolved by YAML as !!float (5.319e+10), then coerced into the Color
+// string field as "5.319e+10". GitHub then rejects the label sync with
+// HTTP 422 "Validation Failed: code=invalid, field=color", taking down
+// the ci-test-infra-label-sync periodic.
+func TestLabelsYAMLColors(t *testing.T) {
+	data, err := os.ReadFile("labels.yaml")
+	if err != nil {
+		t.Fatalf("read labels.yaml: %v", err)
+	}
+	var doc interface{}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal labels.yaml: %v", err)
+	}
+	hexColorRE := regexp.MustCompile(`^[0-9a-fA-F]{6}$`)
+	var failures []string
+	walkColors(doc, "$", func(path string, v interface{}) {
+		s, ok := v.(string)
+		if !ok {
+			failures = append(failures, fmt.Sprintf("%s: %v parsed as %T, expected string — quote the value in labels.yaml", path, v, v))
+			return
+		}
+		if !hexColorRE.MatchString(s) {
+			failures = append(failures, fmt.Sprintf("%s: %q is not a 6-digit hex color", path, s))
+		}
+	})
+	if len(failures) > 0 {
+		t.Errorf("labels.yaml has invalid color values:\n  - %s", strings.Join(failures, "\n  - "))
+	}
+}
+
+// walkColors invokes fn on every value found under a "color" map key,
+// recursing through maps and sequences.
+func walkColors(v interface{}, path string, fn func(string, interface{})) {
+	switch x := v.(type) {
+	case map[interface{}]interface{}:
+		for k, val := range x {
+			ks := fmt.Sprintf("%v", k)
+			childPath := path + "." + ks
+			if ks == "color" {
+				fn(childPath, val)
+				continue
+			}
+			walkColors(val, childPath, fn)
+		}
+	case []interface{}:
+		for i, item := range x {
+			walkColors(item, fmt.Sprintf("%s[%d]", path, i), fn)
+		}
 	}
 }


### PR DESCRIPTION
Context: https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-test-infra-label-sync

Snippet from log:
```
{"component":"unset","error":"failed to update labels: [update failed update-repo-label change kubernetes/autoscaler: status code 422 not one of [200], body: {\"message\":\"Validation Failed\",\"errors\":[{\"resource\":\"Label\",\"code\":\"invalid\",\"field\":\"color\"}],\"documentation_url\":\"https://docs.github.com/rest/issues/labels#update-a-label\",\"status\":\"422\"}]","file":"k8s.io/test-infra/label_sync/main.go:834","func":"main.main","level":"error","msg":"failed to update kubernetes","severity":"error","time":"2026-05-11T19:17:50Z"}
```

Two colors in labels.yaml ('5319e7' and '108737') were unquoted scalars that YAML resolved as !!float and !!int respectively. sigs.k8s.io/yaml then coerced them into the Color string field as "5.319e+10" and "108737". GitHub rejected the first with HTTP 422 "Validation Failed, field=color", which has been failing every run of the ci-test-infra-label-sync periodic since the kubernetes/autoscaler labels were added on 2026-05-02.

Quote both values so they parse as !!str, and add a unit test that walks labels.yaml using go.yaml.in/yaml/v2 and asserts every "color" scalar (a) unmarshals as a Go string — proving the YAML source had it tagged !!str rather than coerced from another type — and (b) matches the 6-digit hex regex GitHub requires.

xref: https://github.com/kubernetes/test-infra/pull/36927
xref: https://github.com/kubernetes/test-infra/pull/17473