### PR TITLE
DRA: reduce resource requirements for E2E node jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -690,12 +690,14 @@ periodics:
         - name: KUBE_SSH_USER
           value: core
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: ci-node-crio-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -747,12 +749,14 @@ periodics:
         - name: KUBE_SSH_USER
           value: core
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: ci-node-e2e-containerd-1-7-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -800,12 +804,14 @@ periodics:
         - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7-ubuntu.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: ci-node-e2e-containerd-1-7-cos-dra
     cluster: k8s-infra-prow-build
@@ -853,12 +859,14 @@ periodics:
         - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7-cos.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: ci-node-e2e-containerd-2-0-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -909,12 +917,14 @@ periodics:
         - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config-ubuntu.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: ci-node-e2e-containerd-2-0-cos-dra
     cluster: k8s-infra-prow-build
@@ -965,12 +975,14 @@ periodics:
         - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config-cos.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: ci-node-e2e-containerd-1-7-ubuntu-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1015,12 +1027,14 @@ periodics:
         - '--test-args=--feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false --service-feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false --runtime-config=api/alpha=true,api/beta=true --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7-ubuntu.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: ci-node-e2e-containerd-1-7-cos-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1065,12 +1079,14 @@ periodics:
         - '--test-args=--feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false --service-feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false --runtime-config=api/alpha=true,api/beta=true --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7-cos.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: ci-node-e2e-containerd-2-0-ubuntu-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1118,12 +1134,14 @@ periodics:
         - '--test-args=--feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false --service-feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false --runtime-config=api/alpha=true,api/beta=true --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config-ubuntu.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: ci-node-e2e-containerd-2-0-cos-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1171,9 +1189,11 @@ periodics:
         - '--test-args=--feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false --service-feature-gates=AllAlpha=true,AllBeta=true,EventedPLEG=false --runtime-config=api/alpha=true,api/beta=true --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config-cos.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi

--- a/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
@@ -53,12 +53,14 @@ presubmits:
         - name: KUBE_SSH_USER
           value: core
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: pull-test-infra-node-e2e-containerd-1-7-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -103,12 +105,14 @@ presubmits:
         - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7-ubuntu.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: pull-test-infra-node-e2e-containerd-1-7-cos-dra
     cluster: k8s-infra-prow-build
@@ -153,12 +157,14 @@ presubmits:
         - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/dra/image-config-containerd-1.7-cos.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: pull-test-infra-node-e2e-containerd-2-0-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -206,12 +212,14 @@ presubmits:
         - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config-ubuntu.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
 
   - name: pull-test-infra-node-e2e-containerd-2-0-cos-dra
     cluster: k8s-infra-prow-build
@@ -259,9 +267,11 @@ presubmits:
         - '--test-args=--container-runtime-endpoint=unix:///var/run/containerd/containerd.sock --container-runtime-process-name=/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-release-2.1/image-config-cos.yaml
         resources:
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
           limits:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi
           requests:
-            cpu: 2
-            memory: 6Gi
+            cpu: 0.5
+            memory: 500Mi

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -312,6 +312,15 @@ presubmits:
           requests:
             cpu: 2
             memory: 12Gi
+          {%- elif ci and job_type == "node" or testinfra %}
+          # E2E node jobs just control remote execution and thus
+          # need few resources, but only when using release packages.
+          limits:
+            cpu: 0.5
+            memory: 500Mi
+          requests:
+            cpu: 0.5
+            memory: 500Mi
           {%- else %}
           limits:
             cpu: 2


### PR DESCRIPTION
After switching from compilation from source to downloading packages all periodic jobs and the test-infra presubmits need less resources because they don't do much work besides shuffling files around.

/assign @bart0sh 