### PR TITLE
Kueue: increase and align the memory for integration tests

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -162,10 +162,10 @@ periodics:
           resources:
             requests:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
             limits:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-shard-2-main
     cluster: eks-prow-build-cluster
@@ -205,10 +205,10 @@ periodics:
           resources:
             requests:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
             limits:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-multikueue-main
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -79,10 +79,10 @@ periodics:
           resources:
             requests:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
             limits:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-shard-1-release-0-17
     cluster: eks-prow-build-cluster
@@ -122,10 +122,10 @@ periodics:
           resources:
             requests:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
             limits:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-shard-2-release-0-17
     cluster: eks-prow-build-cluster
@@ -165,10 +165,10 @@ periodics:
           resources:
             requests:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
             limits:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-multikueue-release-0-17
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -122,10 +122,10 @@ periodics:
           resources:
             requests:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
             limits:
               cpu: "7"
-              memory: "10Gi"
+              memory: "14Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-shard-2-release-0-18
     cluster: eks-prow-build-cluster
@@ -204,10 +204,10 @@ periodics:
           resources:
             requests:
               cpu: "7"
-              memory: "12Gi"
+              memory: "14Gi"
             limits:
               cpu: "7"
-              memory: "12Gi"
+              memory: "14Gi"
   - interval: 12h
     name: periodic-kueue-test-scheduling-perf-release-0-18
     cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -96,10 +96,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
               limits:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
     - name: pull-kueue-test-integration-shard-2-main
       cluster: eks-prow-build-cluster
       branches:
@@ -130,10 +130,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
               limits:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
     - name: pull-kueue-test-integration-multikueue-main
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -96,10 +96,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
               limits:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
     - name: pull-kueue-test-integration-shard-2-main
       cluster: eks-prow-build-cluster
       branches:
@@ -130,10 +130,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
               limits:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
     - name: pull-kueue-test-integration-multikueue-main
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -62,10 +62,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
               limits:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
     - name: pull-kueue-test-integration-shard-1-release-0-17
       cluster: eks-prow-build-cluster
       branches:
@@ -96,10 +96,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
               limits:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
     - name: pull-kueue-test-integration-shard-2-release-0-17
       cluster: eks-prow-build-cluster
       branches:
@@ -130,10 +130,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
               limits:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
     - name: pull-kueue-test-integration-multikueue-release-0-17
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -62,10 +62,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
               limits:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
     - name: pull-kueue-test-integration-shard-1-release-0-17
       cluster: eks-prow-build-cluster
       branches:
@@ -96,10 +96,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
               limits:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
     - name: pull-kueue-test-integration-shard-2-release-0-17
       cluster: eks-prow-build-cluster
       branches:
@@ -130,10 +130,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
               limits:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
     - name: pull-kueue-test-integration-multikueue-release-0-17
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -96,10 +96,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
               limits:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
     - name: pull-kueue-test-integration-shard-2-release-0-18
       cluster: eks-prow-build-cluster
       branches:
@@ -130,10 +130,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
               limits:
                 cpu: "7"
-                memory: "10Gi"
+                memory: "12Gi"
     - name: pull-kueue-test-integration-multikueue-release-0-18
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -96,10 +96,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
               limits:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
     - name: pull-kueue-test-integration-shard-2-release-0-18
       cluster: eks-prow-build-cluster
       branches:
@@ -130,10 +130,10 @@ presubmits:
             resources:
               requests:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
               limits:
                 cpu: "7"
-                memory: "12Gi"
+                memory: "14Gi"
     - name: pull-kueue-test-integration-multikueue-release-0-18
       cluster: eks-prow-build-cluster
       branches:


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kueue/issues/12095

This PR increases memory of intergrations tests by value of 2

Plan Followed in this PR

File | shard-0 | shard-1 | shard-2 | Action needed
kueue-presubmits-main.yaml | 14Gi ✅ | 10Gi ❌ | 10Gi ❌ | shards 1 & 2 → 14Gi
kueue-presubmits-release-0-18.yaml | 14Gi ✅ | 10Gi ❌ | 10Gi ❌ | shards 1 & 2 → 14Gi
kueue-presubmits-release-0-17.yaml | 10Gi ❌ | 10Gi ❌ | 10Gi ❌ | all three shards → 14Gi

