### PR TITLE
kubekins-e2e-v2: bump kind to 0.32.0

### DIFF
--- a/images/kubekins-e2e-v2/cloudbuild.yaml
+++ b/images/kubekins-e2e-v2/cloudbuild.yaml
@@ -25,7 +25,7 @@ substitutions:
   _GIT_TAG: '12345'
   _K8S_RELEASE: stable
   _K8S_BRANCH: master
-  _KIND_VERSION: '0.31.0'
+  _KIND_VERSION: '0.32.0'
   _KUBETEST2_VERSION: 'master'
   _YQ_VERSION: v4.49.2
   _DOCKER_VERSION: 5:29.*


### PR DESCRIPTION
Bumps the kind binary pinned in the kubekins-e2e-v2 image from 0.31.0 to 0.32.0 (https://github.com/kubernetes-sigs/kind/releases/tag/v0.32.0).

kind 0.31.0 still writes a kubeadm.k8s.io/v1beta3 ClusterConfiguration, which kubeadm in Kubernetes master (v1.36) now rejects. This breaks jobs that build a Kubernetes-from-master KIND node image, including etcd's ci-etcd-k8s-coverage-amd64 periodic. kind 0.32.0 emits the supported config version.

Previous bump: b3926f0b93 (0.30.0 to 0.31.0).

/cc @upodroid