### PR TITLE
Update lws e2e presubmits to Kubernetes 1.36

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -53,37 +53,6 @@ presubmits:
           requests:
             cpu: 3
             memory: 10Gi
-  - name: pull-lws-test-e2e-main-1-32
-    cluster: eks-prow-build-cluster
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/lws
-    annotations:
-      testgrid-dashboards: sig-apps-lws-presubmits
-      testgrid-tab-name: pull-lws-test-e2e-main-1-32
-      description: "Run lws end to end tests for Kubernetes 1.32"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.32.11
-          command:
-            - runner.sh
-          args:
-            - make
-            - test-e2e
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 3
-              memory: 10Gi
-            requests:
-              cpu: 3
-              memory: 10Gi
   - name: pull-lws-test-e2e-main-1-33
     cluster: eks-prow-build-cluster
     always_run: true
@@ -100,7 +69,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.33.7
+              value: kindest/node:v1.33.12
           command:
             - runner.sh
           args:
@@ -131,7 +100,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.34.3
+              value: kindest/node:v1.34.8
           command:
             - runner.sh
           args:
@@ -148,8 +117,7 @@ presubmits:
               memory: 10Gi
   - name: pull-lws-test-e2e-main-1-35
     cluster: eks-prow-build-cluster
-    always_run: false  # TODO after https://github.com/kubernetes-sigs/lws/issues/751 fixed
-    optional: true # TODO after https://github.com/kubernetes-sigs/lws/issues/751 fixed
+    always_run: true
     decorate: true
     path_alias: sigs.k8s.io/lws
     annotations:
@@ -163,7 +131,38 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.35.0
+              value: kindest/node:v1.35.5
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+  - name: pull-lws-test-e2e-main-1-36
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/lws
+    annotations:
+      testgrid-dashboards: sig-apps-lws-presubmits
+      testgrid-tab-name: pull-lws-test-e2e-main-1-36
+      description: "Run lws end to end tests for Kubernetes 1.36"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.36.1
           command:
             - runner.sh
           args:
@@ -194,7 +193,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.34.0 # TODO after https://github.com/kubernetes-sigs/lws/issues/751 fixed
+              value: kindest/node:v1.36.1
           command:
             - runner.sh
           args:
@@ -225,7 +224,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.35.0
+              value: kindest/node:v1.36.1
           command:
             - runner.sh
           args:


### PR DESCRIPTION
## Summary
Slide the lws e2e presubmit version matrix forward to track Kubernetes 1.36:
- Drop the 1.32 job (oldest in the rolling window)
- Bump 1.33/1.34/1.35 to the latest patch node images shipped with kind v0.32.0 (v1.33.12 / v1.34.8 / v1.35.5)
- Add a new 1.36 job (v1.36.1)
- Promote the 1.35 job back to blocking (`always_run`) now that the previously failing tests are expected to pass on v1.35.5
- Move the cert-manager and gang-scheduling e2e jobs to v1.36.1

Marked WIP pending CI signal on the newly blocking 1.35/1.36 jobs.

The 1.35 e2e job was previously marked optional due to kubernetes-sigs/lws#751; the latest v1.35.5 patch image is expected to resolve it, so the job is promoted back to blocking.

## Test plan
- [ ] Prow config check / `make verify` passes
- [ ] New 1-36 e2e job runs green
- [ ] 1-35 job green on v1.35.5 (confirms kubernetes-sigs/lws#751 no longer reproduces)