### PR TITLE
Add CAPZ release v1.26 tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.25.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.25.yaml
@@ -154,7 +154,7 @@ periodics:
         - name: GINKGO_FOCUS
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
-          value: \[Managed Kubernetes\]
+          value: \[Managed Kubernetes\]|\[KubeRay\]
       resources:
         limits:
           cpu: 6

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.26.yaml
@@ -154,7 +154,7 @@ periodics:
         - name: GINKGO_FOCUS
           value: "Workload cluster creation"
         - name: GINKGO_SKIP
-          value: \[Managed Kubernetes\]
+          value: \[Managed Kubernetes\]|\[KubeRay\]
       resources:
         limits:
           cpu: 6

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.26.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-v1beta1-release-1.26.yaml
@@ -1,0 +1,215 @@
+periodics:
+- name: periodic-cluster-api-provider-azure-conformance-v1beta1-release-1-26
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  minimum_interval: 72h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.26
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    serviceAccountName: azure
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260608-c0707d679d-1.32
+        command:
+          - runner.sh
+        args:
+          - ./scripts/ci-conformance.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 6
+            memory: "9Gi"
+          requests:
+            cpu: 6
+            memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-conformance-v1beta1-release-1-26
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs conformance & node conformance tests on a stable k8s version with cluster-api-provider-azure release-1.26 (v1beta1)
+- name: periodic-cluster-api-provider-azure-conformance-v1beta1-with-ci-artifacts-release-1-26
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  minimum_interval: 72h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.26
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    - org: kubernetes-sigs
+      repo: cloud-provider-azure
+      base_ref: master
+      path_alias: sigs.k8s.io/cloud-provider-azure
+      workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260608-c0707d679d-1.32
+        command:
+          - runner.sh
+        args:
+          - ./scripts/ci-conformance.sh
+        env:
+        - name: E2E_ARGS
+          value: "-kubetest.use-ci-artifacts"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 6
+            memory: "9Gi"
+          requests:
+            cpu: 6
+            memory: "9Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-conformance-k8s-ci-v1beta1-release-1-26
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Runs conformance & node conformance tests on latest kubernetes main with cluster-api-provider-azure release-1.26 (v1beta1)
+- name: periodic-cluster-api-provider-azure-capi-e2e-v1beta1-release-1-26
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  minimum_interval: 72h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.26
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260608-c0707d679d-1.32
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: "Cluster API E2E tests"
+        - name: GINKGO_SKIP
+          value: "\\[K8s-Upgrade\\]|API Version Upgrade"
+      resources:
+        limits:
+          cpu: 6
+          memory: "9Gi"
+        requests:
+          cpu: 6
+          memory: "9Gi"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-capi-e2e-v1beta1-release-1-26
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs Cluster API E2E tests on cluster-api-provider-azure release-1.26 (v1beta1)
+- name: periodic-cluster-api-provider-azure-e2e-v1beta1-release-1-26
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  minimum_interval: 72h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.26
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260608-c0707d679d-1.32
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: "Workload cluster creation"
+        - name: GINKGO_SKIP
+          value: \[Managed Kubernetes\]
+      resources:
+        limits:
+          cpu: 6
+          memory: "9Gi"
+        requests:
+          cpu: 6
+          memory: "9Gi"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-e2e-v1beta1-release-1-26
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs Cluster API Provider Azure E2E tests on cluster-api-provider-azure release-1.26 (v1beta1)
+- name: periodic-cluster-api-provider-azure-e2e-aks-v1beta1-release-1-26
+  cluster: eks-prow-build-cluster
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  minimum_interval: 72h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.26
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    serviceAccountName: azure
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260608-c0707d679d-1.32
+      command:
+        - runner.sh
+      args:
+        - ./scripts/ci-e2e.sh
+      env:
+        - name: GINKGO_FOCUS
+          value: \[Managed Kubernetes\]
+        - name: GINKGO_SKIP
+          value: ""
+      resources:
+        limits:
+          cpu: 6
+          memory: "9Gi"
+        requests:
+          cpu: 6
+          memory: "9Gi"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: capz-periodic-e2e-aks-v1beta1-release-1-26
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+    description: Runs managed Kubernetes E2E tests on cluster-api-provider-azure release-1.26 (v1beta1)


### PR DESCRIPTION
Adds capz-dependent periodic jobs for the new `release-1.26` branch. This is additive: we now support three release branches (`release-1.26`, `release-1.25`, `release-1.24`). Follows the v1.25 bump in kubernetes/test-infra#37347.

/area jobs
/sig cluster-lifecycle