### PR TITLE
etcd: add pull-etcd-devcontainer-tests ci job

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -914,3 +914,34 @@ presubmits:
           limits:
             cpu: "2"
             memory: "4Gi"
+
+  - name: pull-etcd-devcontainer-tests
+    cluster: eks-prow-build-cluster
+    always_run: false
+    run_if_changed: '^.devcontainer/devcontainer.json$'
+    branches:
+      - main
+    decorate: true
+    annotations:
+      testgrid-dashboards: sig-etcd-presubmits
+      testgrid-tab-name: pull-etcd-devcontainer-tests
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260601-2cbf4bdb47-master
+        command:
+          - runner.sh
+        args:
+          - bash
+          - -c
+          - |
+            make test-devcontainer
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+          limits:
+            cpu: "2"
+            memory: "4Gi"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true


### PR DESCRIPTION
This is the final piece to automate the devcontainer version updates. This job will be triggered by PRs such as etcd-io/etcd#21752.