### PR TITLE
Bump 5k scalability jobs memory from 27Gi to 32Gi

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1289,10 +1289,10 @@ periodics:
       resources:
         requests:
           cpu: 7
-          memory: "27Gi"
+          memory: "32Gi"
         limits:
           cpu: 7
-          memory: "27Gi"
+          memory: "32Gi"
 
 # NOTE: When making changes to this job, please ensure that you also keep the original job
 # ci-kubernetes-e2e-gce-scale-performance-100 in sig-scalability-release-blocking-jobs.yaml

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -510,10 +510,10 @@ presubmits:
         resources:
           requests:
             cpu: 7
-            memory: "27Gi"
+            memory: "32Gi"
           limits:
             cpu: 7
-            memory: "27Gi"
+            memory: "32Gi"
 
   # Mirrors pull-perf-tests-gce-master-scale-performance-100 with CL2_RESTART_APISERVER set to true.
   # TODO(Jefftree): revert after testing to be stable.
@@ -1370,7 +1370,7 @@ presubmits:
         resources:
           requests:
             cpu: 7
-            memory: "27Gi"
+            memory: "32Gi"
           limits:
             cpu: 7
-            memory: "27Gi"
+            memory: "32Gi"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -183,10 +183,10 @@ periodics:
       resources:
         requests:
           cpu: 7
-          memory: "27Gi"
+          memory: "32Gi"
         limits:
           cpu: 7
-          memory: "27Gi"
+          memory: "32Gi"
 
 - name: ci-kubernetes-e2e-gce-scale-performance-100
   tags:


### PR DESCRIPTION
Restores the four 5k-node scalability jobs from 27Gi to 32Gi, fixing the OOMKills (hopefully) from https://github.com/kubernetes/test-infra/issues/37056