### PR TITLE
ca: add presubmit job using branch-aware k8s version script

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -494,17 +494,7 @@ periodics:
     containers:
     - command:
       - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=ca
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-nodes=3
-      - --gcp-zone=us-central1-b
-      - --provider=gce
-      - --test=false
-      - --test-cmd=../cluster-autoscaler/hack/e2e/run-e2e.sh
-      - --timeout=400m
+      - ../cluster-autoscaler/hack/e2e/run-e2e-presubmit.sh
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
       resources:
         limits:

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -494,7 +494,7 @@ periodics:
     containers:
     - command:
       - runner.sh
-      - ../cluster-autoscaler/hack/e2e/run-e2e-presubmit.sh
+      - ./cluster-autoscaler/hack/e2e/run-e2e-presubmit.sh
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
       resources:
         limits:

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -645,17 +645,7 @@ presubmits:
       containers:
       - command:
           - runner.sh
-          - /workspace/scenarios/kubernetes_e2e.py
-        args:
-        - --extract=ci/latest
-        - --gcp-node-image=gci
-        - --gcp-nodes=3
-        - --gcp-zone=us-central1-b
-        - --provider=gce
-        - --test=false
-        - --test-cmd=../cluster-autoscaler/hack/e2e/run-e2e.sh
-        - --test-cmd-args=--presubmit
-        - --timeout=400m
+          - ../cluster-autoscaler/hack/e2e/run-e2e-presubmit.sh
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
         resources:
           limits:

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -645,7 +645,7 @@ presubmits:
       containers:
       - command:
           - runner.sh
-          - ../cluster-autoscaler/hack/e2e/run-e2e-presubmit.sh
+          - ./cluster-autoscaler/hack/e2e/run-e2e-presubmit.sh
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
         resources:
           limits:


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it -
adds a presubmit job pull-autoscaling-e2e-gci-gce-ca-test for the
kubernetes/autoscaler repo that calls a branch-aware entrypoint script
run-e2e-presubmit.sh

The script dynamically derives the correct Kubernetes version from go.mod
and passes --extract=ci/latest-X.Y to kubernetes_e2e.py ensuring PRs
targeting release branches boot a matching k8s cluster instead of always
using ci/latest

Companion autoscaler PR - kubernetes/autoscaler#9640

#### Which issue(s) this PR fixes -
Fixes kubernetes/autoscaler#9349

#### special note for reviewer -
Single job definition and no per-branch duplication
The logic lives in thescript in the autoscaler repo so the config stays clean and self-maintaining

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

