### PR TITLE
Disable CL2_INFORMER_RUN_ON_CONTROL_PLANE for the 5k experimental test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1154,8 +1154,9 @@ periodics:
       env:
       - name: CL2_ENABLE_INFORMER_LATENCY_TEST
         value: "true"
-      - name: CL2_INFORMER_RUN_ON_CONTROL_PLANE
-        value: "true"
+      # Disabled: see https://github.com/kubernetes/test-infra/pull/37027
+      # - name: CL2_INFORMER_RUN_ON_CONTROL_PLANE
+      #   value: "true"
       - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
         value: "21474836480"
       - name: CL2_EXECSERVICE_CPU_REQUESTS


### PR DESCRIPTION
Reverts the env var added in https://github.com/kubernetes/test-infra/pull/36984. Since the flag was enabled on 2026-05-11, the periodic has failed both subsequent runs (05-12, 05-13) with `LIST pods cluster` perc99 hitting the 60s histogram cap, exceeding the 30s SLO.

| Date | LIST p99 | Metric JSON | Spyglass |
|---|---|---|---|
| 05-13 (FAIL) | 60.00s (cap) | [json](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/2054607902848585728/artifacts/APIResponsivenessPrometheus_simple_load_2026-05-13T19:11:14Z.json) | [spyglass](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/2054607902848585728) |
| 05-12 (FAIL) | 60.00s (cap) | [json](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/2054245608394330112/artifacts/APIResponsivenessPrometheus_simple_load_2026-05-12T19:16:52Z.json) | [spyglass](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/2054245608394330112) |
| 05-10 (PASS) | 29.49s | [json](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/2053520864233656320/artifacts/APIResponsivenessPrometheus_simple_load_2026-05-10T19:09:11Z.json) | [spyglass](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/2053520864233656320) |
| 05-09 (PASS) | 20.35s | [json](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/2053158472878395392/artifacts/APIResponsivenessPrometheus_simple_load_2026-05-09T18:55:01Z.json) | [spyglass](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/2053158472878395392) |

[Testgrid Link](https://testgrid.k8s.io/sig-scalability-gce#gce-master-scale-resource-size
)

Analysis and data was fetched by Gemini.

/sig scalability
/cc @p0lyn0mial