### PR TITLE
Update agent-sandbox presubmits to skip AI agent and linter configs

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: presubmit-test-autogen-up-to-date
     cluster: eks-prow-build-cluster
     # Skip ONLY config/metadata, docs/, md files, and GitHub files, but will run for site/.
-    skip_if_only_changed: "^docs/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS)$|^\\.github/"
+    skip_if_only_changed: "^(docs|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     labels:
       preset-service-account: 'true'
@@ -26,7 +26,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: presubmit-agent-sandbox-unit-test
     cluster: eks-prow-build-cluster
-    skip_if_only_changed: "^(docs|site)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS)$|^\\.github/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     spec:
       containers:
@@ -83,7 +83,7 @@ presubmits:
       testgrid-tab-name: presubmit-lint-api
   - name: presubmit-agent-sandbox-e2e-test
     cluster: eks-prow-build-cluster
-    skip_if_only_changed: "^(docs|site)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS)$|^\\.github/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -108,7 +108,7 @@ presubmits:
       testgrid-tab-name: presubmit-e2e-test
   - name: presubmit-agent-sandbox-benchmarks-kops-gcp
     cluster: k8s-infra-prow-build
-    skip_if_only_changed: "^(docs|site)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS)$|^\\.github/workflows/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/workflows/"
     decorate: true
     always_run: false # Require manual invocation, while we iterate
     optional: true # Don't block merges, while we iterate


### PR DESCRIPTION
Skip `.agents`, `.coderabbit.yaml`, `SECURITY_CONTACTS`, and `cloudbuild.yaml` in `skip_if_only_changed` for agent-sandbox presubmits, as they do not affect controller logic, builds, or test execution.