### PR TITLE
Remove RangeStream enablement on pull 5k test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -451,8 +451,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_FEATURE_GATES
-          value: "+EtcdRangeStream"
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
           value: "true"
         - name: CL2_RESTART_APISERVER


### PR DESCRIPTION
This PR removes the +EtcdRangeStream feature gate from the pull-kubernetes-gce-master-scale-performance-5000 presubmit job.