### PR TITLE
Mark pull-kubebuilder-e2e-k8s-1-36-0 optional until k8s 1.36 support lands

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 60m
-    optional: false
+    optional: true
     skip_if_only_changed: "^docs/|^designs/|^roadmap/|^scripts/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
     path_alias: sigs.k8s.io/kubebuilder
     branches:


### PR DESCRIPTION
### What

Mark `pull-kubebuilder-e2e-k8s-1-36-0` as `optional: true` in the kubebuilder presubmit config.

### Why

The job was added as required in #36923, but two prerequisites have not landed yet:

1. **`common.sh:convert_to_tools_ver`** in kubebuilder has no case for `1.36`. When the job sets `KIND_K8S_VERSION=v1.36.0`, the function hits the catch-all, prints "k8s version not supported," and exits immediately.

2. **`kindest/node:v1.36.0` does not exist** on Docker Hub yet. Even if the tools mapping were added, `kind create cluster` would fail.

This causes every PR to fail this required check, forcing maintainers to manually `/override` it (e.g., [#5694](https://github.com/kubernetes-sigs/kubebuilder/pull/5694), [#5695](https://github.com/kubernetes-sigs/kubebuilder/pull/5695)).

Tracked in:
- kubernetes-sigs/kubebuilder#5667 (k8s 1.36 support umbrella)
- kubernetes-sigs/kubebuilder#5674 (CLI support PR)

Once those land and `kindest/node:v1.36.0` is published, this can be switched back to `optional: false`.

/cc @camilamacedo86