### PR TITLE
Increase CPU and memory for ppc64le e2e-slow-kubetest2 job.

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -348,11 +348,11 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "1500m"
-              memory: "8Gi"
+              cpu: "2"
+              memory: "10Gi"
             limits:
-              cpu: "1500m"
-              memory: "8Gi"
+              cpu: "2"
+              memory: "10Gi"
           command:
             - runner.sh
           args:


### PR DESCRIPTION
This PR increases the CPU and memory allocation for the `ci-kubernetes-ppc64le-e2e-slow-kubetest2` job in `cloud-provider-ibmcloud-ppc64le-periodics.yaml`.

The change is intended to improve stability for the frequently flaking **ppc64le e2e slow CSI tests**, where volume unmount operations are taking longer and resulting in timeout issues during cleanup.
