### PR TITLE
contributor-site: require Netlify deploy status checks

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -296,6 +296,13 @@ branch-protection:
             users: []
             teams:
             - stage-bots
+        contributor-site:
+          required_status_checks:
+            contexts:
+            - deploy/netlify
+            - Header rules
+            - Pages changed
+            - Redirect rules
         controller-manager:
           restrictions:
             users: []


### PR DESCRIPTION
## Summary

Add a per-repo entry under `branch-protection.orgs.kubernetes.repos` in `config/prow/config.yaml` for `kubernetes/contributor-site` that requires the four Netlify check contexts.

Fixes https://github.com/kubernetes/contributor-site/issues/736

## Context

https://github.com/kubernetes/contributor-site/pull/728. All four Netlify checks failed on that PR, but Tide still merged it.

## Change

Adds a per-repo override in Prow's branch-protection config:

```yaml
        contributor-site:
          required_status_checks:
            contexts:
            - deploy/netlify
            - Header rules
            - Pages changed
            - Redirect rules
```

- `protect: true` and the org-level branch excludes (`^revert-`, `^dependabot/`, `^copilot/`, `^greenkeeper/`) are already inherited from `branch-protection.orgs.kubernetes`, so they don't need to be repeated.
- `EasyCLA` continues to be required — Prow merges the per-repo list with the org default.
- Default branch is `master` (confirmed via GitHub API), so no `branches:` override is needed.

## CC

@cblecker (per the original suggestion in kubernetes/contributor-site#736), @jberkus, @palnabarun, @LMKTFY