### PR TITLE
Enable CL2 Prometheus server on ci-kubernetes-e2e-azure-scalability

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-azure.yaml
@@ -47,6 +47,7 @@ periodics:
           ./run-e2e.sh cluster-loader2
           --nodes=100 \
           --provider=aks \
+          --enable-prometheus-server=true \
           --testconfig=testing/load/config.yaml \
           --testconfig=testing/huge-service/config.yaml \
           --testconfig=testing/access-tokens/config.yaml \


### PR DESCRIPTION
Adds `--enable-prometheus-server=true` to start the in-cluster CL2 Prometheus server, matching sibling scalability jobs like `sig-scalability-periodic-dra.yaml`, so the job's Prometheus-based SLO panels stop coming up blank.