### PR TITLE
Add kubernetes/kubernetes presubmit for windows e2e node tests

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/windows-e2enode.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-e2enode.yaml
@@ -39,6 +39,52 @@ periodics:
     testgrid-tab-name: windows-e2e-node-master
 
 presubmits:
+  kubernetes/kubernetes:
+    - name: pull-kubernetes-e2enode-windows-master
+      always_run: false
+      branches:
+        - master
+        - main
+      cluster: eks-prow-build-cluster
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      optional: true
+      labels:
+        preset-dind-enabled: "true"
+        preset-azure-community: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: windows-testing
+          base_ref: master
+          path_alias: sigs.k8s.io/windows-testing
+          workdir: true
+      path_alias: k8s.io/kubernetes
+      run_if_changed: '.*windows\.go$'
+      spec:
+        serviceAccountName: azure
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260615-7f7c36e951-master
+            command:
+              - "runner.sh"
+              - "./scripts/ci-k8s-e2e-node-test.sh"
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 2
+                memory: "5Gi"
+              limits:
+                cpu: 2
+                memory: "5Gi"
+            env:
+              - name: VM_LOCATION
+                value: northeurope
+              - name: CONTAINERD_VERSION
+                value: "nightly"
+      annotations:
+        testgrid-dashboards: sig-windows-presubmit
+        testgrid-tab-name: pr-kubernetes-e2enode-windows-master
   kubernetes-sigs/windows-testing:
     - name: pull-kubernetes-e2enode-windows
       always_run: false
@@ -71,6 +117,8 @@ presubmits:
             env:
               - name: VM_LOCATION
                 value: northeurope
+              - name: CONTAINERD_VERSION
+                value: "nightly"
       annotations:
         testgrid-dashboards: sig-windows-presubmit
         testgrid-tab-name: pr-windows-e2e-node-master

--- a/config/tests/jobs/policy/presubmit-jobs.yaml
+++ b/config/tests/jobs/policy/presubmit-jobs.yaml
@@ -104,6 +104,8 @@ optional_and_run_if_changed:
       run_if_changed: ^(pkg\/controller\/volume|pkg\/kubelet\/volumemanager|pkg\/volume|pkg\/util\/mount|test\/e2e\/storage|test\/e2e\/testing-manifests\/storage-csi)
     - name: pull-kubernetes-e2e-storage-kind-vac
       run_if_changed: ^(pkg\/controller\/volume|pkg\/kubelet\/volumemanager|pkg\/volume|pkg\/util\/mount|test\/e2e\/storage|test\/e2e\/testing-manifests\/storage-csi)
+    - name: pull-kubernetes-e2enode-windows-master
+      run_if_changed: .*windows\.go$
     - name: pull-kubernetes-kind-dra
       branches:
         - release-1.33


### PR DESCRIPTION
Split the e2e node presubmit into two jobs.
 one triggered on kubernetes/kubernetes PRs that touch
windows .go files (building kubelet from the PR), and one on kubernetes-sigs/windows-testing PRs that touch scripts.

Temp set the contianerd to use nightly build