### PR TITLE
Kueue: test-infra work for unit tests, shard 0 and shard 1 are introduced

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -1,13 +1,54 @@
 periodics:
   - interval: 12h
-    name: periodic-kueue-test-unit-main
+    name: periodic-kueue-test-unit-shard-0-main
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-unit-main
+      testgrid-tab-name: periodic-kueue-test-unit-shard-0-main
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue unit tests"
+      description: "Run periodic kueue unit shard 0 test"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      pod_unscheduled_timeout: 10m
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.26
+          env:
+            - name: GO_TEST_FLAGS
+              value: "-race -count 3"
+            - name: GOMAXPROCS
+              value: "6"
+          command:
+            - make
+          args:
+            - test
+          resources:
+            requests:
+              cpu: "6"
+              memory: "6Gi"
+            limits:
+              cpu: "6"
+              memory: "6Gi"
+  - interval: 12h
+    name: periodic-kueue-test-unit-shard-1-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-unit-shard-1-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue unit shard 1 test"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-17.yaml
@@ -1,13 +1,54 @@
 periodics:
   - interval: 12h
-    name: periodic-kueue-test-unit-release-0-17
+    name: periodic-kueue-test-unit-shard-0-release-0-17
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-unit-release-0-17
+      testgrid-tab-name: periodic-kueue-test-unit-shard-0-release-0-17
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue unit tests"
+      description: "Run periodic kueue unit shard 0 tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.17
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      pod_unscheduled_timeout: 10m
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.26
+          env:
+            - name: GO_TEST_FLAGS
+              value: "-race -count 3"
+            - name: GOMAXPROCS
+              value: "6"
+          command:
+            - make
+          args:
+            - test
+          resources:
+            requests:
+              cpu: "6"
+              memory: "6Gi"
+            limits:
+              cpu: "6"
+              memory: "6Gi"
+  - interval: 12h
+    name: periodic-kueue-test-unit-shard-1-release-0-17
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-unit-shard-1-release-0-17
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue unit shard 1 tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -1,13 +1,54 @@
 periodics:
   - interval: 12h
-    name: periodic-kueue-test-unit-release-0-18
+    name: periodic-kueue-test-unit-shard-0-release-0-18
     cluster: eks-prow-build-cluster
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: periodic-kueue-test-unit-release-0-18
+      testgrid-tab-name: periodic-kueue-test-unit-shard-0-release-0-18
       testgrid-alert-email: kueue-alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
-      description: "Run periodic kueue unit tests"
+      description: "Run periodic kueue unit shard 0 tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.18
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      pod_unscheduled_timeout: 10m
+    spec:
+      containers:
+        - image: public.ecr.aws/docker/library/golang:1.26
+          env:
+            - name: GO_TEST_FLAGS
+              value: "-race -count 3"
+            - name: GOMAXPROCS
+              value: "6"
+          command:
+            - make
+          args:
+            - test
+          resources:
+            requests:
+              cpu: "6"
+              memory: "6Gi"
+            limits:
+              cpu: "6"
+              memory: "6Gi"
+  - interval: 12h
+    name: periodic-kueue-test-unit-shard-1-release-0-18
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-unit-shard-1-release-0-18
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic kueue unit shard 1 tests"
       testgrid-num-columns-recent: '30'
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes-sigs/kueue:
-    - name: pull-kueue-test-unit-main
+    - name: pull-kueue-test-unit-shard-0-main
       cluster: eks-prow-build-cluster
       branches:
         - ^main
@@ -12,8 +12,41 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-unit-main
-        description: "Run kueue unit tests"
+        testgrid-tab-name: pull-kueue-test-unit-shard-0-main
+        description: "Run kueue unit shard 0 tests"
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.26
+            env:
+              - name: GO_TEST_FLAGS
+                value: "-race -count 3"
+              - name: GOMAXPROCS
+                value: "6"
+            command:
+              - make
+            args:
+              - test
+            resources:
+              requests:
+                cpu: "6"
+                memory: "6Gi"
+              limits:
+                cpu: "6"
+                memory: "6Gi"
+    - name: pull-kueue-test-unit-shard-1-main
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        pod_unscheduled_timeout: 10m
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-unit-shard-1-main
+        description: "Run kueue unit shard 1 tests"
       spec:
         containers:
           - image: public.ecr.aws/docker/library/golang:1.26

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-17.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes-sigs/kueue:
-    - name: pull-kueue-test-unit-release-0-17
+    - name: pull-kueue-test-unit-shard-0-release-0-17
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.17
@@ -12,8 +12,41 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-unit-release-0-17
-        description: "Run kueue unit tests"
+        testgrid-tab-name: pull-kueue-test-unit-shard-0-release-0-17
+        description: "Run kueue unit shard 0 tests"
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.26
+            env:
+              - name: GO_TEST_FLAGS
+                value: "-race -count 3"
+              - name: GOMAXPROCS
+                value: "6"
+            command:
+              - make
+            args:
+              - test
+            resources:
+              requests:
+                cpu: "6"
+                memory: "6Gi"
+              limits:
+                cpu: "6"
+                memory: "6Gi"
+    - name: pull-kueue-test-unit-shard-1-release-0-17
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.17
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        pod_unscheduled_timeout: 10m
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-unit-shard-1-release-0-17
+        description: "Run kueue unit shard 1 tests"
       spec:
         containers:
           - image: public.ecr.aws/docker/library/golang:1.26

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubernetes-sigs/kueue:
-    - name: pull-kueue-test-unit-release-0-18
+    - name: pull-kueue-test-unit-shard-0-release-0-18
       cluster: eks-prow-build-cluster
       branches:
         - ^release-0.18
@@ -12,8 +12,41 @@ presubmits:
       path_alias: sigs.k8s.io/kueue
       annotations:
         testgrid-dashboards: sig-scheduling
-        testgrid-tab-name: pull-kueue-test-unit-release-0-18
-        description: "Run kueue unit tests"
+        testgrid-tab-name: pull-kueue-test-unit-shard-0-release-0-18
+        description: "Run kueue unit shard 0 tests"
+      spec:
+        containers:
+          - image: public.ecr.aws/docker/library/golang:1.26
+            env:
+              - name: GO_TEST_FLAGS
+                value: "-race -count 3"
+              - name: GOMAXPROCS
+                value: "6"
+            command:
+              - make
+            args:
+              - test
+            resources:
+              requests:
+                cpu: "6"
+                memory: "6Gi"
+              limits:
+                cpu: "6"
+                memory: "6Gi"
+    - name: pull-kueue-test-unit-shard-1-release-0-18
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.18
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        pod_unscheduled_timeout: 10m
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-unit-shard-1-release-0-18
+        description: "Run kueue unit shard 1 tests"
       spec:
         containers:
           - image: public.ecr.aws/docker/library/golang:1.26


### PR DESCRIPTION
This PR includes addition of shard 0 and shard 1 for unit tests that are in Kueue
Its Part of https://github.com/kubernetes-sigs/kueue/pull/12517 
Release branches and main branches are both handled in this PR 