### PR TITLE
Add SIG Node KEP board sync periodic (Project #264 fields into #265)

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-node-kep-wrangler/OWNERS
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-node-kep-wrangler/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+  - haircommander
+  - SergeyKanzhelev
+reviewers:
+  - haircommander
+  - SergeyKanzhelev
+labels:
+  - sig/node
+  - area/prow

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-node-kep-wrangler/sig-node-kep-wrangler-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-node-kep-wrangler/sig-node-kep-wrangler-periodics.yaml
@@ -23,8 +23,8 @@ periodics:
           cpu: 500m
           memory: 1Gi
         limits:
-          cpu: 1
-          memory: 2Gi
+          cpu: 500m
+          memory: 1Gi
       env:
         - name: ORGANIZATION
           value: "kubernetes"

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-node-kep-wrangler/sig-node-kep-wrangler-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-node-kep-wrangler/sig-node-kep-wrangler-periodics.yaml
@@ -35,5 +35,5 @@ periodics:
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
-              name: sig-node-kep-wrangler-github-token
+              name: k8s-triage-robot-github-token
               key: token

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-node-kep-wrangler/sig-node-kep-wrangler-periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-node-kep-wrangler/sig-node-kep-wrangler-periodics.yaml
@@ -1,0 +1,39 @@
+periodics:
+- name: periodic-sync-sig-node-kep-board
+  interval: 6h
+  cluster: k8s-infra-prow-build-trusted
+  decorate: true
+  annotations:
+    testgrid-create-test-group: "true"
+    testgrid-dashboards: sig-node-kep-wrangler
+    description: Mirrors release-team-owned single-select fields (Release Status, PRR Status, Proposed Stage) from the SIG Release Enhancement Tracking board (project 264) onto the SIG Node KEP tracking board (project 265). Read-only on 264; updates existing items only on 265.
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260525-f8de63d82b-master
+      command:
+      - runner.sh
+      args:
+      - ./experiment/sig-node-kep-board-sync/sync.sh
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          cpu: 1
+          memory: 2Gi
+      env:
+        - name: ORGANIZATION
+          value: "kubernetes"
+        - name: SOURCE_PROJECT_NUMBER
+          value: "264"
+        - name: TARGET_PROJECT_NUMBER
+          value: "265"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: sig-node-kep-wrangler-github-token
+              key: token

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -19,9 +19,12 @@ dashboard_groups:
     - sig-node-security-profiles-operator
     - sig-node-image-pushes
     - sig-node-node-readiness-controller
+    - sig-node-kep-wrangler
 
 dashboards:
 - name: sig-node-release-blocking # Tabs included in this group are defined in the jobs that are included.
+
+- name: sig-node-kep-wrangler # Periodic jobs that automate SIG Node KEP tracking (e.g. mirroring the release-team enhancement board).
 
 - name: sig-node-kubelet
 - name: sig-node-containerd

--- a/experiment/sig-node-kep-board-sync/OWNERS
+++ b/experiment/sig-node-kep-board-sync/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - haircommander
+  - SergeyKanzhelev
+reviewers:
+  - haircommander
+  - SergeyKanzhelev
+labels:
+  - sig/node

--- a/experiment/sig-node-kep-board-sync/mapping.json
+++ b/experiment/sig-node-kep-board-sync/mapping.json
@@ -1,0 +1,18 @@
+{
+    "_comment": "Maps single-select fields on the SOURCE project (264) to fields on the TARGET project (265). The keys are field names on 264. 'target_field' is the field name on 265; if omitted, defaults to the source field name. 'options' is an optional per-field map from source option name -> target option name; option names not listed are looked up by exact match on the target.",
+    "Status": {
+        "target_field": "Release Status"
+    },
+    "PRR Status": {
+        "target_field": "PRR Status"
+    },
+    "Stage": {
+        "target_field": "Proposed Stage",
+        "options": {
+            "Alpha": "1 - Alpha",
+            "Beta": "2 - Beta",
+            "Stable": "3 - Stable",
+            "Deprecation/Removal": "4 - Deprecation"
+        }
+    }
+}

--- a/experiment/sig-node-kep-board-sync/sync.sh
+++ b/experiment/sig-node-kep-board-sync/sync.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
-# Copyright 2026 The Kubernetes Authors.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright The Kubernetes Authors.
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Mirrors single-select field values from a source GitHub Projects v2 board
 # (e.g. the SIG Release Enhancement Tracking board, project 264) onto a target
 # board (e.g. the SIG Node KEP tracking board, project 265), translating field

--- a/experiment/sig-node-kep-board-sync/sync.sh
+++ b/experiment/sig-node-kep-board-sync/sync.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Mirrors single-select field values from a source GitHub Projects v2 board
+# (e.g. the SIG Release Enhancement Tracking board, project 264) onto a target
+# board (e.g. the SIG Node KEP tracking board, project 265), translating field
+# and option names per a JSON mapping file.
+#
+# Semantics:
+#   * Read-only on the source project.
+#   * Updates ONLY items already present on the target project.
+#   * Never adds items to or removes items from the target.
+#   * Skips items not found on the source (logged as a warning).
+#   * Skips fields whose translated option has no equivalent on the target.
+#
+# Required environment variables:
+#   GH_TOKEN                   classic PAT with scopes: read:org, project
+#                              (must be SSO-authorized for the org)
+#   ORGANIZATION               e.g. "kubernetes"
+#   SOURCE_PROJECT_NUMBER      e.g. "264"
+#   TARGET_PROJECT_NUMBER      e.g. "265"
+#
+# Optional environment variables:
+#   MAPPING_FILE   path to a JSON mapping (default: ./mapping.json next to this script)
+#   DRY_RUN        if "1", log intended mutations but do not write
+#   ONLY_ISSUE     restrict to one issue, e.g. "kubernetes/enhancements#1234"
+
+set -eu -o pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${ORGANIZATION:?ORGANIZATION is required}"
+: "${SOURCE_PROJECT_NUMBER:?SOURCE_PROJECT_NUMBER is required}"
+: "${TARGET_PROJECT_NUMBER:?TARGET_PROJECT_NUMBER is required}"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MAPPING_FILE="${MAPPING_FILE:-$SCRIPT_DIR/mapping.json}"
+DRY_RUN="${DRY_RUN:-0}"
+ONLY_ISSUE="${ONLY_ISSUE:-}"
+
+[ -r "$MAPPING_FILE" ] || { echo "[Error] MAPPING_FILE not readable: $MAPPING_FILE" >&2; exit 1; }
+
+log()  { printf '[%s] %s\n' "$(date -u +%FT%TZ)" "$*"; }
+warn() { log "WARN: $*" >&2; }
+
+# Strip the human-readable "_comment" key and normalize defaults.
+MAPPING="$(jq 'with_entries(select(.key | startswith("_") | not))
+               | with_entries(.value.target_field //= .key)
+               | with_entries(.value.options     //= {})' "$MAPPING_FILE")"
+
+project_meta() {
+  local number="$1"
+  gh api graphql --paginate -F org="$ORGANIZATION" -F number="$number" -f query='
+    query($org: String!, $number: Int!) {
+      organization(login: $org) {
+        projectV2(number: $number) {
+          id
+          fields(first: 50) {
+            nodes {
+              ... on ProjectV2SingleSelectField {
+                id name
+                options { id name }
+              }
+            }
+          }
+        }
+      }
+    }'
+}
+
+project_items() {
+  local number="$1"
+  gh api graphql --paginate -F org="$ORGANIZATION" -F number="$number" -f query='
+    query($org: String!, $number: Int!, $endCursor: String) {
+      organization(login: $org) {
+        projectV2(number: $number) {
+          items(first: 100, after: $endCursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              content {
+                ... on Issue {
+                  id number
+                  repository { nameWithOwner }
+                }
+              }
+              fieldValues(first: 20) {
+                nodes {
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    field { ... on ProjectV2SingleSelectField { name } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }'
+}
+
+log "Fetching source project metadata (#$SOURCE_PROJECT_NUMBER)..."
+SRC_META="$(project_meta "$SOURCE_PROJECT_NUMBER")"
+log "Fetching target project metadata (#$TARGET_PROJECT_NUMBER)..."
+DST_META="$(project_meta "$TARGET_PROJECT_NUMBER")"
+DST_PROJECT_ID="$(jq -r '.data.organization.projectV2.id' <<<"$DST_META")"
+
+log "Fetching source project items..."
+SRC_ITEMS="$(project_items "$SOURCE_PROJECT_NUMBER")"
+log "Fetching target project items..."
+DST_ITEMS="$(project_items "$TARGET_PROJECT_NUMBER")"
+
+# Index source items by underlying issue node id -> {source field name -> option name}.
+SRC_INDEX="$(jq '
+  [ .data.organization.projectV2.items.nodes[]
+    | select(.content.id != null)
+    | { key: .content.id,
+        value: ( [ .fieldValues.nodes[]
+                   | select(.field.name != null)
+                   | { (.field.name): .name } ] | add ) } ]
+  | from_entries' <<<"$SRC_ITEMS")"
+
+mapfile -t SRC_FIELDS < <(jq -r 'keys[]' <<<"$MAPPING")
+
+updates=0
+skips_missing=0
+skips_no_option=0
+noops=0
+
+# Process substitution keeps the loop in the parent shell so counters persist.
+while IFS= read -r row; do
+  item_id="$(jq -r '.itemId'  <<<"$row")"
+  issue_id="$(jq -r '.issueId' <<<"$row")"
+  issue_ref="$(jq -r '"\(.repo)#\(.issueNo)"' <<<"$row")"
+
+  if [ -n "$ONLY_ISSUE" ] && [ "$issue_ref" != "$ONLY_ISSUE" ]; then
+    continue
+  fi
+
+  src_fields="$(jq --arg id "$issue_id" '.[$id] // empty' <<<"$SRC_INDEX")"
+  if [ -z "$src_fields" ] || [ "$src_fields" = "null" ]; then
+    warn "skip $issue_ref: not present on source project #$SOURCE_PROJECT_NUMBER"
+    skips_missing=$((skips_missing + 1))
+    continue
+  fi
+
+  for src_field in "${SRC_FIELDS[@]}"; do
+    dst_field="$(jq -r --arg f "$src_field" '.[$f].target_field' <<<"$MAPPING")"
+
+    src_val="$(jq -r --arg f "$src_field" '.[$f] // empty' <<<"$src_fields")"
+    [ -z "$src_val" ] && continue
+
+    translated_val="$(jq -r --arg f "$src_field" --arg v "$src_val" \
+      '.[$f].options[$v] // $v' <<<"$MAPPING")"
+
+    dst_val="$(jq -r --arg f "$dst_field" '.current[$f] // empty' <<<"$row")"
+    if [ "$translated_val" = "$dst_val" ]; then
+      noops=$((noops + 1))
+      continue
+    fi
+
+    dst_field_id="$(jq -r --arg f "$dst_field" '
+      .data.organization.projectV2.fields.nodes[]
+      | select(.name == $f) | .id' <<<"$DST_META")"
+    dst_option_id="$(jq -r --arg f "$dst_field" --arg o "$translated_val" '
+      .data.organization.projectV2.fields.nodes[]
+      | select(.name == $f)
+      | .options[]? | select(.name == $o) | .id' <<<"$DST_META")"
+
+    if [ -z "$dst_field_id" ] || [ -z "$dst_option_id" ]; then
+      warn "skip $issue_ref field=\"$dst_field\": no \"$translated_val\" option on target (source \"$src_field\"=\"$src_val\")"
+      skips_no_option=$((skips_no_option + 1))
+      continue
+    fi
+
+    log "update $issue_ref \"$dst_field\": \"${dst_val:-<unset>}\" -> \"$translated_val\" (source \"$src_field\"=\"$src_val\")"
+    updates=$((updates + 1))
+    if [ "$DRY_RUN" = "1" ]; then
+      continue
+    fi
+    gh api graphql --silent \
+      -F project="$DST_PROJECT_ID" \
+      -F item="$item_id" \
+      -F field="$dst_field_id" \
+      -F option="$dst_option_id" \
+      -f query='
+        mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $project, itemId: $item, fieldId: $field,
+            value: { singleSelectOptionId: $option }
+          }) { projectV2Item { id } }
+        }'
+  done
+done < <(jq -c '
+  .data.organization.projectV2.items.nodes[]
+  | select(.content.id != null)
+  | { itemId: .id,
+      issueId: .content.id,
+      issueNo: .content.number,
+      repo: .content.repository.nameWithOwner,
+      current: ( [ .fieldValues.nodes[]
+                   | select(.field.name != null)
+                   | { (.field.name): .name } ] | add ) }' <<<"$DST_ITEMS")
+
+log "Sync finished. updates=$updates noops=$noops skips_missing=$skips_missing skips_no_option=$skips_no_option dry_run=$DRY_RUN"


### PR DESCRIPTION
## What this PR does

Adds a periodic job for SIG Node that syncs selected single-select fields from SIG Release Enhancements Tracking (Project 264) to SIG Node KEP planning (Project 265).

### Added
- Job config: config/jobs/kubernetes/sig-k8s-infra/trusted/sig-node-kep-wrangler/sig-node-kep-wrangler-periodics.yaml
- Sync script: experiment/sig-node-kep-board-sync/sync.sh
- Field mapping: experiment/sig-node-kep-board-sync/mapping.json
- OWNERS:
  - config/jobs/kubernetes/sig-k8s-infra/trusted/sig-node-kep-wrangler/OWNERS
  - experiment/sig-node-kep-board-sync/OWNERS
- TestGrid dashboard wiring:
  - config/testgrids/kubernetes/sig-node/config.yaml

## Sync scope
- Source project: `264` (SIG Release Enhancements Tracking)
- Target project: `265` (SIG Node KEP planning)

### Current mappings
SIG Release -> SIG Node
- `Status` -> `Release Status`
- `PRR Status` -> `PRR Status`
- `Stage` -> `Proposed Stage`
  - `Alpha` -> `1 - Alpha`
  - `Beta` -> `2 - Beta`
  - `Stable` -> `3 - Stable`
  - `Deprecation/Removal` -> `4 - Deprecation`

## Behavior

- Read-only on source project
- Updates only existing items on target project
- Does not add/remove project items
- Writes only when mapped field values differ

## Auth / secret

This job references the existing triage bot secret:
- `k8s-triage-robot-github-token`

The token behind this secret should have Projects v2 access for:
- Read on project `264`
- Write on project `265`

Validated locally with `sync.sh` with a personal PAT but not with the k8s-triage-robot-github-token and the existing secret k8s-triage-robot-github-token

Closes https://github.com/kubernetes/k8s.io/issues/9557