### PR TITLE
CAPO: Use runner entrypoint for build job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
         command:
+        - "runner.sh"
         - "./scripts/ci-build.sh"
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
We want to check that image building works. For this we need docker. DinD is already enabled, but without the runner.sh entrypoint, the docker service is never started (or cleaned up in the end).