### PR TITLE
Set ETCD_VERSION=3.7.0-rc.0 on kops scalability jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -60,6 +60,8 @@ presubmits:
           value: gce
         - name: KUBE_NODE_COUNT
           value: "100"
+        - name: ETCD_VERSION
+          value: "3.7.0-rc.0"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -90,6 +90,8 @@ periodics:
         value: "amazonvpc"
       - name: KUBE_NODE_COUNT
         value: "5000"
+      - name: ETCD_VERSION
+        value: "3.7.0-rc.0"
       - name: CL2_LOAD_TEST_THROUGHPUT
         value: "50"
       - name: CL2_DELETE_TEST_THROUGHPUT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1467,6 +1467,8 @@ periodics:
         value: gce
       - name: KUBE_NODE_COUNT
         value: "5000"
+      - name: ETCD_VERSION
+        value: "3.7.0-rc.0"
       - name: CL2_LOAD_TEST_THROUGHPUT
         value: "50"
       - name: CL2_DELETE_TEST_THROUGHPUT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -476,6 +476,8 @@ presubmits:
           value: gce
         - name: KUBE_NODE_COUNT
           value: "5000"
+        - name: ETCD_VERSION
+          value: "3.7.0-rc.0"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -141,6 +141,8 @@ periodics:
         value: gce
       - name: KUBE_NODE_COUNT
         value: "5000"
+      - name: ETCD_VERSION
+        value: "3.7.0-rc.0"
       - name: CL2_LOAD_TEST_THROUGHPUT
         value: "50"
       - name: CL2_DELETE_TEST_THROUGHPUT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -141,8 +141,6 @@ periodics:
         value: gce
       - name: KUBE_NODE_COUNT
         value: "5000"
-      - name: ETCD_VERSION
-        value: "3.7.0-rc.0"
       - name: CL2_LOAD_TEST_THROUGHPUT
         value: "50"
       - name: CL2_DELETE_TEST_THROUGHPUT


### PR DESCRIPTION
No effect until https://github.com/kubernetes/kops/pull/18458 merges, after which these jobs pass --set spec.etcdClusters[*].version=3.7.0-rc.0 since they track kops master.