### PR TITLE
v1.36 windows jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.36-windows-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.36-windows-presubmits.yaml
@@ -1,0 +1,54 @@
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-e2e-capz-windows-1-36
+    cluster: eks-prow-build-cluster
+    always_run: false
+    branches:
+    - release-1.36
+    decorate: true
+    extra_refs:
+    - base_ref: main
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      repo: cluster-api-provider-azure
+      workdir: false
+    - base_ref: master
+      org: kubernetes-sigs
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      repo: cloud-provider-azure
+    - org: kubernetes-sigs
+      repo: windows-testing
+      base_ref: master
+      path_alias: k8s.io/windows-testing
+      workdir: true
+    labels:
+      preset-azure-community: "true"
+      preset-capz-containerd-2-0-latest: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-windows-common-pull: "true"
+      preset-dind-enabled: "true"
+    optional: true
+    path_alias: k8s.io/kubernetes
+    spec:
+      serviceAccountName: azure
+      containers:
+      - command:
+        - "runner.sh"
+        - "env"
+        - KUBERNETES_VERSION=latest-1.36
+        - "./capz/run-capz-e2e.sh"
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.36
+        name: ""
+        resources:
+          requests:
+            cpu: "2"
+            memory: "9Gi"
+          limits:
+            cpu: "2"
+            memory: "9Gi"
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-windows-presubmit
+      testgrid-tab-name: pull-kubernetes-e2e-capz-windows-1-36
+      testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.36-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.36-windows.yaml
@@ -1,0 +1,107 @@
+periodics:
+- name: ci-kubernetes-e2e-capz-master-windows-1-36
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io, release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.36-informing, sig-windows-1.36-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-1.36
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    repo: cluster-api-provider-azure
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/windows-testing
+    repo: windows-testing
+    workdir: true
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    repo: cloud-provider-azure
+  interval: 24h
+  labels:
+    preset-azure-community: "true"
+    preset-capz-containerd-2-0-latest: "true"
+    preset-capz-windows-2022: "true"
+    preset-capz-windows-common: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    serviceAccountName: azure
+    containers:
+    - command:
+      - runner.sh
+      - env
+      - KUBERNETES_VERSION=latest-1.36
+      - ./capz/run-capz-e2e.sh
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.36
+      name: ""
+      resources:
+        limits:
+          cpu: "2"
+          memory: 9Gi
+        requests:
+          cpu: "2"
+          memory: 9Gi
+      securityContext:
+        privileged: true
+- name: ci-kubernetes-e2e-capz-1-36-windows-serial-slow
+  cluster: eks-prow-build-cluster
+  interval: 48h
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-azure-community: "true"
+    preset-capz-containerd-2-0-latest: "true"
+    preset-capz-serial-slow: "true"
+    preset-capz-gmsa-setup: "true"
+    preset-capz-windows-2022: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+    workdir: false
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.36
+        command:
+          - "runner.sh"
+          - "env"
+          - KUBERNETES_VERSION=latest-1.36
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: GINKGO_FOCUS
+            value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
+          - name: GINKGO_SKIP
+            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|\[Alpha\]|\[FeatureGate:SchedulerAsyncPreemption\]|\[Beta\]
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-1.36-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-1-36-serial-slow

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -1711,57 +1711,6 @@ periodics:
           memory: 24Gi
       securityContext:
         privileged: true
-- annotations:
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io,
-      release-team@kubernetes.io
-    testgrid-dashboards: sig-release-1.36-informing, sig-windows-master-release, sig-windows-signal
-    testgrid-tab-name: capz-windows-1.36
-  cluster: eks-prow-build-cluster
-  decorate: true
-  decoration_config:
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubernetes-sigs
-    path_alias: sigs.k8s.io/cluster-api-provider-azure
-    repo: cluster-api-provider-azure
-  - base_ref: master
-    org: kubernetes-sigs
-    path_alias: sigs.k8s.io/windows-testing
-    repo: windows-testing
-    workdir: true
-  - base_ref: master
-    org: kubernetes-sigs
-    path_alias: sigs.k8s.io/cloud-provider-azure
-    repo: cloud-provider-azure
-  interval: 3h
-  labels:
-    preset-azure-community: "true"
-    preset-capz-containerd-2-0-latest: "true"
-    preset-capz-windows-2022: "true"
-    preset-capz-windows-common: "true"
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  name: ci-kubernetes-e2e-capz-master-windows-1-36
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - env
-      - KUBERNETES_VERSION=latest-1.36
-      - ./capz/run-capz-e2e.sh
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.36
-      name: ""
-      resources:
-        limits:
-          cpu: "2"
-          memory: 9Gi
-        requests:
-          cpu: "2"
-          memory: 9Gi
-      securityContext:
-        privileged: true
-    serviceAccountName: azure
 postsubmits: {}
 presubmits:
   kubernetes/kubernetes:
@@ -5330,57 +5279,6 @@ presubmits:
           requests:
             cpu: "5"
             memory: 12Gi
-  - always_run: false
-    branches:
-    - release-1.36
-    cluster: eks-prow-build-cluster
-    context: pull-kubernetes-e2e-capz-windows
-    decorate: true
-    decoration_config:
-      timeout: 2h30m0s
-    extra_refs:
-    - base_ref: main
-      org: kubernetes-sigs
-      path_alias: sigs.k8s.io/cluster-api-provider-azure
-      repo: cluster-api-provider-azure
-    - base_ref: master
-      org: kubernetes-sigs
-      path_alias: sigs.k8s.io/cloud-provider-azure
-      repo: cloud-provider-azure
-    - base_ref: master
-      org: kubernetes-sigs
-      path_alias: k8s.io/windows-testing
-      repo: windows-testing
-      workdir: true
-    labels:
-      preset-azure-community: "true"
-      preset-capz-containerd-2-0-latest: "true"
-      preset-capz-windows-2022: "true"
-      preset-capz-windows-common-pull: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    name: pull-kubernetes-e2e-capz-windows
-    optional: true
-    path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-      - command:
-        - runner.sh
-        - env
-        - KUBERNETES_VERSION=latest-1.36
-        - ./capz/run-capz-e2e.sh
-        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-1.36
-        name: ""
-        resources:
-          limits:
-            cpu: "2"
-            memory: 9Gi
-          requests:
-            cpu: "2"
-            memory: 9Gi
-        securityContext:
-          privileged: true
-      serviceAccountName: azure
   kubernetes/perf-tests:
   - always_run: false
     branches:

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -5,6 +5,7 @@ dashboard_groups:
     - sig-windows-1.33-release
     - sig-windows-1.34-release
     - sig-windows-1.35-release
+    - sig-windows-1.36-release
     - sig-windows-master-release
     - sig-windows-presubmit
     - sig-windows-gce
@@ -17,6 +18,7 @@ dashboards:
 - name: sig-windows-1.33-release
 - name: sig-windows-1.34-release
 - name: sig-windows-1.35-release
+- name: sig-windows-1.36-release
 - name: sig-windows-master-release
 - name: sig-windows-presubmit
 - name: sig-windows-gce


### PR DESCRIPTION
Moves automatically added v1.36 sig windows jobs to be with the others and adds missing serial-slow and presubmit jobs