### PR TITLE
Bump kops version in staging-registry jobs

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -129,7 +129,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --create-args="--channel=alpha --gce-service-account=default --networking=kubenet --set=spec.assets.containerProxy=registry-sandbox.k8s.io" \
-          --kops-version=1.34.1 \
+          --kops-version=1.35.1 \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
           -- \
@@ -156,9 +156,9 @@ periodics:
     test.kops.k8s.io/cloud: gce
     test.kops.k8s.io/distro: u2404
     test.kops.k8s.io/extra_flags: --channel=alpha --gce-service-account=default --networking=kubenet --set=spec.assets.containerProxy=registry-sandbox.k8s.io
-    test.kops.k8s.io/k8s_version: '1.34'
+    test.kops.k8s.io/k8s_version: 'stable'
     test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: 'latest'
+    test.kops.k8s.io/kops_version: '1.35'
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: sig-k8s-infra-canaries, sig-k8s-infra-registry
     testgrid-days-of-results: '7'
@@ -193,7 +193,7 @@ periodics:
           --up --down \
           --cloud-provider=azure \
           --create-args="--channel=alpha --networking=kubenet --set=spec.assets.containerProxy=registry-sandbox.k8s.io" \
-          --kops-version=1.34.1 \
+          --kops-version=1.35.1 \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
           -- \
@@ -215,9 +215,9 @@ periodics:
     test.kops.k8s.io/cloud: azure
     test.kops.k8s.io/distro: u2404
     test.kops.k8s.io/extra_flags: --channel=alpha --networking=kubenet --set=spec.assets.containerProxy=registry-sandbox.k8s.io
-    test.kops.k8s.io/k8s_version: '1.34'
+    test.kops.k8s.io/k8s_version: 'stable'
     test.kops.k8s.io/kops_channel: alpha
-    test.kops.k8s.io/kops_version: 'latest'
+    test.kops.k8s.io/kops_version: '1.35'
     test.kops.k8s.io/networking: kubenet
     testgrid-dashboards: sig-k8s-infra-canaries, sig-k8s-infra-registry
     testgrid-days-of-results: '7'


### PR DESCRIPTION
This should fix this cluster creation failure:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-staging-registry-azure/2073180188019003392

`W0703 23:04:24.499754    9643 state.go:46] failed to run /home/prow/go/src/k8s.io/kops/_rundir/7452e344-82aa-42f2-ad97-5931f0bc0104/kops get cluster e2e-e2e-kops-staging-registry-azure -ojson; stderr=Error: error reading cluster configuration "e2e-e2e-kops-staging-registry-azure": error reading &{%!s(*vfs.VFSContext=&{{{} {0 0}} {0xc0004ca5d0 0xc792640 <nil> <nil> <nil> <nil>}}) stkopsstatestore cluster-state/e2e-e2e-kops-staging-registry-azure/config }: AZURE_STORAGE_ACCOUNT must be set`

/cc @hakman