### PR TITLE
etcd: enable dind for pull-etcd-devcontainer-tests

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -922,6 +922,8 @@ presubmits:
     branches:
       - main
     decorate: true
+    labels:
+      preset-dind-enabled: "true"
     annotations:
       testgrid-dashboards: sig-etcd-presubmits
       testgrid-tab-name: pull-etcd-devcontainer-tests


### PR DESCRIPTION
https://github.com/etcd-io/etcd/pull/21752 failed because Docker in Docker wasn't enabled in the job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/21752/pull-etcd-devcontainer-tests/2063002653201272832

So, add the label so the job can run.