### PR TITLE
Add on-demand kueue website link-check presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -2060,3 +2060,38 @@ presubmits:
               limits:
                 cpu: "6"
                 memory: "6Gi"
+    - name: pull-kueue-verify-website-links-preview-main
+      cluster: eks-prow-build-cluster
+      optional: true
+      always_run: false
+      branches:
+        - ^main
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        pod_unscheduled_timeout: 10m
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-verify-website-links-preview-main
+        description: "Check links on a PR's Netlify deploy preview, on demand (non-blocking)"
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
+            command:
+              - runner.sh
+            args:
+              - make
+              - verify-website-links-preview
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "6"
+                memory: "6Gi"
+              limits:
+                cpu: "6"
+                memory: "6Gi"


### PR DESCRIPTION
This adds an on-demand, non-blocking presubmit, `pull-kueue-verify-website-links-preview-main`, for `kubernetes-sigs/kueue`.

The job runs make verify-website-links-preview to check links against a PR's Netlify deploy preview instead of the live site. This lets contributors verify website links before merge; today they are only checked after merge by `periodic-kueue-verify-website-links-main`.

The job is optional and only runs when requested: `/test pull-kueue-verify-website-links-preview-main`

It starts as on-demand/non-blocking by design. The Kueue-side target skips successfully when no fresh same-commit preview can be resolved, and otherwise preserves the normal link checker result.

Companion Kueue-side change: kubernetes-sigs/kueue#12530
Refs: kubernetes-sigs/kueue#12472
