### PR TITLE
ec2-dra: make the 500-node DRA presubmit opt-in

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
@@ -118,7 +118,7 @@ presubmits:
   - name: pull-perf-tests-ec2-500-node-dra-with-workload-amazonvpc-using-cl2
     cluster: eks-prow-build-cluster
     optional: true # new/expensive AWS scale job: provide signal without blocking merges
-    run_if_changed: '^clusterloader2/testing/dra/.*$'
+    always_run: false
     max_concurrency: 1
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
Makes the expensive 500-node EC2 DRA presubmit opt-in: replaces `run_if_changed` with `always_run: false` so it runs only on an explicit `/test` (still `optional: true`, non-blocking), matching the `pull-perf-tests-ec2-master-scale-performance-*` scale presubmits.