### PR TITLE
Add list benchmark periodic jobs for yaml, table, json-pretty

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1177,7 +1177,7 @@ periodics:
           cpu: 3
           memory: "8Gi"
 
-- interval: 4h
+- interval: 24h
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-benchmark-list-yaml
   tags:
@@ -1249,7 +1249,7 @@ periodics:
           cpu: 3
           memory: "8Gi"
 
-- interval: 4h
+- interval: 24h
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-benchmark-list-table
   tags:
@@ -1321,7 +1321,7 @@ periodics:
           cpu: 3
           memory: "8Gi"
 
-- interval: 4h
+- interval: 24h
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-benchmark-list-json-pretty
   tags:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1177,6 +1177,222 @@ periodics:
           cpu: 3
           memory: "8Gi"
 
+- interval: 4h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-benchmark-list-yaml
+  tags:
+    - "perfDashPrefix: benchmark list yaml"
+    - "perfDashJobType: benchmarkList"
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-periodics: "true"
+    preset-e2e-scalability-periodics-master: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  annotations:
+    testgrid-dashboards: sig-scalability-benchmarks
+    testgrid-tab-name: gce-benchmark-list-yaml
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260511-f09cee265c-master
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=benchmark-list
+      - --extract=ci/latest
+      - --gcp-master-size=n2-standard-32
+      - --gcp-node-size=e2-standard-32
+      - --gcp-node-image=gci
+      - --gcp-nodes=1
+      - --gcp-project-type=scalability-project
+      - --gcp-zone=us-east1-b
+      - --provider=gce
+      - --metadata-sources=cl2-metadata.json
+      - --env=KUBE_FEATURE_GATES=DetectCacheInconsistency=false
+      - --env=KUBE_GCE_PRIVATE_CLUSTER=false
+      - --env=CL2_LIST_CONFIG_MAP_BYTES=100000
+      - --env=CL2_LIST_CONFIG_MAP_NUMBER=10000
+      - --env=CL2_LIST_BENCHMARK_PODS=10
+      - --env=CL2_LIST_BENCHMARK_CONTENT_TYPE=yaml
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=1
+      - --test-cmd-args=--provider=gce
+      - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
+      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
+      - --test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true
+      - --test-cmd-args=--report-dir=$(ARTIFACTS)
+      - --test-cmd-args=--testconfig=testing/list/config.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=60m
+      - --use-logexporter
+      - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)
+      resources:
+        requests:
+          cpu: 3
+          memory: "8Gi"
+        limits:
+          cpu: 3
+          memory: "8Gi"
+
+- interval: 4h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-benchmark-list-table
+  tags:
+    - "perfDashPrefix: benchmark list table"
+    - "perfDashJobType: benchmarkList"
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-periodics: "true"
+    preset-e2e-scalability-periodics-master: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  annotations:
+    testgrid-dashboards: sig-scalability-benchmarks
+    testgrid-tab-name: gce-benchmark-list-table
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260511-f09cee265c-master
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=benchmark-list
+      - --extract=ci/latest
+      - --gcp-master-size=n2-standard-32
+      - --gcp-node-size=e2-standard-32
+      - --gcp-node-image=gci
+      - --gcp-nodes=1
+      - --gcp-project-type=scalability-project
+      - --gcp-zone=us-east1-b
+      - --provider=gce
+      - --metadata-sources=cl2-metadata.json
+      - --env=KUBE_FEATURE_GATES=DetectCacheInconsistency=false
+      - --env=KUBE_GCE_PRIVATE_CLUSTER=false
+      - --env=CL2_LIST_CONFIG_MAP_BYTES=100000
+      - --env=CL2_LIST_CONFIG_MAP_NUMBER=10000
+      - --env=CL2_LIST_BENCHMARK_PODS=10
+      - --env=CL2_LIST_BENCHMARK_CONTENT_TYPE=table
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=1
+      - --test-cmd-args=--provider=gce
+      - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
+      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
+      - --test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true
+      - --test-cmd-args=--report-dir=$(ARTIFACTS)
+      - --test-cmd-args=--testconfig=testing/list/config.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=60m
+      - --use-logexporter
+      - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)
+      resources:
+        requests:
+          cpu: 3
+          memory: "8Gi"
+        limits:
+          cpu: 3
+          memory: "8Gi"
+
+- interval: 4h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-benchmark-list-json-pretty
+  tags:
+    - "perfDashPrefix: benchmark list json-pretty"
+    - "perfDashJobType: benchmarkList"
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-periodics: "true"
+    preset-e2e-scalability-periodics-master: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  annotations:
+    testgrid-dashboards: sig-scalability-benchmarks
+    testgrid-tab-name: gce-benchmark-list-json-pretty
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260511-f09cee265c-master
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=benchmark-list
+      - --extract=ci/latest
+      - --gcp-master-size=n2-standard-32
+      - --gcp-node-size=e2-standard-32
+      - --gcp-node-image=gci
+      - --gcp-nodes=1
+      - --gcp-project-type=scalability-project
+      - --gcp-zone=us-east1-b
+      - --provider=gce
+      - --metadata-sources=cl2-metadata.json
+      - --env=KUBE_FEATURE_GATES=DetectCacheInconsistency=false
+      - --env=KUBE_GCE_PRIVATE_CLUSTER=false
+      - --env=CL2_LIST_CONFIG_MAP_BYTES=100000
+      - --env=CL2_LIST_CONFIG_MAP_NUMBER=10000
+      - --env=CL2_LIST_BENCHMARK_PODS=10
+      - --env=CL2_LIST_BENCHMARK_CONTENT_TYPE=json-pretty
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=1
+      - --test-cmd-args=--provider=gce
+      - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
+      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
+      - --test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true
+      - --test-cmd-args=--report-dir=$(ARTIFACTS)
+      - --test-cmd-args=--testconfig=testing/list/config.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=60m
+      - --use-logexporter
+      - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)
+      resources:
+        requests:
+          cpu: 3
+          memory: "8Gi"
+        limits:
+          cpu: 3
+          memory: "8Gi"
+
 # Exploratory tests for resource size limit as proposed in https://github.com/kubernetes/kubernetes/issues/134375
 - cron: '1 5 1-31/1 * *' # Run daily at 21:01 PST (05:01 UTC)
   name: ci-kubernetes-e2e-gce-scale-resource-size


### PR DESCRIPTION
Adds ci-kubernetes-benchmark-list-{yaml,table,json-pretty} periodics on the sig-scalability-benchmarks dashboard. table/json-pretty depend on kubernetes/perf-tests#4059. Part of kubernetes/kubernetes#130169.