### PR TITLE
Remove pull-cloud-provider-gcp-scenario-kops-simple job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -26,7 +26,7 @@ presubmits:
           requests:
             cpu: 4
             memory: 16Gi
-  
+
   - name: cloud-provider-gcp-verify-all
     cluster: k8s-infra-prow-build
     always_run: true
@@ -124,7 +124,7 @@ presubmits:
           requests:
             cpu: 4
             memory: 14Gi
-  
+
   - name: cloud-provider-gcp-verify-up-to-date
     cluster: k8s-infra-prow-build
     always_run: true

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -26,6 +26,7 @@ presubmits:
           requests:
             cpu: 4
             memory: 16Gi
+  
   - name: cloud-provider-gcp-verify-all
     cluster: k8s-infra-prow-build
     always_run: true
@@ -90,57 +91,6 @@ presubmits:
         - make
         - run-e2e-test
 
-  - name: pull-cloud-provider-gcp-scenario-kops-simple
-    cluster: k8s-infra-prow-build
-    always_run: true
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 80m
-    path_alias: cloud-provider-gcp
-    annotations:
-      testgrid-dashboards: provider-gcp-presubmits
-      description: Runs the kops-simple scenario against PRs
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-k8s-ssh: "true"
-      preset-service-account: "true"
-    extra_refs:
-    - org: kubernetes
-      repo: kops
-      base_ref: master
-      path_alias: kops
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: kubernetes
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
-        resources:
-          limits:
-            cpu: 4
-            memory: 14Gi
-          requests:
-            cpu: 4
-            memory: 14Gi
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        command:
-        - runner.sh
-        args:
-        - "/bin/bash"
-        - "-c"
-        - set -o errexit;
-          set -o nounset;
-          set -o pipefail;
-          set -o xtrace;
-          cd $GOPATH/src/cloud-provider-gcp;
-          e2e/add-kubernetes-to-workspace.sh;
-          e2e/scenarios/kops-simple
-
   - name: cloud-provider-gcp-e2e-full
     cluster: k8s-infra-prow-build
     always_run: true
@@ -174,6 +124,7 @@ presubmits:
           requests:
             cpu: 4
             memory: 14Gi
+  
   - name: cloud-provider-gcp-verify-up-to-date
     cluster: k8s-infra-prow-build
     always_run: true


### PR DESCRIPTION
All presubmit tests are based on kops so we don't need this job. Remove to save resources.

/assign LogicalShark