### PR TITLE
triage/summarize: fix duplicate failures when multiple test files passed to loadTests

### DIFF
--- a/triage/summarize/files.go
+++ b/triage/summarize/files.go
@@ -323,15 +323,15 @@ func loadTests(testsFilepaths []string, memoize bool) (map[string][]failure, err
 		return tests, nil
 	}
 
-	// jsonTests temporarily stores the tests as they are retrieved from the JSON file
-	// until they can be converted to failure objects
-	jsonFailures := make([]jsonFailure, 0)
 	for _, filepath := range testsFilepaths {
+		// jsonFailures temporarily stores the failures from this file
+		// until they can be converted to failure objects
+		jsonFailures := make([]jsonFailure, 0)
+
 		file, err := os.Open(filepath)
 		if err != nil {
 			return nil, fmt.Errorf("Could not open tests file '%s': %s", filepath, err)
 		}
-		defer file.Close()
 
 		// Read each line in the file as its own JSON object
 		decoder := json.NewDecoder(file)
@@ -341,10 +341,12 @@ func loadTests(testsFilepaths []string, memoize bool) (map[string][]failure, err
 			if err := decoder.Decode(&jf); err == io.EOF {
 				break // reached EOF
 			} else if err != nil {
+				file.Close()
 				return nil, err
 			}
 			jsonFailures = append(jsonFailures, jf)
 		}
+		file.Close()
 
 		// Convert the failure information to internal failure objects and store them in tests
 		for _, jf := range jsonFailures {


### PR DESCRIPTION
`loadTests` in `triage/summarize/files.go` takes a slice of test file paths (from `flag.Args()`), but `jsonFailures` was declared outside the loop and never reset between files. 
The conversion loop then iterated over all accumulated failures, not just the current file's - so failures from file N get inserted once for every remaining file. 
With 2 files you get file 1 duplicated, with 3 files tripled, etc.

Also `defer file.Close()` inside the loop deferred until function return, keeping all files open simultaneously.

Fix: move `jsonFailures` declaration inside the loop (fresh slice per file) and replace deferred close with explicit `file.Close()` calls.

Reproduce: run triage with two test files where file1 has failures. Entries from file1 appear twice in the output clustered results.