### PR TITLE
Override kind node image for 1.36 in compatibility-versions e2e

### DIFF
--- a/experiment/compatibility-versions/common.sh
+++ b/experiment/compatibility-versions/common.sh
@@ -182,8 +182,10 @@ EOF
   # actually create the cluster
   # TODO(BenTheElder): settle on verbosity for this script
   KIND_CREATE_ATTEMPTED=true
+  local node_image="kindest/node:v${PREV_VERSION}-ci"
+  kind build node-image "ci/latest-${PREV_VERSION}" --image "${node_image}"
   kind create cluster \
-    --image="kindest/node:v${PREV_VERSION}.0" \
+    --image="${node_image}" \
     --retain \
     --wait=1m \
     -v=3 \


### PR DESCRIPTION
kind shipped 1.36 as v1.36.1 with no v1.36.0, so the hardcoded kindest/node:v${PREV_VERSION}.0 breaks every n-1 job at cluster creation. Override the node image for 1.36.