### PR TITLE
gubernator: format junit.xml in README

### DIFF
--- a/gubernator/README.md
+++ b/gubernator/README.md
@@ -2,7 +2,7 @@
 
 Gubernator is a frontend for displaying Kubernetes test results stored in GCS.
 
-It runs on Google App Engine, and parses JSON and junit.xml results for display.
+It runs on Google App Engine, and parses JSON and `junit.xml` results for display.
 
 https://gubernator.k8s.io/
 


### PR DESCRIPTION
This formats `junit.xml` as inline code in the Gubernator README.