### PR TITLE
Use the new build and highmem nodepools

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -44,6 +44,11 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     serviceAccountName: prow-build
+    nodeSelector:
+      node.kubernetes.io/instance-type: c4d-standard-16-lssd
+    tolerations:
+      - key: build
+        operator: Exists
     containers:
     - image: gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default
       imagePullPolicy: Always
@@ -68,11 +73,11 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: "7"
-          memory: "24Gi"
+          cpu: 15
+          memory: 50Gi
         requests:
-          cpu: "7"
-          memory: "24Gi"
+          cpu: 15
+          memory: 50Gi
   rerun_auth_config:
     github_team_slugs:
       - org: kubernetes
@@ -120,10 +125,10 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 6
+          cpu: 7
           memory: "12Gi"
         requests:
-          cpu: 6
+          cpu: 7
           memory: "12Gi"
   rerun_auth_config:
     github_team_slugs:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1217,6 +1217,9 @@ periodics:
     description: "Exploratory tests for resource size limit as proposed in https://github.com/kubernetes/kubernetes/issues/134375"
   spec:
     serviceAccountName: prow-build
+    tolerations:
+      - key: highmem
+        operator: Exists
     containers:
     - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260512-1f34ef0df3-master
       command:
@@ -1289,10 +1292,10 @@ periodics:
       resources:
         requests:
           cpu: 7
-          memory: "27Gi"
+          memory: "40Gi"
         limits:
           cpu: 7
-          memory: "27Gi"
+          memory: "40Gi"
 
 # NOTE: When making changes to this job, please ensure that you also keep the original job
 # ci-kubernetes-e2e-gce-scale-performance-100 in sig-scalability-release-blocking-jobs.yaml

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -439,6 +439,9 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-e2e-gce-master-scale-performance-5000
     spec:
       serviceAccountName: prow-build
+      tolerations:
+        - key: highmem
+          operator: Exists
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260512-1f34ef0df3-master
         command:
@@ -510,10 +513,10 @@ presubmits:
         resources:
           requests:
             cpu: 7
-            memory: "27Gi"
+            memory: "40Gi"
           limits:
             cpu: 7
-            memory: "27Gi"
+            memory: "40Gi"
 
   # Mirrors pull-perf-tests-gce-master-scale-performance-100 with CL2_RESTART_APISERVER set to true.
   # TODO(Jefftree): revert after testing to be stable.
@@ -1300,6 +1303,9 @@ presubmits:
       testgrid-tab-name: pull-perf-tests-gce-master-scale-performance-5000
     spec:
       serviceAccountName: prow-build
+      tolerations:
+        - key: highmem
+          operator: Exists
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260512-1f34ef0df3-master
         command:
@@ -1370,7 +1376,7 @@ presubmits:
         resources:
           requests:
             cpu: 7
-            memory: "27Gi"
+            memory: "40Gi"
           limits:
             cpu: 7
-            memory: "27Gi"
+            memory: "40Gi"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -115,6 +115,9 @@ periodics:
     description: "Uses kubetest2 to run k8s.io/perf-tests/run-e2e.sh against a 5000-node cluster created with kops"
   spec:
     serviceAccountName: prow-build
+    tolerations:
+      - key: highmem
+        operator: Exists
     containers:
     - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260512-1f34ef0df3-master
       command:
@@ -183,10 +186,10 @@ periodics:
       resources:
         requests:
           cpu: 7
-          memory: "27Gi"
+          memory: "40Gi"
         limits:
           cpu: 7
-          memory: "27Gi"
+          memory: "40Gi"
 
 - name: ci-kubernetes-e2e-gce-scale-performance-100
   tags:

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -64,6 +64,16 @@ var buildClusters = []string{
 	"k8s-infra-s390x-prow-build",
 }
 
+// These are special prowjobs that can't fit on our standard build nodes
+// They should be be configured with appropriate nodeSelectors/tolerations
+var jobsExemptFromResourceLimits = []string{
+	"ci-kubernetes-build",
+	"ci-kubernetes-e2e-gce-scale-performance-5000",
+	"ci-kubernetes-e2e-gce-scale-resource-size",
+	"pull-kubernetes-gce-master-scale-performance-5000",
+	"pull-perf-tests-gce-master-scale-performance-5000",
+}
+
 func matchesAnyRegex(job string, patterns []string) (bool, error) {
 	if job == "" || len(patterns) == 0 {
 		return false, nil
@@ -1122,7 +1132,7 @@ func allStaticJobs() []cfg.JobBase {
 	return jobs
 }
 
-func verifyPodQOSGuaranteed(spec *coreapi.PodSpec, required bool) (errs []error) {
+func verifyPodQOSGuaranteed(spec *coreapi.PodSpec, required bool, jobName string) (errs []error) {
 	should := "should"
 	if required {
 		should = "must"
@@ -1147,12 +1157,18 @@ func verifyPodQOSGuaranteed(spec *coreapi.PodSpec, required bool) (errs []error)
 			} else if limit.Cmp(request) != 0 {
 				errs = append(errs, fmt.Errorf("resources.limits[%v] (%v) %v match resources.request[%v] (%v)", r, limit.String(), should, r, request.String()))
 			} else if r == coreapi.ResourceMemory {
+				if slices.Contains(jobsExemptFromResourceLimits, jobName) {
+					continue
+				}
 				// Enforce a maximum memory limit to allow jobs to fit in an 8 core, 30G Node
 				maxMem := resource.MustParse("27Gi")
 				if limit.Cmp(maxMem) > 0 {
 					errs = append(errs, fmt.Errorf("container '%v' resources.limits[%v] (%v) %v be at most %v", c.Name, r, limit.String(), should, maxMem.String()))
 				}
 			} else if r == coreapi.ResourceCPU {
+				if slices.Contains(jobsExemptFromResourceLimits, jobName) {
+					continue
+				}
 				// Enforce a maximum CPU limit to allow jobs to fit in an 8 core, 30G Node
 				maxCPU := resource.MustParse("7")
 				if limit.Cmp(maxCPU) > 0 {
@@ -1274,7 +1290,7 @@ func TestK8sInfraProwBuildJobsCIPolicy(t *testing.T) {
 			continue
 		}
 		// job Pod must qualify for Guaranteed QoS
-		errs := verifyPodQOSGuaranteed(job.Spec, true)
+		errs := verifyPodQOSGuaranteed(job.Spec, true, job.Name)
 		if len(errs) > 0 {
 			jobsToFix++
 		}


### PR DESCRIPTION
We spawned 2 special nodepools designed for build jobs (size of 2 all the time) and highmem(scales from 1 to as many needed).

Fixes: #37056
Closes: #37059

@serathius 