### PR TITLE
SIG-Storage: run container-object-storage-interface e2e on kops

### DIFF
--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface.yaml
@@ -129,30 +129,43 @@ presubmits:
               resource: limits.cpu
 
   - name: pull-container-object-storage-interface-e2e
-    cluster: eks-prow-build-cluster
-    always_run: true
+    cluster: k8s-infra-prow-build
+    always_run: false
+    optional: true
     decorate: true
     path_alias: sigs.k8s.io/container-object-storage-interface
     labels:
-      preset-dind-enabled: "true" # e2e uses docker and kind, requires DinD
+      preset-dind-enabled: "true" # e2e builds images with docker, requires DinD
+      preset-service-account: "true" # kops uses boskos-backed GCE projects
+      preset-k8s-ssh: "true" # kops needs SSH access to nodes
+    extra_refs:
+    - org: kubernetes
+      repo: kops
+      base_ref: master
+      path_alias: k8s.io/kops
     annotations:
       testgrid-dashboards: sig-storage-container-object-storage-interface
-      testgrid-tab-name: e2e
-      description: E2e tests in container-object-storage-interface repo.
+      testgrid-tab-name: e2e-kops-gce
+      description: E2e tests in container-object-storage-interface repo on a kops-created GCE cluster.
     spec:
+      serviceAccountName: k8s-kops-test
       containers:
       - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
         command:
         - runner.sh
         args:
-        - ./hack/prow-e2e.sh
+        - bash
+        - -xc
+        - |
+          make -C $GOPATH/src/k8s.io/kops test-e2e-install
+          ./hack/prow-e2e-kops.sh
         resources:
           limits:
             cpu: 4
-            memory: 6Gi
+            memory: 14Gi
           requests:
             cpu: 4
-            memory: 6Gi
+            memory: 14Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Move the COSI E2E presubmit from the EKS/Kind-style setup to the k8s-infra-prow-build cluster with kubetest2-kops dependencies.

The job now checks out kops, uses the kops test service account and GCE presets, and invokes the repo-side kops E2E entrypoint while remaining optional during bring-up.