### PR TITLE
etcd: remove 3.6 and 3.7 smoke tests

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -495,8 +495,6 @@ presubmits:
     cluster: k8s-infra-prow-build
     always_run: true
     branches:
-    - release-3.7
-    - release-3.6
     - release-3.5
     decorate: true
     annotations:


### PR DESCRIPTION
#37177 (re)enabled smoke tests for 3.6 and 3.7. But those branches no longer have this test.