### PR TITLE
Bump memory requests for scheduler-library presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-library/scheduler-library-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-library/scheduler-library-presubmits-main.yaml
@@ -16,10 +16,10 @@ presubmits:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260706-7056f81a85-master
         resources:
           requests:
-            memory: "2Gi"
+            memory: "4Gi"
             cpu: "2"
           limits:
-            memory: "2Gi"
+            memory: "4Gi"
             cpu: "2"
         command:
         - runner.sh


### PR DESCRIPTION
https://github.com/kubernetes-sigs/scheduler-library/pull/2 is failing with OOM: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_scheduler-library/2/pull-scheduler-library-verify-main/2074045931195469824