### PR TITLE
Bump kpromo presubmits to v4.5.1-0

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/releng/artifact-promotion-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v4.2.0-0
+      - image: registry.k8s.io/artifact-promoter/kpromo:v4.5.1-0
         command:
         - /kpromo
         args:
@@ -67,7 +67,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: registry.k8s.io/artifact-promoter/kpromo:v4.2.0-0
+      - image: registry.k8s.io/artifact-promoter/kpromo:v4.5.1-0
         command:
         - /kpromo
         args:


### PR DESCRIPTION
#37195 rolled the image promotion postsubmit and periodic jobs to v4.5.1-0 but left the pull-k8sio-cip and pull-k8sio-file-promo presubmits on v4.2.0-0. That older binary times out when a prow manifest diff contains no digests, which is failing pull-k8sio-cip on kubernetes/k8s.io#9674.