### PR TITLE
Kueue: align resources for integration tests periodics and presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -108,14 +108,14 @@ periodics:
             - test-integration-baseline
           env:
             - name: GOMAXPROCS
-              value: "6"
+              value: "7"
           resources:
             requests:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
             limits:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-extended-main
     cluster: eks-prow-build-cluster
@@ -146,14 +146,14 @@ periodics:
             - test-integration-extended
           env:
             - name: GOMAXPROCS
-              value: "6"
+              value: "7"
           resources:
             requests:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
             limits:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-multikueue-main
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
@@ -69,14 +69,14 @@ periodics:
             - test-integration-baseline
           env:
             - name: GOMAXPROCS
-              value: "6"
+              value: "7"
           resources:
             requests:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
             limits:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-extended-release-0-16
     cluster: eks-prow-build-cluster
@@ -107,14 +107,14 @@ periodics:
             - test-integration-extended
           env:
             - name: GOMAXPROCS
-              value: "6"
+              value: "7"
           resources:
             requests:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
             limits:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-multikueue-release-0-16
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -108,14 +108,14 @@ periodics:
             - test-integration-baseline
           env:
             - name: GOMAXPROCS
-              value: "6"
+              value: "7"
           resources:
             requests:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
             limits:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-extended-release-0-17
     cluster: eks-prow-build-cluster
@@ -146,14 +146,14 @@ periodics:
             - test-integration-extended
           env:
             - name: GOMAXPROCS
-              value: "6"
+              value: "7"
           resources:
             requests:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
             limits:
-              cpu: "6"
-              memory: "9Gi"
+              cpu: "7"
+              memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-multikueue-release-0-17
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
To align the resources between periodic and presubmit jobs, so that the time results are comparable.

The presubmits now run around 2min faster then periodics which shows that the jobs are saturated on cpu.