### PR TITLE
sig-scalability-presubmit-jobs: align testgrid tab name with prow job name for 5k scale presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -438,7 +438,7 @@ presubmits:
       path_alias: k8s.io/perf-tests
     annotations:
       testgrid-dashboards: presubmits-kubernetes-scalability, sig-scalability-gce
-      testgrid-tab-name: pull-kubernetes-e2e-gce-master-scale-performance-5000
+      testgrid-tab-name: pull-kubernetes-gce-master-scale-performance-5000
     spec:
       serviceAccountName: prow-build
       tolerations:


### PR DESCRIPTION
renames the tab to match the job name `pull-kubernetes-gce-master-scale-performance-5000`

xref: https://testgrid.k8s.io/sig-scalability-gce#pull-kubernetes-e2e-gce-master-scale-performance-5000

also, renaming the tab will wipe the history.