### PR TITLE
node-feature-discovery: bump build-image-cross-generic memory to 16Gi

### DIFF
--- a/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
+++ b/config/jobs/kubernetes-sigs/node-feature-discovery/node-feature-discovery-presubmits-generic.yaml
@@ -53,10 +53,10 @@ presubmits:
         resources:
           limits:
             cpu: 4
-            memory: 8Gi
+            memory: 16Gi
           requests:
             cpu: 4
-            memory: 8Gi
+            memory: 16Gi
   - name: pull-node-feature-discovery-build-gh-pages-generic
     cluster: eks-prow-build-cluster
     run_if_changed: "^docs/"


### PR DESCRIPTION
The presubmit `pull-node-feature-discovery-build-image-cross-generic` is
failing ~75 % of runs with non-deterministic Go-runtime memory corruption
inside the QEMU-emulated `linux/arm64` buildx stage during
`go mod download`. Three distinct crash signatures across three
consecutive runs on kubernetes-sigs/node-feature-discovery#2507:

- `runtime: pointer 0x... to unallocated span`
- SIGSEGV at PC=0
- `marked free object in span` / `found pointer to free object`

The job builds 5 platforms concurrently (amd64, arm64, arm/v7, s390x,
ppc64le) inside a single 8 Gi container. Bumping to 16 Gi gives the
arm64 emulated container enough headroom to avoid QEMU
translation-cache thrashing. All three crashes happen inside the
QEMU-emulated stage, not the host Go process — consistent with QEMU
translation-cache pressure under memory thrash, not a host-side Go
toolchain bug.

**Precedent on `eks-prow-build-cluster`:** 65 existing jobs already run
at >=16 Gi memory on this cluster, including `cluster-api-provider-azure`,
`cluster-api-provider-gcp`, `kubernetes-sigs/prow`, and `controller-tools`
(at 24 Gi). The bump puts this job at the median for the multi-arch
build-image workload class. `limits == requests` is preserved, so the
pod stays in Guaranteed QoS class.

**Considered alternatives:** reducing buildx concurrency, or splitting
into per-arch jobs. Both roughly double critical-path latency for the
same outcome and add fan-out matrix bookkeeping; rejected on cost.
If 16 Gi still proves insufficient, next mitigations are
(a) serialize platform builds in NFD's Makefile, or
(b) request native arm64 runners.

Job history:
https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-node-feature-discovery-build-image-cross-generic

/sig testing
/area node-feature-discovery
/cc @marquiz