### PR TITLE
Scrape etcd metrics in the gce 5k periodic scale jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1273,6 +1273,8 @@ periodics:
         value: "nftables"
       - name: PROMETHEUS_SCRAPE_KUBE_PROXY
         value: "true"
+      - name: PROMETHEUS_SCRAPE_ETCD
+        value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -159,6 +159,8 @@ periodics:
         value: "nftables"
       - name: PROMETHEUS_SCRAPE_KUBE_PROXY
         value: "true"
+      - name: PROMETHEUS_SCRAPE_ETCD
+        value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT


### PR DESCRIPTION
The gce 5k presubmit pull-kubernetes-gce-master-scale-performance-5000 already sets PROMETHEUS_SCRAPE_ETCD=true, and its prometheus_snapshot.tar correctly loads the etcd server metrics (etcd_server_*, etcd_disk_*, etcd_mvcc_*). Verified in https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/directory/pull-kubernetes-gce-master-scale-performance-5000/2069433752324411392

Enable the same on the two periodic gce 5k jobs (ci-kubernetes-e2e-gce-scale-performance-5000 and ci-kubernetes-e2e-gce-scale-performance-5000-experimental) so their snapshots capture etcd too.

/sig scalability
