### PR TITLE
Pin watch-list benchmark presubmits to us-east1-b zone

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -146,6 +146,7 @@ presubmits:
         - --gcp-node-size=e2-standard-16
         - --gcp-nodes=1
         - --gcp-project-type=scalability-project
+        - --gcp-zone=us-east1-b
         - --provider=gce
         - --test=false
         - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
@@ -210,6 +211,7 @@ presubmits:
         - --gcp-node-size=e2-standard-16
         - --gcp-nodes=1
         - --gcp-project-type=scalability-project
+        - --gcp-zone=us-east1-b
         - --provider=gce
         - --test=false
         - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh


### PR DESCRIPTION
The `pull-kubernetes-e2e-gce-watch-list-benchmark` and `-off` presubmits set no `--gcp-zone`, so they fall through to the kube-up default `us-central1-b`, which is experiencing a GCE `n2-standard-32` stockout. The [last 3 runs all failed](https://testgrid.k8s.io/sig-scalability-benchmarks#gce-watch-list-off-benchmark) for this reason.

Every other sig-scalability job already pins `--gcp-zone=us-east1-b`. This pins both watch-list benchmarks to match.