### PR TITLE
triage: bump ci-test-infra-triage timeout to 5h

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -147,7 +147,7 @@ periodics:
     base_ref: master
     path_alias: k8s.io/test-infra
   decoration_config:
-    timeout: 3h
+    timeout: 5h
   max_concurrency: 1
   annotations:
     testgrid-num-failures-to-alert: '18'

--- a/triage/Dockerfile
+++ b/triage/Dockerfile
@@ -53,4 +53,4 @@ COPY --from=build /test-infra/triage/triage /
 COPY --from=build /test-infra/triage/update_summaries.sh /
 COPY --from=build /test-infra/triage/generate_job_repos.py /
 
-ENTRYPOINT ["timeout", "10800", "/update_summaries.sh"]
+ENTRYPOINT ["timeout", "18000", "/update_summaries.sh"]


### PR DESCRIPTION
Bump timeout for https://github.com/kubernetes/test-infra/issues/37091

Tried a few things already there, going with this now temporarily. There were LOT of failures in kops ci jobs in the time period which throws off the algorithm i think. Hopefully this should settle down now.