### PR TITLE
Add Kops Azure FF to staging-registry job

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/registry.k8s.io/canaries.yaml
@@ -193,6 +193,7 @@ periodics:
           --up --down \
           --cloud-provider=azure \
           --create-args="--channel=alpha --networking=kubenet --set=spec.assets.containerProxy=registry-sandbox.k8s.io" \
+          --env KOPS_FEATURE_FLAGS=Azure \
           --kops-version=1.35.1 \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/37388

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-staging-registry-azure/2073316085267959808

`Error: azure support is currently alpha, and is feature-gated. Please export KOPS_FEATURE_FLAGS=Azure`

/cc @hakman