### PR TITLE
Enable EtcdRangeStream on pull-kubernetes-gce-master-scale-performance-5000

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -451,6 +451,8 @@ presubmits:
         securityContext:
           privileged: true
         env:
+        - name: KUBE_FEATURE_GATES
+          value: "+EtcdRangeStream"
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
           value: "true"
         - name: CL2_RESTART_APISERVER


### PR DESCRIPTION
Turns on the EtcdRangeStream feature gate (+EtcdRangeStream) for the 5k-node scale presubmit.

100 node was successful (experimental) https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-100-experimental/2065545590925692928

Want to capture data with gate on, goal is to revert this in 1.37 as we should have it on by default.