### PR TITLE
kubespray: add image-builder staging push postsubmit

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kubespray.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kubespray.yaml
@@ -1,0 +1,23 @@
+postsubmits:
+  kubernetes-sigs/kubespray:
+    - name: post-kubespray-push-kubevirt-image-builder-canary
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-cluster-lifecycle-kubespray, sig-k8s-infra-gcb
+        testgrid-tab-name: kubevirt-image-builder-push
+      decorate: true
+      run_if_changed: '^test-infra/image-builder/.*'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20260419-39c657fdbf
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-images
+              - --scratch-bucket=gs://k8s-staging-images-gcb
+              - --build-dir=.
+              - --gcb-config=test-infra/image-builder/cloudbuild-staging.yaml
+              - .


### PR DESCRIPTION
## What this PR does / why we need it

Adds a trusted postsubmit job for Kubespray image-builder to publish a single canary image to the community-owned OCI staging registry.

This follows the existing `config/jobs/image-pushing` pattern and runs through Cloud Build instead of mounting registry credentials into a normal Prow job.

## Changes

- Adds `post-kubespray-push-kubevirt-image-builder-canary`
- Runs in `k8s-infra-prow-build-trusted`
- Uses `gcb-builder`
- Calls Kubespray's `test-infra/image-builder/cloudbuild-staging.yaml`
- Starts with `ubuntu-2404` only

## Context

Related Kubespray issue:
- https://github.com/kubernetes-sigs/kubespray/issues/12383

Related staging registry setup:
- kubernetes/k8s.io PR: https://github.com/kubernetes/k8s.io/pull/9521

Related Kubespray publish config:
- kubernetes-sigs/kubespray PR: https://github.com/kubernetes-sigs/kubespray/pull/13273

## Does this PR introduce a user-facing change?

NONE