### PR TITLE
Add helm-chart tag trigger for aws-ebs-csi-driver postsubmit

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cloud-provider-aws.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cloud-provider-aws.yaml
@@ -48,6 +48,8 @@ postsubmits:
         # trigger another image build. Images are only built for tags that follow
         # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+        # For publishing the Helm chart to staging.
+        - ^helm-chart-
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
This PR adds a trigger so the postsubmit fires when the chart-releaser GitHub Action creates a helm-chart tag.

This is needed for https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2957, which adds a step to cloudbuild.sh that packages the Helm chart and pushes it to the staging registry.