### PR TITLE
prow: update secrets-store-csi-driver unit image to go1.26-trixie

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -46,7 +46,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.26-trixie
         imagePullPolicy: Always
         command:
           - make


### PR DESCRIPTION
I'm currently working on bumping the CSI Driver version to 1.26 in https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/2045.

This is leading to go toolchain mismatches in the prow unit test job [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_secrets-store-csi-driver/2045/pull-secrets-store-csi-driver-unit/2062976369251323904).

Bump the image tag to `latest-go1.26-trixie`.

Confirmed the tag exists with `crane ls gcr.io/k8s-staging-releng/releng-ci | grep go1.26`.