### PR TITLE
E2E node containerd: revert ci-kubernetes-node-e2e-containerd changes

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-k8s-ssh: "true"
   decorate: true
   decoration_config:
-    timeout: 110m # Still lower than the 2h interval, but getting close after adding serial jobs.
+    timeout: 90m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -31,7 +31,7 @@ periodics:
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]"
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
           - --timeout=80m
         env:
           - name: GOPATH
@@ -47,7 +47,7 @@ periodics:
     testgrid-dashboards: sig-release-master-blocking, sig-node-release-blocking, sig-node-containerd
     testgrid-tab-name: ci-node-e2e
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, release-team@kubernetes.io
-    description: "Uses kubetest to run node-e2e tests with containerd, including slow and serial tests (+NodeConformance, -Flaky)"
+    description: "Uses kubetest to run node-e2e tests with containerd, excluding slow and serial tests (+NodeConformance, -Flaky|Slow|Serial)"
 
 - name: ci-kubernetes-node-kubelet-serial-containerd
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
This reverts ci-kubernetes-node-e2e-containerd back to excluding serial and slow tests. They need to be included in separate jobs because they take too long.

/assign @kannon92 