### PR TITLE
Graduate the restart experiment to the release-blocking and presubmit 5k jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -456,6 +456,8 @@ presubmits:
         #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
           value: "false"
+        - name: CL2_RESTART_APISERVER
+          value: "true"
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
           value: "21474836480"
         - name: CL2_EXECSERVICE_CPU_REQUESTS
@@ -484,6 +486,8 @@ presubmits:
           value: "false"
         - name: NODE_MODE
           value: "master"
+        - name: CONTROL_PLANE_COUNT
+          value: "3"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-96"
         - name: ADDONS_NODE_SIZE

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -123,6 +123,8 @@ periodics:
       env:
       - name: CL2_ENABLE_INFORMER_LATENCY_TEST
         value: "false"
+      - name: CL2_RESTART_APISERVER
+        value: "true"
       - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
         value: "21474836480"
       - name: CL2_EXECSERVICE_CPU_REQUESTS
@@ -150,7 +152,7 @@ periodics:
       - name: NODE_MODE
         value: "master"
       - name: CONTROL_PLANE_COUNT
-        value: "1"
+        value: "3"
       - name: CONTROL_PLANE_SIZE
         value: "c4-standard-96"
       - name: ADDONS_NODE_SIZE


### PR DESCRIPTION
Folds the `restart` experiment from the experimental 5k presubmit into the release-blocking `ci-kubernetes-e2e-gce-scale-performance-5000` and the `pull-kubernetes-gce-master-scale-performance-5000` presubmit.

It adds two parameters to both jobs:
- `CL2_RESTART_APISERVER: "true"` restarts the apiserver during the test
- `CONTROL_PLANE_COUNT: "3"` runs an HA control plane (was 1)

TestGrid shows 4 green runs: https://testgrid.k8s.io/sig-scalability-gce#pull-kubernetes-gce-master-scale-performance-5000-experimental

Individual runs:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-5000-experimental/2071719755345039360
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-5000-experimental/2071777797344333824
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-5000-experimental/2071835684926132224
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-5000-experimental/2071893300989661184

Most of the metrics looked similar. etcd db allocs increased (5.3gb -> 6.5gb) because restarting apiserver increased snapshots, HA creates leader election renews, etc.

## Metrics broken by HA

Two perfdash panels regress under the 3 master control plane. Both scrape a single instance instead of aggregating across the control plane. Numbers below are recent perfdash builds and vary run to run.

| Metric | Single master | HA | What happens | perfdash |
|---|---|---|---|---|
| Scheduler latency, Filter/load Perc99 | 2.1 to 2.5 ms, stable | 0 on most runs | Flips between the real latency and 0 build to build depending on whether the scraped master is the leader or a standby | [panel](https://perf-dash.k8s.io/#/?jobname=gce-5000Nodes&metriccategoryname=Scheduler&metricname=SchedulingLatency&Operation=Filter&TestName=load) |
| Init events, pods | 99M to 320M | 0.5M to 79M | Undercounts by a large factor | [panel](https://perf-dash.k8s.io/#/?jobname=gce-5000Nodes-experimental&metriccategoryname=APIServer&metricname=LoadInitEventsCount&group=&resource=pods) |

There is one diff that this still uses etcd 3.6 instead of 3.7. I figured since etcd 3.7 is releasing next week, we can just bump it there instead.


## Related PRs
- kubernetes/perf-tests#4179
- kubernetes/perf-tests#4180
- kubernetes/test-infra#37416