### PR TITLE
Revert "triage: seed clustering with previous run output"

### DIFF
--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -85,16 +85,12 @@ mkdir -p triage_tests
 gsutil cp -r "${TRIAGE_TEMP_GCS_PATH}/*" triage_tests/
 gzip -df triage_tests/*.gz
 
-# Seed clustering with the previous run's output. A missing file (first run
-# after a rebuild, or after the bucket is reset) is fine — /triage logs a
-# warning and falls back to a cold cluster.
-gsutil cp "${TRIAGE_GCS_PATH}/failure_data.json" failure_data_previous.json || true
+# gsutil cp "${TRIAGE_BUCKET}/failure_data.json failure_data_previous.json
 
 mkdir -p slices
 
 /triage \
   --builds triage_builds.json \
-  --previous failure_data_previous.json \
   --output failure_data.json \
   --output_slices slices/failure_data_PREFIX.json \
   ${NUM_WORKERS:+"--num_workers=${NUM_WORKERS}"} \


### PR DESCRIPTION
Reverts ed427d8d5a3d484b2f11748057ecd82c4fd64cb0.

The change was intended to speed up `clusterGlobal` (commit message promised 175m → 10-15m) by seeding the clusters map with the previous run's keys so the EXISTING short-circuit covers the ~99% of clusters that persist across the 3-hour cadence. In practice it has regressions. Reverting to restore the previously-working behavior.