### PR TITLE
Add WAS e2e presubmit for jobset

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -207,6 +207,42 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-jobset-test-e2e-main-was
+    cluster: eks-prow-build-cluster
+    optional: true
+    branches:
+    - ^main
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    decorate: true
+    path_alias: sigs.k8s.io/jobset
+    annotations:
+      testgrid-dashboards: sig-apps-jobset-presubmits
+      testgrid-tab-name: pull-jobset-test-e2e-main-was
+      description: "Run jobset end to end scheduling tests with WAS feature gates enabled"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
+          env:
+            - name: BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang:1.26
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind-scheduling
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-jobset-verify-main
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds an optional e2e presubmit job for `kubernetes-sigs/jobset` that exercises Workload-Aware Scheduling (WAS), mirroring the existing `pull-kueue-test-e2e-k8s-main-was` presubmit added for kueue.

The new job (`pull-jobset-test-e2e-main-was`) runs `make test-e2e-kind-scheduling`, which is the actual WAS e2e make target defined in jobset's `Makefile` (jobset's target names differ slightly from kueue's, and `test-e2e-kind-scheduling` already depends on `kind-image-build`, so it does not need to be invoked separately).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for reviewer**:

- Job is `optional: true` so it will not block PR merges while WAS support in jobset is still maturing, matching how the kueue WAS presubmit was initially introduced.
- Verified against `../jobset`'s `Makefile` that `test-e2e-kind-scheduling` is the correct target for running WAS-gated e2e tests (see `WAS_KIND_CLUSTER_NAME`/`WAS_NODE_IMAGE` and related targets).

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
