### PR TITLE
kops: don't set AZURE_STORAGE_ACCOUNT

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presets.yaml
+++ b/config/jobs/kubernetes/kops/kops-presets.yaml
@@ -56,8 +56,6 @@ presets:
       value: "d1aa7522-0959-442e-80ee-8c4f7fb4c184"
     - name: AZURE_FEDERATED_TOKEN_FILE
       value: "/var/run/secrets/azure-token/serviceaccount/token"
-    - name: AZURE_STORAGE_ACCOUNT
-      value: "stkopsstatestore"
   volumes:
     - name: azure-token
       projected:


### PR DESCRIPTION
No need for this after https://github.com/kubernetes/kops/pull/18260.

/cc @upodroid @ameukam 