### PR TITLE
kOps: Bump Azure Ubuntu node images

### DIFF
--- a/config/jobs/kubernetes/kops/helpers.py
+++ b/config/jobs/kubernetes/kops/helpers.py
@@ -231,9 +231,9 @@ def latest_azure_image(publisher, offer, sku, arch="X86_64"):
     # az vm image show --urn Canonical:ubuntu-24_04-lts:server:latest | jq .name
     if publisher == 'Canonical' and offer == 'ubuntu-24_04-lts':
         if arch == 'arm64':
-            image_name = "Canonical:ubuntu-24_04-lts:server-arm64:24.04.202606060"
+            image_name = "Canonical:ubuntu-24_04-lts:server-arm64:24.04.202606110"
         else:
-            image_name = "Canonical:ubuntu-24_04-lts:server:24.04.202606060"
+            image_name = "Canonical:ubuntu-24_04-lts:server:24.04.202606120"
 
     # az vm image show --urn Debian:debian-13:13-gen2:latest | jq .name
     elif publisher == 'Debian' and offer == 'debian-13':

--- a/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
@@ -172,7 +172,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=azure \
-          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=calico" \
+          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606120' --channel=alpha --networking=calico" \
           --env=KOPS_FEATURE_FLAGS=Azure \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
@@ -379,7 +379,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=azure \
-          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=calico" \
+          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606120' --channel=alpha --networking=calico" \
           --env=KOPS_FEATURE_FLAGS=Azure \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.33.txt \
@@ -586,7 +586,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=azure \
-          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=calico" \
+          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606120' --channel=alpha --networking=calico" \
           --env=KOPS_FEATURE_FLAGS=Azure \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
@@ -793,7 +793,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=azure \
-          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=calico" \
+          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606120' --channel=alpha --networking=calico" \
           --env=KOPS_FEATURE_FLAGS=Azure \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \

--- a/config/jobs/kubernetes/kops/kops-periodics-gossip.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gossip.yaml
@@ -100,7 +100,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=azure \
-          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=cilium --control-plane-count=1 --node-count=4 --dns=private --api-loadbalancer-type=public" \
+          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606120' --channel=alpha --networking=cilium --control-plane-count=1 --node-count=4 --dns=private --api-loadbalancer-type=public" \
           --env=KOPS_FEATURE_FLAGS=Azure \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -368,7 +368,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=azure \
-          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=cilium --control-plane-count=3 --node-count=4 --dns=private --api-loadbalancer-type=public" \
+          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606120' --channel=alpha --networking=cilium --control-plane-count=3 --node-count=4 --dns=private --api-loadbalancer-type=public" \
           --env=KOPS_FEATURE_FLAGS=Azure \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -164,7 +164,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=azure \
-          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=calico" \
+          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606120' --channel=alpha --networking=calico" \
           --env=KOPS_FEATURE_FLAGS=Azure \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -425,7 +425,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=azure \
-          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=cilium" \
+          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606120' --channel=alpha --networking=cilium" \
           --env=KOPS_FEATURE_FLAGS=Azure \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -884,7 +884,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=azure \
-          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=kindnet" \
+          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606120' --channel=alpha --networking=kindnet" \
           --env=KOPS_FEATURE_FLAGS=Azure \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -1145,7 +1145,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=azure \
-          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=kubenet" \
+          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606120' --channel=alpha --networking=kubenet" \
           --env=KOPS_FEATURE_FLAGS=Azure \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \

--- a/config/jobs/kubernetes/kops/pinned.list
+++ b/config/jobs/kubernetes/kops/pinned.list
@@ -1,5 +1,5 @@
-azure://images/Canonical/ubuntu-24_04-lts/server:X86_64=Canonical:ubuntu-24_04-lts:server:24.04.202606060
-azure://images/Canonical/ubuntu-24_04-lts/server-arm64:arm64=Canonical:ubuntu-24_04-lts:server-arm64:24.04.202606060
+azure://images/Canonical/ubuntu-24_04-lts/server:X86_64=Canonical:ubuntu-24_04-lts:server:24.04.202606120
+azure://images/Canonical/ubuntu-24_04-lts/server-arm64:arm64=Canonical:ubuntu-24_04-lts:server-arm64:24.04.202606110
 azure://images/Debian/debian-13/13-gen2:X86_64=Debian:debian-13:13-gen2:0.20260615.2510
 gce://images/debian-cloud/debian-12:X86_64=debian-cloud/debian-12-bookworm-v20260609
 gce://images/debian-cloud/debian-12-arm64:ARM64=debian-cloud/debian-12-bookworm-arm64-v20260611


### PR DESCRIPTION
Bump the hard-coded Azure Ubuntu 24.04 (noble) node images to the latest available, aligning CI with kOps channels update kubernetes/kops#18501: amd64 24.04.202606120, arm64 24.04.202606110.

/cc @rifelpet @ameukam @upodroid 