### PR TITLE
tests: check for typos in YAML

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -82,7 +82,9 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	conf, err := cfg.Load(*configPath, *jobConfigPath, nil, "")
+	// We want to catch unknown fields (most likely caused by typos),
+	// so use LoadStrict instead of Load here.
+	conf, err := cfg.LoadStrict(*configPath, *jobConfigPath, nil, "")
 	if err != nil {
 		fmt.Printf("Could not load config: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
By asking Prow to load the configs with strict parsing, typos get caught:

    $ go test ./config/tests/jobs/
    Could not load config: error unmarshalling ../../jobs/kubernetes/sig-node/dra-ci.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field "auxiliaryXXX"
    FAIL	k8s.io/test-infra/config/tests/jobs	0.473s