### PR TITLE
Kops - Remove remaining --zones flags from aws jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -693,8 +693,7 @@ def generate_misc():
                    k8s_version="ci",
                    networking="cilium",
                    runs_per_day=1,
-                   extra_flags=["--zones=eu-central-1a",
-                                "--node-size=m6g.large",
+                   extra_flags=["--node-size=m6g.large",
                                 "--control-plane-size=m6g.large"],
                    extra_dashboards=['kops-network-plugins']),
         build_test(name_override="kops-gce-cni-cilium-k8s-ci",
@@ -716,7 +715,6 @@ def generate_misc():
                                 '--topology=private',
                                 '--dns=public',
                                 '--bastion',
-                                '--zones=us-west-2a',
                                 ],
                    extra_dashboards=['kops-network-plugins', 'kops-ipv6']),
         # A special test for IPv6 using Cilium CNI
@@ -730,7 +728,6 @@ def generate_misc():
                                 '--topology=private',
                                 '--dns=public',
                                 '--bastion',
-                                '--zones=us-west-2a',
                                 ],
                    extra_dashboards=['kops-network-plugins', 'kops-ipv6']),
         # A special test for IPv6 using Kindnet CNI
@@ -744,7 +741,6 @@ def generate_misc():
                                 '--topology=private',
                                 '--dns=public',
                                 '--bastion',
-                                '--zones=us-west-2a',
                                 ],
                    extra_dashboards=['kops-network-plugins', 'kops-ipv6']),
         # A special test for IPv6 on Flatcar
@@ -792,7 +788,6 @@ def generate_misc():
                    runs_per_day=1,
                    terraform_version="1.5.5",
                    extra_flags=[
-                       "--zones=us-west-1a",
                        "--dns=public",
                    ],
                    extra_dashboards=['kops-misc']),
@@ -806,7 +801,6 @@ def generate_misc():
                        '--ipv6',
                        '--topology=private',
                        '--bastion',
-                       "--zones=us-west-1a",
                        "--dns=public",
                    ],
                    extra_dashboards=['kops-misc', 'kops-ipv6']),
@@ -820,7 +814,6 @@ def generate_misc():
                    runs_per_day=3,
                    extra_flags=[
                        "--control-plane-count=3",
-                       "--zones=eu-west-1a,eu-west-1b,eu-west-1c"
                    ],
                    extra_dashboards=["kops-misc"]),
 
@@ -1408,8 +1401,7 @@ def generate_conformance():
                 name_override=f"kops-aws-conformance-{version.replace('.', '-')}",
                 networking='calico',
                 distro="u2404",
-                extra_flags=["--zones=eu-central-1a",
-                             "--node-size=t3.large",
+                extra_flags=["--node-size=t3.large",
                              "--control-plane-size=t3.large"],
                 test_parallelism=1,
                 test_timeout_minutes=150,
@@ -1427,8 +1419,7 @@ def generate_conformance():
                 name_override=f"kops-aws-conformance-arm64-{version.replace('.', '-')}",
                 networking='calico',
                 distro="u2404arm64",
-                extra_flags=["--zones=eu-central-1a",
-                             "--node-size=t4g.large",
+                extra_flags=["--node-size=t4g.large",
                              "--control-plane-size=t4g.large"],
                 test_parallelism=1,
                 test_timeout_minutes=150,
@@ -1480,7 +1471,6 @@ def generate_distros():
         extra_flags = []
         if 'arm64' in distro:
             extra_flags.extend([
-                "--zones=eu-west-1a",
                 "--node-size=m6g.large",
                 "--control-plane-size=m6g.large"
             ])
@@ -1511,7 +1501,6 @@ def generate_presubmits_distros():
         extra_flags = []
         if 'arm64' in distro:
             extra_flags.extend([
-                "--zones=eu-west-1a",
                 "--node-size=m6g.large",
                 "--control-plane-size=m6g.large"
             ])
@@ -2077,7 +2066,6 @@ def generate_nftables():
         extra_flags = ["--set=cluster.spec.kubeProxy.proxyMode=nftables"]
         if 'arm64' in distro:
             extra_flags.extend([
-                "--zones=eu-west-1a",
                 "--node-size=m6g.large",
                 "--control-plane-size=m6g.large"
             ])
@@ -2299,7 +2287,6 @@ def generate_presubmits_network_plugins():
                     extra_flags=['--ipv6',
                                  '--topology=private',
                                  '--bastion',
-                                 '--zones=us-west-2a',
                                  '--dns=public',
                                  ],
                     run_if_changed=run_if_changed,
@@ -2332,8 +2319,7 @@ def generate_presubmits_e2e():
             networking='calico',
             extra_flags=[
                 "--control-plane-count=3",
-                "--node-count=6",
-                "--zones=eu-central-1a,eu-central-1b,eu-central-1c"],
+                "--node-count=6"],
             tab_name='e2e-containerd-ci-ha',
             always_run=False,
             focus_regex=r'\[Conformance\]|\[NodeConformance\]',
@@ -2559,8 +2545,7 @@ def generate_presubmits_e2e():
             cloud="aws",
             distro="u2404arm64",
             networking="calico",
-            extra_flags=["--zones=eu-central-1a",
-                         "--node-size=m6g.large",
+            extra_flags=["--node-size=m6g.large",
                          "--control-plane-size=m6g.large"],
         ),
 

--- a/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
@@ -2,7 +2,7 @@
 # 13 jobs, total of 161 runs per week
 periodics:
 
-# {"cloud": "aws", "distro": "u2404", "extra_flags": "--zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+# {"cloud": "aws", "distro": "u2404", "extra_flags": "--node-size=t3.large --control-plane-size=t3.large", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-conformance-master
   cron: '4 2-23/24 * * *'
   labels:
@@ -32,7 +32,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260604' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260604' --channel=alpha --networking=calico --node-size=t3.large --control-plane-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
           --test=kops \
@@ -63,7 +63,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404
-    test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large
+    test.kops.k8s.io/extra_flags: --node-size=t3.large --control-plane-size=t3.large
     test.kops.k8s.io/k8s_version: ci
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -72,7 +72,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-conformance-master
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--node-size=t4g.large --control-plane-size=t4g.large", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-conformance-arm64-master
   cron: '44 4-23/24 * * *'
   labels:
@@ -102,7 +102,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --node-size=t4g.large --control-plane-size=t4g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
           --test=kops \
@@ -133,7 +133,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large
+    test.kops.k8s.io/extra_flags: --node-size=t4g.large --control-plane-size=t4g.large
     test.kops.k8s.io/k8s_version: ci
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -209,7 +209,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-azure-conformance-master
 
-# {"cloud": "aws", "distro": "u2404", "extra_flags": "--zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large", "k8s_version": "1.33", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+# {"cloud": "aws", "distro": "u2404", "extra_flags": "--node-size=t3.large --control-plane-size=t3.large", "k8s_version": "1.33", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-conformance-1-33
   cron: '20 18-23/24 * * *'
   labels:
@@ -239,7 +239,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260604' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260604' --channel=alpha --networking=calico --node-size=t3.large --control-plane-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.33.txt \
           --test=kops \
@@ -270,7 +270,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404
-    test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large
+    test.kops.k8s.io/extra_flags: --node-size=t3.large --control-plane-size=t3.large
     test.kops.k8s.io/k8s_version: '1.33'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -279,7 +279,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-conformance-1-33
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large", "k8s_version": "1.33", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--node-size=t4g.large --control-plane-size=t4g.large", "k8s_version": "1.33", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-conformance-arm64-1-33
   cron: '22 1-23/24 * * *'
   labels:
@@ -309,7 +309,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --node-size=t4g.large --control-plane-size=t4g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.33.txt \
           --test=kops \
@@ -340,7 +340,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large
+    test.kops.k8s.io/extra_flags: --node-size=t4g.large --control-plane-size=t4g.large
     test.kops.k8s.io/k8s_version: '1.33'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -416,7 +416,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-azure-conformance-1-33
 
-# {"cloud": "aws", "distro": "u2404", "extra_flags": "--zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large", "k8s_version": "1.34", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+# {"cloud": "aws", "distro": "u2404", "extra_flags": "--node-size=t3.large --control-plane-size=t3.large", "k8s_version": "1.34", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-conformance-1-34
   cron: '15 1-23/24 * * *'
   labels:
@@ -446,7 +446,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260604' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260604' --channel=alpha --networking=calico --node-size=t3.large --control-plane-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -477,7 +477,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404
-    test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large
+    test.kops.k8s.io/extra_flags: --node-size=t3.large --control-plane-size=t3.large
     test.kops.k8s.io/k8s_version: '1.34'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -486,7 +486,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-conformance-1-34
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large", "k8s_version": "1.34", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--node-size=t4g.large --control-plane-size=t4g.large", "k8s_version": "1.34", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-conformance-arm64-1-34
   cron: '57 2-23/24 * * *'
   labels:
@@ -516,7 +516,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --node-size=t4g.large --control-plane-size=t4g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -547,7 +547,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large
+    test.kops.k8s.io/extra_flags: --node-size=t4g.large --control-plane-size=t4g.large
     test.kops.k8s.io/k8s_version: '1.34'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -623,7 +623,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-azure-conformance-1-34
 
-# {"cloud": "aws", "distro": "u2404", "extra_flags": "--zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large", "k8s_version": "1.35", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+# {"cloud": "aws", "distro": "u2404", "extra_flags": "--node-size=t3.large --control-plane-size=t3.large", "k8s_version": "1.35", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-conformance-1-35
   cron: '45 7-23/24 * * *'
   labels:
@@ -653,7 +653,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260604' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260604' --channel=alpha --networking=calico --node-size=t3.large --control-plane-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -684,7 +684,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404
-    test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=t3.large --control-plane-size=t3.large
+    test.kops.k8s.io/extra_flags: --node-size=t3.large --control-plane-size=t3.large
     test.kops.k8s.io/k8s_version: '1.35'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -693,7 +693,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-conformance-1-35
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large", "k8s_version": "1.35", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--node-size=t4g.large --control-plane-size=t4g.large", "k8s_version": "1.35", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-conformance-arm64-1-35
   cron: '51 12-23/24 * * *'
   labels:
@@ -723,7 +723,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --node-size=t4g.large --control-plane-size=t4g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -754,7 +754,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=t4g.large --control-plane-size=t4g.large
+    test.kops.k8s.io/extra_flags: --node-size=t4g.large --control-plane-size=t4g.large
     test.kops.k8s.io/k8s_version: '1.35'
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -262,7 +262,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-u2204
 
-# {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-distro-u2204arm64
   cron: '22 4-23/8 * * *'
   labels:
@@ -292,7 +292,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260602' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260602' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -319,7 +319,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2204arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -393,7 +393,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-u2404
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-distro-u2404arm64
   cron: '41 3-23/8 * * *'
   labels:
@@ -423,7 +423,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -450,7 +450,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -524,7 +524,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-u2510
 
-# {"cloud": "aws", "distro": "u2510arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "u2510arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-distro-u2510arm64
   cron: '5 7-23/8 * * *'
   labels:
@@ -554,7 +554,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260603' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260603' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -581,7 +581,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2510arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -655,7 +655,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-u2604
 
-# {"cloud": "aws", "distro": "u2604arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "u2604arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-distro-u2604arm64
   cron: '24 6-23/8 * * *'
   labels:
@@ -685,7 +685,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260604' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260604' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -712,7 +712,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2604arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -786,7 +786,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-al2023
 
-# {"cloud": "aws", "distro": "al2023arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "al2023arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-distro-al2023arm64
   cron: '52 6-23/8 * * *'
   labels:
@@ -816,7 +816,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.11.20260526.0-kernel-6.12-arm64' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.11.20260526.0-kernel-6.12-arm64' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -843,7 +843,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: al2023arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -917,7 +917,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-rhel9
 
-# {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-distro-rhel10arm64
   cron: '9 3-23/8 * * *'
   labels:
@@ -947,7 +947,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260513-arm64-0-Hourly2-GP3' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
+          --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260513-arm64-0-Hourly2-GP3' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -974,7 +974,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: rhel10arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
+    test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -1048,7 +1048,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-distro-rocky9
 
-# {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-distro-rocky10arm64
   cron: '31 5-23/8 * * *'
   labels:
@@ -1078,7 +1078,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1105,7 +1105,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: rocky10arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
+    test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -72,7 +72,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-eks-pod-identity
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-cni-cilium-k8s-ci
   cron: '5 15-23/24 * * *'
   labels:
@@ -102,7 +102,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --zones=eu-central-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
           --test=kops \
@@ -131,7 +131,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: ci
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -208,7 +208,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-gce-cni-cilium-k8s-ci
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --dns=public --bastion --zones=us-west-2a", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --dns=public --bastion", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-cni-calico-ipv6
   cron: '29 0-23/8 * * *'
   labels:
@@ -238,7 +238,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --ipv6 --topology=private --dns=public --bastion --zones=us-west-2a" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --ipv6 --topology=private --dns=public --bastion" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -265,7 +265,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --ipv6 --topology=private --dns=public --bastion --zones=us-west-2a
+    test.kops.k8s.io/extra_flags: --ipv6 --topology=private --dns=public --bastion
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -274,7 +274,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-calico-ipv6
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --dns=public --bastion --zones=us-west-2a", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --dns=public --bastion", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-cni-cilium-ipv6
   cron: '22 3-23/8 * * *'
   labels:
@@ -304,7 +304,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --ipv6 --topology=private --dns=public --bastion --zones=us-west-2a" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --ipv6 --topology=private --dns=public --bastion" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -331,7 +331,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --ipv6 --topology=private --dns=public --bastion --zones=us-west-2a
+    test.kops.k8s.io/extra_flags: --ipv6 --topology=private --dns=public --bastion
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -340,7 +340,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-cni-cilium-ipv6
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --dns=public --bastion --zones=us-west-2a", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --dns=public --bastion", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
 - name: e2e-kops-aws-cni-kindnet-ipv6
   cron: '17 3-23/8 * * *'
   labels:
@@ -370,7 +370,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=kindnet --ipv6 --topology=private --dns=public --bastion --zones=us-west-2a" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=kindnet --ipv6 --topology=private --dns=public --bastion" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -397,7 +397,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --ipv6 --topology=private --dns=public --bastion --zones=us-west-2a
+    test.kops.k8s.io/extra_flags: --ipv6 --topology=private --dns=public --bastion
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -606,7 +606,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-warm-pool
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--zones=us-west-1a --dns=public", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--dns=public", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-scenario-terraform
   cron: '5 13-23/24 * * *'
   labels:
@@ -636,7 +636,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --zones=us-west-1a --dns=public" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --dns=public" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --terraform-version=1.5.5 \
@@ -664,7 +664,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --zones=us-west-1a --dns=public
+    test.kops.k8s.io/extra_flags: --dns=public
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -673,7 +673,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-scenario-terraform
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion --zones=us-west-1a --dns=public", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion --dns=public", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-scenario-ipv6-terraform
   cron: '17 23-23/24 * * *'
   labels:
@@ -703,7 +703,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --ipv6 --topology=private --bastion --zones=us-west-1a --dns=public" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --ipv6 --topology=private --bastion --dns=public" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --terraform-version=1.5.5 \
@@ -731,7 +731,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion --zones=us-west-1a --dns=public
+    test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion --dns=public
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -740,7 +740,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-scenario-ipv6-terraform
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--control-plane-count=3 --zones=eu-west-1a,eu-west-1b,eu-west-1c", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--control-plane-count=3", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "calico"}
 - name: e2e-kops-aws-ha-euwest1
   cron: '10 5-23/8 * * *'
   labels:
@@ -770,7 +770,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --control-plane-count=3 --zones=eu-west-1a,eu-west-1b,eu-west-1c" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --control-plane-count=3" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -797,7 +797,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --control-plane-count=3 --zones=eu-west-1a,eu-west-1b,eu-west-1c
+    test.kops.k8s.io/extra_flags: --control-plane-count=3
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest

--- a/config/jobs/kubernetes/kops/kops-periodics-nftables.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-nftables.yaml
@@ -266,7 +266,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-nftables-u2204
 
-# {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
+# {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
 - name: e2e-kops-aws-nftables-u2204arm64
   cron: '16 2-23/8 * * *'
   labels:
@@ -296,7 +296,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260602' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260602' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -323,7 +323,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2204arm64
-    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -398,7 +398,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-nftables-u2404
 
-# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
 - name: e2e-kops-aws-nftables-u2404arm64
   cron: '7 5-23/8 * * *'
   labels:
@@ -428,7 +428,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -455,7 +455,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
-    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -530,7 +530,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-nftables-u2510
 
-# {"cloud": "aws", "distro": "u2510arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
+# {"cloud": "aws", "distro": "u2510arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
 - name: e2e-kops-aws-nftables-u2510arm64
   cron: '51 1-23/8 * * *'
   labels:
@@ -560,7 +560,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260603' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260603' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -587,7 +587,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2510arm64
-    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -662,7 +662,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-nftables-u2604
 
-# {"cloud": "aws", "distro": "u2604arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
+# {"cloud": "aws", "distro": "u2604arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
 - name: e2e-kops-aws-nftables-u2604arm64
   cron: '38 0-23/8 * * *'
   labels:
@@ -692,7 +692,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260604' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260604' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -719,7 +719,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2604arm64
-    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -794,7 +794,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-nftables-al2023
 
-# {"cloud": "aws", "distro": "al2023arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
+# {"cloud": "aws", "distro": "al2023arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
 - name: e2e-kops-aws-nftables-al2023arm64
   cron: '55 7-23/8 * * *'
   labels:
@@ -824,7 +824,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.11.20260526.0-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.11.20260526.0-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -851,7 +851,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: al2023arm64
-    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -926,7 +926,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-nftables-rhel9
 
-# {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
+# {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
 - name: e2e-kops-aws-nftables-rhel10arm64
   cron: '18 2-23/8 * * *'
   labels:
@@ -956,7 +956,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260513-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260513-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -983,7 +983,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: rhel10arm64
-    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest
@@ -1058,7 +1058,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-nftables-rocky9
 
-# {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
+# {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "kindnet"}
 - name: e2e-kops-aws-nftables-rocky10arm64
   cron: '32 5-23/8 * * *'
   labels:
@@ -1088,7 +1088,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1115,7 +1115,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: rocky10arm64
-    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+    test.kops.k8s.io/extra_flags: --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -539,7 +539,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-aws-kindnet-ubuntu2204
 
-  # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-aws-distro-ubuntu2204arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -570,7 +570,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260602' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260602' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -599,7 +599,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2204arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -607,7 +607,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-aws-ubuntu2204arm64
 
-  # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
+  # {"cloud": "aws", "distro": "u2204arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
   - name: pull-kops-aws-kindnet-ubuntu2204arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -638,7 +638,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260602' --channel=alpha --networking=kindnet --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260602' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -667,7 +667,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2204arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kindnet
@@ -809,7 +809,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-aws-kindnet-ubuntu2404
 
-  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-aws-distro-ubuntu2404arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -840,7 +840,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -869,7 +869,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2404arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -877,7 +877,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-aws-ubuntu2404arm64
 
-  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
+  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
   - name: pull-kops-aws-kindnet-ubuntu2404arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -908,7 +908,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=kindnet --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -937,7 +937,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2404arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kindnet
@@ -1079,7 +1079,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-aws-kindnet-ubuntu2510
 
-  # {"cloud": "aws", "distro": "u2510arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "aws", "distro": "u2510arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-aws-distro-ubuntu2510arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1110,7 +1110,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260603' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260603' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1139,7 +1139,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2510arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -1147,7 +1147,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-aws-ubuntu2510arm64
 
-  # {"cloud": "aws", "distro": "u2510arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
+  # {"cloud": "aws", "distro": "u2510arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
   - name: pull-kops-aws-kindnet-ubuntu2510arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1178,7 +1178,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260603' --channel=alpha --networking=kindnet --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260603' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1207,7 +1207,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2510arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kindnet
@@ -1349,7 +1349,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-aws-kindnet-ubuntu2604
 
-  # {"cloud": "aws", "distro": "u2604arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "aws", "distro": "u2604arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-aws-distro-ubuntu2604arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1380,7 +1380,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260604' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260604' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1409,7 +1409,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2604arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -1417,7 +1417,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-aws-ubuntu2604arm64
 
-  # {"cloud": "aws", "distro": "u2604arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
+  # {"cloud": "aws", "distro": "u2604arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
   - name: pull-kops-aws-kindnet-ubuntu2604arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1448,7 +1448,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260604' --channel=alpha --networking=kindnet --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260604' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1477,7 +1477,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2604arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kindnet
@@ -1619,7 +1619,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-aws-kindnet-al2023
 
-  # {"cloud": "aws", "distro": "al2023arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "aws", "distro": "al2023arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-aws-distro-al2023arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1650,7 +1650,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='137112412989/al2023-ami-2023.11.20260526.0-kernel-6.12-arm64' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='137112412989/al2023-ami-2023.11.20260526.0-kernel-6.12-arm64' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1679,7 +1679,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: al2023arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -1687,7 +1687,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-aws-al2023arm64
 
-  # {"cloud": "aws", "distro": "al2023arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
+  # {"cloud": "aws", "distro": "al2023arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
   - name: pull-kops-aws-kindnet-al2023arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1718,7 +1718,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='137112412989/al2023-ami-2023.11.20260526.0-kernel-6.12-arm64' --channel=alpha --networking=kindnet --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='137112412989/al2023-ami-2023.11.20260526.0-kernel-6.12-arm64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1747,7 +1747,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: al2023arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kindnet
@@ -1889,7 +1889,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-aws-kindnet-rhel9
 
-  # {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-aws-distro-rhel10arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1920,7 +1920,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260513-arm64-0-Hourly2-GP3' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
+            --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260513-arm64-0-Hourly2-GP3' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1949,7 +1949,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: rhel10arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -1957,7 +1957,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-aws-rhel10arm64
 
-  # {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
+  # {"cloud": "aws", "distro": "rhel10arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
   - name: pull-kops-aws-kindnet-rhel10arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1988,7 +1988,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260513-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='309956199498/RHEL-10.1.0_HVM-20260513-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -2017,7 +2017,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: rhel10arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kindnet
@@ -2159,7 +2159,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-aws-kindnet-rocky9
 
-  # {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-aws-distro-rocky10arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -2190,7 +2190,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=cilium --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
+            --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=cilium --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -2219,7 +2219,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: rocky10arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.networking.cilium.enableBPFMasquerade=true
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -2227,7 +2227,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-aws-rocky10arm64
 
-  # {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
+  # {"cloud": "aws", "distro": "rocky10arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
   - name: pull-kops-aws-kindnet-rocky10arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -2258,7 +2258,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=kindnet --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='792107900819/Rocky-10-EC2-Base-10.1-20251116.0.aarch64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -2287,7 +2287,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: rocky10arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-west-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kindnet

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -73,7 +73,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-containerd-ci
 
-  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--control-plane-count=3 --node-count=6 --zones=eu-central-1a,eu-central-1b,eu-central-1c", "k8s_version": "ci", "kops_channel": "alpha", "networking": "calico"}
+  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--control-plane-count=3 --node-count=6", "k8s_version": "ci", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-k8s-ci-ha
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -104,7 +104,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --control-plane-count=3 --node-count=6 --zones=eu-central-1a,eu-central-1b,eu-central-1c" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --control-plane-count=3 --node-count=6" \
             --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -136,7 +136,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2404arm64
-      test.kops.k8s.io/extra_flags: --control-plane-count=3 --node-count=6 --zones=eu-central-1a,eu-central-1b,eu-central-1c
+      test.kops.k8s.io/extra_flags: --control-plane-count=3 --node-count=6
       test.kops.k8s.io/k8s_version: ci
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
@@ -1347,7 +1347,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-aws-apiserver-nodes
 
-  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--zones=eu-central-1a --node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
+  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--node-size=m6g.large --control-plane-size=m6g.large", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-arm64
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1378,7 +1378,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --zones=eu-central-1a --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1407,7 +1407,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2404arm64
-      test.kops.k8s.io/extra_flags: --zones=eu-central-1a --node-size=m6g.large --control-plane-size=m6g.large
+      test.kops.k8s.io/extra_flags: --node-size=m6g.large --control-plane-size=m6g.large
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -72,7 +72,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-amazonvpc
 
-  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion --zones=us-west-2a --dns=public", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
+  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion --dns=public", "k8s_version": "stable", "kops_channel": "alpha", "networking": "amazonvpc"}
   - name: pull-kops-e2e-cni-amazonvpc-ipv6
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -103,7 +103,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=amazonvpc --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=amazonvpc --ipv6 --topology=private --bastion --dns=public" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -132,7 +132,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2404arm64
-      test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public
+      test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion --dns=public
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: amazonvpc
@@ -344,7 +344,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-gce-cni-calico
 
-  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion --zones=us-west-2a --dns=public", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
+  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion --dns=public", "k8s_version": "stable", "kops_channel": "alpha", "networking": "calico"}
   - name: pull-kops-e2e-cni-calico-ipv6
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -376,7 +376,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=calico --ipv6 --topology=private --bastion --dns=public" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -405,7 +405,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2404arm64
-      test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public
+      test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion --dns=public
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: calico
@@ -617,7 +617,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-gce-cni-cilium
 
-  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion --zones=us-west-2a --dns=public", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion --dns=public", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-cni-cilium-ipv6
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -649,7 +649,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=cilium --ipv6 --topology=private --bastion --dns=public" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -678,7 +678,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2404arm64
-      test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public
+      test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion --dns=public
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium
@@ -1235,7 +1235,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: e2e-gce-cni-kindnet
 
-  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion --zones=us-west-2a --dns=public", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
+  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion --dns=public", "k8s_version": "stable", "kops_channel": "alpha", "networking": "kindnet"}
   - name: pull-kops-e2e-cni-kindnet-ipv6
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1267,7 +1267,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=kindnet --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260604' --channel=alpha --networking=kindnet --ipv6 --topology=private --bastion --dns=public" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1296,7 +1296,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2404arm64
-      test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion --zones=us-west-2a --dns=public
+      test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion --dns=public
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: kindnet


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/37250 and https://github.com/kubernetes/kops/pull/18463

All ARM grid jobs that have ran since the test-infra PR have passed ([example](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-cilium-etcd-u2604arm64-k33-ko35/2066124308706496512)) so we can continue with the remaining AWS kops jobs.

/cc @hakman