### PR TITLE
add restart to experimental 5k scalability job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1444,6 +1444,8 @@ periodics:
       # Disabled: see https://github.com/kubernetes/test-infra/pull/37027
       # - name: CL2_INFORMER_RUN_ON_CONTROL_PLANE
       #   value: "true"
+      - name: CL2_RESTART_APISERVER
+        value: "true"
       - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
         value: "21474836480"
       - name: CL2_EXECSERVICE_CPU_REQUESTS
@@ -1452,6 +1454,8 @@ periodics:
         value: "16Gi"
       - name: CL2_REALISTIC_POD
         value: "true"
+      - name: CL2_HEAP_PROFILE_INTERVAL
+        value: "5m"
       #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
@@ -1472,7 +1476,7 @@ periodics:
       - name: NODE_MODE
         value: "master"
       - name: CONTROL_PLANE_COUNT
-        value: "1"
+        value: "3"
       - name: CONTROL_PLANE_SIZE
         value: "c4-standard-96"
       - name: ADDONS_NODE_SIZE


### PR DESCRIPTION
Matches the 5k presubmit (3 control planes, apiserver restart, heap profiling). Passing run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-5000/2062929683812454400