### PR TITLE
Updating windows jobs in sig-cloud-provider/azure/release-master.yaml

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-master.yaml
@@ -132,12 +132,14 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.21
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: azuredisk-csi-driver
         base_ref: master
@@ -146,13 +148,20 @@ presubmits:
         repo: cloud-provider-azure
         base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -162,14 +171,10 @@ presubmits:
           env:
             - name: AZURE_STORAGE_DRIVER # azuredisk-csi-driver config
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
+            - name: AZURE_VM_TYPE # azuredisk-csi-driver config
+              value: "standard"
             - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
             - name: WORKER_MACHINE_COUNT # CAPZ config
@@ -320,12 +325,14 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.21
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: azurefile-csi-driver
         base_ref: master
@@ -334,13 +341,20 @@ presubmits:
         repo: cloud-provider-azure
         base_ref: master
         path_alias: sigs.k8s.io/cloud-provider-azure
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=latest
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -350,12 +364,6 @@ presubmits:
           env:
             - name: runInTreeVolumeTestsOnly # azurefile-csi-driver config
               value: "true"
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
             - name: WORKER_MACHINE_COUNT # CAPZ config


### PR DESCRIPTION
Updating the remaining windows jobs in sig-cloud-provider/azure/release-master.yaml to use run-capz-e2e.sh instead of ci-entrypoint.sh

Part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/6305

/sig windows
/assign @mboersma @andyzhangx 