### PR TITLE
sig-scalability: run 100-node apiserver-restart presubmit with HA control plane

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -581,7 +581,7 @@ presubmits:
         - name: KUBE_PROXY_MODE
           value: "nftables"
         - name: CONTROL_PLANE_COUNT
-          value: "1"
+          value: "3"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-32"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY


### PR DESCRIPTION
Run with 3 apiservers so restarting one won't affect cluster slo.

Depends on:
- https://github.com/kubernetes/perf-tests/pull/4076