### PR TITLE
Bump CRI-O to v1.36.0 for all e2e_node CI lanes

### DIFF
--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dd1e7bdc854ed4846a7f15c5e0c17e0140a1d817b%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_drop_infra_ctr.ign
+++ b/jobs/e2e_node/crio/crio_drop_infra_ctr.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dd1e7bdc854ed4846a7f15c5e0c17e0140a1d817b%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_eventedpleg.ign
+++ b/jobs/e2e_node/crio/crio_eventedpleg.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dd1e7bdc854ed4846a7f15c5e0c17e0140a1d817b%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_hugepages.ign
+++ b/jobs/e2e_node/crio/crio_hugepages.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dd1e7bdc854ed4846a7f15c5e0c17e0140a1d817b%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_imagefs.ign
+++ b/jobs/e2e_node/crio/crio_imagefs.ign
@@ -78,7 +78,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dd1e7bdc854ed4846a7f15c5e0c17e0140a1d817b%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_splitfs.ign
+++ b/jobs/e2e_node/crio/crio_splitfs.ign
@@ -78,7 +78,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dd1e7bdc854ed4846a7f15c5e0c17e0140a1d817b%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/crio_swap1g.ign
+++ b/jobs/e2e_node/crio/crio_swap1g.ign
@@ -60,7 +60,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dd1e7bdc854ed4846a7f15c5e0c17e0140a1d817b%22%0A"
         },
         "mode": 420
       }

--- a/jobs/e2e_node/crio/crio_userns.ign
+++ b/jobs/e2e_node/crio/crio_userns.ign
@@ -70,7 +70,7 @@
         "path": "/etc/systemd/system.conf.d/10-env.conf",
         "contents": {
           "compression": "",
-          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3D34f5b852c54c6c99e5686b9dfa99578d79502790%22%0A"
+          "source": "data:,%5BManager%5D%0ADefaultEnvironment%3D%22CRIO_SCRIPT_COMMIT%3Da7cafc89fd6011acbc8668f325752ea8f6dde0ae%22%0ADefaultEnvironment%3D%22CRIO_COMMIT%3Dd1e7bdc854ed4846a7f15c5e0c17e0140a1d817b%22%0A"
         },
         "mode": 420
       },

--- a/jobs/e2e_node/crio/templates/base/env.yaml
+++ b/jobs/e2e_node/crio/templates/base/env.yaml
@@ -7,4 +7,4 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
+          DefaultEnvironment="CRIO_COMMIT=d1e7bdc854ed4846a7f15c5e0c17e0140a1d817b"

--- a/jobs/e2e_node/crio/templates/crio.yaml
+++ b/jobs/e2e_node/crio/templates/crio.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
+          DefaultEnvironment="CRIO_COMMIT=d1e7bdc854ed4846a7f15c5e0c17e0140a1d817b"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_drop_infra_ctr.yaml
+++ b/jobs/e2e_node/crio/templates/crio_drop_infra_ctr.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
+          DefaultEnvironment="CRIO_COMMIT=d1e7bdc854ed4846a7f15c5e0c17e0140a1d817b"
     - path: /etc/crio/crio.conf.d/30-crio-drop-infra-ctr.conf
       contents:
         local: 30-crio-drop-infra-ctr.conf

--- a/jobs/e2e_node/crio/templates/crio_eventedpleg.yaml
+++ b/jobs/e2e_node/crio/templates/crio_eventedpleg.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
+          DefaultEnvironment="CRIO_COMMIT=d1e7bdc854ed4846a7f15c5e0c17e0140a1d817b"
     - path: /etc/crio/crio.conf.d/40-evented-pleg.conf
       contents:
         local: 40-evented-pleg.conf

--- a/jobs/e2e_node/crio/templates/crio_hugepages.yaml
+++ b/jobs/e2e_node/crio/templates/crio_hugepages.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
+          DefaultEnvironment="CRIO_COMMIT=d1e7bdc854ed4846a7f15c5e0c17e0140a1d817b"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_imagefs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_imagefs.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
+          DefaultEnvironment="CRIO_COMMIT=d1e7bdc854ed4846a7f15c5e0c17e0140a1d817b"
     - path: /etc/containers/storage.conf
       contents:
         local: 50-storage.conf

--- a/jobs/e2e_node/crio/templates/crio_splitfs.yaml
+++ b/jobs/e2e_node/crio/templates/crio_splitfs.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
+          DefaultEnvironment="CRIO_COMMIT=d1e7bdc854ed4846a7f15c5e0c17e0140a1d817b"
     - path: /etc/containers/storage.conf
       contents:
         local: 60-storage-split-disk.conf

--- a/jobs/e2e_node/crio/templates/crio_swap1g.yaml
+++ b/jobs/e2e_node/crio/templates/crio_swap1g.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
+          DefaultEnvironment="CRIO_COMMIT=d1e7bdc854ed4846a7f15c5e0c17e0140a1d817b"
 systemd:
   units:
     - name: configure-sysctl.service

--- a/jobs/e2e_node/crio/templates/crio_userns.yaml
+++ b/jobs/e2e_node/crio/templates/crio_userns.yaml
@@ -37,7 +37,7 @@ storage:
         inline: |
           [Manager]
           DefaultEnvironment="CRIO_SCRIPT_COMMIT=a7cafc89fd6011acbc8668f325752ea8f6dde0ae"
-          DefaultEnvironment="CRIO_COMMIT=34f5b852c54c6c99e5686b9dfa99578d79502790"
+          DefaultEnvironment="CRIO_COMMIT=d1e7bdc854ed4846a7f15c5e0c17e0140a1d817b"
     # Note: this ignition file assumes FCOS has shadow-utils installed.
     # As of the time of writing this, it does.
     - path: /etc/subuid


### PR DESCRIPTION
xref: https://github.com/kubernetes/test-infra/pull/37196#issuecomment-4634272945