### PR TITLE
website: require Netlify deploy status checks

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -495,6 +495,12 @@ branch-protection:
             teams:
             - stage-bots
         website:
+          required_status_checks:
+            contexts:
+            - deploy/netlify
+            - Header rules
+            - Pages changed
+            - Redirect rules
           protect: true
     kubernetes-client:
       protect: true


### PR DESCRIPTION
# Context

kubernetes/website#53679 (\"Bump Docsy to 0.7.x\"), merged on Mar 24, 2026, with all 6 deploy-preview checks passing. The post-merge Netlify **production** build then failed with:

```
ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0
and will be removed in Hugo 0.134.0. Use .Site.Config.Services.GoogleAnalytics.
make: *** [Makefile:68: production-build] Error 1
Failing build: Failed to build site
```

Fixes https://github.com/kubernetes/website/issues/55982