### PR TITLE
Add Prow job for sig-network userns tests

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-userns.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-userns.yaml
@@ -1,0 +1,30 @@
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-userns-tests
+    cluster: k8s-infra-prow-build
+    optional: true
+    always_run: false
+    skip_report: false
+    decorate: true
+    decoration_config:
+      timeout: 10m
+      grace_period: 5m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260511-f09cee265c-master
+        command:
+        - make
+        - test-userns
+        resources:
+          limits:
+            cpu: 2
+            memory: 4Gi
+          requests:
+            cpu: 2
+            memory: 4Gi
+    annotations:
+      testgrid-dashboards: sig-network-userns
+      testgrid-tab-name: pr-sig-network-userns
+      description: Runs unprivileged user namespace tests for rootless nftables
+      testgrid-alert-email: antonio.ojea.garcia@gmail.com

--- a/config/testgrids/kubernetes/sig-network/config.yaml
+++ b/config/testgrids/kubernetes/sig-network/config.yaml
@@ -18,6 +18,7 @@ dashboard_groups:
     - sig-network-kindnet
     - sig-network-kube-agentic-networking
     - sig-network-dranet
+    - sig-network-userns
 
 dashboards:
 - name: sig-network-dns
@@ -94,3 +95,4 @@ dashboards:
 - name: sig-network-kindnet
 - name: sig-network-kube-agentic-networking
 - name: sig-network-dranet
+- name: sig-network-userns


### PR DESCRIPTION
Add an optional presubmit job `pull-kubernetes-userns-tests` for running
kube-proxy nftables tests that require unprivileged user namespaces.

The job uses the `usernstest` build tag to gate the test files, runs in
privileged mode (required for user network namespaces), and is optional
so it does not block normal CI.

Related: kubernetes/kubernetes#138993