### PR TITLE
Migrating remaining CAPZ + Windows jobs to use templates/scripting from windows-testing repo

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
@@ -246,24 +246,33 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.20
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.32
+        base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -280,81 +289,14 @@ presubmits:
               memory: "9Gi"
               cpu: 4
           env:
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.32"
             - name: WORKER_MACHINE_COUNT
               value: "1" # create one linux node
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-driver-smb-e2e-windows-2022
       description: "Run E2E Windows tests on a capz Windows 2022 cluster for SMB CSI driver."
-      testgrid-num-columns-recent: '30'
-  - name: pull-csi-driver-smb-e2e-windows-2019
-    cluster: eks-prow-build-cluster
-    decorate: true
-    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    optional: true
-    path_alias: github.com/kubernetes-csi/csi-driver-smb
-    branches:
-      - (master)|(^release-.+$)
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-community: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: cluster-api-provider-azure
-        base_ref: release-1.20
-        path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
-      - org: kubernetes-sigs
-        repo: cloud-provider-azure
-        base_ref: release-1.32
-        path_alias: sigs.k8s.io/cloud-provider-azure
-        workdir: false
-    spec:
-      serviceAccountName: azure
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
-          command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-          args:
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/github.com/kubernetes-csi/csi-driver-smb &&
-              make e2e-test
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "9Gi"
-              cpu: 4
-            limits:
-              memory: "9Gi"
-              cpu: 4
-          env:
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2019"
-            - name: NODE_MACHINE_TYPE # CAPZ config
-              value: "Standard_D4s_v3"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.32"
-            - name: WORKER_MACHINE_COUNT
-              value: "1" # create one linux node
-    annotations:
-      testgrid-dashboards: sig-storage-csi-other
-      testgrid-tab-name: pull-csi-driver-smb-e2e-windows-2019
-      description: "Run E2E Windows tests on a capz Windows 2019 cluster for SMB CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-csi-driver-smb-e2e-windows-2022-hostprocess
     cluster: eks-prow-build-cluster
@@ -365,24 +307,33 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.20
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.32
+        base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -399,88 +350,16 @@ presubmits:
               cpu: 4
               memory: 8Gi
           env:
-            - name: WINDOWS # smb-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # smb-csi-driver config
-              value: "true"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE # smb-csi-driver config
-              value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.32"
             - name: WORKER_MACHINE_COUNT
               value: "0" # create one linux node
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # smb-csi-driver config
+              value: "true"
+            - name: DISABLE_ZONE # smb-csi-driver config
+              value: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-other
       testgrid-tab-name: pull-csi-driver-smb-e2e-windows-2022-hostprocess
       description: "Run E2E Windows Host-Process tests on a capz Windows 2022 cluster for SMB CSI driver."
-      testgrid-num-columns-recent: '30'
-  - name: pull-csi-driver-smb-e2e-windows-2019-hostprocess
-    cluster: eks-prow-build-cluster
-    decorate: true
-    always_run: false
-    path_alias: github.com/kubernetes-csi/csi-driver-smb
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-community: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: cluster-api-provider-azure
-        base_ref: release-1.20
-        path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
-      - org: kubernetes-sigs
-        repo: cloud-provider-azure
-        base_ref: release-1.32
-        path_alias: sigs.k8s.io/cloud-provider-azure
-        workdir: false
-    spec:
-      serviceAccountName: azure
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
-          command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-          args:
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/github.com/kubernetes-csi/csi-driver-smb &&
-              make e2e-test
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 4
-              memory: 8Gi
-            requests:
-              cpu: 4
-              memory: 8Gi
-          env:
-            - name: WINDOWS # smb-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2019"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # smb-csi-driver config
-              value: "true"
-            - name: NODE_MACHINE_TYPE # CAPZ config
-              value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE # smb-csi-driver config
-              value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.32"
-            - name: WORKER_MACHINE_COUNT
-              value: "1" # create one linux node
-    annotations:
-      testgrid-dashboards: sig-storage-csi-other
-      testgrid-tab-name: pull-csi-driver-smb-e2e-windows-2019-hostprocess
-      description: "Run E2E Windows Host-Process tests on a capz Windows 2019 cluster for SMB CSI driver."
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -61,6 +61,8 @@ periodics:
         env:
           - name: AZURE_VM_TYPE # azuredisk-csi-driver config
             value: "standard"
+          - name: NODE_MACHINE_TYPE # CAPZ config
+            value: "Standard_D4s_v3"
   annotations:
     testgrid-dashboards: provider-azure-azuredisk-csi-driver, sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: ci-azuredisk-csi-driver-e2e-capz-windows
@@ -323,24 +325,33 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.21
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.32
+        base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -359,92 +370,22 @@ presubmits:
           env:
             - name: AZURE_STORAGE_DRIVER
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
-            - name: TEST_MIGRATION
-              value: "true"
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
+            - name: AZURE_VM_TYPE # azuredisk-csi-driver config
+              value: "standard"
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE # azuredisk-csi-driver config
+            - name: TEST_MIGRATION
               value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.32.2"
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
+              value: "true"
             - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
       testgrid-tab-name: pr-azuredisk-csi-driver-e2e-migration-windows
       description: "Run E2E tests on a cluster for Azure Disk CSI driver with CSI migration feature enabled on Windows nodes."
-      testgrid-num-columns-recent: '30'
-  - name: pull-azuredisk-csi-driver-e2e-capz-windows-2019
-    cluster: eks-prow-build-cluster
-    decorate: true
-    decoration_config:
-      timeout: 3h
-    always_run: false
-    path_alias: sigs.k8s.io/azuredisk-csi-driver
-    branches:
-    - (master)|(^release-.+$)
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-community: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: cluster-api-provider-azure
-        base_ref: release-1.21
-        path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
-      - org: kubernetes-sigs
-        repo: cloud-provider-azure
-        base_ref: release-1.32
-        path_alias: sigs.k8s.io/cloud-provider-azure
-        workdir: false
-    spec:
-      serviceAccountName: azure
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
-          command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-          args:
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
-              make e2e-test
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 4
-              memory: 8Gi
-            requests:
-              cpu: 4
-              memory: 8Gi
-          env:
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: NODE_MACHINE_TYPE # CAPZ config
-              value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE # azuredisk-csi-driver config
-              value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.32.2"
-            - name: WORKER_MACHINE_COUNT
-              value: "0" # Don't create any linux worker nodes
-    annotations:
-      testgrid-dashboards: provider-azure-azuredisk-csi-driver
-      testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-windows-2019
-      description: "Run E2E tests on a capz Windows 2019 cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz-windows-2022
     cluster: eks-prow-build-cluster
@@ -459,24 +400,33 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.21
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.33
+        base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -493,20 +443,14 @@ presubmits:
               cpu: 4
               memory: 8Gi
           env:
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
-            - name: NODE_MACHINE_TYPE # CAPZ config
-              value: "Standard_D4s_v3"
+            - name: AZURE_VM_TYPE # azuredisk-csi-driver config
+              value: "standard"
             - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.33.2"
+            - name: NODE_MACHINE_TYPE # CAPZ config
+              value: "Standard_D4s_v3"
             - name: WORKER_MACHINE_COUNT # CAPZ config
-              value: "0" # Don't create any linux worker nodes
+              value: "0"
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
       testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-windows-2022
@@ -654,72 +598,6 @@ presubmits:
       testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-vmssflex
       description: "Run E2E tests on a capz cluster with vmssflex nodes for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
-  - name: pull-azuredisk-csi-driver-e2e-capz-windows-2019-hostprocess
-    cluster: eks-prow-build-cluster
-    decorate: true
-    decoration_config:
-      timeout: 3h
-    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    path_alias: sigs.k8s.io/azuredisk-csi-driver
-    branches:
-    - (master)|(^release-.+$)
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-community: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: cluster-api-provider-azure
-        base_ref: release-1.20
-        path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
-      - org: kubernetes-sigs
-        repo: cloud-provider-azure
-        base_ref: release-1.32
-        path_alias: sigs.k8s.io/cloud-provider-azure
-        workdir: false
-    spec:
-      serviceAccountName: azure
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
-          command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-          args:
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
-              make e2e-test
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 4
-              memory: 8Gi
-            requests:
-              cpu: 4
-              memory: 8Gi
-          env:
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
-              value: "true"
-            - name: NODE_MACHINE_TYPE # CAPZ config
-              value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE # azuredisk-csi-driver config
-              value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.32"
-            - name: WORKER_MACHINE_COUNT
-              value: "0" # Don't create any linux worker nodes
-    annotations:
-      testgrid-dashboards: provider-azure-azuredisk-csi-driver
-      testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-windows-2019-hostprocess
-      description: "Run E2E tests on a capz Windows 2019 cluster for Azure Disk CSI driver."
-      testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-capz-windows-2022-hostprocess
     cluster: eks-prow-build-cluster
     decorate: true
@@ -733,24 +611,33 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.20
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.32
+        base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -767,22 +654,16 @@ presubmits:
               cpu: 4
               memory: 8Gi
           env:
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
+            - name: AZURE_VM_TYPE # azuredisk-csi-driver config
+              value: "standard"
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE # azuredisk-csi-driver config
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # azuredisk-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.32"
             - name: WORKER_MACHINE_COUNT # CAPZ config
-              value: "0" # Don't create any linux worker nodes
+              value: "0"
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver
       testgrid-tab-name: pull-azuredisk-csi-driver-e2e-capz-windows-2022-hostprocess

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -187,25 +187,33 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
-      preset-azure-windows: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.21
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.32
+        base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -224,24 +232,17 @@ presubmits:
           env:
             - name: AZURE_STORAGE_DRIVER
               value: "kubernetes.io/azure-file" # In-tree Azure file storage class
-            - name: TEST_MIGRATION
-              value: "true"
             - name: DISABLE_ZONE # azurefile-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.32.2"
-            - name: WINDOWS # azuredisk-csi-driver config
+            - name: TEST_MIGRATION # azurefile-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # azurefile-csi-driver config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
+
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # azurefile-csi-driver config
+              value: "true"
             - name: WORKER_MACHINE_COUNT # CAPZ config
-              value: "0" # Don't create any linux worker nodes
+              value: "0"
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver
       testgrid-tab-name: pr-azurefile-csi-driver-e2e-migration-windows
@@ -357,64 +358,6 @@ presubmits:
       testgrid-tab-name: pr-azurefile-csi-driver-external-e2e-nfs
       description: "Run External E2E tests for Azure File CSI driver using NFS protocol."
       testgrid-num-columns-recent: '30'
-  - name: pull-azurefile-csi-driver-e2e-capz-windows-2019
-    cluster: eks-prow-build-cluster
-    decorate: true
-    always_run: false
-    path_alias: sigs.k8s.io/azurefile-csi-driver
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-community: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: cluster-api-provider-azure
-        base_ref: release-1.21
-        path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
-      - org: kubernetes-sigs
-        repo: cloud-provider-azure
-        base_ref: release-1.30
-        path_alias: sigs.k8s.io/cloud-provider-azure
-        workdir: false
-    spec:
-      serviceAccountName: azure
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
-          command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-          args:
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-              make e2e-test
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 4
-              memory: 8Gi
-            requests:
-              cpu: 4
-              memory: 8Gi
-          env:
-            - name: WINDOWS # azurefile-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: NODE_MACHINE_TYPE # CAPZ config
-              value: "Standard_D4s_v3"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.30.2"
-            - name: WORKER_MACHINE_COUNT # CAPZ config
-              value: "0" # Don't create any linux worker nodes
-    annotations:
-      testgrid-dashboards: provider-azure-azurefile-csi-driver
-      testgrid-tab-name: pull-azurefile-csi-driver-e2e-capz-windows-2019
-      description: "Run E2E tests on a capz Windows 2019 cluster for Azure File CSI driver."
-      testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-capz-windows-2022
     cluster: eks-prow-build-cluster
     decorate: true
@@ -424,24 +367,33 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.21
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.32
+        base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -458,86 +410,17 @@ presubmits:
               cpu: 4
               memory: 8Gi
           env:
-            - name: WINDOWS # azurefile-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
-            - name: NODE_MACHINE_TYPE # CAPZ config
-              value: "Standard_D4s_v3"
             - name: DISABLE_ZONE # azurefile-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.32.2"
-            - name: WORKER_MACHINE_COUNT
-              value: "0" # Don't create any linux worker nodes
+            - name: NODE_MACHINE_TYPE # CAPZ config
+              value: "Standard_D4s_v3"
+
+            - name: WORKER_MACHINE_COUNT # CAPZ config
+              value: "0"
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver
       testgrid-tab-name: pull-azurefile-csi-driver-e2e-capz-windows-2022
       description: "Run E2E tests on a capz Windows 2022 cluster for Azure File CSI driver."
-      testgrid-num-columns-recent: '30'
-  - name: pull-azurefile-csi-driver-e2e-capz-windows-2019-hostprocess
-    cluster: eks-prow-build-cluster
-    decorate: true
-    decoration_config:
-      timeout: 3h
-    skip_if_only_changed: "^docs/|^site/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)$"
-    path_alias: sigs.k8s.io/azurefile-csi-driver
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-community: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: cluster-api-provider-azure
-        base_ref: release-1.20
-        path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
-      - org: kubernetes-sigs
-        repo: cloud-provider-azure
-        base_ref: release-1.32
-        path_alias: sigs.k8s.io/cloud-provider-azure
-        workdir: false
-    spec:
-      serviceAccountName: azure
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
-          command:
-            - runner.sh
-            - ./scripts/ci-entrypoint.sh
-          args:
-            - bash
-            - -c
-            - >-
-              cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-              make e2e-test
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 4
-              memory: 8Gi
-            requests:
-              cpu: 4
-              memory: 8Gi
-          env:
-            - name: WINDOWS # azurefile-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # azurefile-csi-driver config
-              value: "true"
-            - name: NODE_MACHINE_TYPE # CAPZ config
-              value: "Standard_D4s_v3"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.32"
-            - name: WORKER_MACHINE_COUNT # CAPZ config
-              value: "0" # Don't create any linux worker nodes
-    annotations:
-      testgrid-dashboards: provider-azure-azurefile-csi-driver
-      testgrid-tab-name: pull-azurefile-csi-driver-e2e-capz-windows-2019-hostprocess
-      description: "Run E2E tests on a capz Windows 2019 Host-Process cluster for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e-capz-windows-2022-hostprocess
     cluster: eks-prow-build-cluster
@@ -550,24 +433,33 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.20
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.32
+        base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -584,22 +476,15 @@ presubmits:
               cpu: 4
               memory: 8Gi
           env:
-            - name: WINDOWS # azurefile-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # azurefile-csi-driver config
+            - name: DISABLE_ZONE # azurefile-csi-driver config
               value: "true"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE # azurefile-csi-driver config
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # azurefile-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.32"
-            - name: WORKER_MACHINE_COUNT
-              value: "0" # Don't create any linux worker nodes
+
+            - name: WORKER_MACHINE_COUNT # CAPZ config
+              value: "0"
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver
       testgrid-tab-name: pull-azurefile-csi-driver-e2e-capz-windows-2022-hostprocess
@@ -613,27 +498,34 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-capz-windows-2025: "true"
-      preset-capz-containerd-1-7-latest: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2025: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.20
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.32
+        base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -650,22 +542,17 @@ presubmits:
               cpu: 4
               memory: 8Gi
           env:
-            - name: WINDOWS # azurefile-csi-driver config
+            - name: DISABLE_ZONE # azurefile-csi-driver config
               value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
+            - name: NODE_MACHINE_TYPE # CAPZ config
+              value: "Standard_D4s_v3"
             - name: WINDOWS_SERVER_VERSION # CAPZ config
               value: "windows-2025"
             - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # azurefile-csi-driver config
               value: "true"
-            - name: NODE_MACHINE_TYPE # CAPZ config
-              value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE # azurefile-csi-driver config
-              value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.32"
-            - name: WORKER_MACHINE_COUNT
-              value: "0" # Don't create any linux worker nodes
+
+            - name: WORKER_MACHINE_COUNT # CAPZ config
+              value: "0"
     annotations:
       testgrid-dashboards: provider-azure-azurefile-csi-driver
       testgrid-tab-name: pull-azurefile-csi-driver-e2e-capz-windows-2025-hostprocess

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -132,12 +132,14 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.21
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: azuredisk-csi-driver
         base_ref: master
@@ -146,13 +148,20 @@ presubmits:
         repo: cloud-provider-azure
         base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -162,14 +171,10 @@ presubmits:
           env:
             - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
+            - name: AZURE_VM_TYPE # azuredisk-csi-driver config
+              value: "standard"
             - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
             - name: WORKER_MACHINE_COUNT # CAPZ config
@@ -320,12 +325,14 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.21
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: azurefile-csi-driver
         base_ref: master
@@ -334,13 +341,20 @@ presubmits:
         repo: cloud-provider-azure
         base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -350,12 +364,6 @@ presubmits:
           env:
             - name: runInTreeVolumeTestsOnly # azurefile-csi-driver config
               value: "true"
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
             - name: WORKER_MACHINE_COUNT # CAPZ config


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/6305
/sig windows
/assign @andyzhangx @jackfrancis @mboersma @zylxjtu 