### PR TITLE
add always_run false to not have was jobs run on PRs

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -1232,6 +1232,7 @@ presubmits:
     - name: pull-kueue-test-e2e-k8s-main-was
       cluster: eks-prow-build-cluster
       optional: true
+      always_run: false
       branches:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"


### PR DESCRIPTION
https://github.com/kubernetes-sigs/kueue/pull/11575#issuecomment-4548564010

This should make the job optional and never run on PRs.

You can run this by commenting /test pull-kueue-test-e2e-k8s-main-was