### PR TITLE
Add karpenter-provider-cluster-api e2e presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/karpenter-provider-cluster-api/OWNERS
+++ b/config/jobs/kubernetes-sigs/karpenter-provider-cluster-api/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-cluster-lifecycle-leads
+- elmiko
+- maxcao13
+
+reviewers:
+- elmiko
+- maxcao13

--- a/config/jobs/kubernetes-sigs/karpenter-provider-cluster-api/karpenter-provider-cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/karpenter-provider-cluster-api/karpenter-provider-cluster-api-presubmits.yaml
@@ -1,0 +1,32 @@
+presubmits:
+  kubernetes-sigs/karpenter-provider-cluster-api:
+  - name: pull-karpenter-provider-cluster-api-e2e
+    cluster: k8s-infra-prow-build
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md|adoc)$|^(?:.*/)?(?:\\.gitignore|OWNERS|OWNERS_ALIASES|PROJECT|LICENSE)$"
+    decorate: true
+    path_alias: "sigs.k8s.io/karpenter-provider-cluster-api"
+    branches:
+    - ^main$
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decoration_config:
+      timeout: 40m
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
+        command:
+        - runner.sh
+        - ./test/hack/ci-e2e.sh
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "4"
+            memory: 16Gi
+          requests:
+            cpu: "4"
+            memory: 16Gi
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-karpenter-provider-cluster-api
+      testgrid-tab-name: pull-karpenter-provider-cluster-api-e2e

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -18,6 +18,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-system-validators
     - sig-cluster-lifecycle-kubespray
     - sig-cluster-lifecycle-image-builder
+    - sig-cluster-lifecycle-karpenter-provider-cluster-api
     - sig-cluster-lifecycle-kubeup-to-kops
 
 dashboards:
@@ -53,6 +54,7 @@ dashboards:
 - name: sig-cluster-lifecycle-system-validators
 - name: sig-cluster-lifecycle-kubespray
 - name: sig-cluster-lifecycle-image-builder
+- name: sig-cluster-lifecycle-karpenter-provider-cluster-api
 - name: sig-cluster-lifecycle-kubeup-to-kops
 
 test_groups:


### PR DESCRIPTION
See: https://github.com/kubernetes-sigs/karpenter-provider-cluster-api/issues/95

In the [karpenter capi repo](https://github.com/kubernetes-sigs/karpenter-provider-cluster-api) `./test/hack/ci-e2e.sh` doesn't exist yet, but in a followup PR to the base repo, I will add that script which will install `ko` and `kind` and run the regular `test/hack/e2e.sh` flow, and try to make it work within the base repo instead of messing around with config here.

We also need to add a new testgrid dashboard. I put it in a new dashboard called `sig-cluster-lifecycle-karpenter-provider-cluster-api`.