### PR TITLE
Rename perfdash prefix to gce-5000Nodes-experimental

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1397,7 +1397,7 @@ periodics:
 - cron: '1 5 * * 2,6' # Run twice a week at 21:01 PST (05:01 UTC)
   name: ci-kubernetes-e2e-gce-scale-performance-5000-experimental
   tags:
-  - "perfDashPrefix: gce-5000Nodes-1.5GB-pods"
+  - "perfDashPrefix: gce-5000Nodes-experimental"
   - "perfDashBuildsCount: 270"
   - "perfDashJobType: performance"
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
1.5GB is no longer unique to this test, rename to experimental