### PR TITLE
Align AWS 5k scale test workload with GCE 5k job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -96,6 +96,16 @@ periodics:
         value: "50"
       - name: CL2_RATE_LIMIT_POD_CREATION
         value: "false"
+      - name: CL2_REALISTIC_POD
+        value: "true"
+      - name: CL2_ENABLE_INFORMER_LATENCY_TEST
+        value: "true"
+      - name: CL2_EXECSERVICE_CPU_REQUESTS
+        value: "8"
+      - name: CL2_EXECSERVICE_MEMORY_REQUESTS
+        value: "16Gi"
+      - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
+        value: "21474836480"
       - name: NODE_MODE
         value: "master"
       - name: CONTROL_PLANE_COUNT
@@ -125,10 +135,10 @@ periodics:
       resources:
         requests:
           cpu: 7
-          memory: 24Gi
+          memory: 40Gi
         limits:
           cpu: 7
-          memory: 24Gi
+          memory: 40Gi
 
 # This job is the same as above, but using 100 nodes instead of 5000
 - name: ci-kubernetes-e2e-kops-aws-small-scale-amazonvpc-using-cl2

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -69,6 +69,7 @@ var buildClusters = []string{
 var jobsExemptFromResourceLimits = []string{
 	"ci-kubernetes-build",
 	"ci-kubernetes-e2e-gce-scale-performance-5000",
+	"ci-kubernetes-e2e-kops-aws-scale-amazonvpc-using-cl2",
 	"ci-kubernetes-e2e-gce-scale-resource-size",
 	"pull-kubernetes-gce-master-scale-performance-5000",
 	"pull-perf-tests-gce-master-scale-performance-5000",


### PR DESCRIPTION
The kops AWS 5000-node scale test (`ci-kubernetes-e2e-kops-aws-scale-amazonvpc-using-cl2`) runs the same CL2 load as the GCE 5000-node job (`ci-kubernetes-e2e-gce-scale-performance-5000`) through the same `run-test.sh`, but it was missing the workload and measurement settings the GCE job has since gained since the realistic pod experiment, so the two providers were no longer exercising the same workload.

This aligns the AWS 5k job with the GCE 5k job:
