### PR TITLE
disable checking CLAs via the label and use the EasyCLA status directly

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -101,56 +101,6 @@ periodics:
       secret:
         secretName: k8s-triage-robot-github-token
 
-- name: ci-k8s-triage-robot-cla
-  interval: 10m
-  cluster: k8s-infra-prow-build-trusted
-  decorate: true
-  annotations:
-    testgrid-dashboards: sig-contribex-k8s-triage-robot
-    description: A sample job to make sure things work
-    testgrid-tab-name: cla
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
-      command:
-      - commenter
-      args:
-      - |-
-        --query=org:kubernetes
-        org:kubernetes-sigs
-        org:kubernetes-client
-        org:kubernetes-csi
-        is:pr
-        is:open
-        -label:"cncf-cla: no"
-        -label:"cncf-cla: yes"
-      - --token=/etc/github-token/token
-      - --endpoint=http://ghproxy.test-pods.svc.cluster.local
-      - |-
-        --comment=Unknown CLA label state. Rechecking for CLA labels.
-
-        Send feedback to sig-contributor-experience at [kubernetes/community](https://github.com/kubernetes/community).
-
-        /check-cla
-        /easycla
-      - --template
-      - --ceiling=10
-      - --confirm
-      volumeMounts:
-      - name: token
-        mountPath: /etc/github-token
-      resources:
-        limits:
-          cpu: 1
-          memory: 2Gi
-        requests:
-          cpu: 1
-          memory: 2Gi
-    volumes:
-    - name: token
-      secret:
-        secretName: k8s-triage-robot-github-token
-
 - name: ci-k8s-triage-robot-close-issues
   interval: 1h
   cluster: k8s-infra-prow-build-trusted

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-triage-robot-retester.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-triage-robot-retester.yaml
@@ -28,11 +28,9 @@ periodics:
         -label:do-not-merge/work-in-progress
         label:lgtm
         label:approved
-        label:"cncf-cla: yes"
         status:failure
         -label:needs-rebase
         -label:needs-ok-to-test
-        -label:"cncf-cla: no"
         repo:kubernetes/kops
         repo:kubernetes/kubernetes
         repo:kubernetes/test-infra

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -751,7 +751,6 @@ tide:
     labels:
     - lgtm
     - approved
-    - "cncf-cla: yes"
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
@@ -766,7 +765,6 @@ tide:
     labels:
     - lgtm
     - approved
-    - "cncf-cla: yes"
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
@@ -782,7 +780,6 @@ tide:
   - author: k8s-ci-robot
     labels: # k8s-ci-robot should only create autobump PR with this label
     - skip-review
-    - "cncf-cla: yes"
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
@@ -797,7 +794,6 @@ tide:
   - author: k8s-infra-ci-robot
     labels: # k8s-infra-ci-robot should only create autobump PR with this label
     - skip-review
-    - "cncf-cla: yes"
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
@@ -814,7 +810,6 @@ tide:
     - kubernetes-sigs/provider-aws-test-infra
     labels: # provider-aws-test-infra-admins team gates the skip-review label via plugins.yaml restricted_labels
     - skip-review
-    - "cncf-cla: yes"
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
@@ -829,7 +824,6 @@ tide:
     labels:
     - lgtm
     - approved
-    - "cncf-cla: yes"
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
@@ -848,7 +842,6 @@ tide:
     labels:
       - lgtm
       - approved
-      - "cncf-cla: yes"
     missingLabels:
       - do-not-merge
       - do-not-merge/blocked-paths
@@ -864,7 +857,6 @@ tide:
     labels:
     - lgtm
     - approved
-    - "cncf-cla: yes"
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1348,7 +1348,6 @@ plugins:
     - assign
     - blunderbuss
     - cat
-    - cla
     - dog
     - golint
     - goose
@@ -1515,7 +1514,6 @@ plugins:
     - assign
     - blunderbuss
     - cat
-    - cla
     - dog
     - goose
     - heart
@@ -1554,7 +1552,6 @@ plugins:
     - assign
     - blunderbuss
     - cat
-    - cla
     - dog
     - goose
     - heart
@@ -1587,7 +1584,6 @@ plugins:
     - assign
     - blunderbuss
     - cat
-    - cla
     - dog
     - goose
     - heart
@@ -1818,16 +1814,6 @@ plugins:
     - milestone
     - override
     - release-note
-
-  containerd/cri:
-    plugins:
-    - assign
-    - cla
-    - label
-    - lgtm
-    - lifecycle
-    - size
-    - trigger
 
   etcd-io:
     plugins:

--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -177,8 +177,6 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="approved" href="#approved">`approved`</a> | Indicates a PR has been approved by an approver from all required OWNERS files.| approvers |  [approve](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/approve) |
 | <a id="cherry-pick-approved" href="#cherry-pick-approved">`cherry-pick-approved`</a> | Indicates a cherry-pick PR into a release branch has been approved by the release branch manager. <br><br> This was previously `cherrypick-approved`, | humans | |
-| <a id="cncf-cla  no" href="#cncf-cla  no">`cncf-cla: no`</a> | Indicates the PR's author has not signed the CNCF CLA.| prow |  [cla](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/cla) |
-| <a id="cncf-cla  yes" href="#cncf-cla  yes">`cncf-cla: yes`</a> | Indicates the PR's author has signed the CNCF CLA.| prow |  [cla](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/cla) |
 | <a id="do-not-merge" href="#do-not-merge">`do-not-merge`</a> | DEPRECATED. Indicates that a PR should not merge. Label can only be manually applied/removed.| humans | |
 | <a id="do-not-merge/blocked-paths" href="#do-not-merge/blocked-paths">`do-not-merge/blocked-paths`</a> | Indicates that a PR should not merge because it touches files in blocked paths.| prow |  [blockade](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/blockade) |
 | <a id="do-not-merge/cherry-pick-not-approved" href="#do-not-merge/cherry-pick-not-approved">`do-not-merge/cherry-pick-not-approved`</a> | Indicates that a PR is not yet approved to merge into a release branch.| prow |  [cherrypickunapproved](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/cherrypickunapproved) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -164,18 +164,6 @@ default:
       previously:
         - name: committee/product-security
     - color: e11d21
-      description: Indicates the PR's author has not signed the CNCF CLA.
-      name: 'cncf-cla: no'
-      target: prs
-      prowPlugin: cla
-      addedBy: prow
-    - color: bfe5bf
-      description: Indicates the PR's author has signed the CNCF CLA.
-      name: 'cncf-cla: yes'
-      target: prs
-      prowPlugin: cla
-      addedBy: prow
-    - color: e11d21
       description: DEPRECATED. Indicates that a PR should not merge. Label can only be manually applied/removed.
       name: do-not-merge
       target: prs


### PR DESCRIPTION
[EasyCLA](https://github.com/linuxfoundation/easycla) is a tool from LF that we use to check CLAs.

I'm proposing we drop the cncf-cla label checks and free up GitHub API capacity. We already mark the EasyCLA status check as required, and LF prints its own messages on the PR when it's not signed.

/cc @kubernetes/sig-contributor-experience-leads @kubernetes/sig-testing-leads 