### PR TITLE
Disable kube-proxy on calico + ebpf

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -579,18 +579,24 @@ def generate_grid():
                             # RHEL10/Rocky10 kernels removed xt_comment and xt_conntrack modules;
                             # the AWS VPC CNI requires these for iptables-nft SNAT rules.
                             continue
-                        # https://github.com/kubernetes/kops/issues/17915
-                        extra_flags.extend([
-                            "--set=cluster.spec.kubeProxy.proxyMode=nftables",
-                        ])
-                        if 'cilium' in networking:
-                            extra_flags.extend([
-                                "--set=cluster.spec.networking.cilium.enableBPFMasquerade=true",
-                            ])
                         if networking == 'calico':
+                            # Calico BPF mode takes over kube-proxy's role; from
+                            # v3.31 felix also binds the kube-proxy healthz port,
+                            # so kube-proxy must be disabled to avoid the conflict.
+                            # https://docs.tigera.io/calico-enterprise/latest/operations/ebpf/install#disable-kube-proxy-or-avoid-conflicts
                             extra_flags.extend([
+                                "--set=cluster.spec.kubeProxy.enabled=false",
                                 "--set=cluster.spec.networking.calico.bpfEnabled=true",
                             ])
+                        else:
+                            # https://github.com/kubernetes/kops/issues/17915
+                            extra_flags.extend([
+                                "--set=cluster.spec.kubeProxy.proxyMode=nftables",
+                            ])
+                            if 'cilium' in networking:
+                                extra_flags.extend([
+                                    "--set=cluster.spec.networking.cilium.enableBPFMasquerade=true",
+                                ])
                     results.append(
                         build_test(cloud="aws",
                                    distro=distro_short,
@@ -624,18 +630,24 @@ def generate_grid():
                             "--set=cluster.spec.cloudProvider.gce.useStartupScript=true"
                         ])
                     if 'rhel10' in distro or 'rocky10' in distro:
-                        # https://github.com/kubernetes/kops/issues/17915
-                        extra_flags.extend([
-                            "--set=cluster.spec.kubeProxy.proxyMode=nftables",
-                        ])
-                        if 'cilium' in networking:
-                            extra_flags.extend([
-                                "--set=cluster.spec.networking.cilium.enableBPFMasquerade=true",
-                            ])
                         if networking == 'calico':
+                            # Calico BPF mode takes over kube-proxy's role; from
+                            # v3.31 felix also binds the kube-proxy healthz port,
+                            # so kube-proxy must be disabled to avoid the conflict.
+                            # https://docs.tigera.io/calico-enterprise/latest/operations/ebpf/install#disable-kube-proxy-or-avoid-conflicts
                             extra_flags.extend([
+                                "--set=cluster.spec.kubeProxy.enabled=false",
                                 "--set=cluster.spec.networking.calico.bpfEnabled=true",
                             ])
+                        else:
+                            # https://github.com/kubernetes/kops/issues/17915
+                            extra_flags.extend([
+                                "--set=cluster.spec.kubeProxy.proxyMode=nftables",
+                            ])
+                            if 'cilium' in networking:
+                                extra_flags.extend([
+                                    "--set=cluster.spec.networking.cilium.enableBPFMasquerade=true",
+                                ])
                     results.append(
                         build_test(cloud="gce",
                                    runs_per_day=2,


### PR DESCRIPTION
intending to fix all calico + rocky10/rhel10 jobs:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-calico-rocky10-k33-ko35/2054714355370430464

https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-grid-gce-calico-rocky10-k33-ko35/2054714355370430464/artifacts/cluster-info/kube-system/calico-node-lfv5b/calico-node.log

`2026-05-14 00:43:26.438 [ERROR][58] felix/int_dataplane.go 2845: BPF Proxy Healthz server failed, restarting in 1s error=failed to start proxy healthz on :10256: listen tcp :10256: bind: address already in use`

https://docs.tigera.io/calico-enterprise/latest/operations/ebpf/install#disable-kube-proxy-or-avoid-conflicts

/cc @hakman