### PR TITLE
Skip ServiceAccountIssuerDiscovery in cloud-provider-azure-conformance-capz

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -1284,7 +1284,7 @@ periodics:
       - name: KUBERNETES_VERSION  # CAPZ config
         value: "latest"
       - name: GINKGO_ARGS  # cloud-provider-azure config
-        value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator --report-dir=/logs/artifacts --disable-log-dump=true
+        value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|Should.be.able.to.support.the.1\.17.Sample.API.Server.using.the.current.Aggregator|ServiceAccountIssuerDiscovery --report-dir=/logs/artifacts --disable-log-dump=true
       - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
         value: "1"
       - name: CLUSTER_PROVISIONING_TOOL  # cloud-provider-azure config


### PR DESCRIPTION
The `[sig-auth] ServiceAccounts ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer` conformance test fails in the cloud-provider-azure-conformance-capz prow job.

## Root Cause

The in-cluster OIDC discovery validator pod fails TLS verification against the Azure Blob Storage static website used as `SERVICE_ACCOUNT_ISSUER` in CAPZ workload clusters. The pod's CA bundle does not include the Microsoft/DigiCert CA that signs `*.web.core.windows.net` certificates.

```
x509: certificate signed by unknown authority
```

This is an environment limitation with the CAPZ workload identity OIDC setup, not a cloud-provider-azure bug.

## Change

Add `|ServiceAccountIssuerDiscovery` to the `--ginkgo.skip` pattern in the `GINKGO_ARGS` env var for the `cloud-provider-azure-conformance-capz` periodic job.

/cc @nilo19 @lzhecheng