### PR TITLE
Rename resource-size scale job to performance-5000-experimental

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1395,7 +1395,7 @@ periodics:
 
 # Exploratory tests for resource size limit as proposed in https://github.com/kubernetes/kubernetes/issues/134375
 - cron: '1 5 * * 2,6' # Run twice a week at 21:01 PST (05:01 UTC)
-  name: ci-kubernetes-e2e-gce-scale-resource-size
+  name: ci-kubernetes-e2e-gce-scale-performance-5000-experimental
   tags:
   - "perfDashPrefix: gce-5000Nodes-1.5GB-pods"
   - "perfDashBuildsCount: 270"
@@ -1423,7 +1423,7 @@ periodics:
     workdir: true
   annotations:
     testgrid-dashboards: sig-scalability-gce, google-gce
-    testgrid-tab-name: gce-master-scale-resource-size
+    testgrid-tab-name: gce-master-scale-performance-5000-experimental
     description: "Exploratory tests for resource size limit as proposed in https://github.com/kubernetes/kubernetes/issues/134375"
   spec:
     serviceAccountName: prow-build

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -69,7 +69,7 @@ var buildClusters = []string{
 var jobsExemptFromResourceLimits = []string{
 	"ci-kubernetes-build",
 	"ci-kubernetes-e2e-gce-scale-performance-5000",
-	"ci-kubernetes-e2e-gce-scale-resource-size",
+	"ci-kubernetes-e2e-gce-scale-performance-5000-experimental",
 	"pull-kubernetes-gce-master-scale-performance-5000",
 	"pull-perf-tests-gce-master-scale-performance-5000",
 }


### PR DESCRIPTION
Renames ci-kubernetes-e2e-gce-scale-resource-size to ci-kubernetes-e2e-gce-scale-performance-5000-experimental, following up on https://github.com/kubernetes/test-infra/pull/37207#issuecomment-4635427532.