### PR TITLE
Add Lambda Cloud janitor periodic and instance tagging

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda-janitor.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/lambda/lambda-janitor.yaml
@@ -1,0 +1,36 @@
+periodics:
+- name: maintenance-ci-lambda-janitor
+  cluster: k8s-infra-prow-build
+  interval: 4h
+  labels:
+    preset-lambda-credential: "true"
+  annotations:
+    testgrid-dashboards: sig-testing-maintenance
+    testgrid-tab-name: ci-lambda-janitor
+    description: Terminates Lambda Cloud instances tagged managed-by=prow-k8s-ci whose expires-at is in the past.
+  decorate: true
+  decoration_config:
+    timeout: 30m
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+    workdir: true
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260525-f8de63d82b-master
+      command:
+      - runner.sh
+      args:
+      - bash
+      - -c
+      - |
+        exec "$(go env GOPATH)/src/k8s.io/test-infra/experiment/lambda/janitor.sh"
+      resources:
+        limits:
+          cpu: 1
+          memory: 1Gi
+        requests:
+          cpu: 1
+          memory: 1Gi

--- a/experiment/lambda/janitor.sh
+++ b/experiment/lambda/janitor.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Terminates Lambda Cloud instances tagged managed-by=prow-k8s-ci
+# whose expires-at is in the past. Requires LAMBDA_API_KEY_FILE
+# (supplied by preset-lambda-credential); honors ARTIFACTS for logs.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GOPROXY=direct go install github.com/dims/lambdactl@latest
+
+NOW=$(date +%s)
+LOG_DIR="${ARTIFACTS:-/tmp}/lambda-janitor"
+mkdir -p "${LOG_DIR}"
+INSTANCES_FILE="${LOG_DIR}/instances.json"
+
+echo "Lambda janitor pass at epoch ${NOW}"
+
+lambdactl --json instances > "${INSTANCES_FILE}"
+TOTAL=$(jq 'length' "${INSTANCES_FILE}")
+echo "Total instances on account: ${TOTAL}"
+
+echo "--- Managed instances (managed-by=prow-k8s-ci) ---"
+jq -r '
+  .[] |
+  select(.tags[]? | .key=="managed-by" and .value=="prow-k8s-ci") |
+  ((.tags | map({(.key): .value}) | add) // {}) as $t |
+  "  \(.id)  status=\(.status)  expires-at=\($t["expires-at"] // "<none>")  job=\($t["prow-job"] // "<none>")  build=\($t["build-id"] // "<none>")"
+' "${INSTANCES_FILE}"
+
+# Skip and report managed instances whose expires-at is not a
+# non-negative integer; one bad tag must not block the rest of the pass.
+INVALID=$(jq '
+  [
+    .[] |
+    select(.tags[]? | .key=="managed-by" and .value=="prow-k8s-ci") |
+    select(.status != "terminating" and .status != "terminated") |
+    ((.tags | map({(.key): .value}) | add) // {}) as $t |
+    select($t["expires-at"] != null) |
+    select($t["expires-at"] | test("^[0-9]+$") | not) |
+    {id, expires_at: $t["expires-at"], job: $t["prow-job"]}
+  ]
+' "${INSTANCES_FILE}")
+INVALID_COUNT=$(jq 'length' <<<"${INVALID}")
+if [[ "${INVALID_COUNT}" != "0" ]]; then
+  echo "WARNING: ${INVALID_COUNT} managed instance(s) have non-numeric expires-at; skipping:"
+  jq -r '.[] | "  \(.id)  expires-at=\(.expires_at|@json)  job=\(.job // "<none>")"' <<<"${INVALID}"
+fi
+
+# Select managed, non-terminating instances whose expires-at is a
+# non-negative integer in the past. The regex gate matches the
+# invalid-pass above, so tonumber here is unconditionally safe.
+EXPIRED=$(jq --arg now "${NOW}" '
+  [
+    .[] |
+    select(.tags[]? | .key=="managed-by" and .value=="prow-k8s-ci") |
+    select(.status != "terminating" and .status != "terminated") |
+    ((.tags | map({(.key): .value}) | add) // {}) as $t |
+    select($t["expires-at"] != null) |
+    select($t["expires-at"] | test("^[0-9]+$")) |
+    select(($t["expires-at"] | tonumber) < ($now | tonumber))
+  ]
+' "${INSTANCES_FILE}")
+EXPIRED_COUNT=$(jq 'length' <<<"${EXPIRED}")
+echo "--- Expired instances to terminate: ${EXPIRED_COUNT} ---"
+
+if [[ "${EXPIRED_COUNT}" == "0" ]]; then
+  echo "No expired instances; exiting."
+  exit 0
+fi
+
+FAILS=0
+while read -r id; do
+  echo "Terminating ${id}..."
+  if ! lambdactl stop "${id}" --yes; then
+    echo "  FAILED to terminate ${id}"
+    FAILS=$((FAILS + 1))
+  fi
+done < <(jq -r '.[].id' <<<"${EXPIRED}")
+
+echo "Pass complete. terminated=$((EXPIRED_COUNT - FAILS)) failures=${FAILS}"
+
+if [[ "${FAILS}" -gt 0 ]]; then
+  exit 1
+fi

--- a/experiment/lambda/lib/lambda-common.sh
+++ b/experiment/lambda/lib/lambda-common.sh
@@ -18,11 +18,13 @@
 #
 # Required env: JOB_NAME, BUILD_ID (set by Prow)
 # Optional env: GPU_TYPE (default: gpu_1x_a10, set empty to accept any)
+#               LAMBDA_TTL_HOURS (default: 4) -- janitor reap horizon
 
 set -o errexit; set -o nounset; set -o pipefail
 
 LAMBDA_SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR)
 LAMBDA_GPU_TYPE="${GPU_TYPE-gpu_1x_a10}"
+LAMBDA_TTL_HOURS="${LAMBDA_TTL_HOURS:-4}"
 LAMBDA_SSH_DIR=""
 LAMBDA_SSH_KEY=""
 LAMBDA_SSH_KEY_ID=""
@@ -51,9 +53,21 @@ lambda_launch() {
   if [ -n "${LAMBDA_GPU_TYPE}" ]; then
     gpu_args=(--gpu "${LAMBDA_GPU_TYPE}")
   fi
+  # Tags let the janitor terminate orphans when the EXIT trap is
+  # skipped (SIGKILL, OOM, pod eviction).
+  local now expires_at
+  now=$(date +%s)
+  expires_at=$(( now + LAMBDA_TTL_HOURS * 3600 ))
+  local tag_args=(
+    --tag "managed-by=prow-k8s-ci"
+    --tag "launched-at=${now}"
+    --tag "expires-at=${expires_at}"
+    --tag "prow-job=${JOB_NAME}"
+    --tag "build-id=${BUILD_ID}"
+  )
   local launch_output
   launch_output=$(lambdactl --json watch \
-    "${gpu_args[@]}" \
+    "${gpu_args[@]}" "${tag_args[@]}" \
     --ssh "${LAMBDA_SSH_KEY_NAME}" \
     --name "${LAMBDA_SSH_KEY_NAME}" \
     --interval 30 \


### PR DESCRIPTION
We left one of the lambda.ai instances running too long and blew up our budget. This PR is to make sure we cleanup!

As there is no TTL in the API and no created / modified timestamps, let's use tags to make it work for us

- Stamp every Lambda Cloud GPU instance launched by the CI scripts with `managed-by`, `launched-at`, `expires-at`, `prow-job`, `build-id` tags. These give a reaper enough context to identify and terminate orphans whose in-process `EXIT` trap never fires (SIGKILL, OOM, pod eviction).
- Add `maintenance-ci-lambda-janitor`, a 4h periodic on `k8s-infra-prow-build` that calls `lambdactl --json instances`, filters to `managed-by=prow-k8s-ci` with `expires-at` in the past, and terminates them. The full managed inventory is logged too, so leaks remain visible in spyglass even before they expire.
- Default TTL is 4h (`LAMBDA_TTL_HOURS` env var, overridable per-job), which covers the 2h prow decoration timeout plus build/test setup time.