### PR TITLE
Updating windows azure ccm and azuredisk periodic jobs to use capi templates from windows-testing

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -1,3 +1,68 @@
+periodics:
+- name: ci-azuredisk-csi-driver-e2e-capz-windows
+  cluster: eks-prow-build-cluster
+  interval: 72h
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+    preset-capz-windows-common: "true"
+    preset-capz-windows-2022: "true"
+    preset-capz-containerd-2-0-latest: "true"
+    preset-capz-windows-azuredisk: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: azuredisk-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/azuredisk-csi-driver
+    workdir: false
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  spec:
+    serviceAccountName: azure
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+        command:
+          - "runner.sh"
+          - "env"
+          - "KUBERNETES_VERSION=latest"
+          - "./capz/run-capz-e2e.sh"
+        args:
+          - bash
+          - -c
+          - >-
+            cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+            make e2e-test
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 4
+            memory: 8Gi
+          requests:
+            cpu: 4
+            memory: 8Gi
+  annotations:
+    testgrid-dashboards: provider-azure-azuredisk-csi-driver, sig-windows-master-release, sig-windows-signal
+    testgrid-tab-name: ci-azuredisk-csi-driver-e2e-capz-windows
+    description: "Run E2E tests on a capz Windows 2022 cluster for Azure Disk CSI driver."
+    testgrid-num-columns-recent: '30'
 presubmits:
   kubernetes-sigs/azuredisk-csi-driver:
   - name: pull-azuredisk-csi-driver-verify

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -794,6 +794,150 @@ presubmits:
       description: "Runs Azure specific e2e tests with cloud controller manager and shared health probe."
       testgrid-num-columns-recent: '30'
 periodics:
+- cron: '0 15 * * *'  # Run at 15:00 UTC everyday
+  name: cloud-provider-azure-ccm-windows-capz
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+    preset-capz-windows-common: "true"
+    preset-capz-windows-2022: "true"
+    preset-capz-containerd-2-0-latest: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+      command:
+        - "runner.sh"
+        - "env"
+        - "KUBERNETES_VERSION=latest"
+        - "./capz/run-capz-e2e.sh"
+      args:
+        - bash
+        - -c
+        - >-
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+        - name: TEST_CCM
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU
+          value: "standard"
+        - name: CONTROL_PLANE_MACHINE_COUNT
+          value: "1"
+        - name: CLUSTER_PROVISIONING_TOOL
+          value: "capz"
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure
+    testgrid-tab-name: cloud-provider-azure-ccm-windows-capz
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "[Windows] Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
+- cron: '0 15 * * *'  # Run at 15:00 UTC everyday
+  name: cloud-provider-azure-conformance-windows-capz
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+    preset-capz-windows-common: "true"
+    preset-capz-windows-2022: "true"
+    preset-capz-containerd-2-0-latest: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: false
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: false
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+      command:
+        - "runner.sh"
+        - "env"
+        - "KUBERNETES_VERSION=latest"
+        - "./capz/run-capz-e2e.sh"
+      args:
+        - bash
+        - -c
+        - >-
+          cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
+          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+          make test-e2e-capz
+      securityContext:
+        privileged: true
+      env:
+        - name: TEST_CCM
+          value: "true"
+        - name: AZURE_LOADBALANCER_SKU
+          value: "standard"
+        - name: GINKGO_ARGS
+          value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|\[LinuxOnly\]|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator --node-os-distro=windows --report-dir=/logs/artifacts --disable-log-dump=true
+        - name: CONTROL_PLANE_MACHINE_COUNT
+          value: "1"
+        - name: CLUSTER_PROVISIONING_TOOL
+          value: "capz"
+        - name: GINKGO_PARALLEL_NODES
+          value: "3"
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure
+    testgrid-tab-name: cloud-provider-azure-conformance-windows-capz
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "[Windows] Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - cron: '0 16 * * *'  # Run at 16:00 UTC everyday
   # cloud-provider-azure-master-ipv6-capz runs Azure specific tests periodically using capz:main in an IPv6 single stack cluster.
   name: cloud-provider-azure-master-ipv6-capz
@@ -1166,69 +1310,6 @@ periodics:
     testgrid-tab-name: cloud-provider-azure-master-capz-main
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using capz:main."
-- cron: '0 16 * * *'  # Run at 16:00 UTC everyday
-  name: cloud-provider-azure-ccm-windows-capz
-  cluster: eks-prow-build-cluster
-  decorate: true
-  decoration_config:
-    timeout: 5h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-community: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    workdir: true
-  - org: kubernetes-sigs
-    repo: cloud-provider-azure
-    base_ref: master
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    workdir: false
-  spec:
-    serviceAccountName: azure
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
-      command:
-      - runner.sh
-      args:
-      - ./scripts/ci-entrypoint.sh
-      - bash
-      - -c
-      - >-
-        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-        make test-ccm-e2e
-      securityContext:
-        privileged: true
-      env:
-      - name: TEST_CCM  # CAPZ config
-        value: "true"
-      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
-        value: "standard"
-      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
-        value: "1"
-      - name: TEST_WINDOWS  # CAPZ config
-        value: "true"
-      - name: KUBERNETES_VERSION  # CAPZ config
-        value: "latest"
-      - name: WORKER_MACHINE_COUNT  # CAPZ config
-        value: "0"
-      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
-        value: "capz"
-      resources:
-        limits:
-          cpu: 4
-          memory: 9Gi
-        requests:
-          cpu: 4
-          memory: 9Gi
-  annotations:
-    testgrid-dashboards: provider-azure-cloud-provider-azure
-    testgrid-tab-name: cloud-provider-azure-ccm-windows-capz
-    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
-    description: "[Windows] Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - cron: '0 17 * * *'  # Run at 17:00 UTC everyday
   # cloud-provider-azure-conformance-capz runs Kubernetes conformance tests periodically.
   name: cloud-provider-azure-conformance-capz
@@ -1299,79 +1380,6 @@ periodics:
     testgrid-tab-name: cloud-provider-azure-conformance-capz
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
-- cron: '0 17 * * *'  # Run at 17:00 UTC everyday
-  name: cloud-provider-azure-conformance-windows-capz
-  cluster: eks-prow-build-cluster
-  decorate: true
-  decoration_config:
-    timeout: 5h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-community: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    workdir: true
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: false
-  - org: kubernetes-sigs
-    repo: cloud-provider-azure
-    base_ref: master
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    workdir: false
-  spec:
-    serviceAccountName: azure
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
-      command:
-      - runner.sh
-      args:
-      - ./scripts/ci-entrypoint.sh
-      - bash
-      - -c
-      - >-
-        cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
-        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-        make test-e2e-capz
-      securityContext:
-        privileged: true
-      env:
-      - name: TEST_CCM  # CAPZ config
-        value: "true"
-      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
-        value: "standard"
-      - name: KUBERNETES_VERSION  # CAPZ config
-        value: "latest"
-      - name: GINKGO_ARGS  # cloud-provider-azure config
-        value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|\[LinuxOnly\]|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator --node-os-distro=windows --report-dir=/logs/artifacts --disable-log-dump=true
-      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
-        value: "1"
-      - name: TEST_WINDOWS  # CAPZ config
-        value: "true"
-      - name: WORKER_MACHINE_COUNT  # CAPZ config
-        value: "0"
-      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
-        value: "capz"
-      - name: GINKGO_PARALLEL_NODES  # cloud-provider-azure config
-        value: "3"
-      resources:
-        limits:
-          cpu: 4
-          memory: 9Gi
-        requests:
-          cpu: 4
-          memory: 9Gi
-  annotations:
-    testgrid-dashboards: provider-azure-cloud-provider-azure
-    testgrid-tab-name: cloud-provider-azure-conformance-windows-capz
-    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
-    description: "[Windows] Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - cron: '0 17 * * *'  # Run at 17:00 UTC everyday
   # cloud-provider-azure-slow-capz runs Kubernetes slow tests periodically.
   name: cloud-provider-azure-slow-capz

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -794,150 +794,6 @@ presubmits:
       description: "Runs Azure specific e2e tests with cloud controller manager and shared health probe."
       testgrid-num-columns-recent: '30'
 periodics:
-- cron: '0 15 * * *'  # Run at 15:00 UTC everyday
-  name: cloud-provider-azure-ccm-windows-capz
-  cluster: eks-prow-build-cluster
-  decorate: true
-  decoration_config:
-    timeout: 5h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-community: "true"
-    preset-capz-windows-common: "true"
-    preset-capz-windows-2022: "true"
-    preset-capz-containerd-2-0-latest: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    workdir: false
-  - org: kubernetes-sigs
-    repo: cloud-provider-azure
-    base_ref: master
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    workdir: false
-  - org: kubernetes-sigs
-    repo: windows-testing
-    base_ref: master
-    path_alias: sigs.k8s.io/windows-testing
-    workdir: true
-  spec:
-    serviceAccountName: azure
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
-      command:
-        - "runner.sh"
-        - "env"
-        - "KUBERNETES_VERSION=latest"
-        - "./capz/run-capz-e2e.sh"
-      args:
-        - bash
-        - -c
-        - >-
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-ccm-e2e
-      securityContext:
-        privileged: true
-      env:
-        - name: TEST_CCM
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU
-          value: "standard"
-        - name: CONTROL_PLANE_MACHINE_COUNT
-          value: "1"
-        - name: CLUSTER_PROVISIONING_TOOL
-          value: "capz"
-      resources:
-        limits:
-          cpu: 4
-          memory: 9Gi
-        requests:
-          cpu: 4
-          memory: 9Gi
-  annotations:
-    testgrid-dashboards: provider-azure-cloud-provider-azure
-    testgrid-tab-name: cloud-provider-azure-ccm-windows-capz
-    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
-    description: "[Windows] Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
-- cron: '0 15 * * *'  # Run at 15:00 UTC everyday
-  name: cloud-provider-azure-conformance-windows-capz
-  cluster: eks-prow-build-cluster
-  decorate: true
-  decoration_config:
-    timeout: 5h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-azure-community: "true"
-    preset-capz-windows-common: "true"
-    preset-capz-windows-2022: "true"
-    preset-capz-containerd-2-0-latest: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-azure
-    base_ref: main
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    workdir: false
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
-    workdir: false
-  - org: kubernetes-sigs
-    repo: cloud-provider-azure
-    base_ref: master
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    workdir: false
-  - org: kubernetes-sigs
-    repo: windows-testing
-    base_ref: master
-    path_alias: sigs.k8s.io/windows-testing
-    workdir: true
-  spec:
-    serviceAccountName: azure
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
-      command:
-        - "runner.sh"
-        - "env"
-        - "KUBERNETES_VERSION=latest"
-        - "./capz/run-capz-e2e.sh"
-      args:
-        - bash
-        - -c
-        - >-
-          cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
-          cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
-          make test-e2e-capz
-      securityContext:
-        privileged: true
-      env:
-        - name: TEST_CCM
-          value: "true"
-        - name: AZURE_LOADBALANCER_SKU
-          value: "standard"
-        - name: GINKGO_ARGS
-          value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|\[LinuxOnly\]|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator --node-os-distro=windows --report-dir=/logs/artifacts --disable-log-dump=true
-        - name: CONTROL_PLANE_MACHINE_COUNT
-          value: "1"
-        - name: CLUSTER_PROVISIONING_TOOL
-          value: "capz"
-        - name: GINKGO_PARALLEL_NODES
-          value: "3"
-      resources:
-        limits:
-          cpu: 4
-          memory: 9Gi
-        requests:
-          cpu: 4
-          memory: 9Gi
-  annotations:
-    testgrid-dashboards: provider-azure-cloud-provider-azure
-    testgrid-tab-name: cloud-provider-azure-conformance-windows-capz
-    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
-    description: "[Windows] Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - cron: '0 16 * * *'  # Run at 16:00 UTC everyday
   # cloud-provider-azure-master-ipv6-capz runs Azure specific tests periodically using capz:main in an IPv6 single stack cluster.
   name: cloud-provider-azure-master-ipv6-capz
@@ -1310,6 +1166,73 @@ periodics:
     testgrid-tab-name: cloud-provider-azure-master-capz-main
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) using capz:main."
+- cron: '0 16 * * *'  # Run at 16:00 UTC everyday
+  name: cloud-provider-azure-ccm-windows-capz
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+    preset-capz-windows-common: "true"
+    preset-capz-windows-2022: "true"
+    preset-capz-containerd-2-0-latest: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+      command:
+      - runner.sh
+      - env
+      - KUBERNETES_VERSION=latest
+      - ./capz/run-capz-e2e.sh
+      args:
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-ccm-e2e
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure
+    testgrid-tab-name: cloud-provider-azure-ccm-windows-capz
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "[Windows] Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - cron: '0 17 * * *'  # Run at 17:00 UTC everyday
   # cloud-provider-azure-conformance-capz runs Kubernetes conformance tests periodically.
   name: cloud-provider-azure-conformance-capz
@@ -1380,6 +1303,83 @@ periodics:
     testgrid-tab-name: cloud-provider-azure-conformance-capz
     testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
+- cron: '0 17 * * *'  # Run at 17:00 UTC everyday
+  name: cloud-provider-azure-conformance-windows-capz
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+    preset-capz-windows-common: "true"
+    preset-capz-windows-2022: "true"
+    preset-capz-containerd-2-0-latest: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: false
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: false
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
+      command:
+      - runner.sh
+      - env
+      - KUBERNETES_VERSION=latest
+      - ./capz/run-capz-e2e.sh
+      args:
+      - bash
+      - -c
+      - >-
+        cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
+        cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
+        make test-e2e-capz
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_CCM  # CAPZ config
+        value: "true"
+      - name: AZURE_LOADBALANCER_SKU  # cloud-provider-azure config
+        value: "standard"
+      - name: GINKGO_ARGS  # cloud-provider-azure config
+        value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|\[LinuxOnly\]|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator --node-os-distro=windows --report-dir=/logs/artifacts --disable-log-dump=true
+      - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
+        value: "1"
+      - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config
+        value: "capz"
+      - name: GINKGO_PARALLEL_NODES  # cloud-provider-azure config
+        value: "3"
+      resources:
+        limits:
+          cpu: 4
+          memory: 9Gi
+        requests:
+          cpu: 4
+          memory: 9Gi
+  annotations:
+    testgrid-dashboards: provider-azure-cloud-provider-azure
+    testgrid-tab-name: cloud-provider-azure-conformance-windows-capz
+    testgrid-alert-email: kubernetes-provider-azure-oot@googlegroups.com
+    description: "[Windows] Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - cron: '0 17 * * *'  # Run at 17:00 UTC everyday
   # cloud-provider-azure-slow-capz runs Kubernetes slow tests periodically.
   name: cloud-provider-azure-slow-capz


### PR DESCRIPTION
These jobs are failing because of cluster api template drift between CAPZ and the windows testing project.
We are migrating all of the test-infra jobs that use windows machines on azure to use templates and setup from windows-testing as part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/6305

