### PR TITLE
capg: bump e2e job CPU requests from 2 to 4 cores

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-periodics-main.yaml
@@ -92,13 +92,13 @@ periodics:
           resources:
             limits:
               memory: "9000Mi"
-              cpu: 2000m
+              cpu: 4000m
             requests:
               # these are both a bit below peak usage during build
               # this is mostly for building kubernetes
               memory: "9000Mi"
               # during the tests more like 3-20m is used
-              cpu: 2000m
+              cpu: 4000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: capg-conformance-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -146,10 +146,10 @@ presubmits:
               # this is mostly for building kubernetes
               memory: "9000Mi"
               # during the tests more like 3-20m is used
-              cpu: 2000m
+              cpu: 4000m
             limits:
               memory: "9000Mi"
-              cpu: 2000m
+              cpu: 4000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-e2e-test
@@ -195,10 +195,10 @@ presubmits:
               # this is mostly for building kubernetes
               memory: "9000Mi"
               # during the tests more like 3-20m is used
-              cpu: 2000m
+              cpu: 4000m
             limits:
               memory: "9000Mi"
-              cpu: 2000m
+              cpu: 4000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-conformance-ci-artifacts
@@ -234,10 +234,10 @@ presubmits:
               # this is mostly for building kubernetes
               memory: "9000Mi"
               # during the tests more like 3-20m is used
-              cpu: 2000m
+              cpu: 4000m
             limits:
               memory: "9000Mi"
-              cpu: 2000m
+              cpu: 4000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-conformance
@@ -273,10 +273,10 @@ presubmits:
           resources:
             requests:
               memory: "9000Mi"
-              cpu: 2000m
+              cpu: 4000m
             limits:
               memory: "9000Mi"
-              cpu: 2000m
+              cpu: 4000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-capi-e2e-test
@@ -311,10 +311,10 @@ presubmits:
           resources:
             limits:
               memory: "9000Mi"
-              cpu: 2000m
+              cpu: 4000m
             requests:
               memory: "9000Mi"
-              cpu: 2000m
+              cpu: 4000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-e2e-upgrade


### PR DESCRIPTION
## Summary

- Bump CPU requests/limits from 2000m to 4000m for all CAPG e2e job pods (presubmits and periodics on the main branch)
- Aligns with what cluster-api-provider-aws uses for its e2e jobs (4 CPUs)

## Why

The CAPG e2e tests run Ginkgo with `GINKGO_NODES=3` (3 parallel test workers), but the job pods only had 2 CPU cores. Since the tests are mostly I/O-bound (waiting on GCP API calls and VM provisioning), the oversubscription worked, but having more CPU headroom allows for potentially increasing parallelism further to reduce overall job time.

## Jobs affected

Presubmits:
- `pull-cluster-api-provider-gcp-e2e-test`
- `pull-cluster-api-provider-gcp-conformance-ci-artifacts`
- `pull-cluster-api-provider-gcp-conformance`
- `pull-cluster-api-provider-gcp-capi-e2e`
- `pull-cluster-api-provider-gcp-e2e-workload-upgrade`

Periodics:
- `periodic-cluster-api-provider-gcp-make-conformance-main`

/sig cluster-lifecycle
/area provider/gcp