### PR TITLE
sig-windows: cap maxPods=20 on Hyper-V CI jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -178,6 +178,8 @@ periodics:
         env:
           - name: HYPERV
             value: "true"
+          - name: MAX_PODS
+            value: "20"
   annotations:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
@@ -397,6 +399,8 @@ periodics:
         env:
           - name: HYPERV
             value: "true"
+          - name: MAX_PODS
+            value: "20"
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
           - name: GINKGO_SKIP


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig windows

**What this PR does / why we need it:**

Sets `MAX_PODS=20` on the two Hyper-V Prow jobs:

- `ci-kubernetes-e2e-capz-master-windows-hyperv` (testgrid: [`capz-windows-master-hyperv`](https://testgrid.k8s.io/sig-windows-signal#capz-windows-master-hyperv))
- `ci-kubernetes-e2e-capz-master-windows-hyperv-serial-slow` (testgrid: [`capz-windows-master-hyperv-serial-slow`](https://testgrid.k8s.io/sig-windows-signal#capz-windows-master-hyperv-serial-slow))

Each Hyper-V UVM consumes host non-paged kernel pool that kubelet eviction stats do not see; with the default `maxPods=110`, bursts of pod creation exhaust HNS endpoints and trigger MemoryPressure cascades on the 16 GiB workers, manifesting as flakes on the two dashboards above.

**Which issue(s) this PR fixes:**

None.

**Special notes for your reviewer:**

Depends on [kubernetes-sigs/windows-testing#567](https://github.com/kubernetes-sigs/windows-testing/pull/567), which adds the generic `MAX_PODS` env var to `capz/run-capz-e2e.sh`. That PR is the one that makes this knob actually take effect; this PR just opts the Hyper-V jobs into it.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```