### PR TITLE
Limit cloud-provider-azure multi-zone-vmss-capz to conformance suite

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -1626,7 +1626,7 @@ periodics:
         value: "latest"
       - name: GINKGO_ARGS  # cloud-provider-azure config
         # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
-        value: --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete.Grace.Period|runs.ReplicaSets.to.verify.preemption.running.path|client.go.should.negotiate|should.contain.custom.columns.for.each.resource|Network.should.set.TCP.CLOSE_WAIT.timeout|PodSecurityPolicy|In-tree.Volumes|ephemeral.should.support.expansion.of.pvcs.created.for.ephemeral.pvcs|should.implement.NodePort.and.HealthCheckNodePort.correctly.when.ExternalTrafficPolicy.changes|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator --report-dir=/logs/artifacts --disable-log-dump=true
+        value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete.Grace.Period|runs.ReplicaSets.to.verify.preemption.running.path|client.go.should.negotiate|should.contain.custom.columns.for.each.resource|Network.should.set.TCP.CLOSE_WAIT.timeout|PodSecurityPolicy|In-tree.Volumes|ephemeral.should.support.expansion.of.pvcs.created.for.ephemeral.pvcs|ServiceAccountIssuerDiscovery.should.support.OIDC.discovery.of.service.account.issuer|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
         value: "1"
       - name: WORKER_MACHINE_COUNT  # CAPZ config


### PR DESCRIPTION
The `cloud-provider-azure-conformance-multi-zone-vmss-capz` job was running the full upstream e2e suite (~1110 specs) instead of just the conformance suite (~400 specs) because it was missing the `--ginkgo.focus=\[Conformance\]|\[NodeConformance\]` filter that the sibling CPA conformance jobs use.

That caused tests that rely on cloud capabilities CAPZ's default VMSS deployment doesn't provide (e.g. `ExternalIP` on worker nodes for SSH-based tests under `[HostCleanup]` / `[NFS]`, and the previously-skipped ExternalTrafficPolicy short-circuit test) to run and fail despite not being multi-zone regressions.

This change aligns the focus filter with the sibling jobs, removes the now-redundant short-circuit skip, and adds a small skip for `ServiceAccountIssuerDiscovery` (a conformance test that fails on CAPZ because the cluster's OIDC issuer is served from an Azure blob storage URL whose cert chain isn't trusted by the in-cluster validator).

Refs: kubernetes-sigs/cloud-provider-azure#9863