### PR TITLE
kubernetes/sig-scalability: increase CL2 pod memory for watch-list jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -115,10 +115,10 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "8Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "8Gi"
 
 - name: ci-kubernetes-e2e-gci-gce-scalability-watch-list-on
   cluster: k8s-infra-prow-build
@@ -180,7 +180,7 @@ periodics:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "8Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "8Gi"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -160,10 +160,10 @@ presubmits:
         resources:
           requests:
             cpu: 2
-            memory: "2Gi"
+            memory: "8Gi"
           limits:
             cpu: 2
-            memory: "2Gi"
+            memory: "8Gi"
 
   # Presubmit mirror of ci-kubernetes-e2e-gce-scale-performance-5000-experimental.
   - name: pull-kubernetes-gce-master-scale-performance-5000-experimental


### PR DESCRIPTION
[the latest run](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139925/pull-kubernetes-e2e-gce-watch-list-benchmark/2070482162779426816) of the new `pull-kubernetes-e2e-gce-watch-list-benchmark` job failed due to `Job execution failed: Job pod was OOM killed by the cluster.`

It seems that CL2 runs out of memory at 2Gi when creating that many objects.