### PR TITLE
add periodic e2e Kind test jobs for node-readiness-controller on K8s 1.33-1.36

### DIFF
--- a/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-periodics.yaml
@@ -17,6 +17,8 @@ periodics:
     labels:
       preset-dind-enabled: "true"
     decorate: true
+    decoration_config:
+      timeout: 2h
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
@@ -55,6 +57,8 @@ periodics:
     labels:
       preset-dind-enabled: "true"
     decorate: true
+    decoration_config:
+      timeout: 2h
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
@@ -93,6 +97,8 @@ periodics:
     labels:
       preset-dind-enabled: "true"
     decorate: true
+    decoration_config:
+      timeout: 2h
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
@@ -131,6 +137,8 @@ periodics:
     labels:
       preset-dind-enabled: "true"
     decorate: true
+    decoration_config:
+      timeout: 2h
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master

--- a/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-periodics.yaml
@@ -1,0 +1,153 @@
+periodics:
+  - interval: 12h
+    name: periodic-node-readiness-controller-test-e2e-main-1-36
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: node-readiness-controller
+        base_ref: main
+        path_alias: sigs.k8s.io/node-readiness-controller
+    annotations:
+      testgrid-dashboards: sig-node-node-readiness-controller
+      testgrid-num-failures-to-alert: '1'
+      testgrid-alert-email: ajaysundar.k@gmail.com
+      description: "Run periodic node-readiness-controller e2e tests for Kubernetes 1.36"
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: v1.36
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+  - interval: 12h
+    name: periodic-node-readiness-controller-test-e2e-main-1-35
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: node-readiness-controller
+        base_ref: main
+        path_alias: sigs.k8s.io/node-readiness-controller
+    annotations:
+      testgrid-dashboards: sig-node-node-readiness-controller
+      testgrid-num-failures-to-alert: '1'
+      testgrid-alert-email: ajaysundar.k@gmail.com
+      description: "Run periodic node-readiness-controller e2e tests for Kubernetes 1.35"
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: v1.35
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+  - interval: 12h
+    name: periodic-node-readiness-controller-test-e2e-main-1-34
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: node-readiness-controller
+        base_ref: main
+        path_alias: sigs.k8s.io/node-readiness-controller
+    annotations:
+      testgrid-dashboards: sig-node-node-readiness-controller
+      testgrid-num-failures-to-alert: '1'
+      testgrid-alert-email: ajaysundar.k@gmail.com
+      description: "Run periodic node-readiness-controller e2e tests for Kubernetes 1.34"
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: v1.34
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+  - interval: 12h
+    name: periodic-node-readiness-controller-test-e2e-main-1-33
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: node-readiness-controller
+        base_ref: main
+        path_alias: sigs.k8s.io/node-readiness-controller
+    annotations:
+      testgrid-dashboards: sig-node-node-readiness-controller
+      testgrid-num-failures-to-alert: '1'
+      testgrid-alert-email: ajaysundar.k@gmail.com
+      description: "Run periodic node-readiness-controller e2e tests for Kubernetes 1.33"
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: v1.33
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi


### PR DESCRIPTION
Add periodics kind e2e jobs for k-sigs/node-readiness-controller project, across all supported K8s release branches.

/assign @ajaysundark 