### PR TITLE
cluster-autoscaler: Add 1.36 Azure E2E

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/azure/cluster-autoscaler-azure-presubmits.yaml
@@ -59,6 +59,65 @@ presubmits:
           limits:
             cpu: 4
             memory: "9Gi"
+  - name: pull-cluster-autoscaler-e2e-azure-1-36
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-autoscaling-cluster-autoscaler
+      testgrid-tab-name: cloudprovider-azure-1.36
+    always_run: false
+    optional: true
+    run_if_changed: 'cluster-autoscaler\/cloudprovider\/azure'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-community: "true"
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    path_alias: k8s.io/autoscaler
+    branches:
+      - cluster-autoscaler-release-1.36
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: release-1.24
+      path_alias: sigs.k8s.io/cluster-api-provider-azure
+      workdir: true
+    spec:
+      serviceAccountName: azure
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-1.36
+        command:
+          - runner.sh
+          - ./scripts/ci-entrypoint.sh
+        args:
+          - bash
+          - -c
+          - |
+            cd ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test
+            make test-e2e TAG=$(git rev-parse --short HEAD)
+        env:
+          # CAPZ config
+          - name: ADDITIONAL_ASO_CRDS
+            value: authorization.azure.com/*;managedidentity.azure.com/* # needed for this CLUSTER_TEMPLATE
+          - name: KUBERNETES_VERSION
+            value: "1.36"
+          - name: AKS_TIER
+            value: "Premium" # required for LTS
+          - name: AKS_SUPPORT_PLAN
+            value: "AKSLongTermSupport" # Use LTS
+          - name: CLUSTER_TEMPLATE
+            value: ${GOPATH}/src/k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure/test/templates/cluster-template-prow-aks-aso-cluster-autoscaler.yaml
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 4
+            memory: "9Gi"
+          limits:
+            cpu: 4
+            memory: "9Gi"
   - name: pull-cluster-autoscaler-e2e-azure-1-35
     cluster: eks-prow-build-cluster
     annotations:


### PR DESCRIPTION
This PR adds a Cluster Autoscaler Azure E2E test against the 1.36 release branch of Cluster Autoscaler.