### PR TITLE
[WIP] node-problem-detector: side-load the e2e image instead of pulling it

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -107,8 +107,8 @@ periodics:
         --provider=gce
         --gcp-zone=us-central1-b
         --node-tests=true
-        "--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml --extra-envs=${EXTRA_ENVS}"
-        '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
+        "--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml --extra-envs=${EXTRA_ENVS} --instance-metadata=startup-script</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/sideload-image.sh,sideload-image-url=${NODE_PROBLEM_DETECTOR_IMAGE_ARCHIVE_URL}"
+        '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --prepull-images=false'
         '--test_args=--nodes=8 --focus=NodeProblemDetector'
         --timeout=60m
       resources:

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -136,8 +136,8 @@ presubmits:
           --provider=gce
           --gcp-zone=us-central1-b
           --node-tests=true
-          "--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml --extra-envs=${EXTRA_ENVS}"
-          '--node-test-args=--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/"'
+          "--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml --extra-envs=${EXTRA_ENVS} --instance-metadata=startup-script</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/sideload-image.sh,sideload-image-url=${NODE_PROBLEM_DETECTOR_IMAGE_ARCHIVE_URL}"
+          '--node-test-args=--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/" --prepull-images=false'
           '--test_args=--nodes=8 --focus=NodeProblemDetector'
           --timeout=90m
         resources:

--- a/jobs/e2e_node/containerd/sideload-image.sh
+++ b/jobs/e2e_node/containerd/sideload-image.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GCE startup-script that side-loads a container image archive onto a node e2e
+# VM, so a test can exercise a locally built image instead of pulling one from a
+# registry.
+#
+# Wire it in with the image-config metadata, e.g.
+#   --instance-metadata=startup-script<.../sideload-image.sh,sideload-image-url=<url>
+# The archive (an OCI or docker-archive tarball) is imported into the CRI
+# (k8s.io) containerd namespace. Combine with --prepull-images=false and the
+# test pod's default IfNotPresent policy so the imported image is used with no
+# registry involved. No-op when sideload-image-url is unset.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly META="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
+
+url="$(curl -sf -H 'Metadata-Flavor: Google' "${META}/sideload-image-url" || true)"
+if [[ -z "${url}" ]]; then
+  echo "sideload-image-url instance metadata not set; nothing to side-load"
+  exit 0
+fi
+
+echo "Downloading image archive from ${url}"
+curl -fsSL --retry 5 --retry-delay 3 -o /tmp/sideload-image.tar "${url}"
+
+# init.yaml restarts containerd near the end of node setup; wait for it before
+# importing into the CRI (k8s.io) namespace that the kubelet uses.
+for _ in $(seq 1 90); do
+  if ctr -n k8s.io version >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
+echo "Importing side-loaded image into containerd"
+ctr -n k8s.io images import /tmp/sideload-image.tar


### PR DESCRIPTION
The ci-/pull-npd-e2e-node jobs run the kubernetes node e2e "NodeProblemDetector" test, which deploys a pod from NODE_PROBLEM_DETECTOR_IMAGE. That image is built per run by node-problem-detector's test/build.sh but is not pushed to a registry, so the node e2e image prepull fails.

Side-load it instead: a GCE startup-script imports the image archive (uploaded to GCS by build.sh, URL passed via the npd-image-url instance metadata) into containerd, and --prepull-images=false stops the framework from prepulling it. With the test pod's default IfNotPresent policy the imported image is used with no registry involved.

The startup-script no-ops when npd-image-url is unset, so this is safe to land before the node-problem-detector build.sh change that publishes the archive.