### PR TITLE
Kueue: Split multikueue into extended and baseline for Release-0.17 and Release-0.18

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -687,14 +687,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-multikueue-release-0-17
+    name: periodic-kueue-test-e2e-multikueue-baseline-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-release-0-17
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-baseline-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic multikueue end to end tests"
+      description: "Run periodic baseline multikueue end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -721,7 +721,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-multikueue-e2e-main
+            - test-multikueue-e2e-baseline-main
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-multikueue-extended-release-0-17
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-release-0-17
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic extended multikueue end to end tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.17
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-multikueue-e2e-extended-main
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -721,7 +721,7 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-multikueue-e2e-baseline-main
+            - test-multikueue-e2e-baseline
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -767,7 +767,7 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-multikueue-e2e-extended-main
+            - test-multikueue-e2e-extended
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -725,14 +725,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-multikueue-release-0-18
+    name: periodic-kueue-test-e2e-multikueue-baseline-release-0-18
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-release-0-18
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-baseline-release-0-18
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic multikueue end to end tests"
+      description: "Run periodic multikueue baseline end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -759,7 +759,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-multikueue-e2e-main
+            - test-multikueue-e2e-baseline
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-multikueue-extended-release-0-18
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-release-0-18
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic multikueue extended end to end tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.18
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-multikueue-e2e-extended
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -732,7 +732,7 @@ periodics:
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-baseline-release-0-18
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic multikueue baseline end to end tests"
+      description: "Run periodic baseline multikueue end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -778,7 +778,7 @@ periodics:
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-release-0-18
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic multikueue extended end to end tests"
+      description: "Run periodic extended multikueue end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -732,7 +732,7 @@ periodics:
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-baseline-release-0-18
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic baseline multikueue end to end tests"
+      description: "Run periodic multikueue baseline end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -778,7 +778,7 @@ periodics:
       testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-release-0-18
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic extended multikueue end to end tests"
+      description: "Run periodic multikueue extended end to end tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -485,7 +485,7 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-multikueue-e2e-baseline-main
+              - test-multikueue-e2e-baseline
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -523,7 +523,7 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-multikueue-e2e-extended-main
+              - test-multikueue-e2e-extended
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -468,7 +468,7 @@ presubmits:
       annotations:
         testgrid-dashboards: sig-scheduling
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-baseline-release-0-17
-        description: "Run multikueue baseline end to end tests"
+        description: "Run baseline multikueue end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -506,7 +506,7 @@ presubmits:
       annotations:
         testgrid-dashboards: sig-scheduling
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-release-0-17
-        description: "Run multikueue extended end to end tests"
+        description: "Run extended multikueue end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -458,7 +458,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-multikueue-release-0-17
+    - name: pull-kueue-test-e2e-multikueue-baseline-release-0-17
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.17
@@ -467,8 +467,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-multikueue-release-0-17
-        description: "Run multikueue end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-baseline-release-0-17
+        description: "Run multikueue baseline end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -485,7 +485,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-multikueue-e2e-main
+              - test-multikueue-e2e-baseline-main
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-multikueue-extended-release-0-17
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.17
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-release-0-17
+        description: "Run multikueue extended end to end tests"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-multikueue-e2e-extended-main
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -468,7 +468,7 @@ presubmits:
       annotations:
         testgrid-dashboards: sig-scheduling
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-baseline-release-0-18
-        description: "Run multikueue baseline end to end tests"
+        description: "Run baseline multikueue end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -506,7 +506,7 @@ presubmits:
       annotations:
         testgrid-dashboards: sig-scheduling
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-release-0-18
-        description: "Run multikueue extended end to end tests"
+        description: "Run extended multikueue end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -458,7 +458,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-multikueue-release-0-18
+    - name: pull-kueue-test-e2e-multikueue-baseline-release-0-18
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.18
@@ -467,8 +467,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-multikueue-release-0-18
-        description: "Run multikueue end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-baseline-release-0-18
+        description: "Run multikueue baseline end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -485,7 +485,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-multikueue-e2e-main
+              - test-multikueue-e2e-baseline
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-multikueue-extended-release-0-18
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.18
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-release-0-18
+        description: "Run multikueue extended end to end tests"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-multikueue-e2e-extended
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -468,7 +468,7 @@ presubmits:
       annotations:
         testgrid-dashboards: sig-scheduling
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-baseline-release-0-18
-        description: "Run baseline multikueue end to end tests"
+        description: "Run multikueue baseline end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -506,7 +506,7 @@ presubmits:
       annotations:
         testgrid-dashboards: sig-scheduling
         testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-release-0-18
-        description: "Run extended multikueue end to end tests"
+        description: "Run multikueue extended end to end tests"
       labels:
         preset-dind-enabled: "true"
       spec:


### PR DESCRIPTION
Kueue : Split multikueue into extended and baseline suite for Release-0.17 and Release-0.18

Part of https://github.com/kubernetes-sigs/kueue/pull/11846
Part of https://github.com/kubernetes-sigs/kueue/pull/11881

Adds two new presubmit jobs for the new multikueue-baseline and multikueue-extended
e2e test targets introduced in the Kueue Release-0.17 and Release-0.18
