### PR TITLE
DRA: experiment with upcoming kubetest2 node support for binaries

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -782,6 +782,11 @@ presubmits:
       repo: test-infra
       base_ref: master
       path_alias: k8s.io/test-infra
+    # This ref enables testing https://github.com/kubernetes-sigs/kubetest2/pull/338 before it gets merged.
+    - org: pohly
+      repo: kubetest2
+      base_ref: node-prebuilt-binaries
+      path_alias: sigs.k8s.io/kubetest2
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
@@ -791,11 +796,9 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
-          _output/bin/e2e_node.test remote \
-             --ginkgo-binary=_output/bin/ginkgo \
-             --kubelet-binary=_output/bin/kubelet \
-             --e2e-node-binary=_output/bin/e2e_node.test \
+          go install -C ${GOPATH}/src/sigs.k8s.io/kubetest2 . ./kubetest2-tester-node ./kubetest2-noop
+          kubetest2 noop -test=node -- \
+             --build-binaries \
              --repo-root=. \
              --gcp-zone=us-central1-b \
              --parallelism=1 \
@@ -841,6 +844,11 @@ presubmits:
       repo: test-infra
       base_ref: master
       path_alias: k8s.io/test-infra
+    # This ref enables testing https://github.com/kubernetes-sigs/kubetest2/pull/338 before it gets merged.
+    - org: pohly
+      repo: kubetest2
+      base_ref: node-prebuilt-binaries
+      path_alias: sigs.k8s.io/kubetest2
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
@@ -850,12 +858,12 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
-          _output/bin/e2e_node.test remote \
-             --ginkgo-binary=_output/bin/ginkgo \
-             --kubelet-binary=_output/bin/kubelet \
-             --e2e-node-binary=_output/bin/e2e_node.test \
-             --repo-root=. \
+          go install -C ${GOPATH}/src/sigs.k8s.io/kubetest2 . ./kubetest2-tester-node ./kubetest2-noop
+          kubetest2 noop -test=node -- \
+             --use-binaries-from-package \
+             --test-package-url=https://dl.k8s.io \
+             --test-package-dir=ci/fast \
+             --test-package-marker=latest-fast.txt \
              --gcp-zone=us-central1-b \
              --parallelism=1 \
              --label-filter='DRA && Feature: isSubsetOf { OffByDefault,DynamicResourceAllocation } && !Flaky && !Slow' \
@@ -900,6 +908,11 @@ presubmits:
       repo: test-infra
       base_ref: master
       path_alias: k8s.io/test-infra
+    # This ref enables testing https://github.com/kubernetes-sigs/kubetest2/pull/338 before it gets merged.
+    - org: pohly
+      repo: kubetest2
+      base_ref: node-prebuilt-binaries
+      path_alias: sigs.k8s.io/kubetest2
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
@@ -909,11 +922,9 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
-          _output/bin/e2e_node.test remote \
-             --ginkgo-binary=_output/bin/ginkgo \
-             --kubelet-binary=_output/bin/kubelet \
-             --e2e-node-binary=_output/bin/e2e_node.test \
+          go install -C ${GOPATH}/src/sigs.k8s.io/kubetest2 . ./kubetest2-tester-node ./kubetest2-noop
+          kubetest2 noop -test=node -- \
+             --build-binaries \
              --repo-root=. \
              --gcp-zone=us-central1-b \
              --parallelism=1 \
@@ -955,6 +966,11 @@ presubmits:
     - org: containerd
       repo: containerd
       base_ref: release/2.1
+    # This ref enables testing https://github.com/kubernetes-sigs/kubetest2/pull/338 before it gets merged.
+    - org: pohly
+      repo: kubetest2
+      base_ref: node-prebuilt-binaries
+      path_alias: sigs.k8s.io/kubetest2
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
@@ -964,11 +980,9 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
-          _output/bin/e2e_node.test remote \
-             --ginkgo-binary=_output/bin/ginkgo \
-             --kubelet-binary=_output/bin/kubelet \
-             --e2e-node-binary=_output/bin/e2e_node.test \
+          go install -C ${GOPATH}/src/sigs.k8s.io/kubetest2 . ./kubetest2-tester-node ./kubetest2-noop
+          kubetest2 noop -test=node -- \
+             --build-binaries \
              --repo-root=. \
              --gcp-zone=us-central1-b \
              --parallelism=1 \
@@ -1007,6 +1021,11 @@ presubmits:
       repo: test-infra
       base_ref: master
       path_alias: k8s.io/test-infra
+    # This ref enables testing https://github.com/kubernetes-sigs/kubetest2/pull/338 before it gets merged.
+    - org: pohly
+      repo: kubetest2
+      base_ref: node-prebuilt-binaries
+      path_alias: sigs.k8s.io/kubetest2
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
@@ -1016,12 +1035,12 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
-          _output/bin/e2e_node.test remote \
-             --ginkgo-binary=_output/bin/ginkgo \
-             --kubelet-binary=_output/bin/kubelet \
-             --e2e-node-binary=_output/bin/e2e_node.test \
-             --repo-root=. \
+          go install -C ${GOPATH}/src/sigs.k8s.io/kubetest2 . ./kubetest2-tester-node ./kubetest2-noop
+          kubetest2 noop -test=node -- \
+             --use-binaries-from-package \
+             --test-package-url=https://dl.k8s.io \
+             --test-package-dir=ci/fast \
+             --test-package-marker=latest-fast.txt \
              --gcp-zone=us-central1-b \
              --parallelism=1 \
              --label-filter='DRA && Feature: isSubsetOf { OffByDefault,DynamicResourceAllocation } && !Flaky && !Slow' \
@@ -1062,6 +1081,11 @@ presubmits:
     - org: containerd
       repo: containerd
       base_ref: release/2.1
+    # This ref enables testing https://github.com/kubernetes-sigs/kubetest2/pull/338 before it gets merged.
+    - org: pohly
+      repo: kubetest2
+      base_ref: node-prebuilt-binaries
+      path_alias: sigs.k8s.io/kubetest2
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
@@ -1071,12 +1095,12 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
-          _output/bin/e2e_node.test remote \
-             --ginkgo-binary=_output/bin/ginkgo \
-             --kubelet-binary=_output/bin/kubelet \
-             --e2e-node-binary=_output/bin/e2e_node.test \
-             --repo-root=. \
+          go install -C ${GOPATH}/src/sigs.k8s.io/kubetest2 . ./kubetest2-tester-node ./kubetest2-noop
+          kubetest2 noop -test=node -- \
+             --use-binaries-from-package \
+             --test-package-url=https://dl.k8s.io \
+             --test-package-dir=ci/fast \
+             --test-package-marker=latest-fast.txt \
              --gcp-zone=us-central1-b \
              --parallelism=1 \
              --label-filter='DRA && Feature: isSubsetOf { OffByDefault,DynamicResourceAllocation } && !Flaky && !Slow' \

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -84,6 +84,13 @@ presubmits:
       repo: containerd
       base_ref: release/2.1
     {%- endif %}
+    {%- if job_type == "node" and canary %}
+    # This ref enables testing https://github.com/kubernetes-sigs/kubetest2/pull/338 before it gets merged.
+    - org: pohly
+      repo: kubetest2
+      base_ref: node-prebuilt-binaries
+      path_alias: sigs.k8s.io/kubetest2
+    {%- endif %}
     {%- endif %}
     spec:
       containers:
@@ -97,12 +104,17 @@ presubmits:
         - /bin/bash
         - -xce
         - |
-          make WHAT="github.com/onsi/ginkgo/v2/ginkgo cmd/kubelet test/e2e_node/e2e_node.test"
-          _output/bin/e2e_node.test remote \
-             --ginkgo-binary=_output/bin/ginkgo \
-             --kubelet-binary=_output/bin/kubelet \
-             --e2e-node-binary=_output/bin/e2e_node.test \
+          go install -C ${GOPATH}/src/sigs.k8s.io/kubetest2 . ./kubetest2-tester-node ./kubetest2-noop
+          kubetest2 noop -test=node -- \
+             {%- if all_features %}
+             --use-binaries-from-package \
+             --test-package-url=https://dl.k8s.io \
+             --test-package-dir=ci/fast \
+             --test-package-marker=latest-fast.txt \
+             {%- else %}
+             --build-binaries \
              --repo-root=. \
+             {%- endif %}
              --gcp-zone=us-central1-b \
              --parallelism=1 \
              --label-filter='DRA && Feature: isSubsetOf { {% if all_features %}OffByDefault,{% endif -%} DynamicResourceAllocation } && !Flaky {%- if not ci %} && !Slow {%- endif %}' \


### PR DESCRIPTION
At the moment both the updated node tester and Kubernetes need to be built from source (--build-binaries). Once https://github.com/kubernetes/kubernetes/pull/139096 is merged, the alternative invocation with --use-binaries-from-package can be used in an empty test PR.

/assign @bart0sh 