### PR TITLE
Add 100-node RangeStream scale periodic on etcd 3.6

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -184,3 +184,105 @@ periodics:
           limits:
             cpu: 2
             memory: "8Gi"
+
+# Verify the new RangeStream client against old etcd 3.6 does not cause
+# regressions at 100 nodes. See https://github.com/kubernetes/test-infra/pull/37406
+- name: ci-kubernetes-e2e-gce-scale-performance-100-experimental-etcd36
+  cluster: k8s-infra-prow-build
+  cron: '0 8 * * *' # Run daily at 00:00 PST (08:00 UTC)
+  tags:
+  - "perfDashPrefix: gce-100Nodes-experimental-etcd36"
+  - "perfDashJobType: performance"
+  labels:
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 100m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
+    repo: perf-tests
+    base_ref: master
+    path_alias: k8s.io/perf-tests
+  - org: kubernetes
+    repo: kops
+    base_ref: master
+    workdir: true
+    path_alias: k8s.io/kops
+  annotations:
+    testgrid-dashboards: sig-scalability-experiments
+    testgrid-tab-name: gce-master-scale-performance-100-experimental-etcd36
+    description: "Runs the RangeStream client against etcd 3.6 at 100 nodes to catch regressions on the old etcd version"
+  spec:
+    serviceAccountName: prow-build
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260720-39d457d26c-master
+      command:
+      - runner.sh
+      args:
+      - ./tests/e2e/scenarios/scalability/run-test.sh
+      securityContext:
+        privileged: true
+      env:
+      - name: CL2_RESTART_APISERVER
+        value: "true"
+      - name: KUBE_FEATURE_GATES
+        value: "+EtcdRangeStream"
+      - name: CL2_HEAP_PROFILE_INTERVAL
+        value: "1m"
+      - name: KUBE_SSH_KEY_PATH
+        value: /etc/ssh-key-secret/ssh-private
+      - name: KUBE_SSH_USER
+        value: prow
+      - name: GOPATH
+        value: /home/prow/go
+      - name: CNI_PLUGIN
+        value: gce
+      - name: KUBE_NODE_COUNT
+        value: "100"
+      - name: ETCD_VERSION
+        value: "3.6.12"
+      - name: CL2_LOAD_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_DELETE_TEST_THROUGHPUT
+        value: "50"
+      - name: CL2_RATE_LIMIT_POD_CREATION
+        value: "false"
+      - name: NODE_MODE
+        value: "master"
+      - name: KUBE_PROXY_MODE
+        value: "nftables"
+      - name: CONTROL_PLANE_COUNT
+        value: "3"
+      - name: CONTROL_PLANE_SIZE
+        value: "c4-standard-32"
+      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
+        value: "true"
+      - name: CL2_ENABLE_DNS_PROGRAMMING
+        value: "true"
+      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+        value: "true"
+      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+        value: "99.5"
+      - name: CL2_ALLOWED_SLOW_API_CALLS
+        value: "1"
+      - name: ENABLE_PROMETHEUS_SERVER
+        value: "true"
+      - name: TEAR_DOWN_PROMETHEUS_SERVER
+        value: "false"
+      - name: PROMETHEUS_PVC_STORAGE_CLASS
+        value: "ssd-csi"
+      - name: CLOUD_PROVIDER
+        value: "gce"
+      - name: BOSKOS_RESOURCE_TYPE
+        value: "scalability-project"
+      resources:
+        requests:
+          cpu: 5
+          memory: 16Gi
+        limits:
+          cpu: 5
+          memory: 16Gi


### PR DESCRIPTION
Add a daily 100-node RangeStream periodic on etcd 3.6 to catch regressions from the new client running against the old etcd version.