### PR TITLE
config/jobs: Update agent-sandbox migration test base_ref to main.

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
@@ -38,7 +38,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: agent-sandbox
-    base_ref: feature/v1beta1-migrate
+    base_ref: main
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR updates the `base_ref` of `periodic-agent-sandbox-migration-test` from `feature/v1beta1-migrate` to `main`. Following the successful graduation of the `v1beta1` APIs and the merge of the migration feature branch into `main`, this periodic Prow job must now validate the `v1alpha1` → `v1beta1` upgrade path directly against the `main` branch.

#### Which issue(s) this PR is related to:
Ref https://github.com/kubernetes-sigs/agent-sandbox/pull/993
Ref https://github.com/kubernetes-sigs/agent-sandbox/pull/1007

#### Special notes for your reviewer:
None.