### PR TITLE
ci-test-infra-triage: drop skip_cloning so config/jobs is available

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -148,7 +148,6 @@ periodics:
     path_alias: k8s.io/test-infra
   decoration_config:
     timeout: 3h
-    skip_cloning: true
   max_concurrency: 1
   annotations:
     testgrid-num-failures-to-alert: '18'


### PR DESCRIPTION
Triage board is stuck :( 

<img width="400" height="150" alt="image" src="https://github.com/user-attachments/assets/656449b7-48c2-4b53-ba45-3268aa49c002" />

See failures:
- https://testgrid.k8s.io/sig-testing-misc#triage&width=20
- https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-test-infra-triage

Snippet:
```
+ jobs_dir=/home/prow/go/src/k8s.io/test-infra/config/jobs
+ python3 /generate_job_repos.py /home/prow/go/src/k8s.io/test-infra/config/jobs job_repos.json
Traceback (most recent call last):
  File "/generate_job_repos.py", line 86, in <module>
    main()
  File "/generate_job_repos.py", line 77, in main
    mapping = generate_job_repos(jobs_dir)
  File "/generate_job_repos.py", line 29, in generate_job_repos
    raise FileNotFoundError(f'jobs directory not found: {jobs_dir}')
FileNotFoundError: jobs directory not found: /home/prow/go/src/k8s.io/test-infra/config/jobs
```

The triage job's update_summaries.sh now invokes generate_job_repos.py which reads config/jobs from the test-infra checkout. With skip_cloning: true the extra_refs clone is suppressed and the script fails with FileNotFoundError on /home/prow/go/src/k8s.io/test-infra/ config/jobs. Enabling the clone restores the directory the script expects.