### PR TITLE
Onboard `resource-state-metrics`

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-resource-state-metrics.yaml
+++ b/config/jobs/image-pushing/k8s-staging-resource-state-metrics.yaml
@@ -1,0 +1,21 @@
+postsubmits:
+  kubernetes-sigs/resource-state-metrics:
+    - name: post-resource-state-metrics-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-instrumentation-image-pushes, sig-k8s-infra-gcb
+      decorate: true
+      branches:
+        - ^main$
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: resource-state-metrics
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/image-builder:v20260419-39c657fdbf
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-images
+              - --scratch-bucket=gs://k8s-staging-images-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .


### PR DESCRIPTION
Onboard postsubmits for the fairly recent `kubernetes-sigs/resource-state-metrics` repository.

Also see: https://github.com/kubernetes/k8s.io/pull/9560/changes