### PR TITLE
Enable release-note plugin for DRANET PRs

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1904,6 +1904,10 @@ plugins:
     plugins:
     - milestone
 
+  kubernetes-sigs/dranet:
+    plugins:
+    - release-note
+
 external_plugins:
   kubernetes:
   - name: needs-rebase


### PR DESCRIPTION
Require PR authors to have a release notes section in the PR description to help with release notes generation (specially for things requiring user attention)