### PR TITLE
gubernator: preserve recent batch builds

### DIFF
--- a/gubernator/view_pr.py
+++ b/gubernator/view_pr.py
@@ -84,6 +84,19 @@ def get_pull_prefix(config, org):
     return config['default_external_services']['gcs_pull_prefix']
 
 
+def trim_batch_builds(builds, cutoff):
+    """Return only batch builds newer than the cutoff timestamp."""
+    filtered = {}
+    for job, job_builds in builds.iteritems():
+        keep = [
+            (build, started, finished) for build, started, finished in job_builds
+            if not started or started.get('timestamp') > cutoff
+        ]
+        if keep:
+            filtered[job] = keep
+    return filtered
+
+
 class PRHandler(view_base.BaseHandler):
     """Show a list of test runs for a PR."""
     def get(self, path, pr):
@@ -104,12 +117,7 @@ class PRHandler(view_base.BaseHandler):
                 bs.sort(key=lambda (b, s, f): -(s or {}).get('timestamp', 0))
         if pr == 'batch':  # truncate batch results to last day
             cutoff = time.time() - 60 * 60 * 24
-            builds = {}
-            for job, job_builds in builds.iteritems():
-                builds[job] = [
-                    (b, s, f) for b, s, f in job_builds
-                    if not s or s.get('timestamp') > cutoff
-                ]
+            builds = trim_batch_builds(builds, cutoff)
 
         max_builds, headings, rows = pull_request.builds_to_table(builds)
         digest = ghm.GHIssueDigest.get('%s/%s' % (org, repo), pr)

--- a/gubernator/view_pr_test.py
+++ b/gubernator/view_pr_test.py
@@ -56,6 +56,27 @@ class PathTest(unittest.TestCase):
         check('google', 'cadvisor', '555', 'google_cadvisor/555')
         check('google', 'cadvisor', 'batch', 'google_cadvisor/batch')
 
+    def test_trim_batch_builds(self):
+        builds = {
+            'recent-job': [
+                ('11', {'timestamp': 200}, {'result': 'PASSED'}),
+                ('10', {'timestamp': 50}, {'result': 'FAILED'}),
+            ],
+            'stale-job': [
+                ('9', {'timestamp': 25}, {'result': 'FAILED'}),
+            ],
+            'unfinished-job': [
+                ('8', None, None),
+            ],
+        }
+
+        actual = view_pr.trim_batch_builds(builds, 100)
+
+        self.assertEqual(actual, {
+            'recent-job': [('11', {'timestamp': 200}, {'result': 'PASSED'})],
+            'unfinished-job': [('8', None, None)],
+        })
+
 
 class PRTest(main_test.TestBase):
     BUILDS = {


### PR DESCRIPTION
## Summary
Fix batch PR view truncation in Gubernator.

The current `pr == "batch"` path resets the `builds` map before filtering, so batch builds are dropped instead of being truncated to the last 24 hours.

## Changes
- add a `trim_batch_builds` helper
- preserve only recent batch builds instead of clearing the map
- add a unit test covering the filtering behavior
