### PR TITLE
Bump release-notes e2e image to cypress/base:24.15.0

### DIFF
--- a/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
@@ -102,7 +102,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: cypress/base:24.13.0
+      - image: cypress/base:24.15.0
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
Angular CLI 22 requires Node.js >= 24.15.0. The e2e job for kubernetes-sigs/release-notes currently uses cypress/base:24.13.0 which is too old.

Related: https://github.com/kubernetes-sigs/release-notes/pull/1113