### PR TITLE
Kueue: singlecluster/extended tests are sharded for optimizing the tests to reduce CI time 

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -403,14 +403,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-main-1-33
+    name: periodic-kueue-test-e2e-extended-shard-0-main-1-33
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-main-1-33
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-main-1-33
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.33"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.33"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -437,7 +437,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-main-1-33
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-main-1-33
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.33"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.33"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -495,14 +541,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-main-1-34
+    name: periodic-kueue-test-e2e-extended-shard-0-main-1-34
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-main-1-34
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-main-1-34
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.34"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.34"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -529,7 +575,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-main-1-34
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-main-1-34
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.34"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.34"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -587,14 +679,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-main-1-35
+    name: periodic-kueue-test-e2e-extended-shard-0-main-1-35
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-main-1-35
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-main-1-35
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.35"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.35"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -621,7 +713,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-main-1-35
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-main-1-35
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.35"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -679,14 +817,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-main-1-36
+    name: periodic-kueue-test-e2e-extended-shard-0-main-1-36
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-main-1-36
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-main-1-36
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.36"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.36"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -713,7 +851,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-main-1-36
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-main-1-36
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.36"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.36"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -365,14 +365,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-release-0-17-1-33
+    name: periodic-kueue-test-e2e-extended-shard-0-release-0-17-1-33
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-release-0-17-1-33
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-release-0-17-1-33
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.33"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.33"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -399,7 +399,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-release-0-17-1-33
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-release-0-17-1-33
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.33"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.17
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.33"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -457,14 +503,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-release-0-17-1-34
+    name: periodic-kueue-test-e2e-extended-shard-0-release-0-17-1-34
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-release-0-17-1-34
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-release-0-17-1-34
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.34"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.34"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -491,7 +537,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-release-0-17-1-34
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-release-0-17-1-34
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.34"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.17
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.34"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -549,14 +641,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-release-0-17-1-35
+    name: periodic-kueue-test-e2e-extended-shard-0-release-0-17-1-35
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-release-0-17-1-35
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-release-0-17-1-35
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.35"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.35"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -583,7 +675,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-release-0-17-1-35
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-release-0-17-1-35
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.35"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.17
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -641,14 +779,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-release-0-17-1-36
+    name: periodic-kueue-test-e2e-extended-shard-0-release-0-17-1-36
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-release-0-17-1-36
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-release-0-17-1-36
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.36"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.36"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -675,7 +813,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-release-0-17-1-36
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-release-0-17-1-36
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.36"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.17
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.36"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -403,14 +403,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-release-0-18-1-33
+    name: periodic-kueue-test-e2e-extended-shard-0-release-0-18-1-33
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-release-0-18-1-33
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-release-0-18-1-33
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.33"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.33"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -437,7 +437,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-release-0-18-1-33
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-release-0-18-1-33
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.33"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.18
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.33"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -495,14 +541,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-release-0-18-1-34
+    name: periodic-kueue-test-e2e-extended-shard-0-release-0-18-1-34
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-release-0-18-1-34
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-release-0-18-1-34
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.34"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.34"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -529,7 +575,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-release-0-18-1-34
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-release-0-18-1-34
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.34"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.18
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.34"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -587,14 +679,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-release-0-18-1-35
+    name: periodic-kueue-test-e2e-extended-shard-0-release-0-18-1-35
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-release-0-18-1-35
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-release-0-18-1-35
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.35"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.35"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -621,7 +713,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-release-0-18-1-35
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-release-0-18-1-35
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.35"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.18
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -679,14 +817,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-extended-release-0-18-1-36
+    name: periodic-kueue-test-e2e-extended-shard-0-release-0-18-1-36
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-extended-release-0-18-1-36
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-0-release-0-18-1-36
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue extended end to end tests for Kubernetes 1.36"
+      description: "Run periodic kueue extended end to end tests shard 0 for Kubernetes 1.36"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -713,7 +851,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-extended
+            - test-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-extended-shard-1-release-0-18-1-36
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-extended-shard-1-release-0-18-1-36
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue extended end to end tests shard 1 for Kubernetes 1.36"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.18
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.36"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -192,7 +192,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-main-1-33
+    - name: pull-kueue-test-e2e-extended-shard-0-main-1-33
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -201,8 +201,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-main-1-33
-        description: "Run kueue extended end to end tests for Kubernetes 1.33"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-main-1-33
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.33"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -219,7 +219,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-main-1-33
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-main-1-33
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.33"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.33"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -268,7 +306,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-main-1-34
+    - name: pull-kueue-test-e2e-extended-shard-0-main-1-34
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -277,8 +315,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-main-1-34
-        description: "Run kueue extended end to end tests for Kubernetes 1.34"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-main-1-34
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.34"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -295,7 +333,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-main-1-34
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-main-1-34
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.34"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.34"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -344,7 +420,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-main-1-35
+    - name: pull-kueue-test-e2e-extended-shard-0-main-1-35
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -353,8 +429,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-main-1-35
-        description: "Run kueue extended end to end tests for Kubernetes 1.35"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-main-1-35
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.35"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -371,7 +447,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-main-1-35
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-main-1-35
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.35"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -420,7 +534,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-main-1-36
+    - name: pull-kueue-test-e2e-extended-shard-0-main-1-36
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -429,8 +543,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-main-1-36
-        description: "Run kueue extended end to end tests for Kubernetes 1.36"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-main-1-36
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.36"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -447,7 +561,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-main-1-36
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-main-1-36
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.36"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.36"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -192,7 +192,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-release-0-17-1-33
+    - name: pull-kueue-test-e2e-extended-shard-0-release-0-17-1-33
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.17
@@ -201,8 +201,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-release-0-17-1-33
-        description: "Run kueue extended end to end tests for Kubernetes 1.33"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-release-0-17-1-33
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.33"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -219,7 +219,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-release-0-17-1-33
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.17
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-release-0-17-1-33
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.33"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.33"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -268,7 +306,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-release-0-17-1-34
+    - name: pull-kueue-test-e2e-extended-shard-0-release-0-17-1-34
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.17
@@ -277,8 +315,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-release-0-17-1-34
-        description: "Run kueue extended end to end tests for Kubernetes 1.34"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-release-0-17-1-34
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.34"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -295,7 +333,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-release-0-17-1-34
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.17
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-release-0-17-1-34
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.34"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.34"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -344,7 +420,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-release-0-17-1-35
+    - name: pull-kueue-test-e2e-extended-shard-0-release-0-17-1-35
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.17
@@ -353,8 +429,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-release-0-17-1-35
-        description: "Run kueue extended end to end tests for Kubernetes 1.35"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-release-0-17-1-35
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.35"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -371,7 +447,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-release-0-17-1-35
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.17
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-release-0-17-1-35
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.35"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -420,7 +534,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-release-0-17-1-36
+    - name: pull-kueue-test-e2e-extended-shard-0-release-0-17-1-36
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.17
@@ -429,8 +543,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-release-0-17-1-36
-        description: "Run kueue extended end to end tests for Kubernetes 1.36"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-release-0-17-1-36
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.36"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -447,7 +561,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-release-0-17-1-36
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.17
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-release-0-17-1-36
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.36"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.36"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -609,7 +609,7 @@ presubmits:
                 memory: "10Gi"
               limits:
                 cpu: "7"
-                memory: "10Gi"   
+                memory: "10Gi"
     - name: pull-kueue-test-e2e-multikueue-baseline-release-0-18
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -192,7 +192,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-release-0-18-1-33
+    - name: pull-kueue-test-e2e-extended-shard-0-release-0-18-1-33
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.18
@@ -201,8 +201,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-release-0-18-1-33
-        description: "Run kueue extended end to end tests for Kubernetes 1.33"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-release-0-18-1-33
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.33"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -219,7 +219,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-release-0-18-1-33
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.18
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-release-0-18-1-33
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.33"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.33"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -268,7 +306,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-release-0-18-1-34
+    - name: pull-kueue-test-e2e-extended-shard-0-release-0-18-1-34
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.18
@@ -277,8 +315,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-release-0-18-1-34
-        description: "Run kueue extended end to end tests for Kubernetes 1.34"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-release-0-18-1-34
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.34"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -295,7 +333,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-release-0-18-1-34
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.18
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-release-0-18-1-34
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.34"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.34"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -344,7 +420,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-release-0-18-1-35
+    - name: pull-kueue-test-e2e-extended-shard-0-release-0-18-1-35
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.18
@@ -353,8 +429,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-release-0-18-1-35
-        description: "Run kueue extended end to end tests for Kubernetes 1.35"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-release-0-18-1-35
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.35"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -371,7 +447,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-release-0-18-1-35
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.18
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-release-0-18-1-35
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.35"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -420,7 +534,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-extended-release-0-18-1-36
+    - name: pull-kueue-test-e2e-extended-shard-0-release-0-18-1-36
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.18
@@ -429,8 +543,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-extended-release-0-18-1-36
-        description: "Run kueue extended end to end tests for Kubernetes 1.36"
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-0-release-0-18-1-36
+        description: "Run kueue extended end to end tests shard 0 for Kubernetes 1.36"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -447,7 +561,7 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-extended
+              - test-e2e-extended-shard-0
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -458,6 +572,44 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
+    - name: pull-kueue-test-e2e-extended-shard-1-release-0-18-1-36
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.18
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-extended-shard-1-release-0-18-1-36
+        description: "Run kueue extended end to end tests shard 1 for Kubernetes 1.36"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260525-f8de63d82b-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.36"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-extended-shard-1
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"   
     - name: pull-kueue-test-e2e-multikueue-baseline-release-0-18
       cluster: eks-prow-build-cluster
       branches:


### PR DESCRIPTION
Kueue : Split singlecluster/extended tests into shard-0 and shard-1

Part of https://github.com/kubernetes-sigs/kueue/pull/11893 (main)
Part of https://github.com/kubernetes-sigs/kueue/pull/11917 (release-0.17)
Part of https://github.com/kubernetes-sigs/kueue/pull/11916 (release-0.18)

Adds new presubmit jobs and periodics job for the new sharded version of singlecluster/extended that are introduced in Kubernetes-sigs/kueue 
Release Branches are also updated in this PR