### PR TITLE
add experimental 100-node presubmit with CL2_RESTART_APISERVER

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -513,6 +513,98 @@ presubmits:
             cpu: 7
             memory: "27Gi"
 
+  # Mirrors pull-perf-tests-gce-master-scale-performance-100 with CL2_RESTART_APISERVER set to true.
+  # TODO(Jefftree): revert after testing to be stable.
+  - name: pull-kubernetes-gce-master-scale-performance-100-apiserver-restart
+    cluster: k8s-infra-prow-build
+    always_run: false
+    optional: true
+    skip_report: true
+    branches:
+    - master
+    - main
+    decorate: true
+    path_alias: k8s.io/kubernetes
+    labels:
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 100m
+    extra_refs:
+    - org: kubernetes
+      repo: kops
+      base_ref: master
+      workdir: true
+      path_alias: k8s.io/kops
+    - org: kubernetes
+      repo: perf-tests
+      base_ref: master
+      path_alias: k8s.io/perf-tests
+    spec:
+      serviceAccountName: prow-build
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260504-c27e3ff179-master
+        command:
+        - runner.sh
+        args:
+        - ./tests/e2e/scenarios/scalability/run-test.sh
+        securityContext:
+          privileged: true
+        env:
+        - name: CL2_RESTART_APISERVER
+          value: "true"
+        - name: KUBE_SSH_KEY_PATH
+          value: /etc/ssh-key-secret/ssh-private
+        - name: KUBE_SSH_USER
+          value: prow
+        - name: GOPATH
+          value: /home/prow/go
+        - name: CNI_PLUGIN
+          value: gce
+        - name: KUBE_NODE_COUNT
+          value: "100"
+        - name: CL2_LOAD_TEST_THROUGHPUT
+          value: "50"
+        - name: CL2_DELETE_TEST_THROUGHPUT
+          value: "50"
+        - name: CL2_RATE_LIMIT_POD_CREATION
+          value: "false"
+        - name: NODE_MODE
+          value: "master"
+        - name: KUBE_PROXY_MODE
+          value: "nftables"
+        - name: CONTROL_PLANE_COUNT
+          value: "1"
+        - name: CONTROL_PLANE_SIZE
+          value: "c4-standard-32"
+        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+          value: "true"
+        - name: CL2_ENABLE_DNS_PROGRAMMING
+          value: "true"
+        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+          value: "true"
+        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+          value: "99.5"
+        - name: CL2_ALLOWED_SLOW_API_CALLS
+          value: "1"
+        - name: ENABLE_PROMETHEUS_SERVER
+          value: "true"
+        - name: TEAR_DOWN_PROMETHEUS_SERVER
+          value: "false"
+        - name: PROMETHEUS_PVC_STORAGE_CLASS
+          value: "ssd-csi"
+        - name: CLOUD_PROVIDER
+          value: "gce"
+        - name: BOSKOS_RESOURCE_TYPE
+          value: "scalability-project"
+        resources:
+          requests:
+            cpu: 5
+            memory: 16Gi
+          limits:
+            cpu: 5
+            memory: 16Gi
+
   kubernetes/perf-tests:
   - name: pull-perf-tests-benchmark-kube-dns
     cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -540,6 +540,9 @@ presubmits:
       repo: perf-tests
       base_ref: master
       path_alias: k8s.io/perf-tests
+    annotations:
+      testgrid-dashboards: presubmits-kubernetes-scalability
+      testgrid-tab-name: pull-kubernetes-gce-master-scale-performance-100-apiserver-restart
     spec:
       serviceAccountName: prow-build
       containers:


### PR DESCRIPTION
Mirrors pull-perf-tests-gce-master-scale-performance-100 with CL2_RESTART_APISERVER=true to validate the parameter. Collecting metrics for etcd rangestream, and we can eventually fold this into the actual presubmit/periodic.

I've seen previous experimental jobs target periodics directly, didn't have a good sample to reference for creating an experimental presubmit job. Originally wanted to leave this out of testgrid dashboard but CI complained that the job must have a dashboard. 