### PR TITLE
DRA: use pre-built binaries for e2e-node canary testing

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -791,8 +791,11 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT=test/e2e_node/e2e_node.test
-          _output/local/bin/linux/amd64/e2e_node.test remote \
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
+          _output/bin/e2e_node.test remote \
+             --ginkgo-binary=_output/bin/ginkgo \
+             --kubelet-binary=_output/bin/kubelet \
+             --e2e-node-binary=_output/bin/e2e_node.test \
              --repo-root=. \
              --gcp-zone=us-central1-b \
              --parallelism=1 \
@@ -847,8 +850,11 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT=test/e2e_node/e2e_node.test
-          _output/local/bin/linux/amd64/e2e_node.test remote \
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
+          _output/bin/e2e_node.test remote \
+             --ginkgo-binary=_output/bin/ginkgo \
+             --kubelet-binary=_output/bin/kubelet \
+             --e2e-node-binary=_output/bin/e2e_node.test \
              --repo-root=. \
              --gcp-zone=us-central1-b \
              --parallelism=1 \
@@ -903,8 +909,11 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT=test/e2e_node/e2e_node.test
-          _output/local/bin/linux/amd64/e2e_node.test remote \
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
+          _output/bin/e2e_node.test remote \
+             --ginkgo-binary=_output/bin/ginkgo \
+             --kubelet-binary=_output/bin/kubelet \
+             --e2e-node-binary=_output/bin/e2e_node.test \
              --repo-root=. \
              --gcp-zone=us-central1-b \
              --parallelism=1 \
@@ -955,8 +964,11 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT=test/e2e_node/e2e_node.test
-          _output/local/bin/linux/amd64/e2e_node.test remote \
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
+          _output/bin/e2e_node.test remote \
+             --ginkgo-binary=_output/bin/ginkgo \
+             --kubelet-binary=_output/bin/kubelet \
+             --e2e-node-binary=_output/bin/e2e_node.test \
              --repo-root=. \
              --gcp-zone=us-central1-b \
              --parallelism=1 \
@@ -1004,8 +1016,11 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT=test/e2e_node/e2e_node.test
-          _output/local/bin/linux/amd64/e2e_node.test remote \
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
+          _output/bin/e2e_node.test remote \
+             --ginkgo-binary=_output/bin/ginkgo \
+             --kubelet-binary=_output/bin/kubelet \
+             --e2e-node-binary=_output/bin/e2e_node.test \
              --repo-root=. \
              --gcp-zone=us-central1-b \
              --parallelism=1 \
@@ -1056,8 +1071,11 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT=test/e2e_node/e2e_node.test
-          _output/local/bin/linux/amd64/e2e_node.test remote \
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
+          _output/bin/e2e_node.test remote \
+             --ginkgo-binary=_output/bin/ginkgo \
+             --kubelet-binary=_output/bin/kubelet \
+             --e2e-node-binary=_output/bin/e2e_node.test \
              --repo-root=. \
              --gcp-zone=us-central1-b \
              --parallelism=1 \

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -100,8 +100,11 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT=test/e2e_node/e2e_node.test
-          _output/local/bin/linux/amd64/e2e_node.test remote \
+          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
+          _output/bin/e2e_node.test remote \
+             --ginkgo-binary=_output/bin/ginkgo \
+             --kubelet-binary=_output/bin/kubelet \
+             --e2e-node-binary=_output/bin/e2e_node.test \
              --repo-root=. \
              --gcp-zone=us-central1-b \
              --parallelism=1 \


### PR DESCRIPTION
The benefit is that long-term we might be able to get rid of a bunch of code inside test/e2e_node for building binaries. Short-term it enables running these tests from release archives.

/assign @bart0sh 