### PR TITLE
Sync CAPO owners

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/OWNERS
@@ -3,9 +3,12 @@
 # See sigs.k8s.io/cluster-api-provider-openstack/OWNERS_ALIASES
 approvers:
   - sig-cluster-lifecycle-leads
-  - EmilienM
+  - emilienm
   - lentzi90
+  - mandre
+  - stephenfin
 
 reviewers:
-  - EmilienM
-  - lentzi90
+  - bnallapeta
+  - smoshiur1237
+  - nikParasyr


### PR DESCRIPTION
I have forgotten to keep these up to date.
See https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/OWNERS_ALIASES for CAPO owners.