### PR TITLE
Bump kueue multikueue integration test memory from 10Gi to 12Gi for k8s 1.36 envtest

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -150,10 +150,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
               limits:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
     - name: pull-kueue-test-e2e-baseline-main-1-33
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-16.yaml
@@ -150,10 +150,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
               limits:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
     - name: pull-kueue-test-e2e-baseline-release-0-16-1-33
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -150,10 +150,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
               limits:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
     - name: pull-kueue-test-e2e-baseline-release-0-17-1-33
       cluster: eks-prow-build-cluster
       branches:


### PR DESCRIPTION
xref: https://github.com/kubernetes-sigs/kueue/pull/10936#issuecomment-4560600110