### PR TITLE
Drop no-op CL2_LIST_BENCHMARK_POD_CPU/MEMORY env vars from list-benchmark jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1011,8 +1011,6 @@ periodics:
       - --env=CL2_LIST_CONFIG_MAP_BYTES=100000
       - --env=CL2_LIST_CONFIG_MAP_NUMBER=10000
       - --env=CL2_LIST_BENCHMARK_PODS=10
-      - --env=CL2_LIST_BENCHMARK_POD_CPU=2000
-      - --env=CL2_LIST_BENCHMARK_POD_MEMORY=4096
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
@@ -1084,8 +1082,6 @@ periodics:
       - --env=CL2_LIST_CONFIG_MAP_BYTES=100000
       - --env=CL2_LIST_CONFIG_MAP_NUMBER=10000
       - --env=CL2_LIST_BENCHMARK_PODS=10
-      - --env=CL2_LIST_BENCHMARK_POD_CPU=2000
-      - --env=CL2_LIST_BENCHMARK_POD_MEMORY=4096
       - --env=CL2_LIST_BENCHMARK_CONTENT_TYPE=proto
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
@@ -1158,8 +1154,6 @@ periodics:
       - --env=CL2_LIST_CONFIG_MAP_BYTES=100000
       - --env=CL2_LIST_CONFIG_MAP_NUMBER=10000
       - --env=CL2_LIST_BENCHMARK_PODS=10
-      - --env=CL2_LIST_BENCHMARK_POD_CPU=2000
-      - --env=CL2_LIST_BENCHMARK_POD_MEMORY=4096
       - --env=CL2_LIST_BENCHMARK_CONTENT_TYPE=cbor
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh


### PR DESCRIPTION
These env vars are never plumbed into the perf-tests list benchmark, so removing them is a no-op for job behavior.

https://github.com/search?q=repo%3Akubernetes%2Fperf-tests+CL2_LIST_BENCHMARK_POD_MEMORY&type=code

https://github.com/search?q=repo%3Akubernetes%2Fperf-tests+CL2_LIST_BENCHMARK_POD_CPU&type=code