### PR TITLE
deps: bump sigs.k8s.io/prow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	knative.dev/pkg v0.0.0-20250415155312-ed3e2158b883 // indirect
 	sigs.k8s.io/controller-runtime v0.21.0
-	sigs.k8s.io/prow v0.0.0-20260531012246-24f6b2904e92
+	sigs.k8s.io/prow v0.0.0-20260617174310-37d12bec7117
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1137,8 +1137,8 @@ sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytI
 sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/prow v0.0.0-20260531012246-24f6b2904e92 h1:+m4yPHy4X6KG36IX+soXW2zACZn7DUM6Pd1OwKeofFQ=
-sigs.k8s.io/prow v0.0.0-20260531012246-24f6b2904e92/go.mod h1:JOo+ySKGa5wb168yBTEljj/P+N4sYVfmQQzC3HB9eFU=
+sigs.k8s.io/prow v0.0.0-20260617174310-37d12bec7117 h1:6bKtnvSQLN4cdEpHx0adqhKM1yx/CWqDPDaS+Kqp9Yw=
+sigs.k8s.io/prow v0.0.0-20260617174310-37d12bec7117/go.mod h1:gIk9WX2TVIlkEHdZjKkcFZZMpFA0QfiX16lbcM+yyp0=
 sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=


### PR DESCRIPTION
```
go get -u sigs.k8s.io/prow
go mod tidy
```

This is probably needed to propagate `extra_ref.auxiliary` from YAML files to the Prow cluster. Right now the new field (https://github.com/kubernetes-sigs/prow/pull/733) does not show up in the pod YAML of jobs which set it.

/cc @upodroid 