### PR TITLE
DRA: generate E2E node presubmits for test-infra, III

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
@@ -22,7 +22,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
-    path_alias: k8s.io/kubernetes
+    path_alias: k8s.io/test-infra
     extra_refs:
     - org: kubernetes
       repo: kubernetes
@@ -81,7 +81,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
-    path_alias: k8s.io/kubernetes
+    path_alias: k8s.io/test-infra
     extra_refs:
     - org: kubernetes
       repo: kubernetes
@@ -133,7 +133,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 90m
-    path_alias: k8s.io/kubernetes
+    path_alias: k8s.io/test-infra
     extra_refs:
     - org: kubernetes
       repo: kubernetes

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -68,7 +68,7 @@ presubmits:
     decoration_config:
       timeout: {{timeout}}
     {%- if not ci %}
-    path_alias: k8s.io/kubernetes
+    path_alias: {% if testinfra %}k8s.io/test-infra{% else %}k8s.io/kubernetes{% endif %}
     {%- endif %}
     extra_refs:
     {%- if need_kubernetes_repo and (ci or testinfra) %}


### PR DESCRIPTION
This is a fixup of 44401d7410bacacbcce37a482a57ea7b0c8e9ba9: the path_alias for the main repo in the test-infra presubmits has to be k8s.io/test-infra, otherwise merging the PR branch fails and later the files wouldn't have been found.

/assign @bart0sh 