### PR TITLE
E2E node containerd: add slow and serial periodics

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -81,7 +81,7 @@ periodics:
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && Serial && !Slow && NodeConformance"
+          - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && Serial && NodeConformance"
           - --timeout=80m
         env:
           - name: GOPATH
@@ -97,7 +97,7 @@ periodics:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: ci-node-e2e-serial
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
-    description: "Uses kubetest to run serial node-e2e tests with containerd (+NodeConformance, +Serial, -Flaky|Slow)"
+    description: "Uses kubetest to run serial node-e2e tests with containerd (+NodeConformance, +Serial, -Flaky)"
 
 - name: ci-kubernetes-node-e2e-containerd-slow
   cluster: k8s-infra-prow-build
@@ -131,7 +131,7 @@ periodics:
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && !Serial && Slow && NodeConformance"
+          - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && Slow && NodeConformance"
           - --timeout=80m
         env:
           - name: GOPATH
@@ -147,7 +147,7 @@ periodics:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: ci-node-e2e-slow
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
-    description: "Uses kubetest to run slow node-e2e tests with containerd (+NodeConformance, +Slow, -Flaky|Serial)"
+    description: "Uses kubetest to run slow node-e2e tests with containerd (+NodeConformance, +Slow, -Flaky)"
 
 - name: ci-kubernetes-node-kubelet-serial-containerd
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -49,6 +49,106 @@ periodics:
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io, release-team@kubernetes.io
     description: "Uses kubetest to run node-e2e tests with containerd, excluding slow and serial tests (+NodeConformance, -Flaky|Slow|Serial)"
 
+- name: ci-kubernetes-node-e2e-containerd-serial
+  cluster: k8s-infra-prow-build
+  interval: 2h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --deployment=node
+          - --gcp-zone=us-central1-b
+          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config.yaml
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && Serial && !Slow && NodeConformance"
+          - --timeout=80m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: ci-node-e2e-serial
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
+    description: "Uses kubetest to run serial node-e2e tests with containerd (+NodeConformance, +Serial, -Flaky|Slow)"
+
+- name: ci-kubernetes-node-e2e-containerd-slow
+  cluster: k8s-infra-prow-build
+  interval: 2h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --deployment=node
+          - --gcp-zone=us-central1-b
+          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config.yaml
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && !Serial && Slow && NodeConformance"
+          - --timeout=80m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: ci-node-e2e-slow
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
+    description: "Uses kubetest to run slow node-e2e tests with containerd (+NodeConformance, +Slow, -Flaky|Serial)"
+
 - name: ci-kubernetes-node-kubelet-serial-containerd
   cluster: k8s-infra-prow-build
   interval: 4h

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -108,7 +108,7 @@ presubmits:
         testgrid-alert-stale-results-hours: "24"
         testgrid-create-test-group: "true"
         testgrid-num-failures-to-alert: "10"
-        description: "Uses kubetest to run slow node-e2e tests with containerd (+NodeConformance, +Slow, -Flaky|Serial)"
+        description: "Uses kubetest to run slow node-e2e tests with containerd (+NodeConformance, +Slow, -Flaky)"
       always_run: false
       optional: true
       decorate: true
@@ -137,7 +137,7 @@ presubmits:
               - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
               - --node-tests=true
               - --provider=gce
-              - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && !Serial && Slow && NodeConformance"
+              - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && Slow && NodeConformance"
               - --timeout=80m
               - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
             resources:
@@ -155,7 +155,7 @@ presubmits:
         testgrid-alert-stale-results-hours: "24"
         testgrid-create-test-group: "true"
         testgrid-num-failures-to-alert: "10"
-        description: "Uses kubetest to run slow node-e2e tests with containerd (+NodeConformance, +Serial, -Flaky|Slow)"
+        description: "Uses kubetest to run serial node-e2e tests with containerd (+NodeConformance, +Serial, -Flaky)"
       always_run: false
       optional: true
       decorate: true
@@ -184,7 +184,7 @@ presubmits:
               - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
               - --node-tests=true
               - --provider=gce
-              - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && Serial && !Slow && NodeConformance"
+              - --test_args=--nodes=8 --skip="" --label-filter="!Flaky && Serial NodeConformance"
               - --timeout=80m
               - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
             resources:


### PR DESCRIPTION
These periodics mirror the corresponding presubmits, which is one of the best practices because it ensures that problems with the tests are found before they randomly appear when someone uses the presubmits.

These jobs are necessary because tests marked as NodeConformance are presumably "more important" and thus should be covered even though they are slow and/or serial. It's not clear whether other jobs do that in the same machine configuration as in the main ci-kubernetes-node-e2e-containerd job.

Also, these new jobs, in contrast to those other, more ad-hoc jobs, are good candidates for promotion to release informing and later release blocking, similar to ci-kubernetes-node-e2e-containerd. Maybe then some of the other jobs can be removed.

/assign @kannon92 