### PR TITLE
fix(cloud-provider-azure): skip broken private-registry-secret conformance test in release-1.30 presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.30.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.30.yaml
@@ -139,7 +139,7 @@ presubmits:
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "v1.30.14"
         - name: GINKGO_ARGS  # cloud-provider-azure config
-          value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --report-dir=/logs/artifacts --disable-log-dump=true
+          value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --ginkgo.skip=should.*be.*able.*pull.*private.*registry.*with.*secret --report-dir=/logs/artifacts --disable-log-dump=true
         - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
         - name: CLUSTER_TEMPLATE  # CAPZ config

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.30.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-presubmit-1.30.yaml
@@ -139,7 +139,7 @@ presubmits:
         - name: KUBERNETES_VERSION  # CAPZ config
           value: "v1.30.14"
         - name: GINKGO_ARGS  # cloud-provider-azure config
-          value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\] --ginkgo.skip=should.*be.*able.*pull.*private.*registry.*with.*secret --report-dir=/logs/artifacts --disable-log-dump=true
+          value: --ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]|should\s+be\s+able\s+to\s+pull\s+from\s+private\s+registry\s+with\s+secret --report-dir=/logs/artifacts --disable-log-dump=true
         - name: CONTROL_PLANE_MACHINE_COUNT  # CAPZ config
           value: "1"
         - name: CLUSTER_TEMPLATE  # CAPZ config


### PR DESCRIPTION
#### What this PR does
Adds a narrow `--ginkgo.skip` filter to the `pull-cloud-provider-azure-e2e-capz-1-30` presubmit job to skip the broken Kubernetes 1.30 NodeConformance private registry pull test.

#### Why this is needed
Only the 1.30 CAPZ conformance presubmit is failing on this test. The test depends on a hardcoded private GCR image/credential and now fails with 401 Unauthorized when pulling `gcr.io/authenticated-image-pulling/alpine:3.7`

The test case was removed from Kubernetes 1.31+ and later fixed for 1.35+. Since this job still runs against kubernetes/kubernetes release-1.30, add a job-level narrow skip rather than removing all `NodeConformance` coverage.