### PR TITLE
use github team slugs instead of IDs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cloud-provider-kind.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cloud-provider-kind.yaml
@@ -28,5 +28,6 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
-        github_team_ids:
-          - 2921947 # kind-maintainers
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: kind-maintainers

--- a/config/jobs/image-pushing/k8s-staging-dranet.yaml
+++ b/config/jobs/image-pushing/k8s-staging-dranet.yaml
@@ -28,5 +28,6 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
-        github_team_ids:
-          - 2921947 # kind-maintainers
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: kind-maintainers

--- a/config/jobs/image-pushing/k8s-staging-kind.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kind.yaml
@@ -27,8 +27,9 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
-        github_team_ids:
-          - 2921947 # kind-maintainers
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: kind-maintainers
     - name: post-kind-push-base-image
       skip_branches:
         # do not run on dependabot branches, these exist prior to merge
@@ -58,8 +59,9 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
-        github_team_ids:
-          - 2921947 # kind-maintainers
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: kind-maintainers
     - name: post-kind-push-kindnetd-image
       skip_branches:
         # do not run on dependabot branches, these exist prior to merge
@@ -89,8 +91,9 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
-        github_team_ids:
-          - 2921947 # kind-maintainers
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: kind-maintainers
     - name: post-kind-push-local-path-provisioner-image
       skip_branches:
         # do not run on dependabot branches, these exist prior to merge
@@ -120,8 +123,9 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
-        github_team_ids:
-          - 2921947 # kind-maintainers
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: kind-maintainers
     - name: post-kind-push-local-path-helper-image
       cluster: k8s-infra-prow-build-trusted
       run_if_changed: '(^images/local-path-helper)|(^images/Makefile)'
@@ -151,5 +155,6 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
-        github_team_ids:
-          - 2921947 # kind-maintainers
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: kind-maintainers

--- a/config/jobs/image-pushing/k8s-staging-kindnet.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kindnet.yaml
@@ -28,5 +28,6 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
-        github_team_ids:
-          - 2921947 # kind-maintainers
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: kind-maintainers

--- a/config/jobs/image-pushing/k8s-staging-kube-network-policies.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kube-network-policies.yaml
@@ -28,5 +28,6 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
-        github_team_ids:
-          - 2921947 # kind-maintainers
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: kind-maintainers

--- a/config/jobs/image-pushing/k8s-staging-kubetest2.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kubetest2.yaml
@@ -30,8 +30,9 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
-        github_team_ids:
-          - 3925239 # https://github.com/orgs/kubernetes-sigs/teams/kubetest2-maintainers
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: kubetest2-maintainers
 
 periodics:
   - interval: 72h
@@ -66,5 +67,6 @@ periodics:
             - name: LOG_TO_STDOUT
               value: "y"
     rerun_auth_config:
-      github_team_ids:
-        - 3925239 # https://github.com/orgs/kubernetes-sigs/teams/kubetest2-maintainers
+      github_team_slugs:
+        - org: kubernetes-sigs
+          slug: kubetest2-maintainers

--- a/config/jobs/image-pushing/k8s-staging-nat64.yaml
+++ b/config/jobs/image-pushing/k8s-staging-nat64.yaml
@@ -26,5 +26,6 @@ postsubmits:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
-        github_team_ids:
-          - 2921947 # kind-maintainers
+        github_team_slugs:
+          - org: kubernetes-sigs
+            slug: kind-maintainers

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -173,9 +173,11 @@ deck:
   google_analytics: UA-82843984-5
   rerun_auth_configs:
     '*':
-      github_team_ids:
-      - 2009231 # test-infra-admins
-      - 2460384 # milestone-maintainers
+      github_team_slugs:
+        - org: kubernetes
+          slug: test-infra-admins
+        - org: kubernetes
+          slug: milestone-maintainers
   # additional_allowed_buckets is used only when skip_storage_path_validation is
   # false
   skip_storage_path_validation: false

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -1079,6 +1079,32 @@ func TestValidScenarioArgs(t *testing.T) {
 	}
 }
 
+func TestReRunAuthConfig(t *testing.T) {
+	for _, job := range c.AllStaticPresubmits(nil) {
+		if job.RerunAuthConfig != nil {
+			if len(job.RerunAuthConfig.GitHubTeamIDs) > 0 {
+				t.Errorf("rerun_auth_config.github_team_ids[] is not supported, please use github_team_slugs - job: %s", job.Name)
+			}
+		}
+	}
+
+	for _, job := range c.AllStaticPostsubmits(nil) {
+		if job.RerunAuthConfig != nil {
+			if len(job.RerunAuthConfig.GitHubTeamIDs) > 0 {
+				t.Errorf("rerun_auth_config.github_team_ids[] is not supported, please use github_team_slugs - job: %s", job.Name)
+			}
+		}
+	}
+
+	for _, job := range c.AllPeriodics() {
+		if job.RerunAuthConfig != nil {
+			if len(job.RerunAuthConfig.GitHubTeamIDs) > 0 {
+				t.Errorf("rerun_auth_config.github_team_ids[] is not supported, please use github_team_slugs - job: %s", job.Name)
+			}
+		}
+	}
+}
+
 func allStaticJobs() []cfg.JobBase {
 	jobs := []cfg.JobBase{}
 	for _, job := range c.AllStaticPresubmits(nil) {


### PR DESCRIPTION
Related to https://github.com/kubernetes-sigs/prow/pull/766

The team_id look up in Prow is using an legacy endpoint that isn't supported with GitHub Apps. Using team slugs works fine.