### PR TITLE
jobs: ensure org and repo labels are set

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -5,6 +5,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 80m
@@ -42,6 +44,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 80m

--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -8,6 +8,9 @@ periodics:
     test-grid-alert-email: kubernetes-sig-arch-conformance-test-failures@googlegroups.com
     testgrid-num-failures-to-alert: '1'
     description: 'Uses APISnoop to check that new GA endpoints are conformance tested in latest e2e test run'
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -515,6 +515,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 260m
@@ -552,6 +554,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 260m

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -12,6 +12,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
   spec:
     containers:
@@ -49,6 +51,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gci-gce-sig-cli
   spec:
     containers:
@@ -87,6 +91,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-latest-stable2-gci-kubectl-skew
   spec:
     containers:
@@ -126,6 +132,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-latest-stable2-gci-kubectl-skew-serial
   spec:
     containers:
@@ -170,6 +178,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew
   spec:
     containers:
@@ -211,6 +221,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
   spec:
     containers:
@@ -251,6 +263,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew
   spec:
     containers:
@@ -291,6 +305,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew-serial
   spec:
     containers:
@@ -328,6 +344,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-stable2-latest-gci-kubectl-skew
   spec:
     containers:
@@ -366,6 +384,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-stable2-latest-gci-kubectl-skew-serial
   spec:
     containers:
@@ -403,6 +423,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-stable2-stable3-gci-kubectl-skew
   spec:
     containers:
@@ -442,6 +464,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-stable2-stable3-gci-kubectl-skew-serial
   spec:
     containers:
@@ -480,6 +504,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-stable3-stable2-gci-kubectl-skew
   spec:
     containers:
@@ -518,6 +544,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-stable3-stable2-gci-kubectl-skew-serial
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -1031,6 +1031,8 @@ periodics:
     description: cleanup any EC2 instances older than 2 days
   labels:
     preset-e2e-containerd-ec2: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   decorate: true
   decoration_config:
     timeout: 4h

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -14,6 +14,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   # Keep the job in sync with pull-kubernetes-e2e-gci-gce.
   name: ci-kubernetes-e2e-gci-gce
   spec:
@@ -59,6 +61,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   # Keep the job in sync with pull-kubernetes-e2e-gce (yes, the name is different).
   name: ci-kubernetes-e2e-ubuntu-gce-containerd
   spec:
@@ -109,6 +113,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gci-gce-alpha-enabled-default
   spec:
     containers:
@@ -154,6 +160,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gci-gce-alpha-features
   spec:
     containers:
@@ -196,6 +204,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gci-gce-flaky-repro
   spec:
     containers:
@@ -234,6 +244,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gci-gce-flaky
   spec:
     containers:
@@ -273,6 +285,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gci-gce-reboot
   spec:
     containers:
@@ -311,6 +325,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gci-gce-serial
   spec:
     containers:
@@ -352,6 +368,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gci-gce-slow
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
@@ -9,6 +9,9 @@ periodics:
     testgrid-dashboards: sig-k8s-infra-canaries
     testgrid-tab-name: agentic-ai
     description: Verifies that Prow can run Antigravity using k8s-infra-agentic-ai.
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     serviceAccountName: agy-agent
     containers:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -254,6 +254,9 @@ periodics:
 
 - interval: 6h
   name: ci-fast-forward
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   cluster: k8s-infra-prow-build-trusted
   decorate: true
   spec:
@@ -291,6 +294,9 @@ periodics:
     testgrid-alert-email: release-managers+alerts@kubernetes.io
     testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: verify-image-signatures
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   decorate: true
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-k8s-triage-robot.yaml
@@ -8,6 +8,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds API review process description to kind/api-change PRs
     testgrid-tab-name: api-review-help
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -63,6 +66,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds stable metrics review documentation to area/stable-metrics PRs
     testgrid-tab-name: stable-metrics-help
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -109,6 +115,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: A sample job to make sure things work
     testgrid-tab-name: cla
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -159,6 +168,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Closes rotten issues after 30d of inactivity
     testgrid-tab-name: close-issues
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -228,6 +240,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Closes rotten PRs after 30d of inactivity
     testgrid-tab-name: close-prs
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -418,6 +433,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds lifecycle/rotten to stale issues after 30d of inactivity
     testgrid-tab-name: rotten-issues
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -487,6 +505,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds lifecycle/rotten to stale PRs after 30d of inactivity
     testgrid-tab-name: rotten-prs
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -554,6 +575,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds lifecycle/stale to issues after 90d of inactivity
     testgrid-tab-name: stale-issues
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -623,6 +647,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Adds lifecycle/stale to PRs after 90d of inactivity
     testgrid-tab-name: stale-prs
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -690,6 +717,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Removes lifecycle/frozen from PRs
     testgrid-tab-name: thaw-prs
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -745,6 +775,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Removes the triage/accepted label after 1 year of inactivity
     testgrid-tab-name: re-triage
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -803,6 +836,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Removes the triage/accepted label on important issues after 3 months of inactivity
     testgrid-tab-name: re-triage-important
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -862,6 +898,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     description: Removes the triage/accepted label on critical issues after 1 month of inactivity
     testgrid-tab-name: re-triage-critical
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d
@@ -918,6 +957,8 @@ periodics:
   cluster: k8s-infra-prow-build-trusted
   labels:
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   decorate: true
   annotations:
     testgrid-dashboards: sig-contribex-k8s-triage-robot

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-triage-robot-retester.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-triage-robot-retester.yaml
@@ -7,6 +7,9 @@ periodics:
     testgrid-dashboards: sig-contribex-k8s-triage-robot
     testgrid-tab-name: retester
     description: Automatically /retest-required for approved PRs that are failing tests
+  labels:
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/commenter:v20260515-778139c32d

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-label-sync.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-testing-label-sync.yaml
@@ -4,6 +4,8 @@ periodics:
   cluster: k8s-infra-prow-build-trusted
   labels:
     app: label-sync
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   decorate: true
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-gce.yaml
@@ -342,6 +342,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 60m
@@ -380,6 +382,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 80m
@@ -418,6 +422,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 170m
@@ -452,6 +458,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 80m
@@ -491,6 +499,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 80m
@@ -530,6 +540,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 170m
@@ -565,6 +577,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 340m
@@ -602,6 +616,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 70m
@@ -640,6 +656,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 170m
@@ -677,6 +695,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 170m
@@ -719,6 +739,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 170m
@@ -752,6 +774,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 170m
@@ -787,6 +811,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 520m
@@ -822,6 +848,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 520m
@@ -859,6 +887,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 170m

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -408,6 +408,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-cos-containerd: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 70m
@@ -447,6 +449,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-cos-containerd: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 70m
@@ -846,6 +850,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 70m

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -593,8 +593,6 @@ periodics:
       preset-service-account: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      prow.k8s.io/refs.org: kubernetes
-      prow.k8s.io/refs.repo: kubernetes
     annotations:
       testgrid-dashboards: sig-node-dynamic-resource-allocation
       description: Runs integration tests for DRA which need some additional setup in the job.

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -53,7 +53,7 @@ presubmits:
       {%- if job_type == "node" %}
       preset-k8s-ssh: "true"
       {%- endif %}
-      {%- if ci %}
+      {%- if ci and job_type != "integration" %}
       prow.k8s.io/refs.org: kubernetes
       prow.k8s.io/refs.repo: kubernetes
       {%- endif %}

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml
@@ -62,6 +62,8 @@ periodics:
     preset-ci-gce-device-plugin-gpu: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-device-plugin-gpu-1-33
   spec:
     containers:
@@ -151,6 +153,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kind-dra-1-33
   spec:
     containers:
@@ -987,6 +991,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-alphafeatures-stable3
   spec:
     containers:
@@ -1029,6 +1035,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-default-stable3
   spec:
     containers:
@@ -1068,6 +1076,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-reboot-stable3
   spec:
     containers:
@@ -1105,6 +1115,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-serial-stable3
   spec:
     containers:
@@ -1144,6 +1156,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-slow-stable3
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -62,6 +62,8 @@ periodics:
     preset-ci-gce-device-plugin-gpu: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-device-plugin-gpu-1-34
   spec:
     containers:
@@ -152,6 +154,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kind-dra-1-34
   spec:
     containers:
@@ -234,6 +238,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kind-dra-n-1-1-34
   spec:
     containers:
@@ -1149,6 +1155,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-alphafeatures-stable2
   spec:
     containers:
@@ -1191,6 +1199,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-default-stable2
   spec:
     containers:
@@ -1228,6 +1238,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-reboot-stable2
   spec:
     containers:
@@ -1265,6 +1277,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-serial-stable2
   spec:
     containers:
@@ -1304,6 +1318,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-slow-stable2
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -162,6 +162,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kind-dra-1-35
   spec:
     containers:
@@ -245,6 +247,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kind-dra-n-1-1-35
   spec:
     containers:
@@ -358,6 +362,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kind-dra-n-2-1-35
   spec:
     containers:
@@ -1275,6 +1281,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-alphafeatures-stable1
   spec:
     containers:
@@ -1317,6 +1325,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-default-stable1
   spec:
     containers:
@@ -1356,6 +1366,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-reboot-stable1
   spec:
     containers:
@@ -1393,6 +1405,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-serial-stable1
   spec:
     containers:
@@ -1432,6 +1446,8 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-slow-stable1
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -294,6 +294,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kind-dra-1-36
   spec:
     containers:
@@ -380,6 +382,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kind-dra-n-1-1-36
   spec:
     containers:
@@ -501,6 +505,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kind-dra-n-2-1-36
   spec:
     containers:
@@ -622,6 +628,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kind-dra-n-3-1-36
   spec:
     containers:
@@ -958,15 +966,12 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h20m0s
-  extra_refs:
-  - base_ref: release-1.36
-    org: kubernetes
-    path_alias: k8s.io/kubernetes
-    repo: kubernetes
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   name: ci-kubernetes-e2e-gce-cos-alphafeatures-beta
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -6,6 +6,8 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential-boskos-scale-001-kops: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   decorate: true
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -10,6 +10,8 @@ periodics:
     preset-e2e-scalability-common: "true"
     preset-e2e-scalability-periodics: "true"
     preset-e2e-scalability-periodics-master: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   job_queue_name: "5k-gce-scale-test" # DON'T REMOVE THIS
   decoration_config:

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -289,6 +289,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 150m
@@ -330,6 +332,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   decoration_config:
     timeout: 150m

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -5,6 +5,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   decorate: true
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -62,6 +62,8 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: kubernetes
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -6,6 +6,8 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential-aws-shared-testing: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   decorate: true
   spec:
     containers:
@@ -37,6 +39,8 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   decorate: true
   spec:
     containers:
@@ -66,6 +70,8 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-kops-aws-credential: "true"
+    prow.k8s.io/refs.org: kubernetes
+    prow.k8s.io/refs.repo: test-infra
   decorate: true
   spec:
     containers:

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -1080,19 +1080,6 @@ func TestPreSubmitPathAlias(t *testing.T) {
 // Periodic jobs without such an entry must set the labels explicitly.
 // PostSubmits and PreSubmits can omit extra_refs because they implicitly checkout the repo they are defined for.
 func TestLabelsBeingSet(t *testing.T) {
-	// Some jobs currently lack proper labels. Label them and remove their entry here,
-	// never add to it!
-	legacyJobs := []string{
-		"^ci-aws-ec2-janitor$",
-		"^ci-kubernetes-cross-canary$", // No source code?! That looks wrong. https://testgrid.k8s.io/sig-k8s-infra-canaries#ci-k8s-cross-canary
-		"^ci-fast-forward$",
-		"^periodic-release-verify-image-signatures$",
-		"^ci-k8s-triage-robot", // Several jobs with this prefix.
-		"^issue-creator$",
-		"^ci-test-infra-label-sync$",
-		"^maintenance-ci-", // Several jobs with this prefix."
-	}
-	existingLegacyJobs := sets.New[int]()
 	for _, job := range c.AllPeriodics() {
 		extraRefIndex := slices.IndexFunc(job.ExtraRefs, func(extraRef prowapi.Refs) bool { return !extraRef.Auxiliary })
 		if extraRefIndex >= 0 {
@@ -1106,21 +1093,7 @@ func TestLabelsBeingSet(t *testing.T) {
 			// Handled manually.
 			continue
 		}
-		legacyJobIndex := slices.IndexFunc(legacyJobs, func(pattern string) bool { return regexp.MustCompile(pattern).MatchString(job.Name) })
-		if legacyJobIndex >= 0 {
-			// Exempt.
-			existingLegacyJobs.Insert(legacyJobIndex)
-			continue
-		}
-
 		t.Errorf("%s: periodic job %q does not get prow.k8s.io/refs.org and prow.k8s.io/refs.repo labels from extra_refs set, they must be set manually.", findJobSourceByName(job.Name), job.Name)
-	}
-
-	// Find obsolete legacyJobs entries.
-	for legacyJobIndex, pattern := range legacyJobs {
-		if !existingLegacyJobs.Has(legacyJobIndex) {
-			t.Errorf("Legacy periodic job pattern is unused and must be removed: %s", pattern)
-		}
 	}
 }
 

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -26,6 +26,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -92,6 +93,34 @@ func TestMain(m *testing.M) {
 	c = conf
 
 	os.Exit(m.Run())
+}
+
+// findJobSourceByName tries to determine where a certain job is defined.
+// We don't get the source from the Prow API.
+//
+// We rely here on the canonical formatting of the job name (no quotation marks)
+// and "name: <job name>" being unique in the job definition itself - not 100%
+// reliable, but good enough for diagonostic output. This basically replaces
+// manually looking for the job.
+func findJobSourceByName(name string) string {
+	grep := exec.Command("git", "grep", "-n", "-E", "-e", "^ *(- )?name: "+name+" *$")
+	grep.Dir = *jobConfigPath
+	output, err := grep.CombinedOutput()
+	if err != nil {
+		return "???"
+	}
+	lines := strings.Split(string(output), "\n")
+	if len(lines) > 1 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) != 1 {
+		return "???"
+	}
+	parts := strings.Split(lines[0], ":")
+	if len(parts) < 2 {
+		return "???"
+	}
+	return path.Join(*jobConfigPath, parts[0]) + ":" + parts[1]
 }
 
 func TestReportTemplate(t *testing.T) {
@@ -1042,6 +1071,55 @@ func TestPreSubmitPathAlias(t *testing.T) {
 	for _, job := range c.AllStaticPresubmits([]string{"kubernetes/kubernetes"}) {
 		if job.PathAlias != "k8s.io/kubernetes" {
 			t.Errorf("Invalid PathAlias (%s) in job %s for kubernetes/kubernetes repository", job.Name, job.PathAlias)
+		}
+	}
+}
+
+// The prow.k8s.io/refs.org and prow.k8s.io/refs.repo labels are required for selecting jobs in the Grafana dashboards.
+// Normally Prow sets automatically them based on the first non-auxiliary extra refs entry.
+// Periodic jobs without such an entry must set the labels explicitly.
+// PostSubmits and PreSubmits can omit extra_refs because they implicitly checkout the repo they are defined for.
+func TestLabelsBeingSet(t *testing.T) {
+	// Some jobs currently lack proper labels. Label them and remove their entry here,
+	// never add to it!
+	legacyJobs := []string{
+		"^ci-aws-ec2-janitor$",
+		"^ci-kubernetes-cross-canary$", // No source code?! That looks wrong. https://testgrid.k8s.io/sig-k8s-infra-canaries#ci-k8s-cross-canary
+		"^ci-fast-forward$",
+		"^periodic-release-verify-image-signatures$",
+		"^ci-k8s-triage-robot", // Several jobs with this prefix.
+		"^issue-creator$",
+		"^ci-test-infra-label-sync$",
+		"^maintenance-ci-", // Several jobs with this prefix."
+	}
+	existingLegacyJobs := sets.New[int]()
+	for _, job := range c.AllPeriodics() {
+		extraRefIndex := slices.IndexFunc(job.ExtraRefs, func(extraRef prowapi.Refs) bool { return !extraRef.Auxiliary })
+		if extraRefIndex >= 0 {
+			// Handled automatically. Don't set manually to avoid potentially broken copy-and-paste.
+			if extraRef := job.ExtraRefs[extraRefIndex]; extraRef.Org == job.Labels["prow.k8s.io/refs.org"] || extraRef.Repo == job.Labels["prow.k8s.io/refs.repo"] {
+				t.Errorf("%s: periodic job %q gets prow.k8s.io/refs.org and prow.k8s.io/refs.repo labels from extra_refs, don't set them manually to redundant values.", findJobSourceByName(job.Name), job.Name)
+			}
+			continue
+		}
+		if job.Labels["prow.k8s.io/refs.org"] != "" && job.Labels["prow.k8s.io/refs.repo"] != "" {
+			// Handled manually.
+			continue
+		}
+		legacyJobIndex := slices.IndexFunc(legacyJobs, func(pattern string) bool { return regexp.MustCompile(pattern).MatchString(job.Name) })
+		if legacyJobIndex >= 0 {
+			// Exempt.
+			existingLegacyJobs.Insert(legacyJobIndex)
+			continue
+		}
+
+		t.Errorf("%s: periodic job %q does not get prow.k8s.io/refs.org and prow.k8s.io/refs.repo labels from extra_refs set, they must be set manually.", findJobSourceByName(job.Name), job.Name)
+	}
+
+	// Find obsolete legacyJobs entries.
+	for legacyJobIndex, pattern := range legacyJobs {
+		if !existingLegacyJobs.Has(legacyJobIndex) {
+			t.Errorf("Legacy periodic job pattern is unused and must be removed: %s", pattern)
 		}
 	}
 }


### PR DESCRIPTION
A prior version of this test checked that extra_refs were set. Now setting the labels manually is also accepted. "Auxiliary" repos like test-infra in E2E node jobs are properly skipped.

Redundant explicit labels raise an error because they could get out of sync with the extra_refs. One generated DRA job had such redundant labels; the logic for setting them gets enhanced to avoid this. Overriding the extra_refs is allowed, but currently not done.

To pass the tests, several labels had to be added. Several jobs are undecided, they got exempted from checking for now.

ci-kubernetes-cross-canary is odd: it should fail due to the lack of source code, but doesn't run.

ci-kubernetes-e2e-gce-cos-alphafeatures-beta still cloned unnecessarily - must have been overlooked when cleaning up earlier.

/cc @upodroid @BenTheElder 
/hold

Let's give this enough time for review.
