### PR TITLE
Add pull-kubernetes-gce-master-scale-performance-5000-experimental presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -151,7 +151,7 @@ presubmits:
         - name: EXPERIMENT_VARIANT
           value: "restart"
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
-          value: "true"
+          value: "false"
         - name: CL2_RESTART_APISERVER
           value: "true"
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -103,3 +103,119 @@ presubmits:
           limits:
             cpu: 5
             memory: 16Gi
+
+  # Presubmit mirror of ci-kubernetes-e2e-gce-scale-performance-5000-experimental.
+  - name: pull-kubernetes-gce-master-scale-performance-5000-experimental
+    cluster: k8s-infra-prow-build
+    always_run: false
+    optional: true
+    max_concurrency: 1
+    branches:
+    - master
+    - main
+    decorate: true
+    path_alias: k8s.io/kubernetes
+    labels:
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    job_queue_name: "5k-gce-scale-test" # DON'T REMOVE THIS
+    decoration_config:
+      timeout: 450m
+    extra_refs:
+    - org: kubernetes
+      repo: kops
+      base_ref: master
+      workdir: true
+      path_alias: k8s.io/kops
+    - org: kubernetes
+      repo: perf-tests
+      base_ref: master
+      path_alias: k8s.io/perf-tests
+    annotations:
+      testgrid-dashboards: presubmits-kubernetes-scalability, sig-scalability-gce
+      testgrid-tab-name: pull-kubernetes-gce-master-scale-performance-5000-experimental
+    spec:
+      serviceAccountName: prow-build
+      tolerations:
+        - key: highmem
+          operator: Exists
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+        command:
+        - runner.sh
+        args:
+        - ./tests/e2e/scenarios/scalability/run-test.sh
+        securityContext:
+          privileged: true
+        env:
+        - name: EXPERIMENT_VARIANT
+          value: "restart"
+        - name: CL2_ENABLE_INFORMER_LATENCY_TEST
+          value: "true"
+        - name: CL2_RESTART_APISERVER
+          value: "true"
+        - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
+          value: "21474836480"
+        - name: CL2_EXECSERVICE_CPU_REQUESTS
+          value: "8"
+        - name: CL2_EXECSERVICE_MEMORY_REQUESTS
+          value: "16Gi"
+        - name: CL2_REALISTIC_POD
+          value: "true"
+        - name: CL2_HEAP_PROFILE_INTERVAL
+          value: "5m"
+        - name: KUBE_SSH_KEY_PATH
+          value: /etc/ssh-key-secret/ssh-private
+        - name: KUBE_SSH_USER
+          value: prow
+        - name: GOPATH
+          value: /home/prow/go
+        - name: CNI_PLUGIN
+          value: gce
+        - name: KUBE_NODE_COUNT
+          value: "5000"
+        - name: ETCD_VERSION
+          value: "3.7.0-rc.0"
+        - name: CL2_LOAD_TEST_THROUGHPUT
+          value: "50"
+        - name: CL2_DELETE_TEST_THROUGHPUT
+          value: "50"
+        - name: CL2_RATE_LIMIT_POD_CREATION
+          value: "false"
+        - name: NODE_MODE
+          value: "master"
+        - name: CONTROL_PLANE_COUNT
+          value: "3"
+        - name: CONTROL_PLANE_SIZE
+          value: "c4-standard-96"
+        - name: ADDONS_NODE_SIZE
+          value: "c3-standard-44"
+        - name: KUBE_PROXY_MODE
+          value: "nftables"
+        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+          value: "true"
+        - name: CL2_ENABLE_DNS_PROGRAMMING
+          value: "true"
+        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+          value: "true"
+        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+          value: "99.5"
+        - name: CL2_ALLOWED_SLOW_API_CALLS
+          value: "1"
+        - name: ENABLE_PROMETHEUS_SERVER
+          value: "true"
+        - name: TEAR_DOWN_PROMETHEUS_SERVER
+          value: "false"
+        - name: PROMETHEUS_PVC_STORAGE_CLASS
+          value: "ssd-csi"
+        - name: CLOUD_PROVIDER
+          value: "gce"
+        - name: BOSKOS_RESOURCE_TYPE
+          value: "scalability-scale-project"
+        resources:
+          requests:
+            cpu: 7
+            memory: "40Gi"
+          limits:
+            cpu: 7
+            memory: "40Gi"

--- a/config/testgrids/kubernetes/sig-scalability/config.yaml
+++ b/config/testgrids/kubernetes/sig-scalability/config.yaml
@@ -4,6 +4,11 @@ test_groups:
   column_header:
   - configuration_value: Commit
   - configuration_value: variant
+- name: pull-kubernetes-gce-master-scale-performance-5000-experimental
+  gcs_prefix: kubernetes-ci-logs/pr-logs/directory/pull-kubernetes-gce-master-scale-performance-5000-experimental
+  column_header:
+  - configuration_value: Commit
+  - configuration_value: variant
 
 dashboard_groups:
 - name: sig-scalability

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -71,6 +71,7 @@ var jobsExemptFromResourceLimits = []string{
 	"ci-kubernetes-e2e-gce-scale-performance-5000",
 	"ci-kubernetes-e2e-gce-scale-performance-5000-experimental",
 	"pull-kubernetes-gce-master-scale-performance-5000",
+	"pull-kubernetes-gce-master-scale-performance-5000-experimental",
 	"pull-perf-tests-gce-master-scale-performance-5000",
 }
 


### PR DESCRIPTION
Add pull-kubernetes-gce-master-scale-performance-5000-experimental presubmit

Want to add a mapping

5k experimental presubmit -> 5k experimental job
5k presubmit normal -> 5k gce job

This allows us to test and debug the 5k gce job without affecting experiments

