### PR TITLE
ec2-dra: scrape scheduler and controller-manager metrics

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
@@ -93,6 +93,8 @@ periodics:
         value: "false"
       - name: PROMETHEUS_SCRAPE_KUBELETS
         value: "true"
+      - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
+        value: "false"
       - name: PROMETHEUS_PVC_STORAGE_CLASS
         value: "io2"
       - name: CLOUD_PROVIDER
@@ -183,6 +185,8 @@ presubmits:
           value: "false"
         - name: PROMETHEUS_SCRAPE_KUBELETS
           value: "true"
+        - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
+          value: "false"
         - name: PROMETHEUS_PVC_STORAGE_CLASS
           value: "io2"
         - name: CLOUD_PROVIDER


### PR DESCRIPTION
Sets `PROMETHEUS_SCRAPE_APISERVER_ONLY=false` on the EC2 DRA periodic and presubmit so kube-scheduler and kube-controller-manager metrics are scraped, matching the GCE DRA jobs. The `aws` provider defaults to apiserver-only, which left `PrometheusSchedulingMetrics` empty on these jobs.

Depends on kubernetes/perf-tests#4078 (adds the flag CL2 reads); harmless no-op until that merges.