### PR TITLE
kops: fully enable janitor for the kops-infra-ci account

### DIFF
--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -72,7 +72,6 @@ periodics:
     - command:
       - /app
       args:
-      - --dry-run=true  # validate, then remove to enable deletion
       - --ttl=12h  # must exceed the longest job here (serial-canary ~10.5h)
       - --path=s3://k8s-kops-ci-prow/objs.json
       # managed-by=Terraform covers its TF-managed resources


### PR DESCRIPTION
Dry run looks good, ready to go live:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/maintenance-ci-kops-aws-janitor/2062932129800523776

/cc @ameukam @upodroid @Priyankasaggu11929 