### PR TITLE
Setting AZURE_VM_TYPE for windows azuredisk-csi-driver tests

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -58,6 +58,9 @@ periodics:
           requests:
             cpu: 4
             memory: 8Gi
+        env:
+          - name: AZURE_VM_TYPE # azuredisk-csi-driver config
+            value: "standard"
   annotations:
     testgrid-dashboards: provider-azure-azuredisk-csi-driver, sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: ci-azuredisk-csi-driver-e2e-capz-windows


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/6305

The azuredisk-csi jobs on windows are confiurged with VMs but the azuredisk e2e tests default to assuming VMSS instances.
This env var should sesolve issues like

```log
E0518 01:43:41.982641   20263 azure_controller_common.go:644] error of getting data disks for node capz-conf-54ktl: not a vmss instance
  I0518 01:43:41.982944 20263 pre_provisioned_dangling_attach_volume_tester.go:80] Unexpected error: 
      <*status.Error | 0x2ce5ec816540>: 
      rpc error: code = Internal desc = could not get disk lun for volume /subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/azuredisk-csi-driver-test-cdb7f747-5e78-4fa0-b81a-d727d8d620eb/providers/Microsoft.Compute/disks/reattach-disk-multiple-nodes: not a vmss instance
      {
          s: {
              s: {
                  state: {
                      NoUnkeyedLiterals: {},
                      DoNotCompare: [],
                      DoNotCopy: [],
                      atomicMessageInfo: nil,
                  },
                  sizeCache: 0,
                  unknownFields: nil,
                  Code: 13,
                  Message: "could not get disk lun for volume /subscriptions/46678f10-4bbb-447e-98e8-d2829589f2d8/resourceGroups/azuredisk-csi-driver-test-cdb7f747-5e78-4fa0-b81a-d727d8d620eb/providers/Microsoft.Compute/disks/reattach-disk-multiple-nodes: not a vmss instance",
                  Details: nil,
              },
          },
      }
  I0518 01:43:41.983236 20263 testsuites.go:364] deleting PVC "azuredisk-6819"/"pvc-vft2n"
  I0518 01:43:41.983275 20263 pv.go:205] Deleting PersistentVolumeClaim "pvc-vft2n"
  I0518 01:43:42.195080 20263 testsuites.go:1189] Waiting up to 5m0s for PersistentVolumeClaim pvc-vft2n to be removed
  I0518 01:43:42.388456 20263 testsuites.go:1194] Claim "pvc-vft2n" in namespace "azuredisk-6819" doesn't exist in the system
  [1mSTEP:[0m deleting PV "azuredisk-6819-disk.csi.azure.com-preprovisioned-pv-pkcvp" [38;5;243m@ 05/18/26 01:43:42.388[0m
  I0518 01:43:42.388555 20263 pv.go:193] Deleting PersistentVolume "azuredisk-6819-disk.csi.azure.com-preprovisioned-pv-pkcvp"
  ```
  
 seen in https://testgrid.k8s.io/provider-azure-azuredisk-csi-driver#ci-azuredisk-csi-driver-e2e-capz-windows
