### PR TITLE
[kueue] Skip pull-kueue-test-e2e-k8s-main-was.

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -1311,7 +1311,6 @@ presubmits:
       always_run: false
       branches:
         - ^main
-      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:


### PR DESCRIPTION
The `pull-kueue-test-e2e-k8s-main-wasm` job runs on every PR and takes around 40 minutes. The PR is blocked waiting for it to finish. I propose skipping it by default and running it manually only when it's really needed.

Fixes #11664