### PR TITLE
Revert "kueue : split multikueue into extended and baseline suite"

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -725,14 +725,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-multikueue-baseline-main
+    name: periodic-kueue-test-e2e-multikueue-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-baseline-main
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic baseline multikueue end to end tests"
+      description: "Run periodic multikueue end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -759,53 +759,7 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-multikueue-baseline-e2e-main
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "7"
-              memory: "10Gi"
-            limits:
-              cpu: "7"
-              memory: "10Gi"
-  - interval: 12h
-    name: periodic-kueue-test-e2e-multikueue-extended-main
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-main
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic extended multikueue end to end tests"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: main
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
-          env:
-            - name: E2E_K8S_VERSION
-              value: "1.35"
-            - name: BASE_BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - kind-image-build
-            - test-multikueue-extended-e2e-main
+            - test-multikueue-e2e-main
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -458,7 +458,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-multikueue-baseline-main
+    - name: pull-kueue-test-e2e-multikueue-main
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -467,8 +467,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-multikueue-baseline-main
-        description: "Run baseline multikueue end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-main
+        description: "Run multikueue end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -485,45 +485,7 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-multikueue-baseline-e2e-main
-            # docker-in-docker needs privileged mode
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                cpu: "7"
-                memory: "10Gi"
-              limits:
-                cpu: "7"
-                memory: "10Gi"
-    - name: pull-kueue-test-e2e-multikueue-extended-main
-      cluster: eks-prow-build-cluster
-      branches:
-        - ^main
-      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
-      decorate: true
-      path_alias: sigs.k8s.io/kueue
-      annotations:
-        testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-main
-        description: "Run extended multikueue end to end tests"
-      labels:
-        preset-dind-enabled: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
-            env:
-              - name: E2E_K8S_VERSION
-                value: "1.35"
-              - name: BASE_BUILDER_IMAGE
-                value: public.ecr.aws/docker/library/golang
-            command:
-              # generic runner script, handles DIND, bazelrc for caching, etc.
-              - runner.sh
-            args:
-              - make
-              - kind-image-build
-              - test-multikueue-extended-e2e-main
+              - test-multikueue-e2e-main
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true


### PR DESCRIPTION
Reverts kubernetes/test-infra#37132

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/11832/pull-kueue-test-e2e-multikueue-baseline-main/2060757657148461056

Seems something is wrong here.