### PR TITLE
DRA: generate E2E node presubmits for test-infra

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -21,6 +21,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -108,6 +109,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -212,6 +214,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -316,6 +319,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -453,6 +457,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -590,6 +595,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -727,6 +733,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -19,6 +19,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -106,6 +107,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -213,6 +215,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -338,6 +341,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -463,6 +467,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 90m
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -23,6 +23,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -112,6 +113,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -217,6 +219,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -323,6 +326,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -462,6 +466,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -601,6 +606,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
@@ -740,6 +746,7 @@ presubmits:
     decoration_config:
       timeout: 90m
     path_alias: k8s.io/kubernetes
+    extra_refs:
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master

--- a/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
@@ -1,0 +1,170 @@
+# GENERATED FILE - DO NOT EDIT!
+#
+# Instead, modify dra.jinja and run `make generate-jobs`.
+presubmits:
+  kubernetes/test-infra:
+  - name: pull-test-infra-node-crio-dra
+    cluster: k8s-infra-prow-build
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    always_run: false
+    run_if_changed: /jobs/node_e2e/
+    optional: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    annotations:
+      testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-cri-o
+      description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O
+      testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+      fork-per-release: "true"
+    decorate: true
+    decoration_config:
+      timeout: 90m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
+        command:
+        - runner.sh
+        args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=1
+        - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow'
+        - --timeout=60m
+        - --skip-regex= # Override kubetest2 default in https://github.com/kubernetes-sigs/kubetest2/blob/9f385d26316f5256755bb8fe333970aa5759ec7f/pkg/testers/node/node.go#L92
+        - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config.yaml
+        env:
+        - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+          value: "1"
+        - name: GOPATH
+          value: /go
+        - name: KUBE_SSH_USER
+          value: core
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
+
+  - name: pull-test-infra-node-e2e-containerd-1-7-dra
+    cluster: k8s-infra-prow-build
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    always_run: false
+    run_if_changed: /jobs/node_e2e/
+    optional: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    annotations:
+      testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-containerd
+      description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 1.7
+      testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+      fork-per-release: "true"
+    decorate: true
+    decoration_config:
+      timeout: 90m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
+        command:
+        - runner.sh
+        args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=1
+        - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow'
+        - --timeout=60m
+        - --skip-regex= # Override kubetest2 default in https://github.com/kubernetes-sigs/kubetest2/blob/9f385d26316f5256755bb8fe333970aa5759ec7f/pkg/testers/node/node.go#L92
+        - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
+
+  - name: pull-test-infra-node-e2e-containerd-2-0-dra
+    cluster: k8s-infra-prow-build
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    always_run: false
+    run_if_changed: /jobs/node_e2e/
+    optional: true
+    skip_report: false
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    annotations:
+      testgrid-dashboards: sig-node-dynamic-resource-allocation, sig-node-presubmits, sig-node-containerd
+      description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 2.1
+      testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
+      fork-per-release: "true"
+    decorate: true
+    decoration_config:
+      timeout: 90m
+    path_alias: k8s.io/kubernetes
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+      workdir: true
+    - org: containerd
+      repo: containerd
+      base_ref: release/2.1
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
+        command:
+        - runner.sh
+        args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=1
+        - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow'
+        - --timeout=60m
+        - --skip-regex= # Override kubetest2 default in https://github.com/kubernetes-sigs/kubetest2/blob/9f385d26316f5256755bb8fe333970aa5759ec7f/pkg/testers/node/node.go#L92
+        - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config.yaml
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi

--- a/config/jobs/kubernetes/sig-node/dra.generate.conf
+++ b/config/jobs/kubernetes/sig-node/dra.generate.conf
@@ -6,7 +6,13 @@ template = dra.jinja
 # The name of each generated file is `<base name of template>-<suffix>.yaml`, for example dra-canary.yaml.
 # The name of each generated job is made by substituting `{section}` placeholder with section name, e.g. ci-kind-dra.
 # In the template, <suffix> becomes a boolean which can be used in if checks.
-files = canary:pull-kubernetes-{section}-canary,presubmit:pull-kubernetes-{section},ci:ci-{section}
+#
+# Most of the jobs are for the Kubernetes repo. In addition, some E2E node jobs also get generated
+# for the test-infra repo such that they get triggered when changing the image configurations.
+# The goal is to cover all configurations that are relevant for DRA. This prevents regressions
+# in the Kubernetes jobs because of invalid or unusable image configurations - assuming that
+# the presubmit failures are checked. The jobs are not merge-blocking.
+files = canary:pull-kubernetes-{section}-canary,presubmit:pull-kubernetes-{section},ci:ci-{section},testinfra:pull-test-infra-{section}
 # k8s-infra-prow-build is required for node jobs
 # attempt to run node jobs on eks-prow-build-cluster fails
 # with "boskos failed to acquire project: resources not found" error
@@ -35,6 +41,7 @@ use_dind = true
 cluster = eks-prow-build-cluster
 run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 release_informing = true
+generate = canary,presubmit,ci
 
 # This jobs runs e2e.test with a focus on tests for the Dynamic Resource Allocation feature (currently alpha, soon beta)
 # on a kind cluster with containerd updated to a version with CDI support.
@@ -47,6 +54,7 @@ cluster = eks-prow-build-cluster
 all_features = true
 use_dind = true
 run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+generate = canary,presubmit,ci
 
 # Compared to ci-kind-dra-all, this one also enables slow tests.
 # Needs to be triggered manually.
@@ -69,6 +77,7 @@ use_dind = true
 cluster = eks-prow-build-cluster
 run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 kubelet_skew = 1
+generate = canary,presubmit,ci
 
 # This job runs the current e2e.test against a cluster where the kubelet is from the "current - 2" release.
 #
@@ -80,6 +89,7 @@ use_dind = true
 cluster = eks-prow-build-cluster
 run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 kubelet_skew = 2
+generate = canary,presubmit,ci
 
 # This job runs the current e2e.test against a cluster where the kubelet is from the "current - 3" release.
 #
@@ -91,6 +101,7 @@ use_dind = true
 cluster = eks-prow-build-cluster
 run_if_changed = /(dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
 kubelet_skew = 3
+generate = canary,presubmit,ci
 
 # This executes tests in test/e2e_dra with special requirements (local-up-cluster.sh!).
 # This is an E2E suite, but conceptually it is more like an integration test (the test
@@ -103,6 +114,7 @@ use_dind_cdi = true
 job_type = integration
 cluster = eks-prow-build-cluster
 run_if_changed = /(dra|e2e_dra|dynamicresources|resourceclaim|deviceclass|resourceslice|resourceclaimtemplate|dynamic-resource-allocation|apis/resource|api/resource)/.*\.(go|yaml)
+generate = canary,presubmit,ci
 
 # This job runs the node e2e tests for DRA with CRI-O
 [node-crio-dra]
@@ -113,6 +125,7 @@ description = Runs E2E node tests for Dynamic Resource Allocation on-by-default 
 image_config_file = /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config.yaml
 inject_ssh_public_key = true
 release_informing = true
+generate = canary,presubmit,ci,testinfra
 
 # This job adds all alpha and beta feature gates to node-crio-dra and runs all DRA tests which can work in that configuration.
 [node-crio-dra-alpha-beta-features]
@@ -123,6 +136,7 @@ all_features = true
 description = Runs all E2E node tests for Dynamic Resource Allocation features with CRI-O and with all feature gates enabled (including non-DRA feature gates)
 image_config_file = /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config.yaml
 inject_ssh_public_key = true
+generate = canary,presubmit,ci
 
 # This job runs the same tests as ci-node-crio-dra with Containerd 1.7 runtime
 [node-e2e-containerd-1-7-dra]
@@ -133,6 +147,7 @@ description = Runs E2E node tests for Dynamic Resource Allocation on-by-default 
 image_config_file = /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
 release_informing = true
 run_if_changed = (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resourceslice/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_).*\.(go|yaml)
+generate = canary,presubmit,ci,testinfra
 
 # This job runs the same tests as ci-node-crio-dra with Containerd 2.0 runtime
 [node-e2e-containerd-2-0-dra]
@@ -147,6 +162,7 @@ release_informing = true
 # We switched from CRI-O to containerd because the job seemed to finish a bit sooner and there were failures caused by
 # crio image config changes.
 run_if_changed = (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resourceslice/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_).*\.(go|yaml)
+generate = canary,presubmit,ci,testinfra
 
 # This job adds all alpha and beta feature gates to node-e2e-containerd-1-7-dra and runs all DRA tests which can work in that configuration.
 [node-e2e-containerd-1-7-dra-alpha-beta-features]
@@ -156,6 +172,7 @@ need_test_infra_repo = true
 all_features = true
 description = Runs all E2E node tests for Dynamic Resource Allocation features with containerd 1.7 and with all feature gates enabled (including non-DRA feature gates)
 image_config_file = /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7.yaml
+generate = canary,presubmit,ci
 
 # This job adds all alpha and beta feature gates to node-e2e-containerd-2-0-dra and runs all DRA tests which can work in that configuration.
 [node-e2e-containerd-2-0-dra-alpha-beta-features]
@@ -170,3 +187,4 @@ image_config_file = /home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd
 # We switched from CRI-O to containerd because the job seemed to finish a bit sooner and there were failures caused by
 # crio image config changes.
 run_if_changed = (/dra/|/dynamicresources/|/resourceclaim/|/deviceclass/|/resourceslice/|/resourceclaimtemplate/|/dynamic-resource-allocation/|/pkg/apis/resource/|/api/resource/|/test/e2e_node/dra_).*\.(go|yaml)
+generate = canary,presubmit,ci

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -4,7 +4,11 @@
 periodics:
 {%- else -%}
 presubmits:
+  {%- if testinfra %}
+  kubernetes/test-infra:
+  {%- else %}
   kubernetes/kubernetes:
+  {%- endif %}
 {%- endif %}
 {%- endif %}
 {%- if not ci %}
@@ -30,7 +34,9 @@ presubmits:
     skip_branches:
     - release-\d+\.\d+  # per-release image
     always_run: false
-    {%- if run_if_changed and presubmit %}
+    {%- if testinfra %}
+    run_if_changed: /jobs/node_e2e/
+    {%- elif run_if_changed and presubmit %}
     run_if_changed: {{run_if_changed}}
     {%- endif %}
     optional: true
@@ -64,16 +70,15 @@ presubmits:
     {%- if not ci %}
     path_alias: k8s.io/kubernetes
     {%- endif %}
-    {%- if ci and need_kubernetes_repo or need_test_infra_repo or need_containerd_repo %}
     extra_refs:
-    {%- if ci and need_kubernetes_repo %}
+    {%- if need_kubernetes_repo and (ci or testinfra) %}
     - org: kubernetes
       repo: kubernetes
       base_ref: master
       path_alias: k8s.io/kubernetes
       workdir: true
     {%- endif %}
-    {%- if need_test_infra_repo %}
+    {%- if need_test_infra_repo and not testinfra %}
     - org: kubernetes
       repo: test-infra
       base_ref: master
@@ -83,7 +88,6 @@ presubmits:
     - org: containerd
       repo: containerd
       base_ref: release/2.1
-    {%- endif %}
     {%- endif %}
     spec:
       containers:


### PR DESCRIPTION
All E2E node jobs depend on the shared files in
test-infra:jobs/e2e_node. Editing those comes with the risk of breaking the k/k jobs, with no way to test them before merging.

For DRA it is easy to also generate the corresponding test-infra jobs. They get triggered automatically when the shared config files are modified. As in k/k, test failures are not merge-blocking, so reviewers have to be careful to not ignore real problems.

This covers a variety of machine configurations, but not necessarily all. It also limits testing to DRA tests. Overall we might still want to do the same for other SIG Node jobs.

/cc @ffromani @bart0sh 
/hold

I'm clarifying with SIG Testing whether it's okay to put test-infra jobs into this new `config/jobs/kubernetes/sig-node/dra-testinfra.yaml` file. It keeps the jobs close together and is what our generator readily supports. Placing the file under `config/jobs/kubernetes/test-infra/dra-testinfra.yaml` would imply changing the path handling.
