### PR TITLE
Kueue: shard the multikueue-extended e2e tests for reduction of CI time

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -1139,14 +1139,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-multikueue-extended-main
+    name: periodic-kueue-test-e2e-multikueue-extended-shard-0-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-main
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-shard-0-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic extended multikueue end to end tests"
+      description: "Run periodic extended multikueue end to end tests shard 0"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -1173,7 +1173,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-multikueue-e2e-extended
+            - test-multikueue-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-multikueue-extended-shard-1-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-shard-1-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic extended multikueue end to end tests shard 1"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-multikueue-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -1101,14 +1101,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-multikueue-extended-release-0-17
+    name: periodic-kueue-test-e2e-multikueue-extended-shard-0-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-release-0-17
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-shard-0-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic extended multikueue end to end tests"
+      description: "Run periodic extended multikueue end to end tests shard 0"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -1135,7 +1135,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-multikueue-e2e-extended
+            - test-multikueue-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-multikueue-extended-shard-1-release-0-17
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-shard-1-release-0-17
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic extended multikueue end to end tests shard 1"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.17
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-multikueue-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -1139,14 +1139,14 @@ periodics:
               cpu: "7"
               memory: "10Gi"
   - interval: 12h
-    name: periodic-kueue-test-e2e-multikueue-extended-release-0-18
+    name: periodic-kueue-test-e2e-multikueue-extended-shard-0-release-0-18
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-release-0-18
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-shard-0-release-0-18
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic extended multikueue end to end tests"
+      description: "Run periodic extended multikueue end to end tests shard 0"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"
@@ -1173,7 +1173,53 @@ periodics:
           args:
             - make
             - kind-image-build
-            - test-multikueue-e2e-extended
+            - test-multikueue-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "7"
+              memory: "10Gi"
+            limits:
+              cpu: "7"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-multikueue-extended-shard-1-release-0-18
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-multikueue-extended-shard-1-release-0-18
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic extended multikueue end to end tests shard 1"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.18
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-multikueue-e2e-extended-shard-1
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -800,7 +800,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-multikueue-extended-main
+    - name: pull-kueue-test-e2e-multikueue-extended-shard-0-main
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -809,8 +809,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-main
-        description: "Run extended multikueue end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-shard-0-main
+        description: "Run extended multikueue end to end tests shard 0"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -827,7 +827,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-multikueue-e2e-extended
+              - test-multikueue-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-multikueue-extended-shard-1-main
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-shard-1-main
+        description: "Run extended multikueue end to end tests shard 1"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-multikueue-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -800,7 +800,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-multikueue-extended-release-0-17
+    - name: pull-kueue-test-e2e-multikueue-extended-shard-0-release-0-17
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.17
@@ -809,8 +809,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-release-0-17
-        description: "Run extended multikueue end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-shard-0-release-0-17
+        description: "Run extended multikueue end to end tests shard 0"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -827,7 +827,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-multikueue-e2e-extended
+              - test-multikueue-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-multikueue-extended-shard-1-release-0-17
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.17
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-shard-1-release-0-17
+        description: "Run extended multikueue end to end tests shard 1"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-multikueue-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -800,7 +800,7 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
-    - name: pull-kueue-test-e2e-multikueue-extended-release-0-18
+    - name: pull-kueue-test-e2e-multikueue-extended-shard-0-release-0-18
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.18
@@ -809,8 +809,8 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-release-0-18
-        description: "Run extended multikueue end to end tests"
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-shard-0-release-0-18
+        description: "Run extended multikueue end to end tests shard 0"
       labels:
         preset-dind-enabled: "true"
       spec:
@@ -827,7 +827,45 @@ presubmits:
             args:
               - make
               - kind-image-build
-              - test-multikueue-e2e-extended
+              - test-multikueue-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-multikueue-extended-shard-1-release-0-18
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.18
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-multikueue-extended-shard-1-release-0-18
+        description: "Run extended multikueue end to end tests shard 1"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-multikueue-e2e-extended-shard-1
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true


### PR DESCRIPTION
Splits the single multikueue-extended presubmit and periodic jobs into shard-0 / shard-1, so the two shards run in parallel instead of sequentially within one job.

Part of https://github.com/kubernetes-sigs/kueue/issues/11988
Part of https://github.com/kubernetes-sigs/kueue/pull/12096 (main)
Part of https://github.com/kubernetes-sigs/kueue/pull/12208 (release-0.18)
Part of https://github.com/kubernetes-sigs/kueue/pull/12209 (release-0.17)