### PR TITLE
ec2-dra: keep only DRA kubelet metrics in Prometheus to bound memory

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
@@ -93,6 +93,8 @@ periodics:
         value: "false"
       - name: PROMETHEUS_SCRAPE_KUBELETS
         value: "true"
+      - name: CL2_PROMETHEUS_KUBELET_KEEP_ONLY_DRA
+        value: "true"
       - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
         value: "false"
       - name: PROMETHEUS_PVC_STORAGE_CLASS
@@ -210,6 +212,8 @@ periodics:
         value: "false"
       - name: PROMETHEUS_SCRAPE_KUBELETS
         value: "true"
+      - name: CL2_PROMETHEUS_KUBELET_KEEP_ONLY_DRA
+        value: "true"
       - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
         value: "false"
       - name: PROMETHEUS_PVC_STORAGE_CLASS
@@ -301,6 +305,8 @@ presubmits:
         - name: TEAR_DOWN_PROMETHEUS_SERVER
           value: "false"
         - name: PROMETHEUS_SCRAPE_KUBELETS
+          value: "true"
+        - name: CL2_PROMETHEUS_KUBELET_KEEP_ONLY_DRA
           value: "true"
         - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
           value: "false"


### PR DESCRIPTION
Set CL2_PROMETHEUS_KUBELET_KEEP_ONLY_DRA=true on the 500/5000-node DRA-with-workload jobs (periodics + 500-node presubmit). Bounds Prometheus memory at scale by keeping only dra_* from the kubelet /metrics scrape. Requires kubernetes/perf-tests#4094.