### PR TITLE
Fix VPA binary size job

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-coverage.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-coverage.yaml
@@ -25,7 +25,8 @@ periodics:
       - -c
       - |
         ./vertical-pod-autoscaler/hack/verify-deadcode-elimination.sh
-        cp vertical-pod-autoscaler/_output/junit_deadcode.xml "${ARTIFACTS}/junit_coverage.xml"
+        ls
+        cp ./vertical-pod-autoscaler/hack/../_output/junit_deadcode.xml "${ARTIFACTS}/junit_coverage.xml"
       resources:
         limits:
           cpu: 1


### PR DESCRIPTION
Also add an ls for debugging

The path is weird, but I used the output in
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-binary-size/2060710241376407552 as a reference