### PR TITLE
Kueue: Shard the sequential-extended e2e tests for reduction of CI time

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -1508,14 +1508,14 @@ periodics:
               memory: "10Gi"
 
   - interval: 12h
-    name: periodic-kueue-test-e2e-sequential-extended-main
+    name: periodic-kueue-test-e2e-sequential-extended-shard-0-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-sequential-extended-main
+      testgrid-tab-name: periodic-kueue-test-e2e-sequential-extended-shard-0-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic sequential extended end to end tests"
+      description: "Run periodic sequential extended end to end tests shard 0"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -1542,7 +1542,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-sequential-extended
+            - test-e2e-sequential-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-sequential-extended-shard-1-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-sequential-extended-shard-1-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic sequential extended end to end tests shard 1"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-sequential-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -1469,14 +1469,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-sequential-extended-release-0-17
+    name: periodic-kueue-test-e2e-sequential-extended-shard-0-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-sequential-extended-release-0-17
+      testgrid-tab-name: periodic-kueue-test-e2e-sequential-extended-shard-0-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic sequential extended end to end tests"
+      description: "Run periodic sequential extended end to end tests shard 0"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -1503,7 +1503,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-sequential-extended
+            - test-e2e-sequential-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-sequential-extended-shard-1-release-0-17
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-sequential-extended-shard-1-release-0-17
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic sequential extended end to end tests shard 1"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.17
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-sequential-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -1507,14 +1507,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-sequential-extended-release-0-18
+    name: periodic-kueue-test-e2e-sequential-extended-shard-0-release-0-18
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-sequential-extended-release-0-18
+      testgrid-tab-name: periodic-kueue-test-e2e-sequential-extended-shard-0-release-0-18
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic sequential extended end to end tests"
+      description: "Run periodic sequential extended end to end tests shard 0"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -1541,7 +1541,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-e2e-sequential-extended
+            - test-e2e-sequential-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-sequential-extended-shard-1-release-0-18
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-sequential-extended-shard-1-release-0-18
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic sequential extended end to end tests shard 1"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.18
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-e2e-sequential-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -1105,44 +1105,82 @@ presubmits:
                 cpu: "7"
                 memory: "10Gi"
 
-    - name: pull-kueue-test-e2e-sequential-extended-main
+    - name: pull-kueue-test-e2e-sequential-extended-shard-0-main
       cluster: eks-prow-build-cluster
       branches:
-              - ^main
+        - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
       path_alias: sigs.k8s.io/kueue
       annotations:
-              testgrid-dashboards: sig-scheduling
-              testgrid-tab-name: pull-kueue-test-e2e-sequential-extended-main
-              description: "Run sequential extended end to end tests"
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-sequential-extended-shard-0-main
+        description: "Run sequential extended end to end tests shard 0"
       labels:
-              preset-dind-enabled: "true"
+        preset-dind-enabled: "true"
       spec:
-              containers:
-                - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
-                  env:
-                    - name: E2E_K8S_VERSION
-                      value: "1.35"
-                    - name: BASE_BUILDER_IMAGE
-                      value: public.ecr.aws/docker/library/golang
-                  command:
-                    # generic runner script, handles DIND, bazelrc for caching, etc.
-                    - runner.sh
-                  args:
-                    - make
-                    - kind-image-build
-                    - test-e2e-sequential-extended
-                  # docker-in-docker needs privileged mode
-                  securityContext:
-                    privileged: true
-                  resources:
-                    requests:
-                      cpu: "7"
-                      memory: "10Gi"
-                    limits:
-                      cpu: "7"
-                      memory: "10Gi"
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-sequential-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-sequential-extended-shard-1-main
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-sequential-extended-shard-1-main
+        description: "Run sequential extended end to end tests shard 1"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-sequential-extended-shard-1
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
     - name: pull-kueue-test-e2e-certmanager-main
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -1104,7 +1104,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-sequential-extended-release-0-17
+    - name: pull-kueue-test-e2e-sequential-extended-shard-0-release-0-17
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.17
@@ -1113,8 +1113,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-sequential-extended-release-0-17
-        description: "Run sequential extended end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-sequential-extended-shard-0-release-0-17
+        description: "Run sequential extended end to end tests shard 0"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -1131,7 +1131,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-sequential-extended
+              - test-e2e-sequential-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-sequential-extended-shard-1-release-0-17
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.17
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-sequential-extended-shard-1-release-0-17
+        description: "Run sequential extended end to end tests shard 1"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-sequential-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -1104,7 +1104,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-sequential-extended-release-0-18
+    - name: pull-kueue-test-e2e-sequential-extended-shard-0-release-0-18
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.18
@@ -1113,8 +1113,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-sequential-extended-release-0-18
-        description: "Run sequential extended end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-sequential-extended-shard-0-release-0-18
+        description: "Run sequential extended end to end tests shard 0"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -1131,7 +1131,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-e2e-sequential-extended
+              - test-e2e-sequential-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-sequential-extended-shard-1-release-0-18
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.18
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-sequential-extended-shard-1-release-0-18
+        description: "Run sequential extended end to end tests shard 1"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-sequential-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true


### PR DESCRIPTION
Splits the single sequential-extended presubmit and periodic jobs into shard-0 / shard-1.

Part of https://github.com/kubernetes-sigs/kueue/pull/12004 (main)
Part of https://github.com/kubernetes-sigs/kueue/pull/12064 (release-0.18)
Part of https://github.com/kubernetes-sigs/kueue/pull/12065 (release-0.17)


