### PR TITLE
Drop CI jobs for periodic-kueue-verify-website-links for releases

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -39,45 +39,6 @@ periodics:
             limits:
               cpu: "6"
               memory: "6Gi"
-  - interval: 24h
-    name: periodic-kueue-verify-website-links-release-0-17
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-verify-website-links-release-0-17
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue website link verification"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: release-0.17
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
-          command:
-            - runner.sh
-          args:
-            - make
-            - verify-website-links
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "6"
-              memory: "6Gi"
-            limits:
-              cpu: "6"
-              memory: "6Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-shard-0-release-0-17
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -39,45 +39,6 @@ periodics:
             limits:
               cpu: "6"
               memory: "6Gi"
-  - interval: 24h
-    name: periodic-kueue-verify-website-links-release-0-18
-    cluster: eks-prow-build-cluster
-    annotations:
-      testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-verify-website-links-release-0-18
-      testgrid-alert-email: kueue-alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue website link verification"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: kueue
-        base_ref: release-0.18
-        path_alias: kubernetes-sigs/kueue
-    decorate: true
-    decoration_config:
-      timeout: 1h
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260601-2cbf4bdb47-master
-          command:
-            - runner.sh
-          args:
-            - make
-            - verify-website-links
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "6"
-              memory: "6Gi"
-            limits:
-              cpu: "6"
-              memory: "6Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-shard-0-release-0-18
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
It does not make sense to run the CI jobs from release branches because we anyway only verify the links from the "live" webpage of Kueue, not from code.