### PR TITLE
Bump scheduler-library presubmit memory requests to 8GiB

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-library/scheduler-library-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-library/scheduler-library-presubmits-main.yaml
@@ -16,10 +16,10 @@ presubmits:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260706-7056f81a85-master
         resources:
           requests:
-            memory: "4Gi"
+            memory: "8Gi"
             cpu: "2"
           limits:
-            memory: "4Gi"
+            memory: "8Gi"
             cpu: "2"
         command:
         - runner.sh


### PR DESCRIPTION
https://github.com/kubernetes-sigs/scheduler-library/pull/2 is failing with OOM: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_scheduler-library/2/pull-scheduler-library-verify-main/2074417297816031232

I attempted to increase the memory to 4GiB but it seems it's not enough: #37403. Trying with 8GiB