### PR TITLE
SIG testing: focus on client-go in pull-kubernetes-apidiff-client-go

### DIFF
--- a/config/jobs/kubernetes/sig-testing/apidiff.yaml
+++ b/config/jobs/kubernetes/sig-testing/apidiff.yaml
@@ -51,10 +51,12 @@ presubmits:
 
   - name: pull-kubernetes-apidiff-client-go
     cluster: eks-prow-build-cluster
-    # A job which automatically runs for changes in client-go or the generated code
+    # A job which automatically runs for changes in client-go
     # to have visibility on the changes that will impact the external projects
-    # that are using the Kubernetes golang clients
-    run_if_changed: '((^staging\/src\/k8s.io\/client-go)|(^staging\/src\/k8s.io\/code-generator\/examples))/.*\.go'
+    # that are using the Kubernetes golang clients.
+    # Breaking Go API changes cause it to fail unless the
+    # client-go/CHANGELOG.md file documents those changes.
+    run_if_changed: '^staging\/src\/k8s.io\/client-go/.*\.go'
     optional: true
     decorate: true
     annotations:
@@ -73,7 +75,7 @@ presubmits:
         - /bin/sh
         - -c
         # Base and target are detected automatically by the script based on Prow variables.
-        - "./hack/apidiff.sh ./staging/src/k8s.io/code-generator/examples ./staging/src/k8s.io/client-go"
+        - "./hack/apidiff.sh ./staging/src/k8s.io/client-go"
         resources:
           # Memory limits are derived from pull-kubernetes-verify, with less CPUs.
           limits:

--- a/config/tests/jobs/policy/presubmit-jobs.yaml
+++ b/config/tests/jobs/policy/presubmit-jobs.yaml
@@ -25,7 +25,7 @@ optional_and_run_if_changed:
     - name: check-dependency-stats
       run_if_changed: ^(go.mod|go.sum|vendor)
     - name: pull-kubernetes-apidiff-client-go
-      run_if_changed: ((^staging\/src\/k8s.io\/client-go)|(^staging\/src\/k8s.io\/code-generator\/examples))/.*\.go
+      run_if_changed: ^staging\/src\/k8s.io\/client-go/.*\.go
     - name: pull-kubernetes-audit-kind-conformance
       run_if_changed: ^(test/conformance/testdata/|api/openapi-spec/)
     - name: pull-kubernetes-conformance-image-test


### PR DESCRIPTION
This makes it possible to achieve a clean job run by documenting breaking Go API changes in the client-go/CHANGELOG.md file. This is not possible when also changing code-generator/examples because that has no CHANGELOG.md file.

When documentation of breaking Go API changes become mandatory the check in pull-kubernetes-verify will replace this optional pre-submit.