### PR TITLE
Reduce parallel count to 15 for ppc64le e2e slow job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -372,7 +372,7 @@ periodics:
                 --up --down --auto-approve --retry-on-tf-failure 3 --ignore-destroy-errors\
                 --break-kubetest-on-upfail true \
                 --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt) \
-                --test=ginkgo -- --parallel 30 --test-package-dir ci --test-package-marker latest.txt --focus-regex='\[Slow\]' --skip-regex='\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:'
+                --test=ginkgo -- --parallel 15 --test-package-dir ci --test-package-marker latest.txt --focus-regex='\[Slow\]' --skip-regex='\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:'
 
   - name: ci-kubernetes-e2e-ppc64le-serial-kubetest2
     cron: "30 9-17/8 * * *" # every 8h starting at 09:30 UTC


### PR DESCRIPTION
This PR reduces the `--parallel` count to `15 `for the `ci-kubernetes-ppc64le-e2e-slow-kubetest2` job in `cloud-provider-ibmcloud-ppc64le-periodics.yaml.`

The change is intended to improve stability for the frequently flaking E2E slow CSI tests, which were hitting `context deadline exceeded` and client rate limiter errors during `VolumeAttachment` cleanup.