### PR TITLE
Shard Kueue Release Sequential Baseline E2E Jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-16.yaml
@@ -832,14 +832,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-sequential-baseline-release-0-16
+    name: periodic-kueue-test-e2e-sequential-baseline-shard-0-release-0-16
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-sequential-baseline-release-0-16
+      testgrid-tab-name: periodic-kueue-test-e2e-sequential-baseline-shard-0-release-0-16
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic sequential baseline end to end tests"
+      description: "Run periodic sequential baseline end to end tests shard 0"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -866,7 +866,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-sequential-baseline
+            - test-e2e-sequential-baseline-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-sequential-baseline-shard-1-release-0-16
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-sequential-baseline-shard-1-release-0-16
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic sequential baseline end to end tests shard 1"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.16
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-sequential-baseline-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -871,14 +871,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-sequential-baseline-release-0-17
+    name: periodic-kueue-test-e2e-sequential-baseline-shard-0-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-sequential-baseline-release-0-17
+      testgrid-tab-name: periodic-kueue-test-e2e-sequential-baseline-shard-0-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic sequential baseline end to end tests"
+      description: "Run periodic sequential baseline end to end tests shard 0"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -905,7 +905,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-sequential-baseline
+            - test-e2e-sequential-baseline-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-sequential-baseline-shard-1-release-0-17
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-sequential-baseline-shard-1-release-0-17
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic sequential baseline end to end tests shard 1"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.17
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-sequential-baseline-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
@@ -610,7 +610,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-sequential-baseline-release-0-16
+    - name: pull-kueue-test-e2e-sequential-baseline-shard-0-release-0-16
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.16
@@ -619,8 +619,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-sequential-baseline-release-0-16
-        description: "Run sequential baseline end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-sequential-baseline-shard-0-release-0-16
+        description: "Run sequential baseline end to end tests shard 0"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -637,7 +637,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-sequential-baseline
+              - test-e2e-sequential-baseline-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-sequential-baseline-shard-1-release-0-16
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.16
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-sequential-baseline-shard-1-release-0-16
+        description: "Run sequential baseline end to end tests shard 1"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-sequential-baseline-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -610,7 +610,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-sequential-baseline-release-0-17
+    - name: pull-kueue-test-e2e-sequential-baseline-shard-0-release-0-17
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.17
@@ -619,8 +619,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-sequential-baseline-release-0-17
-        description: "Run sequential baseline end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-sequential-baseline-shard-0-release-0-17
+        description: "Run sequential baseline end to end tests shard 0"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -637,7 +637,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-sequential-baseline
+              - test-e2e-sequential-baseline-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-sequential-baseline-shard-1-release-0-17
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.17
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-sequential-baseline-shard-1-release-0-17
+        description: "Run sequential baseline end to end tests shard 1"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-sequential-baseline-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true


### PR DESCRIPTION
Splits the Kueue sequential baseline release presubmits and periodics  for release branches into:

- `pull-kueue-test-e2e-sequential-baseline-shard-0-release-0-16`
- `pull-kueue-test-e2e-sequential-baseline-shard-1-release-0-16`
- `pull-kueue-test-e2e-sequential-baseline-shard-0-release-0-17`
- `pull-kueue-test-e2e-sequential-baseline-shard-1-release-0-17`


Fixes https://github.com/kubernetes-sigs/kueue/issues/11669