### PR TITLE
Fix gofmt and reduce noisy triage debug logging (alternate branch)

### DIFF
--- a/kubetest/gke_test.go
+++ b/kubetest/gke_test.go
@@ -61,16 +61,16 @@ func TestParseInstanceGroupsFromGcloud(t *testing.T) {
 	urlZoneCTest := fmt.Sprintf(urlTemplate, zoneC, "test")
 
 	cases := []struct {
-		name                  string
-		input                 string
+		name                string
+		input               string
 		instanceGroupPrefix string
-		expected              []*ig
-		expectedError         bool
+		expected            []*ig
+		expectedError       bool
 	}{
 		// Zonal
 		{
-			name:                  "One instance group with default prefix",
-			input:                 urlZoneADefault,
+			name:                "One instance group with default prefix",
+			input:               urlZoneADefault,
 			instanceGroupPrefix: "",
 			expected: []*ig{
 				{
@@ -83,15 +83,15 @@ func TestParseInstanceGroupsFromGcloud(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:                  "One instance group with default prefix, but not matching instanceGroupPrefix",
-			input:                 urlZoneADefault,
+			name:                "One instance group with default prefix, but not matching instanceGroupPrefix",
+			input:               urlZoneADefault,
 			instanceGroupPrefix: "test",
-			expected:              nil,
-			expectedError:         true,
+			expected:            nil,
+			expectedError:       true,
 		},
 		{
-			name:                  "One instance group with test prefix",
-			input:                 urlZoneATest,
+			name:                "One instance group with test prefix",
+			input:               urlZoneATest,
 			instanceGroupPrefix: "test",
 			expected: []*ig{
 				{
@@ -105,8 +105,8 @@ func TestParseInstanceGroupsFromGcloud(t *testing.T) {
 		},
 		// Regional
 		{
-			name:                  "Three instance groups with default prefix",
-			input:                 strings.Join([]string{urlZoneADefault, urlZoneBDefault, urlZoneCDefault}, ";"),
+			name:                "Three instance groups with default prefix",
+			input:               strings.Join([]string{urlZoneADefault, urlZoneBDefault, urlZoneCDefault}, ";"),
 			instanceGroupPrefix: "",
 			expected: []*ig{
 				{
@@ -131,15 +131,15 @@ func TestParseInstanceGroupsFromGcloud(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:                  "Three instance groups with default prefix, but not matching instanceGroupPrefix",
-			input:                 strings.Join([]string{urlZoneADefault, urlZoneBDefault, urlZoneCDefault}, ";"),
+			name:                "Three instance groups with default prefix, but not matching instanceGroupPrefix",
+			input:               strings.Join([]string{urlZoneADefault, urlZoneBDefault, urlZoneCDefault}, ";"),
 			instanceGroupPrefix: "test",
-			expected:              nil,
-			expectedError:         true,
+			expected:            nil,
+			expectedError:       true,
 		},
 		{
-			name:                  "Three instance groups with test prefix",
-			input:                 strings.Join([]string{urlZoneATest, urlZoneBTest, urlZoneCTest}, ";"),
+			name:                "Three instance groups with test prefix",
+			input:               strings.Join([]string{urlZoneATest, urlZoneBTest, urlZoneCTest}, ";"),
 			instanceGroupPrefix: "test",
 			expected: []*ig{
 				{

--- a/label_sync/main_test.go
+++ b/label_sync/main_test.go
@@ -536,8 +536,8 @@ func (f *fakeClient) AddRepoLabel(org, repo, name, description, color string) er
 func (f *fakeClient) UpdateRepoLabel(org, repo, currentName, newName, description, color string) error {
 	return nil
 }
-func (f *fakeClient) DeleteRepoLabel(org, repo, label string) error { return nil }
-func (f *fakeClient) AddLabel(org, repo string, number int, label string) error  { return nil }
+func (f *fakeClient) DeleteRepoLabel(org, repo, label string) error                { return nil }
+func (f *fakeClient) AddLabel(org, repo string, number int, label string) error    { return nil }
 func (f *fakeClient) RemoveLabel(org, repo string, number int, label string) error { return nil }
 func (f *fakeClient) FindIssuesWithOrg(org, query, sort string, asc bool) ([]github.Issue, error) {
 	return nil, nil

--- a/releng/config-forker/pkg/resolve_test.go
+++ b/releng/config-forker/pkg/resolve_test.go
@@ -29,10 +29,10 @@ func TestParseImageRef(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		image    string
-		wantOK   bool
-		wantRef  imageRef
+		name    string
+		image   string
+		wantOK  bool
+		wantRef imageRef
 	}{
 		{
 			name:   "standard GCR image",

--- a/triage/interactive.js
+++ b/triage/interactive.js
@@ -157,7 +157,7 @@ function setElementVisibility(id, visible) {
 function rerender(maxCount) {
   if (!clusteredAll) return;
 
-  console.log('rerender!');
+  console.debug('rerender!');
 
   setElementVisibility('load-status', false);
   setElementVisibility('clusters', true);


### PR DESCRIPTION
This PR mirrors the changes in the other branch: formatting updates to Go test files and changing a noisy triage debug log from `console.log` to `console.debug`.

Changes:
- `kubetest/gke_test.go`
- `label_sync/main_test.go`
- `releng/config-forker/pkg/resolve_test.go`
- `triage/interactive.js`
