### PR TITLE
Fix ci-etcd-k8s-coverage-amd64: rename go_test to run_go_tests

### DIFF
--- a/config/jobs/etcd/etcd-periodics-main.yaml
+++ b/config/jobs/etcd/etcd-periodics-main.yaml
@@ -1144,7 +1144,7 @@ periodics:
           export ETCD_VERIFY=all
           export JUNIT_REPORT_DIR=${ARTIFACTS}
           source ./scripts/test_lib.sh
-          run_for_module "tests" go_test "./robustness/coverage/..." "keep_going" : -timeout=60s -run="^TestInterfaceUse/"
+          run_for_module "tests" run_go_tests "./robustness/coverage/..." -timeout=60s -run="^TestInterfaceUse/"
         volumeMounts:
           - mountPath: /etcd-data
             name: tmpdir


### PR DESCRIPTION
etcd-io/etcd#21826 removed the `go_test` helper this job calls (renamed to `run_go_tests`), so it's been failing with `go_test: command not found` since 2026-05-29. This points it at the new function.

The old `keep_going` arg is dropped because `run_go_tests` forwards everything straight to a single `go test`, which already runs all matched packages and reports failures without bailing early.