### PR TITLE
Revert "Restore --parallel=30 for ppc64le slow e2e job"

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-ppc64le-periodics.yaml
@@ -372,7 +372,7 @@ periodics:
                 --up --down --auto-approve --retry-on-tf-failure 3 --ignore-destroy-errors\
                 --break-kubetest-on-upfail true \
                 --build-version $(curl -Ls https://dl.k8s.io/ci/latest.txt) \
-                --test=ginkgo -- --parallel 30 --test-package-dir ci --test-package-marker latest.txt --focus-regex='\[Slow\]' --skip-regex='\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:'
+                --test=ginkgo -- --parallel 15 --test-package-dir ci --test-package-marker latest.txt --focus-regex='\[Slow\]' --skip-regex='\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:'
 
   - name: ci-kubernetes-e2e-ppc64le-serial-kubetest2
     cron: "30 9-17/8 * * *" # every 8h starting at 09:30 UTC


### PR DESCRIPTION
Reverts commit c3c1ae8b00dd81a4a7288b5e7a5ad487cb671745 through https://github.com/kubernetes/test-infra/pull/37053

Reason: Mitigates flakiness in ci-kubernetes-ppc64le-e2e-slow-kubetest2.

The test suite performs better and has fewer flakes running with `--parallel=15` , specifically regarding the test:
`CSI Mock volume attach When CSIDriver AttachRequired changes from true to false should cleanup VolumeAttachment properly [Slow]`

The parallelism can be increased once when the the root cause is identified.