### PR TITLE
Exclude PreventStaticPodAPIReferences from compatibility-versions feature gate check

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/compatibility-versions-e2e.yaml
@@ -211,7 +211,7 @@ periodics:
       # List of features that are not in scope of emulation version and have been removed. These can pass since they are not subject to the same policies as
       # feature gates that exist in components such as KCM.
       - name: REMOVED_FEATURE_LIST
-        value: "LegacySidecarContainers"
+        value: "LegacySidecarContainers PreventStaticPodAPIReferences"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -267,7 +267,7 @@ periodics:
       # List of features that are not in scope of emulation version and have been removed. These can pass since they are not subject to the same policies as
       # feature gates that exist in components such as KCM.
       - name: REMOVED_FEATURE_LIST
-        value: "LegacySidecarContainers"
+        value: "LegacySidecarContainers PreventStaticPodAPIReferences"
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true


### PR DESCRIPTION
PreventStaticPodAPIReferences is a kubelet feature gate, so it is not bound by the emulated-version compatibility policy that control-plane gates follow and can be removed at any time. It was removed in kubernetes/kubernetes#140226, so add it to REMOVED_FEATURE_LIST alongside LegacySidecarContainers to keep the compatibility-versions feature gate periodics passing.