### PR TITLE
Revert "add skip_cloning to periodics which don't need source code" + "add extra_refs to every periodic job that doesn't have it"

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -9,13 +9,6 @@ periodics:
     testgrid-num-failures-to-alert: '1'
     description: 'Uses APISnoop to check that new GA endpoints are conformance tested in latest e2e test run'
   decorate: true
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: apisnoop
-    base_ref: main
-    path_alias: sigs.k8s.io/apisnoop
-  decoration_config:
-    skip_cloning: true
   spec:
     containers:
     - name: apisnoop-gate

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -531,14 +531,8 @@ periodics:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
   decorate: true
-  extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 260m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -574,14 +568,8 @@ periodics:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
   decorate: true
-  extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 260m
-    skip_cloning: true
   spec:
     containers:
     - command:

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -6,14 +6,8 @@ periodics:
     testgrid-tab-name: gce-serial
   cluster: k8s-infra-prow-build
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 8h40m0s
-    skip_cloning: true
   interval: 12h
   labels:
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -1032,14 +1032,8 @@ periodics:
   labels:
     preset-e2e-containerd-ec2: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
   decoration_config:
     timeout: 4h
-    skip_cloning: true
   spec:
     serviceAccountName: node-e2e-tests
     containers:

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -50,14 +50,8 @@ periodics:
     testgrid-tab-name: gce-ubuntu-master-containerd
   cluster: k8s-infra-prow-build
   decorate: true
-  extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 1h45m0s
-    skip_cloning: true
   # Same as in other release-blocking jobs. If we want to save resources, then we should
   # run some of those less often. This job is the only one which matches a blocking presubmit,
   # so we want to know about problems as quickly as reasonably possible.

--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -31,13 +31,6 @@ periodics:
     cluster: k8s-infra-aks-prow-build
     interval: 2h
     decorate: true
-    decoration_config:
-      skip_cloning: true
-    extra_refs:
-      - org: kubernetes
-        repo: kubernetes
-        base_ref: master
-        path_alias: k8s.io/kubernetes
     max_concurrency: 1
     path_alias: k8s.io/kubernetes
     annotations:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -255,13 +255,6 @@ periodics:
   name: ci-fast-forward
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: release
-    base_ref: master
-    path_alias: k8s.io/release
   spec:
     serviceAccountName: gcb-builder
     containers:
@@ -298,13 +291,6 @@ periodics:
     testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: verify-image-signatures
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: promo-tools
-    base_ref: main
-    path_alias: sigs.k8s.io/promo-tools
   spec:
     containers:
     - image: gcr.io/k8s-staging-artifact-promoter/kpromo:v4.5.0-0

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -4,13 +4,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds API review process description to kind/api-change PRs
@@ -66,13 +59,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds stable metrics review documentation to area/stable-metrics PRs
@@ -119,13 +105,6 @@ periodics:
   interval: 10m
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: A sample job to make sure things work
@@ -176,13 +155,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Closes rotten issues after 30d of inactivity
@@ -252,13 +224,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Closes rotten PRs after 30d of inactivity
@@ -449,13 +414,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds lifecycle/rotten to stale issues after 30d of inactivity
@@ -525,13 +483,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds lifecycle/rotten to stale PRs after 30d of inactivity
@@ -599,13 +550,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds lifecycle/stale to issues after 90d of inactivity
@@ -675,13 +619,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds lifecycle/stale to PRs after 90d of inactivity
@@ -749,13 +686,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Removes lifecycle/frozen from PRs
@@ -811,13 +741,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Removes the triage/accepted label after 1 year of inactivity
@@ -876,13 +799,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Removes the triage/accepted label on important issues after 3 months of inactivity
@@ -942,13 +858,6 @@ periodics:
   interval: 1h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Removes the triage/accepted label on critical issues after 1 month of inactivity
@@ -1010,13 +919,6 @@ periodics:
   labels:
     preset-service-account: "true"
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Creates github issues based on data from various 'IssueSource's.

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-triage-robot-retester.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-triage-robot-retester.yaml
@@ -3,13 +3,6 @@ periodics:
   interval: 20m  # Retest at most 1 PR per 20m, which should not DOS the queue.
   cluster: k8s-infra-prow-build-trusted
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: org
-    base_ref: main
-    path_alias: k8s.io/org
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     testgrid-tab-name: retester

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-label-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-label-sync.yaml
@@ -5,13 +5,6 @@ periodics:
   labels:
     app: label-sync
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
   spec:
     containers:
     - name: label-sync

--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -184,14 +184,8 @@ periodics:
     preset-k8s-ssh: "true"
     preset-ingress-master-yaml: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 340m
-    skip_cloning: true
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master

--- a/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
@@ -344,14 +344,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 80m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -389,14 +383,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 60m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -433,14 +421,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 80m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -477,14 +459,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -517,14 +493,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 80m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -562,14 +532,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 80m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -607,14 +571,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -648,14 +606,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 340m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -692,14 +644,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 340m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -735,14 +681,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 200m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -777,14 +717,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 70m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -821,14 +755,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -865,14 +793,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -914,14 +836,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -953,14 +869,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -994,14 +904,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 520m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -1035,14 +939,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 520m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -1078,14 +976,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 170m
-    skip_cloning: true
   spec:
     containers:
     - command:

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -409,14 +409,8 @@ periodics:
     preset-k8s-ssh: "true"
     preset-e2e-cos-containerd: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 70m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -454,14 +448,8 @@ periodics:
     preset-k8s-ssh: "true"
     preset-e2e-cos-containerd: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 70m
-    skip_cloning: true
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
@@ -859,14 +847,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 70m
-    skip_cloning: true
   spec:
     containers:
     - command:

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -19,13 +19,6 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
-      skip_cloning: true
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-      workdir: true
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
@@ -113,13 +106,6 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
-      skip_cloning: true
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-      workdir: true
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
@@ -227,13 +213,6 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
-      skip_cloning: true
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-      workdir: true
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
@@ -359,13 +338,6 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
-      skip_cloning: true
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-      workdir: true
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master
@@ -491,13 +463,6 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
-      skip_cloning: true
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-      workdir: true
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master

--- a/config/jobs/kubernetes/sig-node/dra.generate.conf
+++ b/config/jobs/kubernetes/sig-node/dra.generate.conf
@@ -97,10 +97,10 @@ kubelet_skew = 3
 # owns the configuration of components, not the caller).
 [dra-integration]
 description = Runs integration tests for DRA which need some additional setup in the job.
+need_kubernetes_repo = true
 use_dind = true
 use_dind_cdi = true
 job_type = integration
-need_kubernetes_repo = true
 cluster = eks-prow-build-cluster
 run_if_changed = /(dra|e2e_dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 
@@ -151,6 +151,7 @@ run_if_changed = (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resour
 # This job adds all alpha and beta feature gates to node-e2e-containerd-1-7-dra and runs all DRA tests which can work in that configuration.
 [node-e2e-containerd-1-7-dra-alpha-beta-features]
 job_type = node
+need_kubernetes_repo = true
 need_test_infra_repo = true
 all_features = true
 description = Runs all E2E node tests for Dynamic Resource Allocation features with containerd 1.7 and with all feature gates enabled (including non-DRA feature gates)

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -61,15 +61,12 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: {{timeout}}
-      {%- if ci and not need_kubernetes_repo and not need_test_infra_repo and not need_containerd_repo %}
-      skip_cloning: true
-      {%- endif %}
     {%- if not ci %}
     path_alias: k8s.io/kubernetes
     {%- endif %}
-    {%- if ci or need_test_infra_repo or need_containerd_repo %}
+    {%- if ci and need_kubernetes_repo or need_test_infra_repo or need_containerd_repo %}
     extra_refs:
-    {%- if ci %}
+    {%- if ci and need_kubernetes_repo %}
     - org: kubernetes
       repo: kubernetes
       base_ref: master

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -57,12 +57,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 1h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.33
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   job_queue_name: gce-gpu-test
   labels:
     preset-ci-gce-device-plugin-gpu: "true"
@@ -989,12 +983,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.33
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 24h
   labels:
     preset-k8s-ssh: "true"
@@ -1037,12 +1025,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.33
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 24h
   labels:
     preset-k8s-ssh: "true"
@@ -1082,12 +1064,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 1h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.33
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 24h
   labels:
     preset-k8s-ssh: "true"
@@ -1125,12 +1101,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 11h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.33
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 24h
   labels:
     preset-k8s-ssh: "true"
@@ -1170,12 +1140,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h50m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.33
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 24h
   labels:
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -57,12 +57,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 1h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.34
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   job_queue_name: gce-gpu-test
   labels:
     preset-ci-gce-device-plugin-gpu: "true"
@@ -1263,14 +1257,6 @@ periodics:
     testgrid-tab-name: gce-cos-alphafeatures-1.34
   cluster: k8s-infra-prow-build
   decorate: true
-  decoration_config:
-    timeout: 2h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.34
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 6h
   labels:
     preset-k8s-ssh: "true"
@@ -1313,12 +1299,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.34
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 6h
   labels:
     preset-k8s-ssh: "true"
@@ -1356,14 +1336,6 @@ periodics:
     testgrid-tab-name: gce-cos-reboot-1.34
   cluster: k8s-infra-prow-build
   decorate: true
-  decoration_config:
-    timeout: 1h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.34
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 6h
   labels:
     preset-k8s-ssh: "true"
@@ -1401,12 +1373,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 11h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.34
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 6h
   labels:
     preset-k8s-ssh: "true"
@@ -1446,12 +1412,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h50m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.34
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 6h
   labels:
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -1384,12 +1384,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.35
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 2h
   labels:
     preset-k8s-ssh: "true"
@@ -1432,12 +1426,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.35
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 2h
   labels:
     preset-k8s-ssh: "true"
@@ -1477,12 +1465,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 1h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.35
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 2h
   labels:
     preset-k8s-ssh: "true"
@@ -1520,12 +1502,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 11h20m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.35
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 2h
   labels:
     preset-k8s-ssh: "true"
@@ -1565,12 +1541,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h50m0s
-    skip_cloning: true
-  extra_refs:
-  - base_ref: release-1.35
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 2h
   labels:
     preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -288,14 +288,7 @@ periodics:
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
-    skip_cloning: true
     timeout: 1h30m0s
-  extra_refs:
-  - base_ref: release-1.36
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
-    workdir: true
   interval: 24h
   labels:
     preset-dind-enabled: "true"
@@ -381,14 +374,7 @@ periodics:
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
-    skip_cloning: true
     timeout: 1h30m0s
-  extra_refs:
-  - base_ref: release-1.36
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
-    workdir: true
   interval: 24h
   labels:
     preset-dind-enabled: "true"
@@ -509,14 +495,7 @@ periodics:
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
-    skip_cloning: true
     timeout: 1h30m0s
-  extra_refs:
-  - base_ref: release-1.36
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
-    workdir: true
   interval: 24h
   labels:
     preset-dind-enabled: "true"
@@ -637,14 +616,7 @@ periodics:
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
-    skip_cloning: true
     timeout: 1h30m0s
-  extra_refs:
-  - base_ref: release-1.36
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
-    workdir: true
   interval: 24h
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -7,13 +7,6 @@ periodics:
     preset-aws-ssh: "true"
     preset-aws-credential-boskos-scale-001-kops: "true"
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
   spec:
     containers:
     - command:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -11,15 +11,9 @@ periodics:
     preset-e2e-scalability-periodics: "true"
     preset-e2e-scalability-periodics-master: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   job_queue_name: "5k-gce-scale-test" # DON'T REMOVE THIS
   decoration_config:
     timeout: 270m
-    skip_cloning: true
   annotations:
     testgrid-num-failures-to-alert: '2'
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com, release-team@kubernetes.io

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -291,14 +291,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 150m
-    skip_cloning: true
   spec:
     containers:
     - command:
@@ -338,14 +332,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   decoration_config:
     timeout: 150m
-    skip_cloning: true
   spec:
     containers:
     - command:

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -6,13 +6,6 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -66,12 +66,6 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 240m
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: kubernetes
-    base_ref: master
-    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260504-c27e3ff179-master

--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -7,13 +7,6 @@ periodics:
     preset-aws-ssh: "true"
     preset-aws-credential-aws-shared-testing: "true"
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
   spec:
     containers:
     - command:
@@ -45,13 +38,6 @@ periodics:
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
   decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
   spec:
     containers:
     - command:

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -58,22 +58,6 @@ func isCritical(clusterName string) bool {
 	return clusterName == "k8s-infra-prow-build" || clusterName == "eks-prow-build-cluster"
 }
 
-func matchesAnyRegex(job string, patterns []string) (bool, error) {
-	if job == "" || len(patterns) == 0 {
-		return false, nil
-	}
-	for _, pattern := range patterns {
-		re, err := regexp.Compile(pattern)
-		if err != nil {
-			return false, fmt.Errorf("invalid regex %q: %w", pattern, err)
-		}
-		if re.MatchString(job) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if *configPath == "" {
@@ -1039,26 +1023,6 @@ func TestPreSubmitPathAlias(t *testing.T) {
 	for _, job := range c.AllStaticPresubmits([]string{"kubernetes/kubernetes"}) {
 		if job.PathAlias != "k8s.io/kubernetes" {
 			t.Errorf("Invalid PathAlias (%s) in job %s for kubernetes/kubernetes repository", job.Name, job.PathAlias)
-		}
-	}
-}
-
-// Prow sets additional pod labels based on the 1st extra_refs set on a Job, therefore every periodic job must specify one
-// PostSubmits and PreSubmits can omit extra_refs because they implicitly checkout the repo they are defined for
-func TestReposBeingSet(t *testing.T) {
-	patterns := []string{
-		`^ci-kubernetes-e2e-gci-gce*`,
-		`^ci-kind-dra-*`,
-		`^ci-kubernetes-e2e-gce-(new|master|latest|stable[1-4])-(new|master|latest|stable[1-4])-gci-kubectl-skew`,
-		`^ci-kubernetes-soak-gci-gce-beta|stable[1-4]$`,
-	}
-	for _, job := range c.AllPeriodics() {
-		match, err := matchesAnyRegex(job.Name, patterns)
-		if err != nil {
-			t.Error(err)
-		}
-		if job.ExtraRefs == nil && !match {
-			t.Errorf("Periodic job %s does not have extra_refs set, every prowjob must checkout a git repository", job.Name)
 		}
 	}
 }


### PR DESCRIPTION
This reverts commits
- 0712a63a0cfb2d4943a5ff60c41e79b373e4b8e1 "add extra_refs to every periodic job that doesn't have it"
- 37c0d10a5e883e507a063ef09a0dea68c67dbc87 "add skip_cloning to periodics which don't need source code"

Adding extra_refs was meant to add information about the branch and repo to the Pod labels. But that has side effects:
- Causes extra work in all jobs for checking out source code.
- Causes testgrid to show the checked out source code revision, which is not necessarily the same as the code under test.

The second commit avoided the overhead, but then testgrid started showing e.g. "master" instead of some revision. Ultimately the right approach is to not use extra_ref (this PR) and add labels differently (in some future PR).

In addition to the reverts above, some manual cleanup was also needed, like removing the TestReposBeingSet test.

/assign @BenTheElder
/cc @upodroid 