### PR TITLE
fix various sig k8s-infra jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
@@ -21,10 +21,18 @@ postsubmits:
           # images are pushed to.
           - --project=k8s-staging-images
           - --scratch-bucket=gs://k8s-staging-images-gcb
+          - --with-git-dir
           - .
           env:
           - name: LOG_TO_STDOUT
             value: "y"
+          resources:
+            requests:
+              cpu: 0.5
+              memory: 1Gi
+            limits:
+              cpu: 0.5
+              memory: 1Gi
   kubernetes-sigs/porche:
   - name: post-porche-push-images
     cluster: k8s-infra-prow-build-trusted
@@ -46,6 +54,13 @@ postsubmits:
           - --scratch-bucket=gs://k8s-staging-images-gcb
           - --with-git-dir
           - .
+          resources:
+            requests:
+              cpu: 0.5
+              memory: 1Gi
+            limits:
+              cpu: 0.5
+              memory: 1Gi
   kubernetes/k8s.io:
   # Special job to deploy the staging registry
   # this should closely match post-registry-push-images
@@ -67,7 +82,7 @@ postsubmits:
       # However they will deploy the terraform changes here
       workdir: true
     spec:
-      serviceAccountName: gcb-builder
+      serviceAccountName: infra-tools
       containers:
         - image: gcr.io/k8s-staging-test-infra/image-builder:v20260419-39c657fdbf
           command:
@@ -81,6 +96,13 @@ postsubmits:
           env:
           - name: LOG_TO_STDOUT
             value: "y"
+          resources:
+            requests:
+              cpu: 0.5
+              memory: 1Gi
+            limits:
+              cpu: 0.5
+              memory: 1Gi
   # normal image pushing jobs below
   - name: post-k8sio-push-image-octodns-docker
     cluster: k8s-infra-prow-build-trusted
@@ -91,7 +113,7 @@ postsubmits:
     branches:
       - ^main$
     spec:
-      serviceAccountName: gcb-builder
+      serviceAccountName: infra-tools
       containers:
         - image: gcr.io/k8s-staging-test-infra/image-builder:v20260419-39c657fdbf
           command:
@@ -103,6 +125,13 @@ postsubmits:
             - --scratch-bucket=gs://k8s-staging-images-gcb
             - --env-passthrough=PULL_BASE_REF
             - dns/octodns-docker
+          resources:
+            requests:
+              cpu: 0.5
+              memory: 1Gi
+            limits:
+              cpu: 0.5
+              memory: 1Gi
   - name: post-k8sio-push-image-k8s-infra
     cluster: k8s-infra-prow-build-trusted
     annotations:

--- a/config/jobs/kubernetes/sig-k8s-infra/k8sio-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/k8sio-presubmit.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes/k8s.io:
-    - name: pull-k8sio-groups-test
+    - name: pull-k8sio-groups
       cluster: eks-prow-build-cluster
       annotations:
         testgrid-create-test-group: "true"
@@ -12,10 +12,11 @@ presubmits:
         - ^main$
       spec:
         containers:
-          - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+          - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260512-1f34ef0df3-master
             command:
-              - make
+              - runner.sh
             args:
+              - make
               - -C
               - ./groups
               - test

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-groups.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-groups.yaml
@@ -23,10 +23,11 @@ periodics:
   spec:
     serviceAccountName: gsuite-groups-manager
     containers:
-    - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260512-1f34ef0df3-master
       command:
-      - make
+      - runner.sh
       args:
+      - make
       - -C
       - groups
       - run
@@ -64,10 +65,11 @@ postsubmits:
     spec:
       serviceAccountName: gsuite-groups-manager
       containers:
-      - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260512-1f34ef0df3-master
         command:
-        - make
+        - runner.sh
         args:
+        - make
         - -C
         - groups
         - run

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-registry.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-registry.yaml
@@ -24,7 +24,7 @@ periodics:
       serviceAccountName: s3-sync
       containers:
         - name: s3-sync
-          image: gcr.io/k8s-staging-infra-tools/k8s-infra@sha256:48fb967be4c36da551584c3004330c7ce37568e4226ea7233eeb08c979374bc6
+          image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260512-1f34ef0df3-master
           command:
             - /bin/bash
             - -c

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -15,8 +15,10 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260512-1f34ef0df3-master
       command:
+      - runner.sh
+      args:
       - ./release-team/hack/sync-enhancements-github-project-beta.sh
       resources:
         requests:
@@ -47,8 +49,10 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-staging-infra-tools/k8s-infra:latest
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260512-1f34ef0df3-master
       command:
+      - runner.sh
+      args:
       - ./release-team/hack/sync-bug-triage-github-project-beta.sh
       resources:
         requests:


### PR DESCRIPTION
We have several instances of `gcr.io/k8s-staging-infra-tools/k8s-infra` being used for go only code, so I switched those jobs to our standard CI image.

Fixed a few more postsubmits as part of https://github.com/kubernetes/k8s.io/issues/9486