### PR TITLE
test(cloud-provider-azure): re-add Windows periodic jobs after capz fix

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -1166,6 +1166,69 @@ periodics:
     testgrid-tab-name: cloud-provider-azure-master-capz-main
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using capz:main."
+- cron: '0 16 * * *'  # Run at 16:00 UTC everyday
+  name: cloud-provider-azure-ccm-windows-capz
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: TEST_WINDOWS  # CAPZ config
+        value: "true"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest"
+      - name: WORKER_MACHINE_COUNT  # CAPZ config
+        value: "0"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure
+    testgrid-tab-name: cloud-provider-azure-ccm-windows-capz
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "[Windows] Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - cron: '0 17 * * *'  # Run at 17:00 UTC everyday
   # cloud-provider-azure-conformance-capz runs Kubernetes conformance tests periodically.
   name: cloud-provider-azure-conformance-capz
@@ -1236,6 +1299,79 @@ periodics:
     testgrid-tab-name: cloud-provider-azure-conformance-capz
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
+- cron: '0 17 * * *'  # Run at 17:00 UTC everyday
+  name: cloud-provider-azure-conformance-windows-capz
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: true
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: false
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+      command:
+      - runner.sh
+      args:
+      - ./scripts/ci-entrypoint.sh
+      - bash
+      - -c
+      - >-
+        cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-e2e-capz
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: KUBERNETES_VERSION  # CAPZ config
+        value: "latest"
+      - name: GINKGO_ARGS  # cloud-provider-azure config
+        value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|\[LinuxOnly\]|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator --node-os-distro=windows --report-dir=/logs/artifacts --disable-log-dump=true
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: TEST_WINDOWS  # CAPZ config
+        value: "true"
+      - name: WORKER_MACHINE_COUNT  # CAPZ config
+        value: "0"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: GINKGO_PARALLEL_NODES  # cloud-provider-azure config
+        value: "3"
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure
+    testgrid-tab-name: cloud-provider-azure-conformance-windows-capz
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "[Windows] Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - cron: '0 17 * * *'  # Run at 17:00 UTC everyday
   # cloud-provider-azure-slow-capz runs Kubernetes slow tests periodically.
   name: cloud-provider-azure-slow-capz


### PR DESCRIPTION
test(cloud-provider-azure): re-add Windows periodic jobs after capz fix https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6293
/area provider/azure