### PR TITLE
publish CI images to ECR as well

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -14,7 +14,7 @@
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
 
-FROM debian:bookworm-20251020
+FROM debian:bookworm-20250623
 
 WORKDIR /workspace
 RUN mkdir -p /workspace

--- a/images/kubekins-e2e-v2/Dockerfile
+++ b/images/kubekins-e2e-v2/Dockerfile
@@ -14,7 +14,7 @@
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
 
-FROM debian:bookworm-20260112
+FROM debian:bookworm-20260623
 ARG TARGETARCH
 
 WORKDIR /workspace

--- a/images/kubekins-e2e-v2/cloudbuild.yaml
+++ b/images/kubekins-e2e-v2/cloudbuild.yaml
@@ -1,25 +1,59 @@
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
-    entrypoint: /buildx-entrypoint
+  - name: amazon/aws-cli
+    entrypoint: /bin/bash
     args:
-    - build
-    - --tag=$_REGISTRY/kubekins-e2e:$_GIT_TAG-$_CONFIG
-    - --tag=$_REGISTRY/kubekins-e2e:latest-$_CONFIG
-    - --build-arg=IMAGE_ARG=$_REGISTRY/kubekins-e2e:$_GIT_TAG-$_CONFIG
-    - --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-    - --build-arg=CFSSL_VERSION=$_CFSSL_VERSION
-    - --build-arg=K8S_RELEASE=$_K8S_RELEASE
-    - --build-arg=K8S_BRANCH=$_K8S_BRANCH
-    - --build-arg=KIND_VERSION=$_KIND_VERSION
-    - --build-arg=KUBETEST2_VERSION=$_KUBETEST2_VERSION
-    - --build-arg=YQ_VERSION=$_YQ_VERSION
-    - --build-arg=DOCKER_VERSION=$_DOCKER_VERSION
-    - --build-arg=HELM_VERSION=$_HELM_VERSION
-    - --build-arg=GH_VERSION=$_GH_VERSION
-    - --push
-    - .
+    - -c
+    - |
+      if [[ "$_REGISTRY" == gcr.io/* ]]; then
+        echo "Detected a presubmit cloudbuild job, skipping AWS ECR login."
+        exit 0
+      fi
+
+      export AWS_ROLE_ARN=$_AWS_ROLE_ARN
+      export AWS_ROLE_SESSION_NAME=cloudbuild-$BUILD_ID
+      export AWS_REGION=$_AWS_REGION
+      mkdir -p ~/.aws/
+      cat << 'EOF' >> ~/.aws/config
+      [profile cloudbuild]
+      credential_process = /workspace/login.sh
+      EOF
+      
+      dnf update -y && dnf install docker -y -q > /dev/null 2>&1
+      aws sts get-caller-identity --profile cloudbuild
+      aws ecr get-login-password --profile cloudbuild | docker login --username AWS --password-stdin "$_AWS_ECR_REGISTRY"
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+    args:
+    - bash
+    - -c
+    - |
+      OUTPUT="type=registry,unpack=false"
+      if [[ "$_REGISTRY" == gcr.io/* ]]; then
+        echo "Detected a presubmit cloudbuild job, skipping image push"
+        OUTPUT="type=oci,dest=path=/tmp/image.tar.gz"
+      fi
+      docker buildx build \
+        --tag=$_REGISTRY/kubekins-e2e:$_GIT_TAG-$_CONFIG \
+        --tag=$_REGISTRY/kubekins-e2e:latest-$_CONFIG \
+        --tag=$_AWS_ECR_REGISTRY/prow/kubekins-e2e:$_GIT_TAG-$_CONFIG \
+        --tag=$_AWS_ECR_REGISTRY/prow/kubekins-e2e:latest-$_CONFIG \
+        --build-arg=IMAGE_ARG=$_REGISTRY/kubekins-e2e:$_GIT_TAG-$_CONFIG \
+        --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
+        --build-arg=CFSSL_VERSION=$_CFSSL_VERSION \
+        --build-arg=K8S_RELEASE=$_K8S_RELEASE \
+        --build-arg=K8S_BRANCH=$_K8S_BRANCH \
+        --build-arg=KIND_VERSION=$_KIND_VERSION \
+        --build-arg=KUBETEST2_VERSION=$_KUBETEST2_VERSION \
+        --build-arg=YQ_VERSION=$_YQ_VERSION \
+        --build-arg=DOCKER_VERSION=$_DOCKER_VERSION \
+        --build-arg=HELM_VERSION=$_HELM_VERSION \
+        --build-arg=GH_VERSION=$_GH_VERSION \
+        --output=$$OUTPUT \
+        .
     dir: .
 substitutions:
+  _AWS_ECR_REGISTRY: 468814281478.dkr.ecr.us-east-2.amazonaws.com
+  _AWS_REGION: us-east-2
+  _AWS_ROLE_ARN: arn:aws:iam::468814281478:role/cloudbuild
   _CFSSL_VERSION: 1.6.5
   _CONFIG: master
   _GIT_TAG: '12345'
@@ -27,10 +61,10 @@ substitutions:
   _K8S_BRANCH: master
   _KIND_VERSION: '0.32.0'
   _KUBETEST2_VERSION: 'master'
-  _YQ_VERSION: v4.49.2
+  _YQ_VERSION: v4.53.3
   _DOCKER_VERSION: 5:29.*
-  _HELM_VERSION: v4.1.0
-  _GH_VERSION: 2.92.0
+  _HELM_VERSION: v4.2.2
+  _GH_VERSION: 2.96.0
   _REGISTRY: us-central1-docker.pkg.dev/k8s-staging-test-infra/images
 timeout: 3600s
 options:

--- a/images/kubekins-e2e-v2/login.sh
+++ b/images/kubekins-e2e-v2/login.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+jwt_token=$(curl -sH "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=sts.amazonaws.com&format=full&licenses=FALSE")
+
+credentials=$(aws sts assume-role-with-web-identity --role-arn $AWS_ROLE_ARN --role-session-name $AWS_ROLE_SESSION_NAME --web-identity-token $jwt_token | jq '.Credentials' | jq '.Version=1')
+
+echo $credentials

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -21,11 +21,11 @@ FROM gcr.io/k8s-staging-test-infra/bootstrap:v20251209-855adc2699
 ENV KUBETEST_IN_DOCKER="true"
 
 # Go standard envs
-ENV GOPATH /go
-ENV PATH /usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=/usr/local/go/bin:$PATH
 
 RUN mkdir -p /go/bin
-ENV PATH $GOPATH/bin:$PATH
+ENV PATH=$GOPATH/bin:$PATH
 
 # setup k8s repo symlink
 RUN mkdir -p /go/src/k8s.io/kubernetes \
@@ -68,7 +68,7 @@ RUN rm -f $(which kubectl) && \
 ARG GO_VERSION
 ARG K8S_BRANCH
 RUN if [ -z "${GO_VERSION}" ]; then \
-      GO_VERSION=$(curl --retry 6 --retry-connrefused -fsSL "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/heads/${K8S_BRANCH}/.go-version"); \
+    GO_VERSION=$(curl --retry 6 --retry-connrefused -fsSL "https://raw.githubusercontent.com/kubernetes/kubernetes/refs/heads/${K8S_BRANCH}/.go-version"); \
     fi && \
     export GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz" && \
     wget -q "https://go.dev/dl/${GO_TARBALL}" && \
@@ -119,6 +119,6 @@ ADD ["images/kubekins-e2e/kops-e2e-runner.sh", \
     "logexporter/cluster/log-dump.sh", \
     "logexporter/cluster/logexporter-daemonset.yaml", \
     "/workspace/"]
-ENV LOG_DUMP_SCRIPT_PATH "/workspace/log-dump.sh"
+ENV LOG_DUMP_SCRIPT_PATH="/workspace/log-dump.sh"
 RUN ["chmod", "+x", "/workspace/get-kube.sh", "/workspace/log-dump.sh"]
 

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -1,4 +1,21 @@
 steps:
+  - name: amazon/aws-cli
+    entrypoint: /bin/bash
+    args:
+    - -c
+    - |
+      export AWS_ROLE_ARN=$_AWS_ROLE_ARN
+      export AWS_ROLE_SESSION_NAME=cloudbuild-$BUILD_ID
+      export AWS_REGION=$_AWS_REGION
+      mkdir -p ~/.aws/
+      cat << 'EOF' >> ~/.aws/config
+      [profile cloudbuild]
+      credential_process = /workspace/images/kubekins-e2e/login.sh
+      EOF
+      
+      dnf update -y && dnf install docker -y -q > /dev/null 2>&1
+      aws sts get-caller-identity --profile cloudbuild
+      aws ecr get-login-password --profile cloudbuild | docker login --username AWS --password-stdin "$_AWS_ECR_REGISTRY"
   - name: golang:latest
     args:
     - go
@@ -13,10 +30,16 @@ steps:
     - GO111MODULE=on
     - GOPROXY=https://proxy.golang.org
     - GOSUMDB=sum.golang.org
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
     args:
+    - docker
+    - buildx
     - build
     - --tag=gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG
+    - --tag=gcr.io/$PROJECT_ID/kubekins-e2e:latest-$_CONFIG
+    - --tag=$_AWS_ECR_REGISTRY/prow/kubekins-e2e-v1:$_GIT_TAG-$_CONFIG
+    - --tag=$_AWS_ECR_REGISTRY/prow/kubekins-e2e-v1:latest-$_CONFIG
+    - --platform=linux/amd64
     - --build-arg=BAZEL_VERSION_ARG=$_BAZEL_VERSION
     - --build-arg=CFSSL_VERSION=$_CFSSL_VERSION
     - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG
@@ -25,35 +48,31 @@ steps:
     - --build-arg=KIND_VERSION=$_KIND_VERSION
     - --build-arg=KUBETEST2_VERSION=$_KUBETEST2_VERSION
     - --build-arg=YQ_VERSION=$_YQ_VERSION
+    - --push
     - -f
     - images/kubekins-e2e/Dockerfile
     - .
-    dir: .
-  - name: gcr.io/cloud-builders/docker
-    args:
-    - tag
-    - gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG
-    - gcr.io/$PROJECT_ID/kubekins-e2e:latest-$_CONFIG
     dir: .
 substitutions:
   _BAZEL_VERSION: 5.2.0
   _OLD_BAZEL_VERSION: 3.4.1
   _CFSSL_VERSION: R1.2
+  _AWS_ECR_REGISTRY: 468814281478.dkr.ecr.us-east-2.amazonaws.com
+  _AWS_REGION: us-east-2
+  _AWS_ROLE_ARN: arn:aws:iam::468814281478:role/cloudbuild
   _CONFIG: master
   _GIT_TAG: '12345'
   _K8S_RELEASE: stable
   _K8S_BRANCH: master
   _KIND_VERSION: ''
   _KUBETEST2_VERSION: 'master'
-  _YQ_VERSION: v4.47.2
+  _YQ_VERSION: v4.53.3
 timeout: 7200s
 options:
   substitution_option: ALLOW_LOOSE
   # this is a large and critical CI image, builds are slow on the default 1 core
   machineType: E2_HIGHCPU_32
-images:
-  - 'gcr.io/$PROJECT_ID/kubekins-e2e:$_GIT_TAG-$_CONFIG'
-  - 'gcr.io/$PROJECT_ID/kubekins-e2e:latest-$_CONFIG'
+serviceAccount: projects/k8s-staging-test-infra/serviceAccounts/gcb-image-builder@k8s-staging-test-infra.iam.gserviceaccount.com
 tags:
   - kubekins-e2e
   - $_CONFIG

--- a/images/kubekins-e2e/login.sh
+++ b/images/kubekins-e2e/login.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+jwt_token=$(curl -sH "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=sts.amazonaws.com&format=full&licenses=FALSE")
+
+credentials=$(aws sts assume-role-with-web-identity --role-arn $AWS_ROLE_ARN --role-session-name $AWS_ROLE_SESSION_NAME --web-identity-token $jwt_token | jq '.Credentials' | jq '.Version=1')
+
+echo $credentials


### PR DESCRIPTION
This change will dual-publish the CI images, and we'll use kyverno to mutate the images in EKS. The image pulls should be faster and cheaper now.






