### PR TITLE
Add CAPZ release v1.25 tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.25.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-provider-azure-conformance-v1beta1-release-1-23
+- name: periodic-cluster-api-provider-azure-conformance-v1beta1-release-1-25
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -12,7 +12,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.23
+      base_ref: release-1.25
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     serviceAccountName: azure
@@ -34,10 +34,10 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-conformance-v1beta1-release-1-23
+    testgrid-tab-name: capz-periodic-conformance-v1beta1-release-1-25
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-1.23 (v1beta1)
-- name: periodic-cluster-api-provider-azure-conformance-v1beta1-with-ci-artifacts-release-1-23
+    description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-1.25 (v1beta1)
+- name: periodic-cluster-api-provider-azure-conformance-v1beta1-with-ci-artifacts-release-1-25
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -50,7 +50,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.23
+      base_ref: release-1.25
       path_alias: sigs.k8s.io/cluster-api-provider-azure
       workdir: true
     - org: kubernetes-sigs
@@ -81,10 +81,10 @@ periodics:
             memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-conformance-k8s-ci-v1beta1-release-1-23
+    testgrid-tab-name: capz-periodic-conformance-k8s-ci-v1beta1-release-1-25
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
-    description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-1.23 (v1beta1)
-- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-23
+    description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-1.25 (v1beta1)
+- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-25
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -97,7 +97,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.23
+      base_ref: release-1.25
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     serviceAccountName: azure
@@ -124,10 +124,10 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-23
+    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-25
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: Runs Cluster API E2E tests on cluster-api-provider-azure release-1.23 (v1beta1)
-- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-23
+    description: Runs Cluster API E2E tests on cluster-api-provider-azure release-1.25 (v1beta1)
+- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-25
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -140,7 +140,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.23
+      base_ref: release-1.25
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     serviceAccountName: azure
@@ -167,10 +167,10 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-23
+    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-25
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: Runs Cluster API Provider Azure E2E tests on cluster-api-provider-azure release-1.23 (v1beta1)
-- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-23
+    description: Runs Cluster API Provider Azure E2E tests on cluster-api-provider-azure release-1.25 (v1beta1)
+- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-25
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -183,7 +183,7 @@ periodics:
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure
-      base_ref: release-1.23
+      base_ref: release-1.25
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     serviceAccountName: azure
@@ -210,6 +210,6 @@ periodics:
         privileged: true
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-23
+    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-25
     testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-    description: Runs managed Kubernetes E2E tests on cluster-api-provider-azure release-1.23 (v1beta1)
+    description: Runs managed Kubernetes E2E tests on cluster-api-provider-azure release-1.25 (v1beta1)


### PR DESCRIPTION
Updates the capz-dependent periodic jobs to use the new `release-1.25` branch, replacing `release-1.23` (now EOL). Follows the v1.24 bump in kubernetes/test-infra#36966.

/area jobs
/sig cluster-lifecycle