### PR TITLE
compatibility: download prev version kubectl client for upgrade test

### DIFF
--- a/experiment/compatibility-versions/common.sh
+++ b/experiment/compatibility-versions/common.sh
@@ -211,31 +211,44 @@ build_test_bins() {
 }
 
 # TODO: Support Mac as a platform along with Linux https://github.com/kubernetes/test-infra/pull/34930#discussion_r2138760351
-download_release_version_bins() {
-  local version=$1
-  curl -LO https://dl.k8s.io/ci/$(curl -Ls https://dl.k8s.io/ci/latest-${version}.txt)/kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz
+download_bins_for_ci_version() {
+  local ci_version=$1
+  local version_description=$2
+
+  curl -LO "https://dl.k8s.io/ci/${ci_version}/kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz"
   if [ $? -ne 0 ]; then
-    echo "failed to download previous version ${version} binaries"
+    echo "failed to download ${version_description} test binaries"
     return 1
   fi
   tar -xf kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz 
   mkdir -p _output/bin
   mv kubernetes/test/bin/* _output/bin
+
+  # Also download the kubectl client binary
+  curl -LO "https://dl.k8s.io/ci/${ci_version}/kubernetes-client-$(go env GOOS)-$(go env GOARCH).tar.gz"
+  if [ $? -eq 0 ]; then
+    tar -xf kubernetes-client-$(go env GOOS)-$(go env GOARCH).tar.gz
+    mv kubernetes/client/bin/kubectl _output/bin/
+    rm -rf kubernetes-client-$(go env GOOS)-$(go env GOARCH).tar.gz kubernetes/
+  else
+    echo "failed to download ${version_description} client binaries, attempting direct kubectl download..."
+    curl -Lo _output/bin/kubectl "https://dl.k8s.io/ci/${ci_version}/bin/$(go env GOOS)/$(go env GOARCH)/kubectl"
+    chmod +x _output/bin/kubectl
+  fi
+
   export PATH="${PWD}/_output/bin:$PATH"
   return 0
 }
 
+download_release_version_bins() {
+  local version=$1
+  local ci_version=$(curl -Ls https://dl.k8s.io/ci/latest-${version}.txt)
+  download_bins_for_ci_version "${ci_version}" "previous version ${version}"
+}
+
 download_current_version_bins() {
-  curl -LO 'https://dl.k8s.io/ci/'"${1}"/'kubernetes-test-'"$(go env GOOS)-$(go env GOARCH)"'.tar.gz'
-  if [ $? -ne 0 ]; then
-    echo "failed to download current version binaries"
-    return 1
-  fi
-  tar -xf kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz
-  mkdir -p _output/bin
-  mv kubernetes/test/bin/* _output/bin
-  export PATH="${PWD}/_output/bin:$PATH"
-  return 0
+  local ci_version=$1
+  download_bins_for_ci_version "${ci_version}" "current version"
 }
 
 # run e2es with ginkgo-e2e.sh
@@ -307,7 +320,8 @@ run_e2e_tests() {
     --provider=skeleton \
     --num-nodes="${NUM_NODES}" \
     --report-dir="${ARTIFACTS}" \
-    --disable-log-dump=true &
+    --disable-log-dump=true \
+    --kubectl-path="${PWD}/_output/bin/kubectl" &
   GINKGO_PID=$!
   wait "$GINKGO_PID"
 }


### PR DESCRIPTION
"Kube-Proxy Version" was removed from `kubectl` when `DisableNodeKubeProxyVersion` was locked to true in https://github.com/kubernetes/kubernetes/commit/9703ce508fa0da17da10f0905af9982eb1e08a09#diff-2427c9864b2b37563ae47e0f73d048c1bb4ea9ab367f803e9e044c117eb38f25 . 
Mixing kubectl version with test version could result in compatibility errors.

This fixes the error of 
```

Kubernetes e2e suite: [It] [sig-cli] Kubectl client Kubectl describe should check if kubectl describe prints relevant information for rc and pods [Conformance] expand_less | 1s
-- | --
{ failed [FAILED] failed to find Kube-Proxy Version: in Name:               kind-control-plane Roles:              control-plane Labels:             beta.kubernetes.io/arch=amd64                     beta.kubernetes.io/os=linux                     kubernetes.io/arch=amd64                     kubernetes.io/hostname=kind-control-plane                     kubernetes.io/os=linux                     node-role.kubernetes.io/control-plane=                     node.kubernetes.io/exclude-from-external-load-balancers= Annotations:        node.alpha.kubernetes.io/ttl: 0                     volumes.kubernetes.io/controller-managed-attach-detach: true CreationTimestamp:  Wed, 27 May 2026 14:36:03 +0000 Taints:             node-role.kubernetes.io/control-plane:NoSchedule Unschedulable:      false Lease:
```
in https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-skip-version-upgrade-n-minus-2/2059644457698988032