### PR TITLE
cluster-api-provider-aws: bump build-docker job memory to 12Gi

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-main.yaml
@@ -106,10 +106,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "8Gi"
+            memory: "12Gi"
           limits:
             cpu: "4"
-            memory: "8Gi"
+            memory: "12Gi"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.10.yaml
@@ -106,10 +106,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "8Gi"
+            memory: "12Gi"
           limits:
             cpu: "4"
-            memory: "8Gi"
+            memory: "12Gi"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.11.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.11.yaml
@@ -106,10 +106,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "8Gi"
+            memory: "12Gi"
           limits:
             cpu: "4"
-            memory: "8Gi"
+            memory: "12Gi"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.9.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits-release-2.9.yaml
@@ -106,10 +106,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "8Gi"
+            memory: "12Gi"
           limits:
             cpu: "4"
-            memory: "8Gi"
+            memory: "12Gi"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/templates/cluster-api-provider-aws-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/templates/cluster-api-provider-aws-presubmits.yaml.tpl
@@ -105,10 +105,10 @@ presubmits:
         resources:
           requests:
             cpu: "4"
-            memory: "8Gi"
+            memory: "12Gi"
           limits:
             cpu: "4"
-            memory: "8Gi"
+            memory: "12Gi"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
The `pull-cluster-api-provider-aws-build-docker` job intermittently OOMs
during GoReleaser cross-compilation (`--parallelism 2`) of the large
`aws-sdk-go-v2/service/ec2` package under the current 8Gi memory limit.

Example failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-aws/6073/pull-cluster-api-provider-aws-build-docker/2072596257372639232

This bumps memory requests/limits from 8Gi to 12Gi for the build-docker
job across all branches (main, release-2.9, release-2.10, release-2.11),
consistent with the higher limits already used by other CAPA jobs (e.g.
the test job uses 16Gi).

/cc @kubernetes-sigs/cluster-api-provider-aws-maintainers @upodroid