### PR TITLE
Bump 5k scale presubmit to a 3-node control plane

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -485,7 +485,7 @@ presubmits:
         - name: NODE_MODE
           value: "master"
         - name: CONTROL_PLANE_COUNT
-          value: "1"
+          value: "3"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-96"
         - name: ADDONS_NODE_SIZE


### PR DESCRIPTION
Sets CONTROL_PLANE_COUNT to 3 on pull-kubernetes-gce-master-scale-performance-5000, matching the 100-node apiserver-restart presubmit.

Passing 100-node apiserver-restart run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-100-apiserver-restart/2062247362662764544

Ideally have https://github.com/kubernetes/perf-tests/pull/4079 merged first.