### PR TITLE
prow: add sig-etcd-leads to lead-opted-in restricted label

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -233,6 +233,7 @@ label:
         - sig-cluster-lifecycle-leads
         - sig-contributor-experience-leads
         - sig-docs-leads
+        - sig-etcd-leads
         - sig-instrumentation-leads
         - sig-k8s-infra-leads
         - sig-multicluster-leads


### PR DESCRIPTION
Add sig-etcd-leads to allowed_teams for lead-opted-in label in kubernetes/enhancements.

ref https://github.com/kubernetes/enhancements/issues/5966#issuecomment-4557591719.

/sig etcd