### PR TITLE
Add branch customized-controller to etcd-operator-presubmits

### DIFF
--- a/config/jobs/etcd/etcd-operator-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-postsubmits.yaml
@@ -5,6 +5,7 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
+    - customized-controller
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-operator-postsubmits
@@ -31,6 +32,7 @@ postsubmits:
     cluster: k8s-infra-prow-build
     branches:
     - main
+    - customized-controller
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -62,6 +64,7 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
+    - customized-controller
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-operator-postsubmits

--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -6,6 +6,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - customized-controller
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-operator-presubmits
@@ -33,6 +34,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - customized-controller
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -64,6 +66,7 @@ presubmits:
     always_run: true
     branches:
     - main
+    - customized-controller
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-operator-presubmits


### PR DESCRIPTION
We're working on an integration branch for etcd-operator to convert it to using a custom controller instead of statefulsets.  This PR is to make sure that whenever we make changes to the branch, the CI checks are run against it.

See more details [here](https://github.com/etcd-io/etcd-operator/pull/404#issuecomment-4914758751).

cc @ahrtr 