### PR TITLE
Disable informer latency measurement on gce 5k scale jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1226,7 +1226,7 @@ periodics:
       - name: EXPERIMENT_VARIANT
         value: "restart"
       - name: CL2_ENABLE_INFORMER_LATENCY_TEST
-        value: "true"
+        value: "false"
       # Disabled: see https://github.com/kubernetes/test-infra/pull/37027
       # - name: CL2_INFORMER_RUN_ON_CONTROL_PLANE
       #   value: "true"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -456,7 +456,7 @@ presubmits:
         - name: EXPERIMENT_VARIANT
           value: "default"
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
-          value: "true"
+          value: "false"
         # - name: CL2_RESTART_APISERVER
         #   value: "true"
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
@@ -1232,9 +1232,9 @@ presubmits:
           privileged: true
         env:
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
-          value: "true"
-        - name: CL2_INFORMER_RUN_ON_CONTROL_PLANE
-          value: "true"
+          value: "false"
+        # - name: CL2_INFORMER_RUN_ON_CONTROL_PLANE
+        #   value: "true"
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
           value: "21474836480"
         - name: CL2_EXECSERVICE_CPU_REQUESTS

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -122,7 +122,7 @@ periodics:
         privileged: true
       env:
       - name: CL2_ENABLE_INFORMER_LATENCY_TEST
-        value: "true"
+        value: "false"
       - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
         value: "21474836480"
       - name: CL2_EXECSERVICE_CPU_REQUESTS


### PR DESCRIPTION
Disable informer latency measurement on gce 5k scale jobs to stabilize https://testgrid.k8s.io/sig-scalability-gce#gce-master-scale-performance-5000