### PR TITLE
Add Kubernetes 1.36 e2e jobs for jobset

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -188,3 +188,43 @@ periodics:
             requests:
               cpu: 3
               memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-main-1-36
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: main
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset, sig-apps-jobset-periodics
+      testgrid-tab-name: periodic-jobset-test-e2e-main-1-36
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.36"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.36.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.26
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-11.yaml
@@ -188,3 +188,43 @@ periodics:
           requests:
             cpu: 3
             memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-release-0-11-1-36
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: release-0.11
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-periodics
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-11-1-36
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.36 on release 0.11"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+        env:
+        - name: E2E_KIND_VERSION
+          value: kindest/node:v1.36.0
+        - name: BUILDER_IMAGE
+          value: public.ecr.aws/docker/library/golang:1.26
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-12.yaml
@@ -188,3 +188,43 @@ periodics:
           requests:
             cpu: 3
             memory: 10Gi
+  - interval: 12h
+    name: periodic-jobset-test-e2e-release-0-12-1-36
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: jobset
+        base_ref: release-0.12
+        path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-periodics
+      testgrid-tab-name: periodic-jobset-test-e2e-release-0-12-1-36
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic jobset end to end tests for Kubernetes 1.36 on release 0.12"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+        env:
+        - name: E2E_KIND_VERSION
+          value: kindest/node:v1.36.0
+        - name: BUILDER_IMAGE
+          value: public.ecr.aws/docker/library/golang:1.26
+        command:
+        # generic runner script, handles DIND, bazelrc for caching, etc.
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 3
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 10Gi

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -170,6 +170,43 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-jobset-test-e2e-main-1-36
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^main
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      testgrid-tab-name: pull-jobset-test-e2e-main-1-36
+      description: "Run jobset end to end tests for Kubernetes 1.36"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.36.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.26
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-jobset-verify-main
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-11.yaml
@@ -165,6 +165,42 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-jobset-test-e2e-release-0-11-1-36
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^release-0.11
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      description: "Run jobset end to end tests for Kubernetes 1.36"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.36.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.26
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-jobset-verify-release-0-11
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-12.yaml
@@ -165,6 +165,42 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-jobset-test-e2e-release-0-12-1-36
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^release-0.12
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      description: "Run jobset end to end tests for Kubernetes 1.36"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.36.0
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.26
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-jobset-verify-release-0-12
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
## Changes

Add Kubernetes 1.36 e2e test jobs for jobset across all branches:

- **Periodic jobs**: `periodic-jobset-test-e2e-{main,release-0-11,release-0-12}-1-36`
- **Presubmit jobs**: `pull-jobset-test-e2e-{main,release-0-11,release-0-12}-1-36`

All jobs use `kindest/node:v1.36.0` with `golang:1.26`.

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI