### PR TITLE
Restore --parallel=30 for ppc64le slow e2e job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -372,7 +372,7 @@ periodics:
                 --up --down --auto-approve --retry-on-tf-failure 3 --ignore-destroy-errors\
                 --break-kubetest-on-upfail true \
                 --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt) \
-                --test=ginkgo -- --parallel 15 --test-package-dir ci --test-package-marker latest.txt --focus-regex='\[Slow\]' --skip-regex='\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:'
+                --test=ginkgo -- --parallel 30 --test-package-dir ci --test-package-marker latest.txt --focus-regex='\[Slow\]' --skip-regex='\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:'
 
   - name: ci-kubernetes-e2e-ppc64le-serial-kubetest2
     cron: "30 9-17/8 * * *" # every 8h starting at 09:30 UTC


### PR DESCRIPTION
This PR restores the `--parallel` count to `30` for the `ci-kubernetes-ppc64le-e2e-slow-kubetest2` job in `cloud-provider-ibmcloud-ppc64le-periodics.yaml`.

The change is intended to bring the job back to its previous execution level after recent stability improvements observed following the memory increase. Recent runs show a significant reduction in flakes, with only a few intermittent failures remaining, some of which are related to PowerVS infrastructure rather than parallelism.

Job history:

* https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-ppc64le-e2e-slow-kubetest2