### PR TITLE
test: split periodic-kueue-test-integration into baseline and extended

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -79,14 +79,14 @@ periodics:
               cpu: "6"
               memory: "6Gi"
   - interval: 12h
-    name: periodic-kueue-test-integration-main
+    name: periodic-kueue-test-integration-baseline-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-integration-main
+      testgrid-tab-name: periodic-kueue-test-integration-baseline-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue test-integration"
+      description: "Run periodic kueue test-integration-baseline"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -105,7 +105,45 @@ periodics:
           command:
             - make
           args:
-            - test-integration
+            - test-integration-baseline
+          env:
+            - name: GOMAXPROCS
+              value: "6"
+          resources:
+            requests:
+              cpu: "6"
+              memory: "9Gi"
+            limits:
+              cpu: "6"
+              memory: "9Gi"
+  - interval: 12h
+    name: periodic-kueue-test-integration-extended-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-integration-extended-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue test-integration-extended"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.26
+          command:
+            - make
+          args:
+            - test-integration-extended
           env:
             - name: GOMAXPROCS
               value: "6"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
@@ -40,14 +40,14 @@ periodics:
               cpu: "6"
               memory: "6Gi"
   - interval: 12h
-    name: periodic-kueue-test-integration-release-0-16
+    name: periodic-kueue-test-integration-baseline-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-integration-release-0-16
+      testgrid-tab-name: periodic-kueue-test-integration-baseline-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue test-integration"
+      description: "Run periodic kueue test-integration-baseline"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -66,7 +66,45 @@ periodics:
           command:
             - make
           args:
-            - test-integration
+            - test-integration-baseline
+          env:
+            - name: GOMAXPROCS
+              value: "6"
+          resources:
+            requests:
+              cpu: "6"
+              memory: "9Gi"
+            limits:
+              cpu: "6"
+              memory: "9Gi"
+  - interval: 12h
+    name: periodic-kueue-test-integration-extended-release-0-16
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-integration-extended-release-0-16
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue test-integration-extended"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.16
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.26
+          command:
+            - make
+          args:
+            - test-integration-extended
           env:
             - name: GOMAXPROCS
               value: "6"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -79,14 +79,14 @@ periodics:
               cpu: "6"
               memory: "6Gi"
   - interval: 12h
-    name: periodic-kueue-test-integration-release-0-17
+    name: periodic-kueue-test-baseline-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-integration-release-0-17
+      testgrid-tab-name: periodic-kueue-test-baseline-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue test-integration"
+      description: "Run periodic kueue test-integration-baseline"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -105,7 +105,45 @@ periodics:
           command:
             - make
           args:
-            - test-integration
+            - test-integration-baseline
+          env:
+            - name: GOMAXPROCS
+              value: "6"
+          resources:
+            requests:
+              cpu: "6"
+              memory: "9Gi"
+            limits:
+              cpu: "6"
+              memory: "9Gi"
+  - interval: 12h
+    name: periodic-kueue-test-extended-release-0-17
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-extended-release-0-17
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue test-integration-extended"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.17
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.26
+          command:
+            - make
+          args:
+            - test-integration-extended
           env:
             - name: GOMAXPROCS
               value: "6"


### PR DESCRIPTION
What this PR does / why we need it:
Splits the periodic-kueue-test-integration job into two separate jobs:

- periodic-kueue-test-integration-baseline: runs tests with label filter "!slow && !redundant"
- periodic-kueue-test-integration-extended: runs tests with label filter "slow || redundant"

This aligns the periodic jobs with the presubmit jobs which already use the 
baseline/extended split model, and reduces CI wall-clock time by running the 
two shards in parallel.

Which issue(s) this PR fixes:
Part of [kubernetes-sigs/kueue#10995](https://github.com/kubernetes-sigs/kueue/issues/10995)

Special notes for your reviewer:
The split for presubmit jobs was already done in the Kueue repo.
This is the corresponding test-infra change for the periodic jobs.

Does this PR introduce a user-facing change:

```
NONE
```