### PR TITLE
Add CAPI Operator release-0.27 jobs back

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-27.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-periodics-release-0-27.yaml
@@ -1,0 +1,64 @@
+periodics:
+- name: periodic-cluster-api-operator-test-release-0-27
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-operator
+    base_ref: release-0.27
+    path_alias: sigs.k8s.io/cluster-api-operator
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.35
+      command:
+      - "./scripts/ci-test.sh"
+      resources:
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+    testgrid-tab-name: capi-operator-test-release-0-27
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-operator-e2e-release-0-27
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-operator
+    base_ref: release-0.27
+    path_alias: sigs.k8s.io/cluster-api-operator
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.35
+      command:
+        - runner.sh
+        - "./scripts/ci-e2e.sh"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+    testgrid-tab-name: capi-operator-e2e-release-0-27
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-27.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-operator/cluster-api-operator-presubmits-release-0-27.yaml
@@ -1,0 +1,169 @@
+presubmits:
+  kubernetes-sigs/cluster-api-operator:
+  - name: pull-cluster-api-operator-build-release-0-27
+    cluster: eks-prow-build-cluster
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.27$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.35
+        command:
+        - runner.sh
+        - ./scripts/ci-build.sh
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+      testgrid-tab-name: capi-operator-pr-build-release-0-27
+  - name: pull-cluster-api-operator-make-release-0-27
+    cluster: eks-prow-build-cluster
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.27$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.35
+        command:
+        - runner.sh
+        - ./scripts/ci-make.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+      testgrid-tab-name: capi-operator-pr-make-release-0-27
+  - name: pull-cluster-api-operator-apidiff-release-0-27
+    cluster: eks-prow-build-cluster
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    optional: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.27$
+    run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.35
+        command:
+        - runner.sh
+        - ./scripts/ci-apidiff.sh
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+      testgrid-tab-name: capi-operator-pr-apidiff-release-0-27
+  - name: pull-cluster-api-operator-verify-release-0-27
+    cluster: eks-prow-build-cluster
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.27$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.35
+        command:
+        - "runner.sh"
+        - ./scripts/ci-verify.sh
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+      testgrid-tab-name: capi-operator-pr-verify-release-0-27
+  - name: pull-cluster-api-operator-test-release-0-27
+    cluster: eks-prow-build-cluster
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-operator
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.27$
+    run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.35
+        args:
+        - runner.sh
+        - ./scripts/ci-test.sh
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "2Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+      testgrid-tab-name: capi-operator-pr-test-release-0-27
+  - name: pull-cluster-api-operator-e2e-release-0-27
+    cluster: eks-prow-build-cluster
+    path_alias: "sigs.k8s.io/cluster-api-operator"
+    optional: false
+    decorate: true
+    run_if_changed: '^((api|cmd|config|controllers|hack|internal|scripts|test|util|webhook)/|go\.mod|go\.sum|Dockerfile|Makefile)'
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    branches:
+    - ^release-0.27$
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.35
+        command:
+          - runner.sh
+        args:
+          - ./scripts/ci-e2e.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-operator
+      testgrid-tab-name: capi-operator-pr-e2e-release-0-27


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/36942 removed CAPI Operator presubmits+periodics release-0-24 (k8s 1.27) jobs which used EOL images. This patch adds them back for latest release-0-27 branch and latest images. 