### PR TITLE
Add variant column header to 5000-node scale jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1439,6 +1439,8 @@ periodics:
       securityContext:
         privileged: true
       env:
+      - name: EXPERIMENT_VARIANT
+        value: "restart"
       - name: CL2_ENABLE_INFORMER_LATENCY_TEST
         value: "true"
       # Disabled: see https://github.com/kubernetes/test-infra/pull/37027

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -435,7 +435,7 @@ presubmits:
       base_ref: master
       path_alias: k8s.io/perf-tests
     annotations:
-      testgrid-dashboards: presubmits-kubernetes-scalability
+      testgrid-dashboards: presubmits-kubernetes-scalability, sig-scalability-gce
       testgrid-tab-name: pull-kubernetes-e2e-gce-master-scale-performance-5000
     spec:
       serviceAccountName: prow-build
@@ -451,6 +451,8 @@ presubmits:
         securityContext:
           privileged: true
         env:
+        - name: EXPERIMENT_VARIANT
+          value: "restart"
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
           value: "true"
         - name: CL2_RESTART_APISERVER

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -1,3 +1,10 @@
+test_groups:
+- name: pull-kubernetes-gce-master-scale-performance-5000
+  gcs_prefix: kubernetes-ci-logs/pr-logs/directory/pull-kubernetes-gce-master-scale-performance-5000
+  column_header:
+  - configuration_value: Commit
+  - configuration_value: variant
+
 dashboard_groups:
 - name: presubmits
   dashboard_names:

--- a/config/testgrids/kubernetes/sig-scalability/config.yaml
+++ b/config/testgrids/kubernetes/sig-scalability/config.yaml
@@ -1,3 +1,10 @@
+test_groups:
+- name: ci-kubernetes-e2e-gce-scale-performance-5000-experimental
+  gcs_prefix: kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-performance-5000-experimental
+  column_header:
+  - configuration_value: Commit
+  - configuration_value: variant
+
 dashboard_groups:
 - name: sig-scalability
   dashboard_names:


### PR DESCRIPTION
Sets EXPERIMENT_VARIANT=restart and declares a `variant` TestGrid column header on the gce 5000-node scale periodic and presubmit, so each in-place reconfiguration of these exploratory jobs is labeled. Also adds the presubmit to the sig-scalability-gce dashboard.

Issue: https://github.com/kubernetes/test-infra/issues/37273