### PR TITLE
Add a e2e presubmit prow job for the mcp-lifecycle-operator

### DIFF
--- a/config/jobs/kubernetes-sigs/mcp-lifecycle-operator/mcp-lifecycle-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/mcp-lifecycle-operator/mcp-lifecycle-operator-presubmits-main.yaml
@@ -24,6 +24,7 @@ presubmits:
   - name: presubmit-mcp-lifecycle-operator-e2e-test
     cluster: eks-prow-build-cluster
     always_run: true
+    optional: true
     decorate: true
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/mcp-lifecycle-operator/mcp-lifecycle-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/mcp-lifecycle-operator/mcp-lifecycle-operator-presubmits-main.yaml
@@ -21,3 +21,36 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-apps-mcp-lifecycle-operator
       testgrid-tab-name: presubmit-mcp-lifecycle-operator-unit-test
+  - name: presubmit-mcp-lifecycle-operator-e2e-test
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - >-
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64 &&
+          chmod +x ./kind &&
+          mv ./kind /usr/local/bin/kind &&
+          make deploy-test-e2e test-e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 4
+            memory: 6Gi
+          limits:
+            cpu: 4
+            memory: 6Gi
+    annotations:
+      testgrid-dashboards: sig-apps-mcp-lifecycle-operator
+      testgrid-tab-name: presubmit-mcp-lifecycle-operator-e2e-test


### PR DESCRIPTION
Port the [e2e test](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/44aabd8a8cf77c31116003e76118a555e60fc879/.github/workflows/test-e2e.yml) from GitHub Actions to a prow presubmit job. The job uses kind with Docker-in-Docker to build the operator image, deploy it to a kind cluster, and run the e2e test suite.

Hint: I made this job optional for now, until we know it runs stable