### PR TITLE
ci-test-infra-triage: bump memory from 12Gi to 24Gi

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml
@@ -189,10 +189,10 @@ periodics:
       resources:
         requests:
           cpu: 7
-          memory: 12Gi
+          memory: 24Gi
         limits:
           cpu: 7
-          memory: 12Gi
+          memory: 24Gi
 
 - name: ci-test-infra-autobump-prowjobs
   cron: "06 14-23 * * 1-5"  # Run every hour at 7:06 - 16:06 PDT (in UTC) Mon-Fri


### PR DESCRIPTION
Trying to fix OOMKill in triage jobs - https://prow.k8s.io/?job=ci-test-infra-triage

- Bumping the container memory to 24Gi to unblock the job. 24Gi matches what sig-release branch jobs and sig-scalability periodics already use, so it stays within the normal range of larger CI jobs.

