### PR TITLE
Enable etcd Prometheus scraping on the gce master 5k scale presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -152,6 +152,8 @@ presubmits:
           value: "c4-standard-32"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
           value: "true"
+        - name: PROMETHEUS_SCRAPE_ETCD
+          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -499,6 +501,8 @@ presubmits:
         - name: KUBE_PROXY_MODE
           value: "nftables"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+          value: "true"
+        - name: PROMETHEUS_SCRAPE_ETCD
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"


### PR DESCRIPTION
Sets `PROMETHEUS_SCRAPE_ETCD=true` on `pull-kubernetes-gce-master-scale-performance-5000` and `pull-kubernetes-e2e-gce-master-scale-performance-100`. Flag defined at https://github.com/kubernetes/perf-tests/blob/8a76880121c78a7683bbe05234bf08bc268af886/clusterloader2/pkg/prometheus/prometheus.go#L87

Figured we want as much data as possible for etcd 3.7. The 100-node job exercises the same kops etcd-listen and CL2 etcd-scrape path, so we can validate cheaply there before relying on the 5k run.