### PR TITLE
Align the 5k GCE presubmit env with ci-kubernetes-e2e-gce-scale-performance-5000

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -453,12 +453,9 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: EXPERIMENT_VARIANT
-          value: "default"
+        #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
           value: "true"
-        # - name: CL2_RESTART_APISERVER
-        #   value: "true"
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
           value: "21474836480"
         - name: CL2_EXECSERVICE_CPU_REQUESTS
@@ -467,9 +464,6 @@ presubmits:
           value: "16Gi"
         - name: CL2_REALISTIC_POD
           value: "true"
-        # - name: CL2_HEAP_PROFILE_INTERVAL
-        #   value: "5m"
-        #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
         - name: KUBE_SSH_KEY_PATH
           value: /etc/ssh-key-secret/ssh-private
         - name: KUBE_SSH_USER
@@ -490,8 +484,6 @@ presubmits:
           value: "false"
         - name: NODE_MODE
           value: "master"
-        # - name: CONTROL_PLANE_COUNT
-        #   value: "3"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-96"
         - name: ADDONS_NODE_SIZE

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -3,7 +3,6 @@ test_groups:
   gcs_prefix: kubernetes-ci-logs/pr-logs/directory/pull-kubernetes-gce-master-scale-performance-5000
   column_header:
   - configuration_value: Commit
-  - configuration_value: variant
 
 dashboard_groups:
 - name: presubmits


### PR DESCRIPTION
Experiments are handled separately in https://github.com/kubernetes/test-infra/pull/37333.