### PR TITLE
Skip minikube presubmit jobs for site-only changes

### DIFF
--- a/config/jobs/kubernetes/minikube/minikube-presubmits.yaml
+++ b/config/jobs/kubernetes/minikube/minikube-presubmits.yaml
@@ -4,7 +4,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^site/"
     labels:
       preset-dind-enabled: "true"
     annotations:
@@ -33,7 +34,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^site/"
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
@@ -62,7 +64,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^site/"
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
@@ -92,7 +95,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^site/"
     optional: true
     labels:
       preset-dind-enabled: "true"
@@ -123,7 +127,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^site/"
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
@@ -153,7 +158,8 @@ presubmits:
     optional: true
     decorate: true
     path_alias: "k8s.io/minikube"
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^site/"
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
@@ -182,7 +188,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^site/"
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
@@ -211,7 +218,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^site/"
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
@@ -241,7 +249,8 @@ presubmits:
     optional: true
     decorate: true
     path_alias: "k8s.io/minikube"
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^site/"
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"
@@ -270,7 +279,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^site/"
     optional: true
     labels:
       preset-dind-enabled: "true"
@@ -300,7 +310,8 @@ presubmits:
     cluster: k8s-infra-prow-build
     decorate: true
     path_alias: "k8s.io/minikube"
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^site/"
     labels:
       preset-dind-enabled: "true"
       preset-service-account: "true"


### PR DESCRIPTION
PRs that only modify files under site/ (documentation content) do not need to run integration tests. Currently all presubmit jobs have always_run: true, which means site-only PRs must pass all tests including flaky ones, blocking simple doc fixes from merging.

For example, https://github.com/kubernetes/minikube/pull/22655 is a 3-line typo fix in documentation that has been blocked by flaky test failures in pull-minikube-docker-docker-linux-x86 and pull-minikube-kvm-containerd-linux-x86.

Change all presubmit jobs to always_run: false with skip_if_only_changed: "^site/" so they are skipped when the PR only touches site/ files, but still run normally for any code changes.