### PR TITLE
enable override on gateway api

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1765,6 +1765,7 @@ plugins:
     plugins:
     - milestone
     - milestonestatus
+    - override
     - release-note
 
   kubernetes-sigs/image-builder:


### PR DESCRIPTION
Enable the /override command to be used on Gateway API repository.

Maintainers may want to override some failing tests that are blocking fixes, instead of disabling the tests