### PR TITLE
Align pull-kubernetes-gce-master-scale-performance-5000-experimental with the non-experimental 5k job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -149,11 +149,11 @@ presubmits:
           privileged: true
         env:
         - name: EXPERIMENT_VARIANT
-          value: "restart"
+          value: "etcd36"
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
           value: "false"
-        - name: CL2_RESTART_APISERVER
-          value: "true"
+        # - name: CL2_RESTART_APISERVER
+        #   value: "true"
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
           value: "21474836480"
         - name: CL2_EXECSERVICE_CPU_REQUESTS
@@ -162,8 +162,8 @@ presubmits:
           value: "16Gi"
         - name: CL2_REALISTIC_POD
           value: "true"
-        - name: CL2_HEAP_PROFILE_INTERVAL
-          value: "5m"
+        # - name: CL2_HEAP_PROFILE_INTERVAL
+        #   value: "5m"
         - name: KUBE_SSH_KEY_PATH
           value: /etc/ssh-key-secret/ssh-private
         - name: KUBE_SSH_USER
@@ -174,8 +174,6 @@ presubmits:
           value: gce
         - name: KUBE_NODE_COUNT
           value: "5000"
-        - name: ETCD_VERSION
-          value: "3.7.0-rc.0"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT
@@ -184,8 +182,8 @@ presubmits:
           value: "false"
         - name: NODE_MODE
           value: "master"
-        - name: CONTROL_PLANE_COUNT
-          value: "3"
+        # - name: CONTROL_PLANE_COUNT
+        #   value: "3"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-96"
         - name: ADDONS_NODE_SIZE


### PR DESCRIPTION
Aligns `pull-kubernetes-gce-master-scale-performance-5000-experimental` with the non-experimental 5k job and switches the experiment to etcd 3.6.

- `EXPERIMENT_VARIANT`: `restart` -> `etcd36`
- Comment out params not in the non-experimental 5k job: `CL2_RESTART_APISERVER`, `CL2_HEAP_PROFILE_INTERVAL`, `CONTROL_PLANE_COUNT`
- Remove the `ETCD_VERSION: 3.7.0-rc.0` override

/sig scalability