### PR TITLE
add service account flag to image builder

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-test-infra.yaml
+++ b/config/jobs/image-pushing/k8s-staging-test-infra.yaml
@@ -266,6 +266,7 @@ postsubmits:
           args:
           - --scratch-bucket=gs://k8s-staging-test-infra-gcb
           - --project=k8s-staging-test-infra
+          - --service-account=projects/k8s-staging-test-infra/serviceAccounts/gcb-image-builder@k8s-staging-test-infra.iam.gserviceaccount.com
           - images/kubekins-e2e-v2/
     - name: post-test-infra-push-alpine
       cluster: k8s-infra-prow-build-trusted

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:545.0.0-alpine
+FROM google/cloud-sdk:575.0.0-alpine
 COPY builder run.sh /
 CMD ["/run.sh"]

--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -199,6 +199,10 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 		args = append(args, "--worker-pool", o.workerPool)
 	}
 
+	if o.serviceAccount != "" {
+		args = append(args, "--service-account", o.serviceAccount)
+	}
+
 	if o.region != "" {
 		args = append(args, "--region", o.region)
 	}
@@ -371,6 +375,7 @@ type options struct {
 	machineType      string
 	workerPool       string
 	region           string
+	serviceAccount   string
 
 	// withGitDirectory will include the .git directory when uploading the source to GCB
 	withGitDirectory bool
@@ -404,6 +409,7 @@ func parseFlags() options {
 	flag.StringVar(&o.region, "region", "global", "If specified, use the given region for the GCB build, otherwise 'global' is used.")
 	flag.StringVar(&o.machineType, "machine-type", "", "If specified, use the given machine type for the GCB build.")
 	flag.StringVar(&o.workerPool, "worker-pool", "", "If specified, use the given worker pool for the GCB build.")
+	flag.StringVar(&o.serviceAccount, "service-account", "", "If specified, use the given service account for the GCB build.")
 
 	flag.Parse()
 


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/37390 requires a custom service account but we need to run it in a presubmit so the service account has to be passed via the flag.


