### PR TITLE
Deploy node-problem-detector for GCE cluster e2e jobs

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -154,6 +154,7 @@ periodics:
         --gcp-node-image=gci
         --gcp-zone=us-central1-b
         --ginkgo-parallel=30
+        --pre-test-cmd=$(GOPATH)/src/k8s.io/node-problem-detector/test/e2e/manifests/deploy-npd.sh
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
       resources:
@@ -199,6 +200,7 @@ periodics:
         --gcp-node-image=gci
         --gcp-zone=us-central1-b
         --ginkgo-parallel=30
+        --pre-test-cmd=$(GOPATH)/src/k8s.io/node-problem-detector/test/e2e/manifests/deploy-npd.sh
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
       resources:
@@ -247,6 +249,7 @@ periodics:
         --ginkgo-parallel=30
         --image-family=ubuntu-2404-lts-amd64
         --image-project=ubuntu-os-cloud
+        --pre-test-cmd=$(GOPATH)/src/k8s.io/node-problem-detector/test/e2e/manifests/deploy-npd.sh
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
       resources:
@@ -295,6 +298,7 @@ periodics:
         --ginkgo-parallel=30
         --image-family=ubuntu-2404-lts-amd64
         --image-project=ubuntu-os-cloud
+        --pre-test-cmd=$(GOPATH)/src/k8s.io/node-problem-detector/test/e2e/manifests/deploy-npd.sh
         --test_args=--ginkgo.focus=NodeProblemDetector
         --timeout=60m
       resources:

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -183,6 +183,7 @@ presubmits:
           --gcp-node-image=gci
           --gcp-zone=us-central1-b
           --ginkgo-parallel=30
+          --pre-test-cmd=$(GOPATH)/src/k8s.io/node-problem-detector/test/e2e/manifests/deploy-npd.sh
           --test_args=--ginkgo.focus=NodeProblemDetector
           --timeout=60m
         resources:
@@ -228,6 +229,7 @@ presubmits:
           --gcp-node-image=gci
           --gcp-zone=us-central1-b
           --ginkgo-parallel=30
+          --pre-test-cmd=$(GOPATH)/src/k8s.io/node-problem-detector/test/e2e/manifests/deploy-npd.sh
           --test_args=--ginkgo.focus=NodeProblemDetector
           --timeout=60m
         resources:
@@ -317,6 +319,7 @@ presubmits:
           --ginkgo-parallel=30
           --image-family=ubuntu-2404-lts-amd64
           --image-project=ubuntu-os-cloud
+          --pre-test-cmd=$(GOPATH)/src/k8s.io/node-problem-detector/test/e2e/manifests/deploy-npd.sh
           --test_args=--ginkgo.focus=NodeProblemDetector
           --timeout=60m
         resources:
@@ -365,6 +368,7 @@ presubmits:
           --ginkgo-parallel=30
           --image-family=ubuntu-2404-lts-amd64
           --image-project=ubuntu-os-cloud
+          --pre-test-cmd=$(GOPATH)/src/k8s.io/node-problem-detector/test/e2e/manifests/deploy-npd.sh
           --test_args=--ginkgo.focus=NodeProblemDetector
           --timeout=60m
         resources:


### PR DESCRIPTION
kubernetes/kubernetes removed the kube-up node-problem-detector addon, so test/e2e/node/node_problem_detector.go no longer finds NPD on GCE clusters and fails looking for a node-problem-detector pod.

Run the node-problem-detector deploy-npd.sh helper via kubetest --pre-test-cmd after cluster bring-up, so NPD is deployed as a DaemonSet before the NodeProblemDetector focus test, for the presubmit and periodic gci/ubuntu and -custom-flags cluster jobs.

/cc @ameukam @upodroid @rifelpet 