### PR TITLE
Add EC2 5000-node DRA scalability periodic; stagger 5k jobs to alternate days

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
@@ -113,6 +113,123 @@ periodics:
           cpu: 7
           memory: 24Gi
 
+- name: ci-kubernetes-e2e-kops-aws-5000-node-dra-with-workload-amazonvpc-using-cl2
+  tags:
+  - "perfDashPrefix: aws-dra-5000Nodes-with-workload"
+  - "perfDashBuildsCount: 270"
+  - "perfDashJobType: performance"
+  cluster: eks-prow-build-cluster
+  cron: "1 7 * * 2,4,6" # Tue/Thu/Sat 07:01 UTC; alternates with the 5k load test (Sun/Mon/Wed/Fri)
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential-boskos-scale-001-kops: "true"
+    preset-dind-enabled: "true"
+  decorate: true
+  job_queue_name: '5k-aws-scale-test'
+  decoration_config:
+    timeout: 480m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    path_alias: k8s.io/kops
+    workdir: true
+  annotations:
+    karpenter.sh/do-not-disrupt: "true"
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/distro: u2204
+    test.kops.k8s.io/k8s_version: stable
+    test.kops.k8s.io/kops_channel: alpha
+    test.kops.k8s.io/networking: amazonvpc
+    testgrid-dashboards: kops-misc, sig-cluster-lifecycle-kops, sig-scalability-aws, sig-scalability-dra
+    testgrid-tab-name: ec2-dra-with-workload-master-scalability-5000
+    testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, eks-scalability@amazon.com
+    testgrid-num-failures-to-alert: '2'
+    description: "Uses kops to run k8s.io/perf-tests/run-e2e.sh against a 5000-node AWS cluster with DRA enabled"
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260601-2cbf4bdb47-master
+      imagePullPolicy: Always
+      command:
+      - runner.sh
+      args:
+      - ./tests/e2e/scenarios/scalability/run-test.sh
+      securityContext:
+        privileged: true
+      env:
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: KUBE_SSH_USER
+        value: ubuntu
+      - name: GOPATH
+        value: /home/prow/go
+      - name: CNI_PLUGIN
+        value: "amazonvpc"
+      - name: KUBE_NODE_COUNT
+        value: "5000"
+      - name: CL2_LOAD_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_MODE
+        value: "Indexed"
+      - name: CL2_NODES_PER_NAMESPACE
+        value: "2500"
+      - name: CL2_JOB_RUNNING_TIME
+        value: "30s"
+      - name: CL2_LONG_JOB_RUNNING_TIME
+        value: "240m"
+      - name: CL2_RATE_LIMIT_POD_CREATION
+        value: "false"
+      - name: NODE_MODE
+        value: "master"
+      - name: CONTROL_PLANE_COUNT
+        value: "1"
+      - name: CONTROL_PLANE_SIZE
+        value: "c8i.24xlarge"
+      - name: KOPS_CONTROLLER_MANAGER_BURST
+        value: "1000"
+      - name: KOPS_CONTROLLER_MANAGER_QPS
+        value: "1000"
+      - name: KOPS_SCHEDULER_QPS
+        value: "1200"
+      - name: KOPS_SCHEDULER_BURST
+        value: "1200"
+      - name: KOPS_APISERVER_MAX_REQUESTS_INFLIGHT
+        value: "2700"
+      - name: ENABLE_PROMETHEUS_SERVER
+        value: "true"
+      - name: TEAR_DOWN_PROMETHEUS_SERVER
+        value: "false"
+      - name: PROMETHEUS_SCRAPE_KUBELETS
+        value: "true"
+      - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
+        value: "false"
+      - name: PROMETHEUS_PVC_STORAGE_CLASS
+        value: "io2"
+      - name: CLOUD_PROVIDER
+        value: "aws"
+      - name: KOPS_IRSA
+        value: "true"
+      - name: NODE_PRELOAD_IMAGES
+        value: "gcr.io/k8s-staging-perf-tests/sleep:v0.0.3"
+      - name: KOPS_CL2_TEST_CONFIG
+        value: testing/dra/config.yaml
+      resources:
+        requests:
+          cpu: 7
+          memory: 24Gi
+        limits:
+          cpu: 7
+          memory: 24Gi
+
 presubmits:
   kubernetes/perf-tests:
   - name: pull-perf-tests-ec2-500-node-dra-with-workload-amazonvpc-using-cl2

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -33,7 +33,7 @@ periodics:
   - "perfDashBuildsCount: 270"
   - "perfDashJobType: performance"
   cluster: eks-prow-build-cluster
-  cron: '1 7 * * *' # Run every day at 3:01 AM EDT/12:01 AM PDT (07:01 UTC)
+  cron: '1 7 * * 0,1,3,5' # Sun/Mon/Wed/Fri 07:01 UTC; alternates with the 5k DRA job (Tue/Thu/Sat)
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"


### PR DESCRIPTION
Add ci-kubernetes-e2e-kops-aws-5000-node-dra-with-workload-amazonvpc-using-cl2 (EC2 equivalent of the GCE 5k DRA periodic).

Stagger it with the existing 5k AWS load test on the shared 5k-aws-scale-test queue so they run on alternate days: load test Sun/Mon/Wed/Fri, DRA Tue/Thu/Sat to make sure we don't break bank.