### PR TITLE
config: add GCP GPU E2E jobs for kubernetes-sigs/ai-conformance

### DIFF
--- a/config/jobs/kubernetes-sigs/ai-conformance/ai-conformance-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/ai-conformance/ai-conformance-periodics-main.yaml
@@ -1,1 +1,39 @@
 periodics:
+- name: ci-ai-conformance-e2e-gcp
+  cluster: k8s-infra-prow-build
+  job_queue_name: gce-gpu-test
+  interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 1h
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: ai-conformance
+    base_ref: main
+    path_alias: github.com/kubernetes-sigs/ai-conformance
+  annotations:
+    testgrid-dashboards: sig-arch-ai-conformance
+    testgrid-tab-name: ci-ai-conformance-e2e-gcp
+    description: "Daily GPU e2e on GCP for AI Conformance main branch"
+  spec:
+    serviceAccountName: prow-build
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+      command:
+      - runner.sh
+      args:
+      - ./test/e2e/run-e2e-gcp.sh
+      env:
+      - name: BOSKOS_HOST
+        value: "http://boskos.test-pods.svc.cluster.local"
+      - name: BOSKOS_RESOURCE_TYPE
+        value: "gpu-project"
+      - name: RUN_IN_PROW
+        value: "true"
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"

--- a/config/jobs/kubernetes-sigs/ai-conformance/ai-conformance-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/ai-conformance/ai-conformance-presubmits-main.yaml
@@ -1,2 +1,41 @@
 presubmits:
-  kubernetes-sigs/wg-ai-conformance:
+  kubernetes-sigs/ai-conformance:
+  - name: pull-ai-conformance-e2e-gcp
+    cluster: k8s-infra-prow-build
+    job_queue_name: gce-gpu-test
+    always_run: false
+    optional: true
+    skip_report: false
+    run_if_changed: '^(test/|go\.mod$|go\.sum$)'
+    max_concurrency: 1
+    branches:
+    - ^main$
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    annotations:
+      testgrid-dashboards: sig-arch-ai-conformance
+      testgrid-tab-name: pull-ai-conformance-e2e-gcp
+      description: "On-demand GPU e2e on GCP for AI Conformance PRs"
+    spec:
+      serviceAccountName: prow-build
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+        command:
+        - runner.sh
+        args:
+        - ./test/e2e/run-e2e-gcp.sh
+        env:
+        - name: BOSKOS_HOST
+          value: "http://boskos.test-pods.svc.cluster.local"
+        - name: BOSKOS_RESOURCE_TYPE
+          value: "gpu-project"
+        - name: RUN_IN_PROW
+          value: "true"
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "8Gi"

--- a/config/testgrids/kubernetes/sig-arch/config.yaml
+++ b/config/testgrids/kubernetes/sig-arch/config.yaml
@@ -6,6 +6,7 @@ dashboard_groups:
   - sig-arch-conformance
   - sig-arch-enhancements
   - sig-arch-code-organization
+  - sig-arch-ai-conformance
 
 # Dashboards
 #
@@ -13,3 +14,4 @@ dashboards:
 - name: sig-arch-conformance
 - name: sig-arch-enhancements
 - name: sig-arch-code-organization
+- name: sig-arch-ai-conformance


### PR DESCRIPTION
Added GCP GPU E2E presubmit (`pull-ai-conformance-e2e-gcp`) and periodic (`ci-ai-conformance-e2e-gcp`) jobs for `kubernetes-sigs/ai-conformance`.

- Executes `./test/e2e/run-e2e-gcp.sh` from `kubernetes-sigs/ai-conformance` (being added in https://github.com/kubernetes-sigs/ai-conformance/pull/76)
- Uses Boskos `gpu-project` pool with `job_queue_name: gce-gpu-test` (ref kubernetes/k8s.io#9145).
- Presubmit is on-demand (`always_run: false`, `optional: true`), periodic runs daily.
