### PR TITLE
Shard Kueue Integration Test Jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -79,14 +79,14 @@ periodics:
               cpu: "6"
               memory: "6Gi"
   - interval: 12h
-    name: periodic-kueue-test-integration-baseline-main
+    name: periodic-kueue-test-integration-shard-0-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-integration-baseline-main
+      testgrid-tab-name: periodic-kueue-test-integration-shard-0-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue test-integration-baseline"
+      description: "Run periodic kueue test-integration shard 0"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -105,10 +105,14 @@ periodics:
           command:
             - make
           args:
-            - test-integration-baseline
+            - test-integration
           env:
             - name: GOMAXPROCS
               value: "7"
+            - name: INTEGRATION_SHARD_INDEX
+              value: "0"
+            - name: INTEGRATION_TOTAL_SHARDS
+              value: "3"
           resources:
             requests:
               cpu: "7"
@@ -117,14 +121,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-integration-extended-main
+    name: periodic-kueue-test-integration-shard-1-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-integration-extended-main
+      testgrid-tab-name: periodic-kueue-test-integration-shard-1-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue test-integration-extended"
+      description: "Run periodic kueue test-integration shard 1"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -143,10 +147,56 @@ periodics:
           command:
             - make
           args:
-            - test-integration-extended
+            - test-integration
           env:
             - name: GOMAXPROCS
               value: "7"
+            - name: INTEGRATION_SHARD_INDEX
+              value: "1"
+            - name: INTEGRATION_TOTAL_SHARDS
+              value: "3"
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-integration-shard-2-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-integration-shard-2-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue test-integration shard 2"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.26
+          command:
+            - make
+          args:
+            - test-integration
+          env:
+            - name: GOMAXPROCS
+              value: "7"
+            - name: INTEGRATION_SHARD_INDEX
+              value: "2"
+            - name: INTEGRATION_TOTAL_SHARDS
+              value: "3"
           resources:
             requests:
               cpu: "7"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -30,7 +30,7 @@ presubmits:
               limits:
                 cpu: "6"
                 memory: "6Gi"
-    - name: pull-kueue-test-integration-baseline-main
+    - name: pull-kueue-test-integration-shard-0-main
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -39,18 +39,22 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-integration-baseline-main
-        description: "Run kueue test-integration-baseline"
+        testgrid-tab-name: pull-kueue-test-integration-shard-0-main
+        description: "Run kueue test-integration shard 0"
       spec:
         containers:
           - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
-              - test-integration-baseline
+              - test-integration
             env:
               - name: GOMAXPROCS
                 value: "7"
+              - name: INTEGRATION_SHARD_INDEX
+                value: "0"
+              - name: INTEGRATION_TOTAL_SHARDS
+                value: "3"
             resources:
               requests:
                 cpu: "7"
@@ -58,7 +62,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-integration-extended-main
+    - name: pull-kueue-test-integration-shard-1-main
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -67,18 +71,54 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-integration-extended-main
-        description: "Run kueue test-integration-extended"
+        testgrid-tab-name: pull-kueue-test-integration-shard-1-main
+        description: "Run kueue test-integration shard 1"
       spec:
         containers:
           - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
-              - test-integration-extended
+              - test-integration
             env:
               - name: GOMAXPROCS
                 value: "7"
+              - name: INTEGRATION_SHARD_INDEX
+                value: "1"
+              - name: INTEGRATION_TOTAL_SHARDS
+                value: "3"
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-integration-shard-2-main
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-integration-shard-2-main
+        description: "Run kueue test-integration shard 2"
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.26
+            command:
+              - make
+            args:
+              - test-integration
+            env:
+              - name: GOMAXPROCS
+                value: "7"
+              - name: INTEGRATION_SHARD_INDEX
+                value: "2"
+              - name: INTEGRATION_TOTAL_SHARDS
+                value: "3"
             resources:
               requests:
                 cpu: "7"


### PR DESCRIPTION
Complement to https://github.com/kubernetes-sigs/kueue/pull/11629, part of https://github.com/kubernetes-sigs/kueue/issues/11536.

We dynamically shard integration tests, rather than manually labeling tests as slow/redundant. This gets rid of need for baseline/extended targets.

Anytime the test suite runs too long in the future, we can simply add another shard, defined here.

Changes to release branches will be done in separate PRs, for easier rollback if necessary.

PR was LLM generated. I manually reviewed the changes.