### PR TITLE
Add minikube's auto-pause image to staging

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-minikube.yaml
+++ b/config/jobs/image-pushing/k8s-staging-minikube.yaml
@@ -7,7 +7,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/images/kubernetes-bootcamp/|hack/prow/image/kubernetes-bootcamp/|hack/prow/prow_images.mk)"
+      run_if_changed: "^(deploy/images/kubernetes-bootcamp/|hack/prow/image/kubernetes-bootcamp/|hack/prow/prow_images\.mk$)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -30,7 +30,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/images/gvisor/|hack/prow/image/gvisor/|hack/prow/prow_images.mk)"
+      run_if_changed: "^(deploy/images/gvisor/|hack/prow/image/gvisor/|hack/prow/prow_images\.mk$)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -53,7 +53,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/images/kube-registry-proxy|hack/prow/image/kube-registry-proxy/|hack/prow/prow_images.mk)"
+      run_if_changed: "^(deploy/images/kube-registry-proxy|hack/prow/image/kube-registry-proxy/|hack/prow/prow_images\.mk$)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -76,7 +76,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/kicbase/|hack/prow/image/kicbase/|hack/prow/prow_images.mk)"
+      run_if_changed: "^(deploy/kicbase/|hack/prow/image/kicbase/|hack/prow/prow_images\.mk$)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -99,7 +99,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/iso/minikube-iso/Dockerfile|hack/prow/image/buildroot-image/|hack/prow/prow_images.mk)"
+      run_if_changed: "^(deploy/iso/minikube-iso/Dockerfile|hack/prow/image/buildroot-image/|hack/prow/prow_images\.mk$)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -122,7 +122,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/storage-provisioner/|pkg/storage/|hack/prow/image/storage-provisioner/|hack/prow/prow_images.mk)"
+      run_if_changed: "^(deploy/storage-provisioner/|pkg/storage/|hack/prow/image/storage-provisioner/|hack/prow/prow_images\.mk$)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -145,7 +145,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/addons/auto-pause/|cmd/auto-pause/|hack/prow/image/auto-pause/|hack/prow/prow_images.mk)"
+      run_if_changed: "^(deploy/addons/auto-pause/|cmd/auto-pause/|hack/prow/image/auto-pause/|hack/prow/prow_images\.mk$)"
       spec:
         serviceAccountName: gcb-builder
         containers:

--- a/config/jobs/image-pushing/k8s-staging-minikube.yaml
+++ b/config/jobs/image-pushing/k8s-staging-minikube.yaml
@@ -53,7 +53,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: '^(deploy/images/kube-registry-proxy|hack/prow/image/kube-registry-proxy/|hack/prow/prow_images\.mk$)'
+      run_if_changed: '^(deploy/images/kube-registry-proxy/|hack/prow/image/kube-registry-proxy/|hack/prow/prow_images\.mk$)'
       spec:
         serviceAccountName: gcb-builder
         containers:

--- a/config/jobs/image-pushing/k8s-staging-minikube.yaml
+++ b/config/jobs/image-pushing/k8s-staging-minikube.yaml
@@ -138,3 +138,26 @@ postsubmits:
             env:
               - name: LOG_TO_STDOUT
                 value: "y"
+    - name: post-minikube-auto-pause-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: minikube-images, sig-k8s-infra-gcb
+      decorate: true
+      branches:
+        - ^master$
+      run_if_changed: '^(deploy/addons/auto-pause/|cmd/auto-pause/)'
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20260419-39c657fdbf
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-images
+              - --scratch-bucket=gs://k8s-staging-images-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - --gcb-config=hack/prow/image/auto-pause/cloudbuild.yaml
+              - .
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"

--- a/config/jobs/image-pushing/k8s-staging-minikube.yaml
+++ b/config/jobs/image-pushing/k8s-staging-minikube.yaml
@@ -7,7 +7,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^deploy/images/kubernetes-bootcamp/"
+      run_if_changed: "^(deploy/images/kubernetes-bootcamp/|hack/prow/image/kubernetes-bootcamp/|hack/prow/prow_images.mk)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -30,7 +30,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^deploy/images/gvisor/"
+      run_if_changed: "^(deploy/images/gvisor/|hack/prow/image/gvisor/|hack/prow/prow_images.mk)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -53,7 +53,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^deploy/images/kube-registry-proxy"
+      run_if_changed: "^(deploy/images/kube-registry-proxy|hack/prow/image/kube-registry-proxy/|hack/prow/prow_images.mk)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -76,7 +76,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^deploy/kicbase/"
+      run_if_changed: "^(deploy/kicbase/|hack/prow/image/kicbase/|hack/prow/prow_images.mk)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -99,7 +99,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^deploy/iso/minikube-iso/Dockerfile"
+      run_if_changed: "^(deploy/iso/minikube-iso/Dockerfile|hack/prow/image/buildroot-image/|hack/prow/prow_images.mk)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -122,7 +122,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: '^(deploy/storage-provisioner/|pkg/storage/)'
+      run_if_changed: "^(deploy/storage-provisioner/|pkg/storage/|hack/prow/image/storage-provisioner/|hack/prow/prow_images.mk)"
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -145,7 +145,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: '^(deploy/addons/auto-pause/|cmd/auto-pause/)'
+      run_if_changed: "^(deploy/addons/auto-pause/|cmd/auto-pause/|hack/prow/image/auto-pause/|hack/prow/prow_images.mk)"
       spec:
         serviceAccountName: gcb-builder
         containers:

--- a/config/jobs/image-pushing/k8s-staging-minikube.yaml
+++ b/config/jobs/image-pushing/k8s-staging-minikube.yaml
@@ -7,7 +7,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/images/kubernetes-bootcamp/|hack/prow/image/kubernetes-bootcamp/|hack/prow/prow_images\.mk$)"
+      run_if_changed: '^(deploy/images/kubernetes-bootcamp/|hack/prow/image/kubernetes-bootcamp/|hack/prow/prow_images\.mk$)'
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -30,7 +30,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/images/gvisor/|hack/prow/image/gvisor/|hack/prow/prow_images\.mk$)"
+      run_if_changed: '^(deploy/images/gvisor/|hack/prow/image/gvisor/|hack/prow/prow_images\.mk$)'
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -53,7 +53,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/images/kube-registry-proxy|hack/prow/image/kube-registry-proxy/|hack/prow/prow_images\.mk$)"
+      run_if_changed: '^(deploy/images/kube-registry-proxy|hack/prow/image/kube-registry-proxy/|hack/prow/prow_images\.mk$)'
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -76,7 +76,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/kicbase/|hack/prow/image/kicbase/|hack/prow/prow_images\.mk$)"
+      run_if_changed: '^(deploy/kicbase/|hack/prow/image/kicbase/|hack/prow/prow_images\.mk$)'
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -99,7 +99,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/iso/minikube-iso/Dockerfile|hack/prow/image/buildroot-image/|hack/prow/prow_images\.mk$)"
+      run_if_changed: '^(deploy/iso/minikube-iso/Dockerfile|hack/prow/image/buildroot-image/|hack/prow/prow_images\.mk$)'
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -122,7 +122,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/storage-provisioner/|pkg/storage/|hack/prow/image/storage-provisioner/|hack/prow/prow_images\.mk$)"
+      run_if_changed: '^(deploy/storage-provisioner/|pkg/storage/|hack/prow/image/storage-provisioner/|hack/prow/prow_images\.mk$)'
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -145,7 +145,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-      run_if_changed: "^(deploy/addons/auto-pause/|cmd/auto-pause/|hack/prow/image/auto-pause/|hack/prow/prow_images\.mk$)"
+      run_if_changed: '^(deploy/addons/auto-pause/|cmd/auto-pause/|hack/prow/image/auto-pause/|hack/prow/prow_images\.mk$)'
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
- adding minikube's auto-pause image to staging registry 
- also Update the `run_if_changed` regex patterns in k8s-staging-minikube.yaml for all 7 staging postsubmits. 
Each job will now trigger not only on source directory changes, but
- also when its corresponding Google Cloud Build config under
`hack/prow/image/<image-name>/` or the shared Makefile
`hack/prow/prow_images.mk` is modified.

Part of bigger effort https://github.com/kubernetes/minikube/issues/20887
follow up from https://github.com/kubernetes/minikube/pull/23021
closes 
https://github.com/kubernetes/minikube/issues/23010