### PR TITLE
Use nightly containerd in windows e2e node presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/windows-e2enode.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-e2enode.yaml
@@ -71,6 +71,8 @@ presubmits:
             env:
               - name: VM_LOCATION
                 value: northeurope
+              - name: CONTAINERD_VERSION
+                value: "nightly"
       annotations:
         testgrid-dashboards: sig-windows-presubmit
         testgrid-tab-name: pr-windows-e2e-node-master


### PR DESCRIPTION
Set CONTAINERD_VERSION=nightly on the pull-kubernetes-e2enode-windows presubmit so the windows-testing scripts install the nightly containerd build, matching the periodic ci-kubernetes-e2enode-windows-master job.