### PR TITLE
triage: bump alpine base image to 3.20

### DIFF
--- a/triage/Dockerfile
+++ b/triage/Dockerfile
@@ -35,9 +35,9 @@ RUN env GOOS=linux \
 
 
 # Stage 2
-FROM alpine:3.15.6
+FROM alpine:3.20
 
-# Google Cloud SDK requires python 3.9+ (https://cloud.google.com/python/setup#installing_the_cloud_sdk).
+# Google Cloud SDK requires python 3.10+ (https://cloud.google.com/python/setup#installing_the_cloud_sdk).
 # update_summaries.sh requires bash.
 RUN apk add --no-cache \
     python3 \


### PR DESCRIPTION
Trying to fix:
```
+ gcloud config set project k8s-infra-prow-build-trusted
ERROR: gcloud failed to load. You are running gcloud with Python 3.9, which is no longer supported by gcloud.
Install a compatible version of Python 3.10-3.14 and set the CLOUDSDK_PYTHON environment variable to point to it.

If you are still experiencing problems, please reinstall the Google Cloud CLI using the instructions here:
    https://cloud.google.com/sdk/docs/install
```
from https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-test-infra-triage/2059032177818996736/build-log.txt