### PR TITLE
Align gce master 5k scale presubmit with the experimental restart periodic

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -210,11 +210,11 @@ presubmits:
           privileged: true
         env:
         - name: EXPERIMENT_VARIANT
-          value: "etcd36"
+          value: "restart"
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
           value: "false"
-        # - name: CL2_RESTART_APISERVER
-        #   value: "true"
+        - name: CL2_RESTART_APISERVER
+          value: "true"
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
           value: "21474836480"
         - name: CL2_EXECSERVICE_CPU_REQUESTS
@@ -223,8 +223,9 @@ presubmits:
           value: "16Gi"
         - name: CL2_REALISTIC_POD
           value: "true"
-        # - name: CL2_HEAP_PROFILE_INTERVAL
-        #   value: "5m"
+        - name: CL2_HEAP_PROFILE_INTERVAL
+          value: "5m"
+        #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
         - name: KUBE_SSH_KEY_PATH
           value: /etc/ssh-key-secret/ssh-private
         - name: KUBE_SSH_USER
@@ -235,6 +236,8 @@ presubmits:
           value: gce
         - name: KUBE_NODE_COUNT
           value: "5000"
+        - name: ETCD_VERSION
+          value: "3.7.0-rc.0"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT
@@ -243,8 +246,8 @@ presubmits:
           value: "false"
         - name: NODE_MODE
           value: "master"
-        # - name: CONTROL_PLANE_COUNT
-        #   value: "3"
+        - name: CONTROL_PLANE_COUNT
+          value: "3"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-96"
         - name: ADDONS_NODE_SIZE
@@ -252,6 +255,8 @@ presubmits:
         - name: KUBE_PROXY_MODE
           value: "nftables"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+          value: "true"
+        - name: PROMETHEUS_SCRAPE_ETCD
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"


### PR DESCRIPTION
Mirrors the env of ci-kubernetes-e2e-gce-scale-performance-5000-experimental so the presubmit runs the same restart experiment.

etcd 36 experiment is completed.