### PR TITLE
E2E node containerd: enable slow and serial tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -31,7 +31,7 @@ periodics:
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]"
           - --timeout=80m
         env:
           - name: GOPATH
@@ -47,7 +47,7 @@ periodics:
     testgrid-dashboards: sig-release-master-blocking, sig-node-release-blocking, sig-node-containerd
     testgrid-tab-name: ci-node-e2e
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, release-team@kubernetes.io
-    description: "Uses kubetest to run node-e2e tests (+NodeConformance, -Flaky|Slow|Serial)"
+    description: "Uses kubetest to run node-e2e tests with containerd, including slow and serial tests (+NodeConformance, -Flaky)"
 
 - name: ci-kubernetes-node-kubelet-serial-containerd
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -61,6 +61,7 @@ presubmits:
         testgrid-alert-stale-results-hours: "24"
         testgrid-create-test-group: "true"
         testgrid-num-failures-to-alert: "10"
+        description: "Uses kubetest to run node-e2e tests with containerd, excluding slow and serial tests (+NodeConformance, -Flaky|Slow|Serial)"
       always_run: true
       optional: false
       decorate: true
@@ -90,6 +91,100 @@ presubmits:
               - --node-tests=true
               - --provider=gce
               - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
+              - --timeout=80m
+              - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
+            resources:
+              limits:
+                cpu: "4"
+                memory: "6Gi"
+              requests:
+                cpu: "4"
+                memory: "6Gi"
+    - name: pull-kubernetes-node-e2e-containerd-slow
+      skip_branches:
+        - release-\d+\.\d+ # per-release image
+      annotations:
+        fork-per-release: "true"
+        testgrid-alert-stale-results-hours: "24"
+        testgrid-create-test-group: "true"
+        testgrid-num-failures-to-alert: "10"
+        description: "Uses kubetest to run slow node-e2e tests with containerd (+NodeConformance, +Slow, -Flaky|Serial)"
+      always_run: false
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 90m
+      path_alias: k8s.io/kubernetes
+      extra_refs:
+        - org: kubernetes
+          repo: test-infra
+          base_ref: master
+          path_alias: k8s.io/test-infra
+      cluster: k8s-infra-prow-build
+      max_concurrency: 12
+      labels:
+        preset-service-account: "true"
+        preset-k8s-ssh: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
+            command:
+              - runner.sh
+              - /workspace/scenarios/kubernetes_e2e.py
+            args:
+              - --deployment=node
+              - --gcp-zone=us-central1-b
+              - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              - --node-tests=true
+              - --provider=gce
+              - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && !Serial && Slow && NodeConformance"
+              - --timeout=80m
+              - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
+            resources:
+              limits:
+                cpu: "4"
+                memory: "6Gi"
+              requests:
+                cpu: "4"
+                memory: "6Gi"
+    - name: pull-kubernetes-node-e2e-containerd-serial
+      skip_branches:
+        - release-\d+\.\d+ # per-release image
+      annotations:
+        fork-per-release: "true"
+        testgrid-alert-stale-results-hours: "24"
+        testgrid-create-test-group: "true"
+        testgrid-num-failures-to-alert: "10"
+        description: "Uses kubetest to run slow node-e2e tests with containerd (+NodeConformance, +Serial, -Flaky|Slow)"
+      always_run: false
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 90m
+      path_alias: k8s.io/kubernetes
+      extra_refs:
+        - org: kubernetes
+          repo: test-infra
+          base_ref: master
+          path_alias: k8s.io/test-infra
+      cluster: k8s-infra-prow-build
+      max_concurrency: 12
+      labels:
+        preset-service-account: "true"
+        preset-k8s-ssh: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
+            command:
+              - runner.sh
+              - /workspace/scenarios/kubernetes_e2e.py
+            args:
+              - --deployment=node
+              - --gcp-zone=us-central1-b
+              - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              - --node-tests=true
+              - --provider=gce
+              - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && Serial && !Slow && NodeConformance"
               - --timeout=80m
               - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
             resources:

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -29,6 +29,12 @@ dashboards:
     - name: pull-node-e2e
       test_group_name: pull-kubernetes-node-e2e-containerd
       base_options: width=10
+    - name: pull-node-e2e-serial
+      test_group_name: pull-kubernetes-node-e2e-containerd-serial
+      base_options: width=10
+    - name: pull-node-e2e-slow
+      test_group_name: pull-kubernetes-node-e2e-containerd-slow
+      base_options: width=10
     - name: pull-e2e-gce
       test_group_name: pull-kubernetes-e2e-containerd-gce
       base_options: width=10


### PR DESCRIPTION
Apparently slow and serial node conformance tests were not run in any periodic for containerd. We should close that gap. The existing ci-kubernetes-node-e2e-containerd has an interval of 2 hours. That should give us enough time to run also slow and serial tests in that same job, without having to increase the interval and thus loosing resolution when looking for commits which introduced a regression.

When working on slow or serial tests or features covered by those there should be a way to run those tests before merging. Using --label-filter it is possible to define jobs that are complementary to the existing pull-kubernetes-node-e2e-containerd. This is better than a job running all tests because it enables running just a relevant subset of the overall tests and avoids wasting resources on running the same non-slow, non-serial test twice.