### PR TITLE
kueue : split multikueue into extended and baseline suite

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -205,14 +205,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-integration-multikueue-baseline-main
+    name: periodic-kueue-test-integration-multikueue-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-integration-multikueue-baseline-main
+      testgrid-tab-name: periodic-kueue-test-integration-multikueue-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue test-multikueue-baseline-integration"
+      description: "Run periodic kueue test-multikueue-integration"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -231,45 +231,7 @@ periodics:
           command:
             - make
           args:
-            - test-multikueue-baseline-integration
-          env:
-            - name: GOMAXPROCS
-              value: "7"
-          resources:
-            requests:
-              cpu: "7"
-              memory: "10Gi"
-            limits:
-              cpu: "7"
-              memory: "10Gi"
-  - interval: 12h
-    name: periodic-kueue-test-integration-multikueue-extended-main
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-integration-multikueue-extended-main
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue test-multikueue-extended-integration"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: main
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: public.ecr.aws/docker/library/golang:1.26
-          command:
-            - make
-          args:
-            - test-multikueue-extended-integration
+            - test-multikueue-integration
           env:
             - name: GOMAXPROCS
               value: "7"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -205,14 +205,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-integration-multikueue-main
+    name: periodic-kueue-test-integration-multikueue-baseline-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-integration-multikueue-main
+      testgrid-tab-name: periodic-kueue-test-integration-multikueue-baseline-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue test-multikueue-integration"
+      description: "Run periodic kueue test-multikueue-baseline-integration"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -231,7 +231,45 @@ periodics:
           command:
             - make
           args:
-            - test-multikueue-integration
+            - test-multikueue-baseline-integration
+          env:
+            - name: GOMAXPROCS
+              value: "7"
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-integration-multikueue-extended-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-integration-multikueue-extended-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue test-multikueue-extended-integration"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.26
+          command:
+            - make
+          args:
+            - test-multikueue-extended-integration
           env:
             - name: GOMAXPROCS
               value: "7"
@@ -725,14 +763,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-multikueue-main
+    name: periodic-kueue-test-e2e-multikueue-baseline-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-main
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-baseline-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic multikueue end to end tests"
+      description: "Run periodic baseline multikueue end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -759,7 +797,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-multikueue-e2e-main
+            - test-multikueue-baseline-e2e-main
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-multikueue-extended-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic extended multikueue end to end tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-multikueue-extended-e2e-main
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -126,7 +126,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-integration-multikueue-baseline-main
+    - name: pull-kueue-test-integration-multikueue-main
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -135,43 +135,15 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-integration-multikueue-baseline-main
-        description: "Run kueue test-multikueue-baseline-integration"
+        testgrid-tab-name: pull-kueue-test-integration-multikueue-main
+        description: "Run kueue test-multikueue-integration"
       spec:
         containers:
           - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
-              - test-multikueue-baseline-integration
-            env:
-              - name: GOMAXPROCS
-                value: "7"
-            resources:
-              requests:
-                cpu: "7"
-                memory: "12Gi"
-              limits:
-                cpu: "7"
-                memory: "12Gi"
-    - name: pull-kueue-test-integration-multikueue-extended-main
-      cluster: eks-prow-build-cluster
-      branches:
-        - ^main
-      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
-      decorate: true
-      path_alias: sigs.k8s.io/kueue
-      annotations:
-        testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-integration-multikueue-extended-main
-        description: "Run kueue test-multikueue-extended-integration"
-      spec:
-        containers:
-          - image: public.ecr.aws/docker/library/golang:1.26
-            command:
-              - make
-            args:
-              - test-multikueue-extended-integration
+              - test-multikueue-integration
             env:
               - name: GOMAXPROCS
                 value: "7"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -126,7 +126,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-integration-multikueue-main
+    - name: pull-kueue-test-integration-multikueue-baseline-main
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -135,15 +135,43 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-integration-multikueue-main
-        description: "Run kueue test-multikueue-integration"
+        testgrid-tab-name: pull-kueue-test-integration-multikueue-baseline-main
+        description: "Run kueue test-multikueue-baseline-integration"
       spec:
         containers:
           - image: public.ecr.aws/docker/library/golang:1.26
             command:
               - make
             args:
-              - test-multikueue-integration
+              - test-multikueue-baseline-integration
+            env:
+              - name: GOMAXPROCS
+                value: "7"
+            resources:
+              requests:
+                cpu: "7"
+                memory: "12Gi"
+              limits:
+                cpu: "7"
+                memory: "12Gi"
+    - name: pull-kueue-test-integration-multikueue-extended-main
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-integration-multikueue-extended-main
+        description: "Run kueue test-multikueue-extended-integration"
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.26
+            command:
+              - make
+            args:
+              - test-multikueue-extended-integration
             env:
               - name: GOMAXPROCS
                 value: "7"
@@ -458,7 +486,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-multikueue-main
+    - name: pull-kueue-test-e2e-multikueue-baseline-main
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -467,8 +495,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-multikueue-main
-        description: "Run multikueue end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-baseline-main
+        description: "Run baseline multikueue end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -485,7 +513,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-multikueue-e2e-main
+              - test-multikueue-baseline-e2e-main
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-multikueue-extended-main
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-main
+        description: "Run extended multikueue end to end tests"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-multikueue-extended-e2e-main
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true


### PR DESCRIPTION
kueue : split multikueue into extended and baseline suite

Part of [PR#11627 (Kueue) ](https://github.com/kubernetes-sigs/kueue/pull/11627) 

Adds two new presubmit jobs for the new multikueue-baseline and multikueue-extended
e2e test targets introduced in the kueue repo.