### PR TITLE
Agent Sandbox API Upgrade test against remote branch

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
@@ -27,3 +27,32 @@ periodics:
         limits:
           cpu: 7
           memory: 14Gi
+- name: periodic-agent-sandbox-migration-test
+  cluster: eks-prow-build-cluster
+  interval: 10m
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-apps-agent-sandbox
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: agent-sandbox
+    base_ref: feature/v1beta1-migrate
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260616-605ef6f86b-master
+      command:
+      - runner.sh
+      - dev/ci/periodics/test-migration
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7
+          memory: 14Gi
+        limits:
+          cpu: 7
+          memory: 14Gi
+

--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
@@ -29,7 +29,7 @@ periodics:
           memory: 14Gi
 - name: periodic-agent-sandbox-migration-test
   cluster: eks-prow-build-cluster
-  interval: 10m
+  interval: 1h
   decorate: true
   annotations:
     testgrid-dashboards: sig-apps-agent-sandbox

--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
@@ -55,4 +55,3 @@ periodics:
         limits:
           cpu: 7
           memory: 14Gi
-

--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
@@ -31,6 +31,8 @@ periodics:
   cluster: eks-prow-build-cluster
   interval: 1h
   decorate: true
+  decoration_config:
+    timeout: 30m
   annotations:
     testgrid-dashboards: sig-apps-agent-sandbox
   extra_refs:


### PR DESCRIPTION
# Add periodic migration upgrade test job for agent-sandbox
## What this PR does / why we need it
This PR adds the new `periodic-agent-sandbox-migration-test` job to the `agent-sandbox` periodics configuration. 
This job executes the automated E2E storage migration tests (`dev/ci/periodics/test-migration`) validating the upgrade and rollback path from `v1alpha1` (older version `v0.4.6`) to the new `v1beta1` API version.
## Key Configurations
* **Job Name**: `periodic-agent-sandbox-migration-test`
* **Target Repository**: `kubernetes-sigs/agent-sandbox`
* **Target Branch**: `feature/v1beta1-migrate` (this is a one time setup upgrade tests. we will remove the conversion hooks after sometime)
* **Schedule Interval**: Run every `10m` for frequent E2E validation during development
* **Presets**: Configured with `preset-dind-enabled` and `preset-kind-volume-mounts` to allow nesting of the local KinD cluster inside Prow's Docker containers
## References
* Related repository changes: `kubernetes-sigs/agent-sandbox` (feature branch `feature/v1beta1-migrate`)

## Testing
Tested locally via

```bash
sudo env "PATH=$PATH" ./config/pj-on-kind.sh periodic-agent-sandbox-migration-test
```