### PR TITLE
Use CAPZ 1.24 for Azure Cluster Autoscaler tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.24
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:
@@ -80,7 +80,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.24
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:
@@ -139,7 +139,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.24
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:
@@ -198,7 +198,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.24
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:
@@ -257,7 +257,7 @@ presubmits:
     extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.21
+      base_ref: release-1.24
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     spec:


### PR DESCRIPTION
This PR updates the Azure Cluster Autoscaler tests to use the latest CAPZ release branch