### PR TITLE
fix: migrate azuredisk periodic Windows job to use CAPZ ci-entrypoint

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -9,19 +9,15 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
     preset-azure-community: "true"
-    preset-capz-windows-common: "true"
-    preset-capz-windows-2022: "true"
-    preset-capz-containerd-2-0-latest: "true"
-    preset-capz-windows-azuredisk: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
-    base_ref: main
+    base_ref: release-1.24
     path_alias: sigs.k8s.io/cluster-api-provider-azure
-    workdir: false
+    workdir: true
   - org: kubernetes-sigs
     repo: cloud-provider-azure
-    base_ref: master
+    base_ref: release-1.35
     path_alias: sigs.k8s.io/cloud-provider-azure
     workdir: false
   - org: kubernetes-sigs
@@ -29,20 +25,13 @@ periodics:
     base_ref: master
     path_alias: sigs.k8s.io/azuredisk-csi-driver
     workdir: false
-  - org: kubernetes-sigs
-    repo: windows-testing
-    base_ref: master
-    path_alias: sigs.k8s.io/windows-testing
-    workdir: true
   spec:
     serviceAccountName: azure
     containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
         command:
-          - "runner.sh"
-          - "env"
-          - "KUBERNETES_VERSION=latest"
-          - "./capz/run-capz-e2e.sh"
+          - runner.sh
+          - ./scripts/ci-entrypoint.sh
         args:
           - bash
           - -c
@@ -59,8 +48,20 @@ periodics:
             cpu: 4
             memory: 8Gi
         env:
-          - name: AZURE_VM_TYPE # azuredisk-csi-driver config
-            value: "standard"
+          - name: WINDOWS # azuredisk-csi-driver config
+            value: "true"
+          - name: TEST_WINDOWS # CAPZ config
+            value: "true"
+          - name: WINDOWS_SERVER_VERSION # CAPZ config
+            value: "windows-2022"
+          - name: NODE_MACHINE_TYPE # CAPZ config
+            value: "Standard_D4s_v3"
+          - name: DISABLE_ZONE # azuredisk-csi-driver config
+            value: "true"
+          - name: KUBERNETES_VERSION # CAPZ config
+            value: "v1.35.2"
+          - name: WORKER_MACHINE_COUNT # CAPZ config
+            value: "0" # Don't create any linux worker nodes
   annotations:
     testgrid-dashboards: provider-azure-azuredisk-csi-driver, sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: ci-azuredisk-csi-driver-e2e-capz-windows


### PR DESCRIPTION
## What

Migrate the `ci-azuredisk-csi-driver-e2e-capz-windows` periodic job to use the same CAPZ-native pattern as the SMB CSI driver Windows jobs.

## Why

The current periodic job has been failing to create Windows nodes because it:
1. Uses `windows-testing` repo's `run-capz-e2e.sh` script which hasn't kept pace with CAPZ changes
2. Tracks CAPZ `main` branch (unstable, breaking changes)
3. Uses `KUBERNETES_VERSION=latest` (unpredictable)
4. Relies on `preset-capz-windows-*` labels that may be incompatible with current CAPZ

The SMB CSI driver Windows jobs work correctly because they use the standard CAPZ pattern.

## Changes

- Use CAPZ's `./scripts/ci-entrypoint.sh` instead of `windows-testing`'s `run-capz-e2e.sh`
- Pin CAPZ to `release-1.24` (stable) instead of `main`
- Pin cloud-provider-azure to `release-1.35`
- Set explicit env vars (`TEST_WINDOWS`, `WINDOWS_SERVER_VERSION`, `NODE_MACHINE_TYPE`, `KUBERNETES_VERSION`, `WORKER_MACHINE_COUNT`) instead of relying on preset labels
- Remove `windows-testing` extra_ref (no longer needed)
- Remove `preset-capz-windows-*` labels (replaced by explicit env vars)
- Pin `KUBERNETES_VERSION` to `v1.35.2` instead of `latest`

## Reference

Working SMB Windows job pattern: https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml#L359-L417

/cc @andyzhangx
