### PR TITLE
Use staging kpromo with --manifest-diff-since for periodic image promo

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -139,8 +139,8 @@ periodics:
       - org: kubernetes
         slug: release-managers
 
-# ci-k8sio-image-promo runs daily as a backstop on top of the postsubmit
-# ~midnight pacific
+# ci-k8sio-image-promo runs daily to catch missed postsubmit promotions
+# from the last 14 days. ~midnight pacific.
 - cron: '0 7 * * *'
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
@@ -159,13 +159,14 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: registry.k8s.io/artifact-promoter/kpromo:v4.5.0-0
+    - image: gcr.io/k8s-staging-artifact-promoter/kpromo:latest
       command:
       - /kpromo
       args:
       - cip
       - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/registry.k8s.io
       - --confirm
+      - --manifest-diff-since=14 days
       - --certificate-identity-regexp=(krel-staging@k8s-releng-prod.iam.gserviceaccount.com)|(krel-trust@k8s-releng-prod.iam.gserviceaccount.com)
       - --certificate-oidc-issuer=https://accounts.google.com
       env:


### PR DESCRIPTION
Switch `ci-k8sio-image-promo` to use the staging latest kpromo image and add `--manifest-diff-since="14 days"` to limit the periodic backstop to digests changed in the last two weeks instead of the entire manifest universe.

This prevents old broken images (tag moves, `_LOST_` sources) from blocking all promotions (kubernetes/k8s.io#9563).

Once `--manifest-diff-since` ships in a promo-tools release, the image reference should be pinned back to a release tag.

Depends on: kubernetes-sigs/promo-tools#1858

/cc @kubernetes/release-managers
/area release-eng
/priority important-soon