### PR TITLE
Disable periodic enhancements sync for v1.37

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-release-release-team-jobs/release-team-periodics.yaml
@@ -1,8 +1,8 @@
 periodics:
 - name: periodic-sync-enhancements-github-project-1-37
   # temporarily disable job by with an impossible cron date instead of deleting it
-  # cron: '0 0 31 2 *'
-  interval: 6h
+  cron: '0 0 31 2 *'
+  # interval: 6h
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   annotations:


### PR DESCRIPTION
Disable the syncing of lead-opted-in KEPs to the v1.37 Release tracking board:📋https://github.com/orgs/kubernetes/projects/264/views/1

PRR Freeze Scheduled on Tuesday 9 June 2026 (AoE) / Wednesday 10 June 2026 12:00 UTC

cc @dipesh-rawat @katcosgrove @fsmunoz 

/hold