### PR TITLE
DRA: Handle merged GangScheduling and GenericWorkload feature gates

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -130,10 +130,7 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - 0 >= 35)); then
-            features+=(
-              'GangScheduling'
-              'GenericWorkload'
-            )
+            features+=('GenericWorkload')
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"
@@ -237,10 +234,7 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - 0 >= 35)); then
-            features+=(
-              'GangScheduling'
-              'GenericWorkload'
-            )
+            features+=('GenericWorkload')
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           make WHAT="github.com/onsi/ginkgo/v2/ginkgo k8s.io/kubernetes/test/e2e/e2e.test"

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -187,14 +187,7 @@ presubmits:
           # valid for Kubernetes 1.35+. Additional features here should not
           # affect behavior of tests that don't require them.
           if ((major >= 1 && minor - {{ kubelet_skew }} >= 35)); then
-          {%- if canary %}
-            features+=(
-              'GangScheduling'
-              'GenericWorkload'
-            )
-          {%- else %}
             features+=('GenericWorkload')
-          {%- endif %}
           fi
           : "Enabling DRA feature(s): ${features[*]}."
           {%- else %}


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/139520 will fold the GangScheduling feature gate into the GenericWorkload feature gate. This change only affects canary jobs. Even those canary jobs don't invoke any of the functionality provided by GangScheduling, so this is functionally a no-op to prepare for the removal of the GangScheduling feature gate.

/assign @bart0sh 

/wg workload-aware-scheduling