### PR TITLE
ci-kubernetes-e2e-kind-ipv6-canary: download for correct arch

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -122,7 +122,7 @@ periodics:
         - runner.sh
         - bash
         - -c
-        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-$(go env GOARCH).tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         # enable IPV6 in bootstrap image
         - name: DOCKER_IN_DOCKER_IPV6_ENABLED


### PR DESCRIPTION
note: only amd64 and arm64 are supported

This job seems to run on arm64 at least sometimes. From the logs it winds up using a stale kind binary.