### PR TITLE
Fix incorrect cron comment for resource size job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1110,7 +1110,7 @@ periodics:
           memory: "8Gi"
 
 # Exploratory tests for resource size limit as proposed in https://github.com/kubernetes/kubernetes/issues/134375
-- cron: '1 17 1-31/1 * *' # Run on odd days at 9:01PST (17:01 UTC)
+- cron: '1 17 1-31/1 * *' # Run daily at 9:01 PST (17:01 UTC)
   name: ci-kubernetes-e2e-gce-scale-resource-size
   tags:
   - "perfDashPrefix: gce-5000Nodes-1.5GB-pods"


### PR DESCRIPTION
Got confused when looking at comment and testgrid. Align the comment.