### PR TITLE
fix(cloud-provider-azure): remove broken command from conformance windows

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -1350,7 +1350,6 @@ periodics:
       - bash
       - -c
       - >-
-        cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig &&
         cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure &&
         make test-e2e-capz
       securityContext:


### PR DESCRIPTION
fix(cloud-provider-azure): remove broken command from conformance windows
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/cloud-provider-azure-conformance-windows-capz/2056057349042343936
> running user provided command: bash -c cp ./kubeconfig ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure/kubeconfig && cd ${GOPATH}/src/sigs.k8s.io/cloud-provider-azure && make test-e2e-capz
cp: cannot stat './kubeconfig': No such file or directory
user provided command failed with exit code 1

Matching `cloud-provider-azure-ccm-windows-capz` command that doesn't do `cp ./kubeconfig`.

/area provider/azure