### PR TITLE
Retire pull-azure-vhds; broaden pull-azure-sigs

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes-sigs/image-builder:
-  - name: pull-azure-vhds
+  - name: pull-azure-sigs
     cluster: eks-prow-build-cluster
     labels:
       preset-azure-community: "true"
@@ -17,37 +17,6 @@ presubmits:
         args:
           - runner.sh
           - "./images/capi/scripts/ci-azure-e2e.sh"
-        resources:
-          requests:
-            cpu: 1000m
-            memory: 4Gi
-          limits:
-            cpu: 1000m
-            memory: 4Gi
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-image-builder
-      testgrid-tab-name: pr-azure-vhds
-  - name: pull-azure-sigs
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-azure-community: "true"
-    decorate: true
-    run_if_changed: 'images/capi/Makefile|images/capi/scripts/ci-azure-e2e\.sh|images/capi/packer/azure/.*'
-    optional: true
-    decoration_config:
-      timeout: 90m
-    max_concurrency: 5
-    path_alias: sigs.k8s.io/image-builder
-    spec:
-      serviceAccountName: azure
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
-        args:
-          - runner.sh
-          - "./images/capi/scripts/ci-azure-e2e.sh"
-        env:
-          - name: AZURE_BUILD_FORMAT
-            value: "sig"
         resources:
           requests:
             cpu: 1000m


### PR DESCRIPTION
Azure has retired unmanaged disks, so `pull-azure-vhds` fails with `BadRequest: Unmanaged disks have been retired`. The VHD builder is being removed in kubernetes-sigs/image-builder#2020.

This PR:
- Removes the `pull-azure-vhds` presubmit.
- Broadens `pull-azure-sigs`' `run_if_changed` to the union of what `pull-azure-vhds` matched (adds `ansible/`, `packer/config`, `packer/goss`, `hack/ensure-*`) so we don't lose Azure coverage on ansible/config-only changes.
- Drops `optional: true` from `pull-azure-sigs` so it gates merges like `pull-azure-vhds` did.
- Removes the now-redundant `AZURE_BUILD_FORMAT=sig` env (the script's VHD branch is gone in the image-builder PR).

/sig cluster-lifecycle
/area image-builder