### PR TITLE
Marking Old EKS Version Test as non-optional

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -419,8 +419,7 @@ presubmits:
   - name: pull-aws-ebs-csi-driver-external-test-eks-oldest
     cluster: eks-prow-build-cluster
     decorate: true
-    optional: true
-    skip_report: true
+    optional: false
     skip_branches:
       - gh-pages
     skip_if_only_changed: "^docs/|^examples/|.md$|OWNERS$|^.github/"


### PR DESCRIPTION
Marking Old EKS Version Test as non-optional and removed `skip_reporting` as it has been [reliably passing](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-aws-ebs-csi-driver-external-test-eks-oldest).