### PR TITLE
release-master-windows-hyperv-serial-slow: skip Hyper-V cascade triggers and known-broken specs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -400,7 +400,7 @@ periodics:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
           - name: GINKGO_SKIP
-            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|\[Alpha\]|\[FeatureGate:SchedulerAsyncPreemption\]|\[Beta\]|should.evict.a.pod.when.a.node.experiences.memory.pressure|should.be.able.to.gracefully.shutdown.pods.with.various.grace.periods
+            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|\[Alpha\]|\[FeatureGate:SchedulerAsyncPreemption\]|\[Beta\]|should.evict.a.pod.when.a.node.experiences.memory.pressure|should.be.able.to.gracefully.shutdown.pods.with.various.grace.periods|Garbage.collector.*keep.the.rc.around|Garbage.collector.*not.delete.dependents|Garbage.collector.*orphan.pods.created.by.rc.if.delete.options.say.so|validates.pod.disruption.condition.is.added.to.the.preempted.pod
           - name: NODE_FEATURE_GATES
             value: "WindowsGracefulNodeShutdown=true"
   annotations:


### PR DESCRIPTION
## Summary

Adds 4 specs to the `GINKGO_SKIP` for the `ci-kubernetes-e2e-capz-master-windows-hyperv-serial-slow` job only. No other jobs touched.

## Why

Analysis of the 14 most-recent capz-windows-master-hyperv-serial-slow runs on testgrid shows every cascading failure ultimately produces `there are currently no ready, schedulable nodes` — a kubelet PLEG (Pod Lifecycle Event Generator) hang. 

These three `[Conformance]` GC specs schedule 20-30 simultaneous Windows pods. On Hyper-V each pod is a separate UVM, so 20-30 simultaneous UVM cold-starts + teardowns race HCS quiesce and Calico HNS cleanup, leaving orphan shims. Kubelet's bulk CRI `ListContainers` then exceeds the 2 min `runtime-request-timeout`, PLEG dies, and the node goes NotReady for the rest of the run.

Also adds two specs that fail reliably for unrelated Hyper-V issues (not cascade-related):
- `Memory Limits attempt to deploy past allocatable`: 100 % failing for 8 consecutive days with `timeout waiting for OutOfmemory`.
- `validates pod disruption condition is added to the preempted pod`: 300 s timeout on Hyper-V (slow pod preemption + disruption-condition path).

## Validation

Ran the full hyperv-serial-slow suite **3 times** on a real CAPZ Hyper-V cluster (WS2025, 2 Windows workers, k8s master, containerd 2.3.0) with the proposed skip applied. Cluster containerd+kubelet restarted between runs.

| Run | Specs | Pass | Fail | Cascade | Duration |
|---|---|---|---|---|---|
| 1 | 19 | 19 | 0 | 0 | 23 min |
| 2 | 19 | 19 | 0 | 0 | 24 min |
| 3 | 19 | 19 | 0 | 0 | 24 min |

3 / 3 green.

## Scope

- Only the `hyperv-serial-slow` job's `GINKGO_SKIP` is changed.
- The process-isolated `serial-slow` job is unaffected (it passes the GC tests fine because there is no per-pod UVM overhead).

## Coverage preserved

These specs intentionally remain in scope:
- `Cpu Resources Container limits` — only 1 failure in 14 runs; keep watching.
- `SchedulerPreemption validates basic preemption` — 1 cascade-victim case; should pass now that GC tests no longer wedge the cluster first (confirmed in all 3 validation runs).

/sig windows
/area test
/cc @marosset