### PR TITLE
kubetest2: 4GB -> 8GB for pull-kubernetes-verify

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-presubmits.yaml
@@ -17,10 +17,10 @@ presubmits:
         resources:
           limits:
             cpu: 4
-            memory: 4Gi
+            memory: 8Gi
           requests:
             cpu: 4
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - name: pull-kubetest2-build


### PR DESCRIPTION
The job got OOMed, let's double the memory. RAM is not a scarce resource in the Prow clusters, so no need to be too conservative.