### PR TITLE
.ko.yaml: bump base images to v20251206-8481528a19

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,12 +1,12 @@
 # Distroless images:
 # defaultBaseImage: gcr.io/distroless/static:nonroot
 baseImageOverrides:
-  k8s.io/test-infra/robots/issue-creator: gcr.io/k8s-staging-test-infra/alpine:v20240716-28236d8b05
-  k8s.io/test-infra/testgrid/cmd/configurator: gcr.io/k8s-staging-test-infra/alpine:v20240716-28236d8b05
-  k8s.io/test-infra/label_sync: gcr.io/k8s-staging-test-infra/alpine:v20240716-28236d8b05
-  k8s.io/test-infra/robots/commenter: gcr.io/k8s-staging-test-infra/alpine:v20240716-28236d8b05
-  k8s.io/test-infra/robots/pr-creator: gcr.io/k8s-staging-test-infra/git:v20240716-28236d8b05
-  k8s.io/test-infra/gcsweb/cmd/gcsweb: gcr.io/k8s-staging-test-infra/alpine:v20240716-28236d8b05
+  k8s.io/test-infra/robots/issue-creator: gcr.io/k8s-staging-test-infra/alpine:v20251206-8481528a19
+  k8s.io/test-infra/testgrid/cmd/configurator: gcr.io/k8s-staging-test-infra/alpine:v20251206-8481528a19
+  k8s.io/test-infra/label_sync: gcr.io/k8s-staging-test-infra/alpine:v20251206-8481528a19
+  k8s.io/test-infra/robots/commenter: gcr.io/k8s-staging-test-infra/alpine:v20251206-8481528a19
+  k8s.io/test-infra/robots/pr-creator: gcr.io/k8s-staging-test-infra/git:v20251206-8481528a19
+  k8s.io/test-infra/gcsweb/cmd/gcsweb: gcr.io/k8s-staging-test-infra/alpine:v20251206-8481528a19
 
 # https://pkg.go.dev/cmd/link
 # -s: omit symbol/debug info


### PR DESCRIPTION
The previously pinned tag v20240716-28236d8b05 has been garbage-collected from gcr.io/k8s-staging-test-infra/{alpine,git}, so every misc-image build fails with MANIFEST_UNKNOWN, breaking the pull-test-infra-misc-image-build-test presubmit on all PRs. Bump to the newest published tag in those repos (v20251206-8481528a19), which both manifests resolve.