### PR TITLE
Disable batch jobs for k/enhancements

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -938,6 +938,9 @@ tide:
             from-branch-protection: true
   batch_size_limit:
     "kubernetes/kubernetes": 15
+    # Disable batches: PRs fail when tested as a batch because of
+    # https://github.com/kubernetes/enhancements/blob/bf34c102c6428a56c792bbae92a5a1dc33c762d4/hack/verify-toc-vs-template.sh#L30
+    "kubernetes/enhancements": -1
   priority:
   - labels: [ "kind/flake", "priority/critical-urgent" ]
   - labels: [ "kind/failing-test", "priority/critical-urgent" ]


### PR DESCRIPTION
Enhancement PRs fail when tested as a batch:

https://prow.k8s.io/?repo=kubernetes%2Fenhancements&type=batch&job=pull-enhancements-verify

hack/verify-toc-vs-template.sh fails on the combined ref:
https://github.com/kubernetes/enhancements/blob/bf34c102c6428a56c792bbae92a5a1dc33c762d4/hack/verify-toc-vs-template.sh#L30

```
fatal: ambiguous argument 'origin/HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Presubmits on k/enhancements seem fairly cheap and fast so even serialized merges should not be problematic (especially compared to the current state where Tide attempts batch merges that never succeed).

Signed-off-by: Petr Muller <muller@redhat.com>
