### PR TITLE
Add CAPZ v1.27 milestone to plugins

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -596,7 +596,8 @@ milestone_applier:
     release-2.6: v2.6
     release-2.5: v2.5
   kubernetes-sigs/cluster-api-provider-azure:
-    main: v1.26
+    main: v1.27
+    release-1.26: v1.26
     release-1.25: v1.25
     release-1.24: v1.24
   kubernetes-sigs/cluster-api-provider-digitalocean:


### PR DESCRIPTION
Updates the current milestone and supported branches for CAPZ to 1.27 and friends.