### PR TITLE
Enable CL2 heap profiling on 5k and 100-node apiserver-restart presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -460,6 +460,8 @@ presubmits:
           value: "16Gi"
         - name: CL2_REALISTIC_POD
           value: "true"
+        - name: CL2_HEAP_PROFILE_INTERVAL
+          value: "5m"
         #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
         - name: KUBE_SSH_KEY_PATH
           value: /etc/ssh-key-secret/ssh-private
@@ -557,6 +559,8 @@ presubmits:
         env:
         - name: CL2_RESTART_APISERVER
           value: "true"
+        - name: CL2_HEAP_PROFILE_INTERVAL
+          value: "1m"
         - name: KUBE_SSH_KEY_PATH
           value: /etc/ssh-key-secret/ssh-private
         - name: KUBE_SSH_USER


### PR DESCRIPTION
Sets CL2_HEAP_PROFILE_INTERVAL on the two scalability presubmits to collect heap profiles for kubernetes/test-infra#37056. 5m on 5k, 1m on 100-node restart.