### PR TITLE
Kueue-test: Increase timeout for CI jobs waiting for available machines

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -20,6 +20,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -60,6 +61,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -99,6 +101,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -141,6 +144,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -183,6 +187,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -225,6 +230,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -263,6 +269,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -301,6 +308,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -339,6 +347,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -377,6 +386,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -423,6 +433,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -469,6 +480,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -515,6 +527,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -561,6 +574,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -607,6 +621,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -653,6 +668,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -699,6 +715,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -745,6 +762,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -791,6 +809,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -837,6 +856,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -883,6 +903,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -929,6 +950,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -975,6 +997,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1021,6 +1044,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1067,6 +1091,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1113,6 +1138,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1159,6 +1185,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1205,6 +1232,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1251,6 +1279,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1297,6 +1326,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1343,6 +1373,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1389,6 +1420,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1435,6 +1467,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1481,6 +1514,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1528,6 +1562,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1574,6 +1609,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1620,6 +1656,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1666,6 +1703,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1712,6 +1750,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1758,6 +1797,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1800,6 +1840,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -20,6 +20,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -60,6 +61,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -99,6 +101,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -141,6 +144,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -183,6 +187,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -225,6 +230,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -263,6 +269,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -301,6 +308,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -339,6 +347,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -385,6 +394,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -431,6 +441,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -477,6 +488,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -523,6 +535,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -569,6 +582,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -615,6 +629,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -661,6 +676,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -707,6 +723,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -753,6 +770,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -799,6 +817,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -845,6 +864,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -891,6 +911,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -937,6 +958,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -983,6 +1005,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1029,6 +1052,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1075,6 +1099,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1121,6 +1146,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1167,6 +1193,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1213,6 +1240,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1259,6 +1287,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1305,6 +1334,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1351,6 +1381,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1397,6 +1428,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1443,6 +1475,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1489,6 +1522,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1535,6 +1569,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1581,6 +1616,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1627,6 +1663,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1673,6 +1710,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1719,6 +1757,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1761,6 +1800,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -20,6 +20,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -60,6 +61,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -99,6 +101,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -141,6 +144,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -183,6 +187,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -225,6 +230,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -263,6 +269,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -301,6 +308,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -339,6 +347,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: public.ecr.aws/docker/library/golang:1.26
@@ -377,6 +386,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -423,6 +433,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -469,6 +480,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -515,6 +527,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -561,6 +574,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -607,6 +621,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -653,6 +668,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -699,6 +715,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -745,6 +762,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -791,6 +809,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -837,6 +856,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -930,6 +950,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -976,6 +997,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1022,6 +1044,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1068,6 +1091,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1114,6 +1138,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1160,6 +1185,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1206,6 +1232,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1252,6 +1279,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1298,6 +1326,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1344,6 +1373,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1390,6 +1420,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1436,6 +1467,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1482,6 +1514,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1528,6 +1561,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1574,6 +1608,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1620,6 +1655,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1666,6 +1702,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1712,6 +1749,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1758,6 +1796,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
@@ -1800,6 +1839,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -883,6 +883,7 @@ periodics:
     decorate: true
     decoration_config:
       timeout: 1h
+      pod_unscheduled_timeout: 10m
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -6,6 +6,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -36,6 +38,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -68,6 +72,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -100,6 +106,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -132,6 +140,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -160,6 +170,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -198,6 +210,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -236,6 +250,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -274,6 +290,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -312,6 +330,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -350,6 +370,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -388,6 +410,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -426,6 +450,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -464,6 +490,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -502,6 +530,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -540,6 +570,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -578,6 +610,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -616,6 +650,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -654,6 +690,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -692,6 +730,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -730,6 +770,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -768,6 +810,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -806,6 +850,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -844,6 +890,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -882,6 +930,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -920,6 +970,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -958,6 +1010,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -996,6 +1050,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1034,6 +1090,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1072,6 +1130,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1111,6 +1171,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1149,6 +1211,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1187,6 +1251,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1225,6 +1291,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1263,6 +1331,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1301,6 +1371,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1339,6 +1411,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1377,6 +1451,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1415,6 +1491,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|^(README|LICENSE|OWNERS)$"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1448,6 +1526,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1487,6 +1567,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1515,6 +1597,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1543,6 +1627,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1576,6 +1662,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1606,6 +1694,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1634,6 +1724,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1671,6 +1763,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1701,6 +1795,8 @@ presubmits:
         - ^main
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1730,6 +1826,8 @@ presubmits:
       branches:
         - ^main
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1765,6 +1863,8 @@ presubmits:
       branches:
         - ^main
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -6,6 +6,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -36,6 +38,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -68,6 +72,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -100,6 +106,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -132,6 +140,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -160,6 +170,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -198,6 +210,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -236,6 +250,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -274,6 +290,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -312,6 +330,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -350,6 +370,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -388,6 +410,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -426,6 +450,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -464,6 +490,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -502,6 +530,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -540,6 +570,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -578,6 +610,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -616,6 +650,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -654,6 +690,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -692,6 +730,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -730,6 +770,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -768,6 +810,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -806,6 +850,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -844,6 +890,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -882,6 +930,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -920,6 +970,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -958,6 +1010,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -996,6 +1050,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1034,6 +1090,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1072,6 +1130,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1110,6 +1170,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1148,6 +1210,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1186,6 +1250,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1224,6 +1290,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1262,6 +1330,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1300,6 +1370,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1338,6 +1410,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1376,6 +1450,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1414,6 +1490,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|^(README|LICENSE|OWNERS)$"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1447,6 +1525,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1485,6 +1565,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1513,6 +1595,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1541,6 +1625,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1574,6 +1660,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1604,6 +1692,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1632,6 +1722,8 @@ presubmits:
         - ^release-0.17
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -6,6 +6,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -36,6 +38,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -68,6 +72,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -100,6 +106,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -132,6 +140,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -160,6 +170,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -198,6 +210,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -236,6 +250,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -274,6 +290,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -312,6 +330,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -350,6 +370,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -388,6 +410,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -426,6 +450,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -464,6 +490,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -502,6 +530,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -540,6 +570,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -578,6 +610,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -616,6 +650,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -654,6 +690,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -692,6 +730,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -730,6 +770,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -768,6 +810,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -806,6 +850,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -844,6 +890,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -882,6 +930,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -920,6 +970,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -958,6 +1010,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -996,6 +1050,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1034,6 +1090,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1072,6 +1130,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1110,6 +1170,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1148,6 +1210,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1186,6 +1250,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1224,6 +1290,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1262,6 +1330,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1300,6 +1370,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1338,6 +1410,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1376,6 +1450,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1414,6 +1490,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|^(README|LICENSE|OWNERS)$"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1447,6 +1525,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1486,6 +1566,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1514,6 +1596,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1542,6 +1626,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1575,6 +1661,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1605,6 +1693,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1633,6 +1723,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1670,6 +1762,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1700,6 +1794,8 @@ presubmits:
         - ^release-0.18
       skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
@@ -1729,6 +1825,8 @@ presubmits:
       branches:
         - ^release-0.18
       decorate: true
+      decoration_config:
+        pod_unscheduled_timeout: 10m
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling


### PR DESCRIPTION
Kueue-test: Increase timeout for CI jobs waiting for available machines

Part of https://github.com/kubernetes-sigs/kueue/issues/12156
Fixes https://github.com/kubernetes-sigs/kueue/issues/12156


This PR just adds pod_unscheduled_timeout: 10m