### PR TITLE
Skip kuberay test in 1.24 test, no ci artifacts

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.24.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.24.yaml
@@ -154,7 +154,7 @@ periodics:
         - name: GINKGO_FOCUS
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
-          value: \[Managed Kubernetes\]
+          value: \[Managed Kubernetes\]|\[KubeRay\]
       resources:
         limits:
           cpu: 6


### PR DESCRIPTION
Same as #36764 but for release-1.24