### PR TITLE
remove skip_report from pull-kubernetes-gce-master-scale-performance-100-apiserver-restart job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -519,7 +519,6 @@ presubmits:
     cluster: k8s-infra-prow-build
     always_run: false
     optional: true
-    skip_report: true
     branches:
     - master
     - main


### PR DESCRIPTION
remove `skip_report: True` from pull-kubernetes-gce-master-scale-performance-100-apiserver-restart job

Noticed it wasn't showing up on the github PR otherwise.