### PR TITLE
Updating remaining azuredisk-csi-driver windows jobs to use run-capz-e2e.sh

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -61,6 +61,8 @@ periodics:
         env:
           - name: AZURE_VM_TYPE # azuredisk-csi-driver config
             value: "standard"
+          - name: NODE_MACHINE_TYPE # CAPZ config
+            value: "Standard_D4s_v3"
   annotations:
     testgrid-dashboards: provider-azure-azuredisk-csi-driver, sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: ci-azuredisk-csi-driver-e2e-capz-windows
@@ -323,24 +325,33 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.21
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
         base_ref: release-1.32
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=v1.32.2
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -359,22 +370,16 @@ presubmits:
           env:
             - name: AZURE_STORAGE_DRIVER
               value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
-            - name: TEST_MIGRATION
-              value: "true"
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
+            - name: AZURE_VM_TYPE # azuredisk-csi-driver config
+              value: "standard"
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE # azuredisk-csi-driver config
+            - name: TEST_MIGRATION
               value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.32.2"
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
+              value: "true"
             - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:
@@ -459,24 +464,33 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.21
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
-        base_ref: release-1.33
+        base_ref: release-1.32
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=v1.32.2
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -493,18 +507,12 @@ presubmits:
               cpu: 4
               memory: 8Gi
           env:
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
-            - name: NODE_MACHINE_TYPE # CAPZ config
-              value: "Standard_D4s_v3"
+            - name: AZURE_VM_TYPE # azuredisk-csi-driver config
+              value: "standard"
             - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "v1.33.2"
+            - name: NODE_MACHINE_TYPE # CAPZ config
+              value: "Standard_D4s_v3"
             - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:
@@ -733,24 +741,33 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-community: "true"
+      preset-capz-windows-common: "true"
+      preset-capz-windows-2022: "true"
+      preset-capz-containerd-2-0-latest: "true"
     extra_refs:
       - org: kubernetes-sigs
         repo: cluster-api-provider-azure
-        base_ref: release-1.20
+        base_ref: main
         path_alias: sigs.k8s.io/cluster-api-provider-azure
-        workdir: true
       - org: kubernetes-sigs
         repo: cloud-provider-azure
         base_ref: release-1.32
         path_alias: sigs.k8s.io/cloud-provider-azure
         workdir: false
+      - org: kubernetes-sigs
+        repo: windows-testing
+        base_ref: master
+        path_alias: sigs.k8s.io/windows-testing
+        workdir: true
     spec:
       serviceAccountName: azure
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
           command:
             - runner.sh
-            - ./scripts/ci-entrypoint.sh
+            - env
+            - KUBERNETES_VERSION=v1.32.2
+            - ./capz/run-capz-e2e.sh
           args:
             - bash
             - -c
@@ -767,20 +784,14 @@ presubmits:
               cpu: 4
               memory: 8Gi
           env:
-            - name: WINDOWS # azuredisk-csi-driver config
-              value: "true"
-            - name: TEST_WINDOWS # CAPZ config
-              value: "true"
-            - name: WINDOWS_SERVER_VERSION # CAPZ config
-              value: "windows-2022"
-            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # CAPZ config
+            - name: AZURE_VM_TYPE # azuredisk-csi-driver config
+              value: "standard"
+            - name: DISABLE_ZONE # azuredisk-csi-driver config
               value: "true"
             - name: NODE_MACHINE_TYPE # CAPZ config
               value: "Standard_D4s_v3"
-            - name: DISABLE_ZONE # azuredisk-csi-driver config
+            - name: WINDOWS_USE_HOST_PROCESS_CONTAINERS # azuredisk-csi-driver config
               value: "true"
-            - name: KUBERNETES_VERSION # CAPZ config
-              value: "latest-1.32"
             - name: WORKER_MACHINE_COUNT # CAPZ config
               value: "0" # Don't create any linux worker nodes
     annotations:


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/6305

Note I am not updating the Windows Server 2019 jobs because they will be removed with https://github.com/kubernetes/test-infra/pull/37125

/sig windows
/assign @mboersma @andyzhangx 