### PR TITLE
label_sync: fix file descriptor leak in writeTemplate

### DIFF
--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -180,11 +180,6 @@ func gatherOptions() (opts options, deprecatedOptions bool) {
 	return o, deprecatedGitHubOptions
 }
 
-func pathExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
 // Writes the golang text template at templatePath to outputPath using the given data
 func writeTemplate(templatePath string, outputPath string, data interface{}) error {
 	// set up template
@@ -198,21 +193,12 @@ func writeTemplate(templatePath string, outputPath string, data interface{}) err
 		return err
 	}
 
-	// ensure output path exists
-	if !pathExists(outputPath) {
-		_, err = os.Create(outputPath)
-		if err != nil {
-			return err
-		}
-	}
-
-	// open file at output path and truncate
-	f, err := os.OpenFile(outputPath, os.O_RDWR, 0644)
+	// open file at output path, creating if needed, and truncate
+	f, err := os.OpenFile(outputPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	f.Truncate(0)
 
 	// render template to output path
 	err = t.Execute(f, data)


### PR DESCRIPTION
#### What this PR does

Fixes a file descriptor leak in `writeTemplate()` in `label_sync/main.go`.

`os.Create(outputPath)` was called to ensure the file exists, but the returned
`*os.File` was assigned to `_` and never closed. The same file was then
re-opened via `os.OpenFile()`. Each invocation leaked one file descriptor.

#### How it is fixed

Replace the two-step create-then-open pattern with a single `os.OpenFile()`
call using `O_RDWR|O_CREATE|O_TRUNC` flags. This:
- Eliminates the leaked file descriptor
- Removes a TOCTOU race between `pathExists()` and `os.Create()`
- Removes the manual `f.Truncate(0)` (redundant with `O_TRUNC`)
- Removes the now-unused `pathExists()` helper

#### Which issue(s) this PR fixes

None (newly discovered via code audit)

/kind bug
/area label_sync