### PR TITLE
capz-windows-master-hyperv-serial-slow: re-enable 3 GC/SchedulerPreemption specs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -404,7 +404,7 @@ periodics:
           - name: GINKGO_FOCUS
             value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
           - name: GINKGO_SKIP
-            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|\[Alpha\]|\[FeatureGate:SchedulerAsyncPreemption\]|\[Beta\]|should.evict.a.pod.when.a.node.experiences.memory.pressure|should.be.able.to.gracefully.shutdown.pods.with.various.grace.periods|Garbage.collector.*keep.the.rc.around|Garbage.collector.*not.delete.dependents|Garbage.collector.*orphan.pods.created.by.rc.if.delete.options.say.so|validates.pod.disruption.condition.is.added.to.the.preempted.pod
+            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|\[Alpha\]|\[FeatureGate:SchedulerAsyncPreemption\]|\[Beta\]|should.evict.a.pod.when.a.node.experiences.memory.pressure|should.be.able.to.gracefully.shutdown.pods.with.various.grace.periods|Garbage.collector.*keep.the.rc.around
           - name: NODE_FEATURE_GATES
             value: "WindowsGracefulNodeShutdown=true"
   annotations:


### PR DESCRIPTION
## What this PR does

Re-enables 3 previously-skipped Kubernetes e2e specs on the
`capz-windows-master-hyperv-serial-slow` testgrid dashboard:

- `[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Serial] [Conformance]`
- `[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Serial] [Conformance]`
- `[sig-scheduling] SchedulerPreemption [Serial] validates pod disruption condition is added to the preempted pod [Conformance]`

These were originally skipped because they consistently OOM'd Windows worker nodes under Hyper-V isolation due to per-pod vmmem.exe overhead exceeding the kubelet's hard-eviction threshold on 16 GiB D4s_v3 workers.

## Why this is safe now

The root cause was excessive Hyper-V pod density: with the default `--max-pods=110`, the e2e helper `estimateMaximumPods(min=10, max=100)` would request up to 100 pods per node, and each pod added ~500-700 MiB
of vmmem host overhead invisible to pod-level kubelet stats.

The `MAX_PODS=20` cap added in [kubernetes-sigs/windows-testing#567](https://github.com/kubernetes-sigs/windows-testing/pull/567) and [test-infra#37141](https://github.com/kubernetes/test-infra/pull/37141)
reduces this to at most 20 pods/node, keeping the 3 specs comfortably inside available memory.

/sig windows
/area provider/azure
/cc @marosset @zylxjtu
