### PR TITLE
Bump kindest/node to v1.36.1 in jobset presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -188,7 +188,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260629-f759c32706-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.36.0
+              value: kindest/node:v1.36.1
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.26
           command:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-11.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-11.yaml
@@ -182,7 +182,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260629-f759c32706-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.36.0
+              value: kindest/node:v1.36.1
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.26
           command:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-12.yaml
@@ -182,7 +182,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260629-f759c32706-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.36.0
+              value: kindest/node:v1.36.1
             - name: BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang:1.26
           command:


### PR DESCRIPTION
## What this PR does

Bumps `kindest/node:v1.36.0` → `kindest/node:v1.36.1` in the jobset presubmit e2e jobs for all branches:
- `jobset-presubmit-main.yaml`
- `jobset-presubmit-release-0-11.yaml`
- `jobset-presubmit-release-0-12.yaml`

## Why

PR #37393 fixed the periodics by bumping to `kindest/node:v1.36.1`, but the corresponding presubmit jobs were missed. This causes presubmit e2e failures like:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_jobset/1263/pull-jobset-test-e2e-release-0-12-1-36/2074171593654800384

## Note

This PR was authored with assistance from an AI coding agent (Claude).