### PR TITLE
test-coverage: analyze how well periodic jobs cover E2E tests

### DIFF
--- a/test-coverage/README.md
+++ b/test-coverage/README.md
@@ -1,0 +1,244 @@
+# test-coverage
+
+`test-coverage` is a CLI tool that reports how thoroughly the Kubernetes
+`e2e` and `e2e_node` Ginkgo test suites are actually exercised by the
+periodic Prow jobs defined in this repository, based on real job run
+results.
+
+For each test in the chosen suite, it shows how many times it was executed
+(and how often it passed) across all matching periodic jobs over a recent
+time window, both in total and broken down per job. Tests that were never
+executed by any matching job are listed separately at the end of the
+report.
+
+## How it works
+
+1. **List the tests.** It runs
+   `go test -v <test package> -args --list-tests` against the given
+   `kubernetes/kubernetes` checkout (`./test/e2e` or `./test/e2e_node`,
+   depending on `-e2e-suite`) to get the authoritative list of Ginkgo test
+   names.
+2. **List the jobs.** It loads the Prow configuration
+   (`config/prow/config.yaml` plus the job directory given via `-job-dir`)
+   using `sigs.k8s.io/prow/pkg/config`, and collects all periodic jobs
+   whose name matches `-job-filter`. Jobs that don't test
+   `kubernetes/kubernetes` at `master` (e.g. jobs testing another repo, or
+   jobs pinned to a release branch such as `release-1.33`) are filtered
+   out automatically, since their results wouldn't be meaningful for the
+   current suite.
+3. **Find recent runs, without listing everything.** Job results are
+   read directly from the public `gs://kubernetes-ci-logs` GCS bucket via
+   its anonymous REST API (no credentials needed). Build IDs are
+   monotonically increasing, snowflake-like numbers, so for each job the
+   tool lists `logs/<job>/` (one HTTP request), sorts the build IDs
+   numerically descending, and then walks them **newest first**, fetching
+   only their small `started.json` file to check the run's start time.
+   As soon as it encounters a run older than `-age`, it stops —
+   it does not need to look at (or download artifacts for) any older
+   runs. This keeps the number of GCS requests proportional to the
+   number of *recent* runs of each job, not to the job's entire history.
+   Finding the recent runs of different jobs is independent work, so it
+   is done concurrently, using up to `-workers` goroutines at a time.
+4. **Parse JUnit results.** For each recent run, it downloads the
+   `junit_*.xml` files under that run's `artifacts/` directory and parses
+   them (using a copy of
+   `k8s.io/kubernetes/third_party/forked/gotestsum/junitxml`). Which
+   suite a run actually executed is determined from the top-level
+   `<testsuite name="...">` element itself (e.g. `"E2eNode Suite"` or
+   `"Kubernetes e2e suite"`), not from individual test cases; this also
+   works for runs that executed the right test binary but ended up
+   running zero tests. A `<testsuite>` element without a `name`
+   attribute (for example the Go code coverage report
+   `junit_coverage.xml` produced by some jobs) is treated as suite
+   `"unknown"`. Runs of a job are processed **newest first, one job at a
+   time** (all runs of a job are handled by the same worker), and as
+   soon as a run is found whose JUnit files belong to a different suite,
+   the rest of that job's (older) runs are skipped without being
+   downloaded, since a job that doesn't run the right suite is very
+   unlikely to have done so in the past; this is also why only that one
+   run counts towards the "number of runs found" in the report for such
+   a job. However, if a run has **no JUnit files at all** (e.g. a build
+   or unit-test job that produces no Ginkgo output), nothing can be
+   concluded about which suite it ran, so this doesn't stop the job:
+   all of its runs within `-age` have to be downloaded and checked,
+   since any of them (even an older one) might turn out to contain
+   JUnit data after all. Such jobs are reported with suite `"none"` and
+   0 executed tests. If a job has **no runs at all** within `-age` (e.g.
+   because it doesn't run that often, or hasn't run recently), its
+   suite is reported as `"unknown"` instead, since in that case not
+   even one run was available to inspect. Skipped test cases are
+   ignored; the rest are recorded as passed or failed based on the
+   presence of a `<failure>` element. Downloading and analyzing the
+   JUnit results of different jobs' runs is independent work, so it is
+   done concurrently, using up to `-workers` goroutines at a time.
+5. **Report.** Finally, it prints a `text/tabwriter`-aligned report:
+   the list of jobs analyzed with how many runs were found for each and
+   which suite ("e2e", "e2e_node", the raw JUnit suite name for anything
+   else, "none" for a job whose runs had no JUnit data at all, or
+   "unknown" for a job with no runs found at all within `-age`) they
+   were detected to run, then for every executed test its total/per-job
+   execution counts and success rates, and finally the list of tests
+   that were never executed by any matching job.
+
+## Usage
+
+Must be run with the current working directory set to the root of the
+`test-infra` repository (so it can find `config/prow/config.yaml` and the
+given job directory).
+
+```
+go run ./test-coverage -kubernetes-repo <path> [-e2e-suite e2e|e2e_node] [-job-dir <path>] [-age <duration>] [-job-filter <regexp>] [-workers <n>]
+```
+
+Flags:
+
+* `-kubernetes-repo` (required): path to a `kubernetes/kubernetes`
+  checkout, used to list the suite's tests via `--list-tests`.
+* `-e2e-suite` (default `e2e_node`): which suite to analyze, `e2e` or
+  `e2e_node`.
+* `-job-dir` (default depends on `-e2e-suite`): directory of periodic job
+  definitions to scan, relative to the test-infra repo root. Defaults to
+  `config/jobs/kubernetes` for `e2e` and
+  `config/jobs/kubernetes/sig-node` for `e2e_node`.
+* `-age` (default `24h`): how far back to look for job runs.
+* `-job-filter` (default `.*`): regular expression used to filter
+  periodic job names.
+* `-workers` (default `10`): number of concurrent workers used to find
+  job runs and to download and analyze their JUnit results from GCS.
+  Increasing it speeds up the tool considerably when many jobs or runs
+  match, at the cost of more concurrent GCS requests.
+
+## Examples
+
+### `e2e_node`
+
+```
+$ go run ./test-coverage -kubernetes-repo ../kubernetes -e2e-suite e2e_node -job-filter '^ci-node-crio-dra' -age 6h
+...
+Found 2 periodic jobs: [ci-node-crio-dra ci-node-crio-dra-alpha-beta-features]
+Finding runs of ci-node-crio-dra since 2026-07-08T05:35:25+02:00 ...
+Found 1 runs of ci-node-crio-dra.
+Finding runs of ci-node-crio-dra-alpha-beta-features since 2026-07-08T05:35:25+02:00 ...
+Found 1 runs of ci-node-crio-dra-alpha-beta-features.
+```
+
+Truncated report output:
+
+```
+Test execution coverage report
+
+Jobs analyzed (2), with number of runs found and average tests executed per run (see https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/<job name>):
+  ci-node-crio-dra                      1  e2e_node  38.0
+  ci-node-crio-dra-alpha-beta-features  1  e2e_node  38.0
+  TOTAL                                 2            38.0
+
+Executed tests (38 of 1217, 100% overall success rate):
+
+[sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] Resource Health [FeatureGate:ResourceHealthStatus] must reuse one gRPC connection for service and health-monitoring calls [Beta] [Serial]: total 2 100.0%
+    ci-node-crio-dra                      1  100.0%
+    ci-node-crio-dra-alpha-beta-features  1  100.0%
+[sig-node] [DRA] [Feature:DynamicResourceAllocation] [FeatureGate:DynamicResourceAllocation] Resource Health [FeatureGate:ResourceHealthStatus] should automatically reconnect both DRA and Health API after connection drop [Beta] [Serial]: total 2 100.0%
+    ci-node-crio-dra                      1  100.0%
+    ci-node-crio-dra-alpha-beta-features  1  100.0%
+...
+
+Tests never executed (1179 of 1217):
+
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [Conformance] [NodeConformance]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: sctp [LinuxOnly] [Feature:SCTPConnectivity]
+[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [Conformance] [NodeConformance]
+...
+```
+
+### `e2e`
+
+```
+$ go run ./test-coverage -kubernetes-repo ../kubernetes -e2e-suite e2e -job-filter '^ci-kind-dra.*' -age 12h
+...
+Found 5 periodic jobs: [ci-kind-dra ci-kind-dra-all ci-kind-dra-n-1 ci-kind-dra-n-2 ci-kind-dra-n-3]
+Finding runs of ci-kind-dra since 2026-07-08T01:23:53+02:00 ...
+Finding runs of ci-kind-dra-n-3 since 2026-07-08T01:23:53+02:00 ...
+Finding runs of ci-kind-dra-n-1 since 2026-07-08T01:23:53+02:00 ...
+Finding runs of ci-kind-dra-n-2 since 2026-07-08T01:23:53+02:00 ...
+Finding runs of ci-kind-dra-all since 2026-07-08T01:23:53+02:00 ...
+Found 2 runs of ci-kind-dra.
+Found 2 runs of ci-kind-dra-n-1.
+Found 2 runs of ci-kind-dra-n-2.
+Found 2 runs of ci-kind-dra-all.
+Found 2 runs of ci-kind-dra-n-3.
+```
+
+Truncated report output:
+
+```
+Test execution coverage report
+
+Jobs analyzed (5), with number of runs found and average tests executed per run (see https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/<job name>):
+  ci-kind-dra      2   e2e  99.0
+  ci-kind-dra-all  2   e2e  114.0
+  ci-kind-dra-n-1  2   e2e  70.0
+  ci-kind-dra-n-2  2   e2e  70.0
+  ci-kind-dra-n-3  2   e2e  64.0
+  TOTAL            10       83.4
+
+Executed tests (88 of 7677, 100% overall success rate):
+
+[sig-api-machinery] ResourceQuota should create a ResourceQuota and capture the life of a ResourceClaim [FeatureGate:DynamicResourceAllocation] [DRA]: total 4 100.0%
+    ci-kind-dra      2  100.0%
+    ci-kind-dra-all  2  100.0%
+[sig-node] [DRA] CRUD Tests resource.k8s.io/v1 DeviceClass [Conformance]: total 4 100.0%
+    ci-kind-dra      2  100.0%
+    ci-kind-dra-all  2  100.0%
+...
+
+Tests never executed (7589 of 7677):
+
+[sig-api-machinery] API Streaming (aka. WatchList) [FeatureGate:WatchList] reflector doesn't support receiving resources as Tables [Beta]
+[sig-api-machinery] API Streaming (aka. WatchList) [FeatureGate:WatchList] reflector using standard List doesn't support receiving resources as Tables [Beta]
+[sig-api-machinery] API Streaming (aka. WatchList) [FeatureGate:WatchList] server supports sending resources in Table format [Beta]
+...
+```
+
+### `e2e`, showing different kinds of analyzed jobs
+
+This example uses a filter that picks out three jobs that each illustrate a
+different case handled by the "Jobs analyzed" table: a job that actually
+runs the `e2e` suite (`ci-kind-dra`), a job that runs a different suite
+(`ci-kubernetes-integration-master`, a gotestsum-based Go integration test
+job detected as `many`, so only its single most recent run needs to be
+checked before it is recognized as the wrong suite and skipped), and a job
+that produces no JUnit output at all (`ci-kubernetes-build-fast`, a build
+job). Since that last kind of job never allows the tool to conclude
+anything about which suite it ran, *all* of its runs found within `-age`
+have to be downloaded and checked, which is why it shows a much higher
+"number of runs found" than the other two jobs despite matching no tests
+at all:
+
+```
+$ go run ./test-coverage -kubernetes-repo ../kubernetes -e2e-suite e2e -job-filter '^ci-kind-dra$|^ci-kubernetes-integration-master$|^ci-kubernetes-build-fast$' -age 6h
+...
+Found 3 periodic jobs: [ci-kind-dra ci-kubernetes-build-fast ci-kubernetes-integration-master]
+Finding runs of ci-kind-dra since 2026-07-08T10:51:18+02:00 ...
+Finding runs of ci-kubernetes-integration-master since 2026-07-08T10:51:18+02:00 ...
+Finding runs of ci-kubernetes-build-fast since 2026-07-08T10:51:18+02:00 ...
+Found 1 runs of ci-kind-dra.
+Found 6 runs of ci-kubernetes-integration-master.
+Found 59 runs of ci-kubernetes-build-fast.
+Ignoring ci-kubernetes-integration-master: ran suite "many" instead of "e2e".
+Analyzed 1 runs of ci-kubernetes-integration-master.
+Analyzed 1 runs of ci-kind-dra.
+Analyzed 59 runs of ci-kubernetes-build-fast.
+```
+
+Truncated report output:
+
+```
+Test execution coverage report
+
+Jobs analyzed (3), with number of runs found and average tests executed per run (see https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/<job name>):
+  ci-kubernetes-build-fast          59  none  0.0
+  ci-kubernetes-integration-master  1   many  0.0
+  ci-kind-dra                       1   e2e   99.0
+  TOTAL                             61        1.6
+...
+```

--- a/test-coverage/README.md
+++ b/test-coverage/README.md
@@ -19,7 +19,7 @@ report.
    depending on `-e2e-suite`) to get the authoritative list of Ginkgo test
    names.
 2. **List the jobs.** It loads the Prow configuration
-   (`config/prow/config.yaml` plus the job directory given via `-job-dir`)
+   (`config/prow/config.yaml` plus the job directories given via `-job-dir`)
    using `sigs.k8s.io/prow/pkg/config`, and collects all periodic jobs
    whose name matches `-job-filter`. Jobs that don't test
    `kubernetes/kubernetes` at `master` (e.g. jobs testing another repo, or
@@ -87,7 +87,7 @@ Must be run with the current working directory set to the root of the
 given job directory).
 
 ```
-go run ./test-coverage -kubernetes-repo <path> [-e2e-suite e2e|e2e_node] [-job-dir <path>] [-age <duration>] [-job-filter <regexp>] [-workers <n>]
+go run ./test-coverage -kubernetes-repo <path> [-e2e-suite e2e|e2e_node] [-job-dir <path>[,<path>...]] [-age <duration>] [-job-filter <regexp>] [-workers <n>]
 ```
 
 Flags:
@@ -96,10 +96,13 @@ Flags:
   checkout, used to list the suite's tests via `--list-tests`.
 * `-e2e-suite` (default `e2e_node`): which suite to analyze, `e2e` or
   `e2e_node`.
-* `-job-dir` (default depends on `-e2e-suite`): directory of periodic job
-  definitions to scan, relative to the test-infra repo root. Defaults to
-  `config/jobs/kubernetes` for `e2e` and
-  `config/jobs/kubernetes/sig-node` for `e2e_node`.
+* `-job-dir` (default depends on `-e2e-suite`): comma-separated list of
+  directories of periodic job definitions to scan, relative to the
+  test-infra repo root. Defaults to `config/jobs/kubernetes` and
+  `config/jobs/kubernetes-sigs` for `e2e` (since some `kubernetes-sigs`
+  subprojects, e.g. `sig-windows`, also run the `test/e2e` suite against
+  `kubernetes/kubernetes`), and `config/jobs/kubernetes/sig-node` for
+  `e2e_node`.
 * `-age` (default `24h`): how far back to look for job runs.
 * `-job-filter` (default `.*`): regular expression used to filter
   periodic job names.

--- a/test-coverage/gcs.go
+++ b/test-coverage/gcs.go
@@ -1,0 +1,134 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// gcsBucket is the public GCS bucket which holds the Prow job results.
+const gcsBucket = "kubernetes-ci-logs"
+
+// gcsClient talks to the public "storage.googleapis.com" REST API. It does
+// not require any credentials because the bucket is world-readable.
+type gcsClient struct {
+	httpClient *http.Client
+}
+
+func newGCSClient() *gcsClient {
+	return &gcsClient{httpClient: http.DefaultClient}
+}
+
+// listObjectsResponse is the subset of the GCS JSON API "objects.list"
+// response that we care about.
+type listObjectsResponse struct {
+	Prefixes []string `json:"prefixes"`
+	Items    []struct {
+		Name string `json:"name"`
+	} `json:"items"`
+	NextPageToken string `json:"nextPageToken"`
+}
+
+// listPrefixes lists the immediate "directories" (common prefixes) below
+// prefix, using "/" as delimiter. prefix must end in "/".
+func (c *gcsClient) listPrefixes(prefix string) ([]string, error) {
+	var result []string
+	pageToken := ""
+	for {
+		u := fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o?prefix=%s&delimiter=%s&fields=%s",
+			url.QueryEscape(gcsBucket),
+			url.QueryEscape(prefix),
+			url.QueryEscape("/"),
+			url.QueryEscape("prefixes,nextPageToken"),
+		)
+		if pageToken != "" {
+			u += "&pageToken=" + url.QueryEscape(pageToken)
+		}
+		var resp listObjectsResponse
+		if err := c.getJSON(u, &resp); err != nil {
+			return nil, fmt.Errorf("listing %q: %w", prefix, err)
+		}
+		result = append(result, resp.Prefixes...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return result, nil
+}
+
+// listFiles lists the object names (not sub-"directories") directly below
+// prefix, using "/" as delimiter. prefix must end in "/".
+func (c *gcsClient) listFiles(prefix string) ([]string, error) {
+	var result []string
+	pageToken := ""
+	for {
+		u := fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o?prefix=%s&delimiter=%s&fields=%s",
+			url.QueryEscape(gcsBucket),
+			url.QueryEscape(prefix),
+			url.QueryEscape("/"),
+			url.QueryEscape("items(name),nextPageToken"),
+		)
+		if pageToken != "" {
+			u += "&pageToken=" + url.QueryEscape(pageToken)
+		}
+		var resp listObjectsResponse
+		if err := c.getJSON(u, &resp); err != nil {
+			return nil, fmt.Errorf("listing %q: %w", prefix, err)
+		}
+		for _, item := range resp.Items {
+			result = append(result, item.Name)
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return result, nil
+}
+
+// getObject downloads the content of a single object.
+func (c *gcsClient) getObject(name string) ([]byte, error) {
+	u := "https://storage.googleapis.com/" + gcsBucket + "/" + strings.TrimPrefix(name, "/")
+	resp, err := c.httpClient.Get(u)
+	if err != nil {
+		return nil, fmt.Errorf("downloading %q: %w", name, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("downloading %q: unexpected status %s", name, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func (c *gcsClient) getJSON(u string, out interface{}) error {
+	resp, err := c.httpClient.Get(u)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %s: %s", resp.Status, string(body))
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/test-coverage/jobs.go
+++ b/test-coverage/jobs.go
@@ -1,0 +1,77 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+
+	prowconfig "sigs.k8s.io/prow/pkg/config"
+)
+
+// mainProwConfigPath is the location of the main Prow config, relative to
+// the root of the test-infra repository. This tool must be invoked with the
+// current working directory set to that root.
+const mainProwConfigPath = "config/prow/config.yaml"
+
+// listPeriodicJobs returns the sorted names of all periodic jobs defined
+// underneath jobDir (a path relative to the test-infra repo root, e.g.
+// "config/jobs/kubernetes/sig-node") whose name matches jobFilter and which
+// test kubernetes/kubernetes at master.
+func listPeriodicJobs(jobDir string, jobFilter *regexp.Regexp) ([]string, error) {
+	c, err := prowconfig.Load(mainProwConfigPath, jobDir, nil, "")
+	if err != nil {
+		return nil, fmt.Errorf("loading Prow config for job dir %q: %w", jobDir, err)
+	}
+
+	var names []string
+	for _, p := range c.AllPeriodics() {
+		if !jobFilter.MatchString(p.Name) {
+			continue
+		}
+		if !testsKubernetesAtMaster(p) {
+			continue
+		}
+		names = append(names, p.Name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// testsKubernetesAtMaster returns whether p tests the kubernetes/kubernetes
+// repository at its master branch, as opposed to not testing kubernetes at
+// all (e.g. "auto-refreshing-official-cve-feed") or testing a previous
+// release branch of it (e.g. "ci-kubernetes-gce-conformance-latest-1-33").
+//
+// A job is considered to test kubernetes/kubernetes if it either has an
+// "extra_refs" entry with org "kubernetes", repo "kubernetes" and
+// "auxiliary" not set to true (e.g. "ci-dra-integration"), or has the
+// labels "prow.k8s.io/refs.org: kubernetes" and
+// "prow.k8s.io/refs.repo: kubernetes" (e.g. "ci-kind-dra").
+//
+// If the matching "extra_refs" entry has a non-empty "base_ref" other than
+// "master", the job is excluded since it tests a previous release.
+func testsKubernetesAtMaster(p prowconfig.Periodic) bool {
+	for _, ref := range p.ExtraRefs {
+		if ref.Org != "kubernetes" || ref.Repo != "kubernetes" || ref.Auxiliary {
+			continue
+		}
+		return ref.BaseRef == "" || ref.BaseRef == "master"
+	}
+	return p.Labels["prow.k8s.io/refs.org"] == "kubernetes" && p.Labels["prow.k8s.io/refs.repo"] == "kubernetes"
+}

--- a/test-coverage/jobs.go
+++ b/test-coverage/jobs.go
@@ -29,25 +29,32 @@ import (
 // current working directory set to that root.
 const mainProwConfigPath = "config/prow/config.yaml"
 
-// listPeriodicJobs returns the sorted names of all periodic jobs defined
-// underneath jobDir (a path relative to the test-infra repo root, e.g.
-// "config/jobs/kubernetes/sig-node") whose name matches jobFilter and which
-// test kubernetes/kubernetes at master.
-func listPeriodicJobs(jobDir string, jobFilter *regexp.Regexp) ([]string, error) {
-	c, err := prowconfig.Load(mainProwConfigPath, jobDir, nil, "")
-	if err != nil {
-		return nil, fmt.Errorf("loading Prow config for job dir %q: %w", jobDir, err)
-	}
-
+// listPeriodicJobs returns the sorted, deduplicated names of all periodic
+// jobs defined underneath jobDirs (paths relative to the test-infra repo
+// root, e.g. "config/jobs/kubernetes/sig-node") whose name matches
+// jobFilter and which test kubernetes/kubernetes at master.
+func listPeriodicJobs(jobDirs []string, jobFilter *regexp.Regexp) ([]string, error) {
+	seen := make(map[string]bool)
 	var names []string
-	for _, p := range c.AllPeriodics() {
-		if !jobFilter.MatchString(p.Name) {
-			continue
+	for _, jobDir := range jobDirs {
+		c, err := prowconfig.Load(mainProwConfigPath, jobDir, nil, "")
+		if err != nil {
+			return nil, fmt.Errorf("loading Prow config for job dir %q: %w", jobDir, err)
 		}
-		if !testsKubernetesAtMaster(p) {
-			continue
+
+		for _, p := range c.AllPeriodics() {
+			if !jobFilter.MatchString(p.Name) {
+				continue
+			}
+			if !testsKubernetesAtMaster(p) {
+				continue
+			}
+			if seen[p.Name] {
+				continue
+			}
+			seen[p.Name] = true
+			names = append(names, p.Name)
 		}
-		names = append(names, p.Name)
 	}
 	sort.Strings(names)
 	return names, nil

--- a/test-coverage/main.go
+++ b/test-coverage/main.go
@@ -1,0 +1,202 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command coverage reports how often each test of a Kubernetes Ginkgo e2e
+// suite ("e2e" or "e2e_node") has actually been executed by the periodic
+// Prow jobs defined in a given job directory, over a recent window of time.
+//
+// It must be run with the current working directory set to the root of the
+// test-infra repository, since it needs to load the main Prow config from
+// there.
+//
+// Example:
+//
+//	go run ./coverage -kubernetes-repo ../kubernetes -e2e-suite e2e_node -job-filter '^ci-node-crio-'
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"regexp"
+	"sort"
+	"sync"
+	"syscall"
+	"time"
+)
+
+func main() {
+	// sigs.k8s.io/prow/pkg/config (used by listPeriodicJobs) transitively
+	// imports sigs.k8s.io/prow/pkg/interrupts, whose init() function
+	// installs its own signal.Notify handler for SIGINT/SIGTERM. Since
+	// this tool never calls interrupts.WaitForGracefulShutdown, that
+	// handler just swallows the signal without doing anything, which
+	// disables Go's default behavior of terminating the process on
+	// SIGINT (i.e. Ctrl-C stops working). Go delivers a signal to every
+	// channel registered for it via signal.Notify, so registering our
+	// own handler here restores the ability to interrupt the tool.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		s := <-sigCh
+		log.Printf("Received %s, exiting.", s)
+		os.Exit(1)
+	}()
+
+	kubernetesRepo := flag.String("kubernetes-repo", "", "Path to a kubernetes/kubernetes repository checkout (required).")
+	e2eSuiteName := flag.String("e2e-suite", "e2e_node", `Which Ginkgo test suite in the "test" directory to analyze: "e2e" or "e2e_node".`)
+	jobDir := flag.String("job-dir", "", "Path to a directory of periodic Prow job definitions, relative to the test-infra repository root. Defaults to the standard job directory for -e2e-suite.")
+	age := flag.Duration("age", 24*time.Hour, "How far back to look for job runs.")
+	jobFilter := flag.String("job-filter", ".*", "Regular expression used to filter periodic job names.")
+	workers := flag.Int("workers", 10, "Number of concurrent workers used to download and analyze job runs from GCS.")
+	flag.Parse()
+
+	if *kubernetesRepo == "" {
+		fmt.Fprintln(os.Stderr, "Usage: coverage -kubernetes-repo <path> [-e2e-suite e2e|e2e_node] [-job-dir <path>] [-age <duration>] [-job-filter <regexp>] [-workers <n>]")
+		flag.PrintDefaults()
+		os.Exit(2)
+	}
+
+	suite, err := lookupE2ESuite(*e2eSuiteName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if *jobDir == "" {
+		*jobDir = suite.defaultJobDir
+	}
+
+	jobFilterRE, err := regexp.Compile(*jobFilter)
+	if err != nil {
+		log.Fatalf("invalid -job-filter %q: %v", *jobFilter, err)
+	}
+
+	if *workers < 1 {
+		log.Fatalf("invalid -workers %d: must be at least 1", *workers)
+	}
+
+	if err := run(*kubernetesRepo, suite, *jobDir, *age, jobFilterRE, *workers, os.Stdout); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(kubernetesRepo string, suite e2eSuite, jobDir string, age time.Duration, jobFilter *regexp.Regexp, workers int, out *os.File) error {
+	log.Printf("Listing %s tests in %s ...", suite.testPackage, kubernetesRepo)
+	tests, err := listGinkgoTests(kubernetesRepo, suite.testPackage)
+	if err != nil {
+		return fmt.Errorf("listing %s tests: %w", suite.testPackage, err)
+	}
+	log.Printf("Found %d tests.", len(tests))
+
+	log.Printf("Listing periodic jobs in %s matching %q ...", jobDir, jobFilter)
+	jobs, err := listPeriodicJobs(jobDir, jobFilter)
+	if err != nil {
+		return fmt.Errorf("listing periodic jobs: %w", err)
+	}
+	log.Printf("Found %d periodic jobs: %v", len(jobs), jobs)
+
+	cutoff := time.Now().Add(-age)
+	client := newGCSClient()
+	cov := newCoverage(tests, jobs)
+
+	// Finding the recent runs of each job is independent per job, so it
+	// is done by up to workers goroutines in parallel.
+	var runsMu sync.Mutex
+	runsByJob := make(map[string][]jobRun)
+	forEachParallel(jobs, workers, func(job string) {
+		log.Printf("Finding runs of %s since %s ...", job, cutoff.Format(time.RFC3339))
+		runs, err := findRecentRuns(client, job, cutoff)
+		if err != nil {
+			log.Printf("warning: %s: %v", job, err)
+			return
+		}
+		log.Printf("Found %d runs of %s.", len(runs), job)
+		runsMu.Lock()
+		defer runsMu.Unlock()
+		runsByJob[job] = runs
+	})
+
+	// Downloading and parsing the JUnit results of a job's runs is done
+	// job by job (newest run first), so that a job is only ever handled
+	// by a single worker: once a run is found that executed the wrong
+	// suite, the remaining (older) runs of that job are skipped, since
+	// it is very unlikely that they ran a different suite than more
+	// recent runs of the same job. Distributing work by job like this,
+	// rather than by individual run, guarantees that a non-matching job
+	// is analyzed exactly once, without needing any shared state (e.g. a
+	// sync.Map) to coordinate between workers. cov is safe for
+	// concurrent use.
+	//
+	// The suite reported for a job is fixed to whatever was determined
+	// by the first (newest) run for which a suite could be detected at
+	// all, and is not overwritten by older runs: a job whose recent runs
+	// correctly executed the expected suite, but which then hits an
+	// older run that (e.g. due to an infrastructure failure) ran a
+	// different or no recognizable suite, should still be reported as
+	// running the suite its recent runs actually ran, not the
+	// unrepresentative older one that merely caused the scan to stop.
+	//
+	// Jobs are processed with the ones that have the most runs first,
+	// since those take the longest; starting them last, after all
+	// smaller jobs have already finished and their workers are idle,
+	// would needlessly delay completion.
+	sort.SliceStable(jobs, func(i, j int) bool {
+		return len(runsByJob[jobs[i]]) > len(runsByJob[jobs[j]])
+	})
+	forEachParallel(jobs, workers, func(job string) {
+		analyzed := 0
+		suiteKnown := false
+		for _, r := range runsByJob[job] {
+			tests, detectedSuite, err := executedTests(client, r, suite)
+			if err != nil {
+				log.Printf("warning: %s/%s: %v", r.job, r.buildID, err)
+				continue
+			}
+			analyzed++
+			if detectedSuite != "" && detectedSuite != suite.junitClassname {
+				suiteName := suiteNameForClassname(detectedSuite)
+				expectedSuiteName := suiteNameForClassname(suite.junitClassname)
+				log.Printf("Ignoring %s: ran suite %q instead of %q.", job, suiteName, expectedSuiteName)
+				// Only record this as the job's suite if no earlier
+				// (newer) run already determined it: older runs that
+				// ran a different (or no) suite, e.g. because of an
+				// infrastructure failure, must not override the
+				// correct suite already established by more recent
+				// runs.
+				if !suiteKnown {
+					cov.recordJobSuite(job, suiteName)
+				}
+				cov.recordRun(job)
+				break
+			}
+			if detectedSuite != "" {
+				if !suiteKnown {
+					cov.recordJobSuite(job, suiteNameForClassname(detectedSuite))
+					suiteKnown = true
+				}
+			}
+			cov.recordRun(job)
+			for _, test := range tests {
+				cov.recordExecution(job, test.name, test.passed)
+			}
+		}
+		log.Printf("Analyzed %d runs of %s.", analyzed, job)
+	})
+
+	return cov.writeReport(out)
+}

--- a/test-coverage/main.go
+++ b/test-coverage/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Command coverage reports how often each test of a Kubernetes Ginkgo e2e
 // suite ("e2e" or "e2e_node") has actually been executed by the periodic
-// Prow jobs defined in a given job directory, over a recent window of time.
+// Prow jobs defined in given job directories, over a recent window of time.
 //
 // It must be run with the current working directory set to the root of the
 // test-infra repository, since it needs to load the main Prow config from
@@ -35,6 +35,7 @@ import (
 	"os/signal"
 	"regexp"
 	"sort"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -60,14 +61,14 @@ func main() {
 
 	kubernetesRepo := flag.String("kubernetes-repo", "", "Path to a kubernetes/kubernetes repository checkout (required).")
 	e2eSuiteName := flag.String("e2e-suite", "e2e_node", `Which Ginkgo test suite in the "test" directory to analyze: "e2e" or "e2e_node".`)
-	jobDir := flag.String("job-dir", "", "Path to a directory of periodic Prow job definitions, relative to the test-infra repository root. Defaults to the standard job directory for -e2e-suite.")
+	jobDir := flag.String("job-dir", "", "Comma-separated list of directories of periodic Prow job definitions, relative to the test-infra repository root. Defaults to the standard job directories for -e2e-suite.")
 	age := flag.Duration("age", 24*time.Hour, "How far back to look for job runs.")
 	jobFilter := flag.String("job-filter", ".*", "Regular expression used to filter periodic job names.")
 	workers := flag.Int("workers", 10, "Number of concurrent workers used to download and analyze job runs from GCS.")
 	flag.Parse()
 
 	if *kubernetesRepo == "" {
-		fmt.Fprintln(os.Stderr, "Usage: coverage -kubernetes-repo <path> [-e2e-suite e2e|e2e_node] [-job-dir <path>] [-age <duration>] [-job-filter <regexp>] [-workers <n>]")
+		fmt.Fprintln(os.Stderr, "Usage: coverage -kubernetes-repo <path> [-e2e-suite e2e|e2e_node] [-job-dir <path>[,<path>...]] [-age <duration>] [-job-filter <regexp>] [-workers <n>]")
 		flag.PrintDefaults()
 		os.Exit(2)
 	}
@@ -77,8 +78,11 @@ func main() {
 		log.Fatal(err)
 	}
 
+	var jobDirs []string
 	if *jobDir == "" {
-		*jobDir = suite.defaultJobDir
+		jobDirs = suite.defaultJobDirs
+	} else {
+		jobDirs = strings.Split(*jobDir, ",")
 	}
 
 	jobFilterRE, err := regexp.Compile(*jobFilter)
@@ -90,12 +94,12 @@ func main() {
 		log.Fatalf("invalid -workers %d: must be at least 1", *workers)
 	}
 
-	if err := run(*kubernetesRepo, suite, *jobDir, *age, jobFilterRE, *workers, os.Stdout); err != nil {
+	if err := run(*kubernetesRepo, suite, jobDirs, *age, jobFilterRE, *workers, os.Stdout); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func run(kubernetesRepo string, suite e2eSuite, jobDir string, age time.Duration, jobFilter *regexp.Regexp, workers int, out *os.File) error {
+func run(kubernetesRepo string, suite e2eSuite, jobDirs []string, age time.Duration, jobFilter *regexp.Regexp, workers int, out *os.File) error {
 	log.Printf("Listing %s tests in %s ...", suite.testPackage, kubernetesRepo)
 	tests, err := listGinkgoTests(kubernetesRepo, suite.testPackage)
 	if err != nil {
@@ -103,8 +107,8 @@ func run(kubernetesRepo string, suite e2eSuite, jobDir string, age time.Duration
 	}
 	log.Printf("Found %d tests.", len(tests))
 
-	log.Printf("Listing periodic jobs in %s matching %q ...", jobDir, jobFilter)
-	jobs, err := listPeriodicJobs(jobDir, jobFilter)
+	log.Printf("Listing periodic jobs in %v matching %q ...", jobDirs, jobFilter)
+	jobs, err := listPeriodicJobs(jobDirs, jobFilter)
 	if err != nil {
 		return fmt.Errorf("listing periodic jobs: %w", err)
 	}

--- a/test-coverage/parallel.go
+++ b/test-coverage/parallel.go
@@ -1,0 +1,55 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "sync"
+
+// forEachParallel calls fn once for every item in items, using up to
+// workers goroutines at a time. It waits for all calls to complete before
+// returning. fn must be safe to call concurrently from multiple
+// goroutines. If workers is less than 1, a single worker is used.
+func forEachParallel[T any](items []T, workers int, fn func(T)) {
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > len(items) {
+		workers = len(items)
+	}
+	if workers <= 1 {
+		for _, item := range items {
+			fn(item)
+		}
+		return
+	}
+
+	work := make(chan T)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for item := range work {
+				fn(item)
+			}
+		}()
+	}
+	for _, item := range items {
+		work <- item
+	}
+	close(work)
+	wg.Wait()
+}

--- a/test-coverage/report.go
+++ b/test-coverage/report.go
@@ -1,0 +1,229 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+	"text/tabwriter"
+)
+
+// execStats counts how often a test was executed, and how many of those
+// executions passed.
+type execStats struct {
+	total  int
+	passed int
+}
+
+// successRate returns the percentage of executions that passed.
+func (s execStats) successRate() float64 {
+	if s.total == 0 {
+		return 0
+	}
+	return 100 * float64(s.passed) / float64(s.total)
+}
+
+// averageTests returns the average number of tests executed per run, given
+// the total number of test executions and the number of runs.
+func averageTests(totalExecutions, runs int) float64 {
+	if runs == 0 {
+		return 0
+	}
+	return float64(totalExecutions) / float64(runs)
+}
+
+// coverage tracks, for every known test, how often it was executed by each
+// job and how often those executions passed.
+//
+// All methods are safe to call concurrently from multiple goroutines,
+// e.g. while runs of different jobs are being analyzed in parallel.
+type coverage struct {
+	// allTests is the full set of test names as reported by --list-tests.
+	allTests []string
+
+	mu sync.Mutex
+	// counts[testName][jobName] = execution stats of jobName for testName.
+	counts map[string]map[string]*execStats
+	// runsPerJob is the number of runs that were analyzed for each job:
+	// this includes runs that turned out to execute the wrong suite (in
+	// which case no tests are counted for them), but not runs that were
+	// skipped entirely because an earlier (newer) run of the same job
+	// already showed it runs the wrong suite.
+	runsPerJob map[string]int
+	// jobSuite[job] is the short name ("e2e", "e2e_node") of the suite
+	// that job was detected to actually execute, or the raw JUnit
+	// "testsuite" name if it doesn't belong to any known suite. It is
+	// unset for jobs whose runs never produced any JUnit data.
+	jobSuite map[string]string
+	// jobs is the sorted list of job names that were analyzed.
+	jobs []string
+}
+
+func newCoverage(allTests, jobs []string) *coverage {
+	return &coverage{
+		allTests:   allTests,
+		counts:     make(map[string]map[string]*execStats),
+		runsPerJob: make(map[string]int),
+		jobSuite:   make(map[string]string),
+		jobs:       jobs,
+	}
+}
+
+func (cov *coverage) recordRun(job string) {
+	cov.mu.Lock()
+	defer cov.mu.Unlock()
+	cov.runsPerJob[job]++
+}
+
+// recordJobSuite records the short name of the suite that job was detected
+// to execute, based on a run's top-level JUnit "testsuite" name.
+func (cov *coverage) recordJobSuite(job, suiteName string) {
+	cov.mu.Lock()
+	defer cov.mu.Unlock()
+	cov.jobSuite[job] = suiteName
+}
+
+func (cov *coverage) recordExecution(job, test string, passed bool) {
+	cov.mu.Lock()
+	defer cov.mu.Unlock()
+	byJob, ok := cov.counts[test]
+	if !ok {
+		byJob = make(map[string]*execStats)
+		cov.counts[test] = byJob
+	}
+	stats, ok := byJob[job]
+	if !ok {
+		stats = &execStats{}
+		byJob[job] = stats
+	}
+	stats.total++
+	if passed {
+		stats.passed++
+	}
+}
+
+// overallSuccessRate returns the percentage of all recorded test executions,
+// across all tests and jobs, that passed.
+func (cov *coverage) overallSuccessRate() float64 {
+	cov.mu.Lock()
+	defer cov.mu.Unlock()
+	var total execStats
+	for _, byJob := range cov.counts {
+		for _, s := range byJob {
+			total.total += s.total
+			total.passed += s.passed
+		}
+	}
+	return total.successRate()
+}
+
+// writeReport writes a human-readable text report to w, using text/tabwriter
+// to align the columns of the various tables it contains.
+func (cov *coverage) writeReport(w io.Writer) error {
+	totalRuns := 0
+	for _, job := range cov.jobs {
+		totalRuns += cov.runsPerJob[job]
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	var err error
+	printf := func(format string, args ...interface{}) {
+		if err != nil {
+			return
+		}
+		_, err = fmt.Fprintf(tw, format, args...)
+	}
+
+	printf("Test execution coverage report\n\n")
+	printf("Jobs analyzed (%d), with number of runs found and average tests executed per run (see https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/<job name>):\n", len(cov.jobs))
+	jobExecTotals := make(map[string]int)
+	for _, byJob := range cov.counts {
+		for job, s := range byJob {
+			jobExecTotals[job] += s.total
+		}
+	}
+	jobsByRuns := append([]string(nil), cov.jobs...)
+	sort.SliceStable(jobsByRuns, func(i, j int) bool {
+		return cov.runsPerJob[jobsByRuns[i]] > cov.runsPerJob[jobsByRuns[j]]
+	})
+	totalExecutions := 0
+	for _, job := range jobsByRuns {
+		suiteName := cov.jobSuite[job]
+		if suiteName == "" {
+			if cov.runsPerJob[job] == 0 {
+				// No runs at all were found for this job within
+				// -age, so nothing can be said about which suite it
+				// runs.
+				suiteName = "unknown"
+			} else {
+				// Runs were analyzed, but none of them contained any
+				// JUnit data at all (e.g. a build job).
+				suiteName = "none"
+			}
+		}
+		totalExecutions += jobExecTotals[job]
+		printf("  %s\t%d\t%s\t%.1f\n", job, cov.runsPerJob[job], suiteName, averageTests(jobExecTotals[job], cov.runsPerJob[job]))
+	}
+	printf("  %s\t%d\t\t%.1f\n\n", "TOTAL", totalRuns, averageTests(totalExecutions, totalRuns))
+
+	tests := append([]string(nil), cov.allTests...)
+	sort.Strings(tests)
+
+	var executed, notExecuted []string
+	for _, test := range tests {
+		if len(cov.counts[test]) > 0 {
+			executed = append(executed, test)
+		} else {
+			notExecuted = append(notExecuted, test)
+		}
+	}
+
+	printf("Executed tests (%d of %d, %.0f%% overall success rate):\n\n", len(executed), len(tests), cov.overallSuccessRate())
+	for _, test := range executed {
+		byJob := cov.counts[test]
+		total := execStats{}
+		for _, s := range byJob {
+			total.total += s.total
+			total.passed += s.passed
+		}
+		printf("%s: total %d %.1f%%\n", test, total.total, total.successRate())
+		jobNames := make([]string, 0, len(byJob))
+		for job := range byJob {
+			jobNames = append(jobNames, job)
+		}
+		sort.Strings(jobNames)
+		sort.SliceStable(jobNames, func(i, j int) bool {
+			return byJob[jobNames[i]].total > byJob[jobNames[j]].total
+		})
+		for _, job := range jobNames {
+			s := byJob[job]
+			printf("    %s\t%d\t%.1f%%\n", job, s.total, s.successRate())
+		}
+	}
+
+	printf("\nTests never executed (%d of %d):\n\n", len(notExecuted), len(tests))
+	for _, test := range notExecuted {
+		printf("%s\n", test)
+	}
+
+	if err != nil {
+		return err
+	}
+	return tw.Flush()
+}

--- a/test-coverage/runs.go
+++ b/test-coverage/runs.go
@@ -1,0 +1,257 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"log"
+	"path"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/test-infra/test-coverage/third_party/forked/gotestsum/junitxml"
+)
+
+// componentSemVerConstraintSuffixRE matches the trailing
+// " [component: [constraint ...], ...]" suffix that Ginkgo's JUnit reporter
+// appends to a test's name for tests using ComponentSemVerConstraint (e.g.
+// framework.WithKubeletMinVersion), for example:
+//
+//	... with multiple drivers using only drapbv1 [KubeletMinVersion:1.34] work [kubelet: [>=1.34]]
+//
+// This suffix is not part of the test name as reported by --list-tests, so
+// it must be stripped for the JUnit test name to match.
+var componentSemVerConstraintSuffixRE = regexp.MustCompile(`\s\[\w+: \[[^][]*](?:, \w+: \[[^][]*])*]$`)
+
+// jobRun identifies one execution ("build") of a Prow job.
+type jobRun struct {
+	job     string
+	buildID string
+	started time.Time
+}
+
+// findRecentRuns returns the runs of job that started at or after cutoff,
+// newest first.
+func findRecentRuns(client *gcsClient, job string, cutoff time.Time) ([]jobRun, error) {
+	prefix := "logs/" + job + "/"
+	prefixes, err := client.listPrefixes(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	buildIDs := make([]string, 0, len(prefixes))
+	for _, p := range prefixes {
+		id := strings.TrimSuffix(strings.TrimPrefix(p, prefix), "/")
+		if id == "" {
+			continue
+		}
+		buildIDs = append(buildIDs, id)
+	}
+	// Build IDs are monotonically increasing snowflake-like numbers, so
+	// sorting numerically, descending, gives us newest-first order.
+	sort.Slice(buildIDs, func(i, j int) bool {
+		ni, erri := strconv.ParseUint(buildIDs[i], 10, 64)
+		nj, errj := strconv.ParseUint(buildIDs[j], 10, 64)
+		if erri != nil || errj != nil {
+			return buildIDs[i] > buildIDs[j]
+		}
+		return ni > nj
+	})
+
+	var runs []jobRun
+	for _, id := range buildIDs {
+		started, ok, err := getStartedTime(client, job, id)
+		if err != nil {
+			log.Printf("warning: %s/%s: %v", job, id, err)
+			continue
+		}
+		if !ok {
+			// Build result not (yet) uploaded, e.g. still running.
+			continue
+		}
+		if started.Before(cutoff) {
+			// Runs are listed newest-first, so once we see one that
+			// is too old, all further ones will be too.
+			break
+		}
+		runs = append(runs, jobRun{job: job, buildID: id, started: started})
+	}
+	return runs, nil
+}
+
+// startedJSON is the relevant subset of the "started.json" metadata file
+// that Prow writes for each job run.
+type startedJSON struct {
+	Timestamp int64 `json:"timestamp"`
+}
+
+// getStartedTime returns the start time recorded in started.json for the
+// given run. ok is false if the file does not exist (e.g. the run has not
+// finished uploading yet).
+func getStartedTime(client *gcsClient, job, buildID string) (_ time.Time, ok bool, _ error) {
+	data, err := client.getObject(fmt.Sprintf("logs/%s/%s/started.json", job, buildID))
+	if err != nil {
+		return time.Time{}, false, nil
+	}
+	var started startedJSON
+	if err := json.Unmarshal(data, &started); err != nil {
+		return time.Time{}, false, fmt.Errorf("parsing started.json: %w", err)
+	}
+	return time.Unix(started.Timestamp, 0), true, nil
+}
+
+// testResult is the outcome of one executed (non-skipped) test case.
+type testResult struct {
+	name   string
+	passed bool
+}
+
+// executedTests downloads and parses all junit_*.xml files directly under
+// the "artifacts" directory of run, and returns the results of all test
+// cases (matching the "[It] " Ginkgo test names, with that prefix stripped)
+// that belong to suite and were executed (i.e. not skipped).
+//
+// detectedSuite is the name of the Ginkgo suite that run actually executed,
+// as taken from the top-level "testsuite" element's "name" attribute (e.g.
+// "E2eNode Suite" or "Kubernetes e2e suite"). Some JUnit files (e.g.
+// "junit_coverage.xml", which lists code coverage numbers instead of test
+// results) have a "testsuite" root element without a "name" attribute at
+// all; those are reported as "unknown" so that they are still recognized
+// as JUnit data (just not belonging to suite), instead of being confused
+// with the run having produced no JUnit data at all. detectedSuite is only
+// empty if no junit files (or no "testsuite" elements) were found at all,
+// e.g. because the job failed before running any tests; the caller should
+// not treat that as having run the wrong suite. A "testsuite" named
+// "kubetest" or "kubetest2" (as found in "junit_runner.xml", written by
+// the kubetest/kubetest2 wrapper itself) is ignored entirely: it merely
+// lists the
+// wrapper's own high-level steps (e.g. "Prepare", "GetDeployer"), not
+// which Ginkgo suite was actually run, and it is always present
+// regardless of whether the run's real test suite produced any results
+// at all (e.g. because the run failed before getting that far). Treating
+// it as a real suite would incorrectly flag runs as "ran the wrong
+// suite" whenever the real suite's JUnit file happens to be missing,
+// which can happen even for jobs whose other, successful runs clearly
+// do execute the expected suite. Some jobs (e.g.
+// "ci-node-e2e-containerd-2-0-ubuntu-dra-alpha-beta-features") produce
+// junit files with several different suite names in the same run, for
+// example because they run more than one test binary. In that case, any
+// well-known suite (i.e. "Kubernetes e2e suite" or "E2eNode Suite", not
+// just the one currently being analyzed) found anywhere in the run is
+// considered the "main" one and reported as detectedSuite. Otherwise, if
+// more than five distinct "testsuite" elements are found, detectedSuite is
+// reported as "many": this heuristic is for gotestsum-produced JUnit
+// files, as found in e.g. "ci-kubernetes-integration", which contain one
+// "testsuite" element per Go test package and thus have too many of them
+// to meaningfully pick one as "the" suite that was executed. Failing both
+// of those, the first suite name encountered is used, which is somewhat
+// arbitrary but not wrong. Regardless of which suite is picked as
+// detectedSuite, test cases are collected from all "testsuite" elements
+// whose name matches suite.junitClassname.
+func executedTests(client *gcsClient, run jobRun, suite e2eSuite) (tests []testResult, detectedSuite string, err error) {
+	artifactsPrefix := fmt.Sprintf("logs/%s/%s/artifacts/", run.job, run.buildID)
+	files, err := client.listFiles(artifactsPrefix)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var firstSuiteName, mainSuiteName string
+	suiteCount := 0
+	for _, f := range files {
+		base := path.Base(f)
+		if !strings.HasPrefix(base, "junit_") || !strings.HasSuffix(base, ".xml") {
+			continue
+		}
+		data, err := client.getObject(f)
+		if err != nil {
+			log.Printf("warning: %s: %v", f, err)
+			continue
+		}
+		suites, err := parseJUnitTestSuites(data)
+		if err != nil {
+			log.Printf("warning: parsing %s: %v", f, err)
+			continue
+		}
+		for _, s := range suites {
+			name := s.Name
+			if name == "" {
+				name = "unknown"
+			}
+			if name == "kubetest" || name == "kubetest2" {
+				// The kubetest/kubetest2 wrapper's own suite, not a
+				// real test suite; see the function doc comment.
+				continue
+			}
+			suiteCount++
+			if firstSuiteName == "" {
+				firstSuiteName = name
+			}
+			if mainSuiteName == "" && isKnownSuiteClassname(name) {
+				mainSuiteName = name
+			}
+			if name != suite.junitClassname {
+				// This testsuite element belongs to a different suite,
+				// e.g. because the job under consideration ran both
+				// "e2e" and "e2e_node" tests, or ran the wrong suite
+				// altogether.
+				continue
+			}
+			for _, c := range s.TestCases {
+				if c.SkipMessage != nil {
+					continue
+				}
+				name := strings.TrimPrefix(c.Name, "[It] ")
+				if name == c.Name {
+					// Not an "[It]" test case, e.g. "[SynchronizedBeforeSuite]".
+					continue
+				}
+				name = componentSemVerConstraintSuffixRE.ReplaceAllString(name, "")
+				tests = append(tests, testResult{name: name, passed: c.Failure == nil})
+			}
+		}
+	}
+	switch {
+	case mainSuiteName != "":
+		detectedSuite = mainSuiteName
+	case suiteCount > 5:
+		detectedSuite = "many"
+	default:
+		detectedSuite = firstSuiteName
+	}
+	return tests, detectedSuite, nil
+}
+
+// parseJUnitTestSuites parses a JUnit XML report whose root element is
+// either <testsuites> or a single <testsuite>, and returns all the
+// top-level test suites found in it.
+func parseJUnitTestSuites(data []byte) ([]junitxml.JUnitTestSuite, error) {
+	var suites junitxml.JUnitTestSuites
+	if err := xml.Unmarshal(data, &suites); err == nil {
+		return suites.Suites, nil
+	}
+
+	var suite junitxml.JUnitTestSuite
+	if err := xml.Unmarshal(data, &suite); err != nil {
+		return nil, err
+	}
+	return []junitxml.JUnitTestSuite{suite}, nil
+}

--- a/test-coverage/suite.go
+++ b/test-coverage/suite.go
@@ -1,0 +1,81 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "fmt"
+
+// e2eSuite describes one of the Ginkgo test suites in the kubernetes/test
+// directory that this tool knows how to analyze.
+type e2eSuite struct {
+	// testPackage is the Go package (relative to the kubernetes repo root)
+	// which contains the suite, e.g. "./test/e2e_node".
+	testPackage string
+	// junitClassname is the "classname" attribute that JUnit testcase
+	// elements have when they were produced by this suite, e.g.
+	// "E2eNode Suite". Used to recognize (and ignore) job runs that
+	// executed a different suite.
+	junitClassname string
+	// defaultJobDir is the default value of the -job-dir flag when this
+	// suite is selected, relative to the test-infra repo root.
+	defaultJobDir string
+}
+
+var e2eSuites = map[string]e2eSuite{
+	"e2e": {
+		testPackage:    "./test/e2e",
+		junitClassname: "Kubernetes e2e suite",
+		defaultJobDir:  "config/jobs/kubernetes",
+	},
+	"e2e_node": {
+		testPackage:    "./test/e2e_node",
+		junitClassname: "E2eNode Suite",
+		defaultJobDir:  "config/jobs/kubernetes/sig-node",
+	},
+}
+
+// lookupE2ESuite returns the e2eSuite for name, or an error if name is not
+// one of the supported suites.
+func lookupE2ESuite(name string) (e2eSuite, error) {
+	suite, ok := e2eSuites[name]
+	if !ok {
+		return e2eSuite{}, fmt.Errorf("unsupported -e2e-suite %q, must be one of \"e2e\" or \"e2e_node\"", name)
+	}
+	return suite, nil
+}
+
+// isKnownSuiteClassname reports whether classname matches the
+// junitClassname of one of the known e2eSuites.
+func isKnownSuiteClassname(classname string) bool {
+	for _, suite := range e2eSuites {
+		if suite.junitClassname == classname {
+			return true
+		}
+	}
+	return false
+}
+
+// suiteNameForClassname returns the short name ("e2e", "e2e_node") of the
+// known e2eSuite whose junitClassname matches classname, or classname
+// itself if it does not belong to any known suite.
+func suiteNameForClassname(classname string) string {
+	for name, suite := range e2eSuites {
+		if suite.junitClassname == classname {
+			return name
+		}
+	}
+	return classname
+}

--- a/test-coverage/suite.go
+++ b/test-coverage/suite.go
@@ -29,21 +29,25 @@ type e2eSuite struct {
 	// "E2eNode Suite". Used to recognize (and ignore) job runs that
 	// executed a different suite.
 	junitClassname string
-	// defaultJobDir is the default value of the -job-dir flag when this
-	// suite is selected, relative to the test-infra repo root.
-	defaultJobDir string
+	// defaultJobDirs are the default values of the -job-dir flag when
+	// this suite is selected, relative to the test-infra repo root. Jobs
+	// from all of these directories are combined.
+	defaultJobDirs []string
 }
 
 var e2eSuites = map[string]e2eSuite{
 	"e2e": {
 		testPackage:    "./test/e2e",
 		junitClassname: "Kubernetes e2e suite",
-		defaultJobDir:  "config/jobs/kubernetes",
+		// kubernetes-sigs is included because several subprojects there
+		// (e.g. sig-windows) run the kubernetes/kubernetes "e2e" suite
+		// against their own images.
+		defaultJobDirs: []string{"config/jobs/kubernetes", "config/jobs/kubernetes-sigs"},
 	},
 	"e2e_node": {
 		testPackage:    "./test/e2e_node",
 		junitClassname: "E2eNode Suite",
-		defaultJobDir:  "config/jobs/kubernetes/sig-node",
+		defaultJobDirs: []string{"config/jobs/kubernetes/sig-node"},
 	},
 }
 

--- a/test-coverage/testlist.go
+++ b/test-coverage/testlist.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+)
+
+// listTestNameRE matches one line of "go test -args --list-tests" output,
+// for example:
+//
+//	../kubernetes/test/e2e_node/apparmor_test.go:88: [sig-node] AppArmor when running with AppArmor should enforce a permissive profile with annotations [NodeConformance]
+//
+// Capture group 1 is the test name without the "<file>:<line>: " prefix.
+var listTestNameRE = regexp.MustCompile(`^\s*\S+:\d+:\s(.+)$`)
+
+// listGinkgoTests runs the Ginkgo suite in testPackage (a package path
+// relative to kubernetesRepoDir, e.g. "./test/e2e_node") with --list-tests
+// and returns the sorted, de-duplicated set of test names that it prints.
+func listGinkgoTests(kubernetesRepoDir, testPackage string) ([]string, error) {
+	cmd := exec.Command("go", "test", "-v", testPackage, "-args", "--list-tests")
+	cmd.Dir = kubernetesRepoDir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("running %q in %s: %w\n%s", cmd.Args, kubernetesRepoDir, err, stderr.String())
+	}
+
+	seen := make(map[string]bool)
+	var tests []string
+	for _, line := range bytes.Split(stdout.Bytes(), []byte("\n")) {
+		m := listTestNameRE.FindSubmatch(line)
+		if m == nil {
+			continue
+		}
+		name := string(m[1])
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		tests = append(tests, name)
+	}
+	if len(tests) == 0 {
+		return nil, fmt.Errorf("no tests found in --list-tests output of %q", cmd.Args)
+	}
+	sort.Strings(tests)
+	return tests, nil
+}

--- a/test-coverage/third_party/forked/gotestsum/LICENSE
+++ b/test-coverage/third_party/forked/gotestsum/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test-coverage/third_party/forked/gotestsum/NOTICE
+++ b/test-coverage/third_party/forked/gotestsum/NOTICE
@@ -1,0 +1,13 @@
+   Copyright The gotestsum Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test-coverage/third_party/forked/gotestsum/junitxml/report.go
+++ b/test-coverage/third_party/forked/gotestsum/junitxml/report.go
@@ -1,0 +1,56 @@
+/*Package junitxml creates a JUnit XML report from a testjson.Execution.
+ */
+package junitxml
+
+import (
+	"encoding/xml"
+)
+
+// JUnitTestSuites is a collection of JUnit test suites.
+type JUnitTestSuites struct {
+	XMLName xml.Name         `xml:"testsuites"`
+	Suites  []JUnitTestSuite `xml:"testsuite,omitempty"`
+}
+
+// JUnitTestSuite is a single JUnit test suite which may contain many
+// testcases.
+type JUnitTestSuite struct {
+	XMLName    xml.Name        `xml:"testsuite"`
+	Tests      int             `xml:"tests,attr"`
+	Failures   int             `xml:"failures,attr"`
+	Time       string          `xml:"time,attr"`
+	Name       string          `xml:"name,attr"`
+	Properties []JUnitProperty `xml:"properties>property,omitempty"`
+	TestCases  []JUnitTestCase `xml:"testcase,omitempty"`
+	Timestamp  string          `xml:"timestamp,attr"`
+}
+
+// JUnitTestCase is a single test case with its result.
+type JUnitTestCase struct {
+	XMLName     xml.Name          `xml:"testcase"`
+	Classname   string            `xml:"classname,attr"`
+	Name        string            `xml:"name,attr"`
+	Time        string            `xml:"time,attr"`
+	SkipMessage *JUnitSkipMessage `xml:"skipped,omitempty"`
+	Failure     *JUnitFailure     `xml:"failure,omitempty"`
+	SystemOut   string            `xml:"system-out,omitempty"`
+	SystemErr   string            `xml:"system-err,omitempty"`
+}
+
+// JUnitSkipMessage contains the reason why a testcase was skipped.
+type JUnitSkipMessage struct {
+	Message string `xml:"message,attr"`
+}
+
+// JUnitProperty represents a key/value pair used to define properties.
+type JUnitProperty struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// JUnitFailure contains data related to a failed test.
+type JUnitFailure struct {
+	Message  string `xml:"message,attr"`
+	Type     string `xml:"type,attr"`
+	Contents string `xml:",chardata"`
+}


### PR DESCRIPTION
testgrid shows us which tests ran in certain jobs. What we don't have is tooling that tells us which tests exist without ever being executed (indicating a lack of a suitable periodic) or which don't get executed in all relevant environments (different clusters for test/e2e, different machine configurations for test/e2e_node).

The new coverage tool provides some answers by determining which tests exist, finding recent job runs which might have executed them, and then reporting which jobs executed each test.

The crucial part is limiting how much data it needs to download. It uses several filters:
- For e2e_node, only consider jobs under sig-node.
- Ignore jobs which don't test kubernetes/kubernetes.
- List job runs by ID (recent first), then stop at a configurable age.

Created using an LLM.