### PR TITLE
Remove redundant CL2_INFORMER_ENABLE_WATCHLIST override on gce-5000 scale job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -455,8 +455,6 @@ presubmits:
           value: "restart"
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
           value: "true"
-        - name: CL2_INFORMER_ENABLE_WATCHLIST
-          value: "false"
         - name: CL2_RESTART_APISERVER
           value: "true"
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB


### PR DESCRIPTION
The informer module now defaults CL2_INFORMER_ENABLE_WATCHLIST to false (kubernetes/perf-tests#4147), so the explicit =false override on this job is no longer needed.

/assign @serathius