### PR TITLE
Kops - Drop GCE grid job frequency to one per week

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -650,7 +650,6 @@ def generate_grid():
                                 ])
                     results.append(
                         build_test(cloud="gce",
-                                   runs_per_day=2,
                                    distro=distro_short,
                                    extra_dashboards=['kops-grid'],
                                    k8s_version=k8s_version,


### PR DESCRIPTION
We initially ran these twice per day because there weren't many jobs (only newer kops and k8s versions) and the faster feedback was valuable. As more kops versions (in scope of the grid tests) supported these GCE jobs, the total number of runs per week exploded. This brings them in-line with AWS grid jobs.

```diff
diff --git a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
index 90a9a0a8d4..f25e063dd7 100644
--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -1,5 +1,5 @@
 # Test jobs generated by build_jobs.py (do not manually edit)
-# 2967 jobs, total of 18138 runs per week
+# 2967 jobs, total of 2967 runs per week
```

/cc @hakman
/cc @dims