### PR TITLE
dra-driver-cpu: increase modernize job memory limit to 4Gi

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
@@ -20,10 +20,10 @@ presubmits:
         resources:
           limits:
             cpu: 1
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 1
-            memory: 2Gi
+            memory: 4Gi
   - name: pull-dra-driver-cpu-e2e-device-mode-individual-amd64
     cluster: eks-prow-build-cluster
     labels:


### PR DESCRIPTION
Sorry for the noise, but I see the job failing with `Job pod was OOM killed by the cluster` in https://github.com/kubernetes-sigs/dra-driver-cpu/pull/213. Hopefully, 4Gi is enough. 
