### PR TITLE
Drop ETCD_VERSION 3.7.0-rc.0 override from sig-scalability scale jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -60,8 +60,6 @@ presubmits:
           value: gce
         - name: KUBE_NODE_COUNT
           value: "100"
-        - name: ETCD_VERSION
-          value: "3.7.0-rc.0"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT
@@ -303,8 +301,6 @@ presubmits:
           value: gce
         - name: KUBE_NODE_COUNT
           value: "5000"
-        - name: ETCD_VERSION
-          value: "3.7.0-rc.0"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -90,8 +90,6 @@ periodics:
         value: "amazonvpc"
       - name: KUBE_NODE_COUNT
         value: "5000"
-      - name: ETCD_VERSION
-        value: "3.7.0-rc.0"
       - name: CL2_LOAD_TEST_THROUGHPUT
         value: "50"
       - name: CL2_DELETE_TEST_THROUGHPUT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1253,8 +1253,6 @@ periodics:
         value: gce
       - name: KUBE_NODE_COUNT
         value: "5000"
-      - name: ETCD_VERSION
-        value: "3.7.0-rc.0"
       - name: CL2_LOAD_TEST_THROUGHPUT
         value: "50"
       - name: CL2_DELETE_TEST_THROUGHPUT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -474,8 +474,6 @@ presubmits:
           value: gce
         - name: KUBE_NODE_COUNT
           value: "5000"
-        - name: ETCD_VERSION
-          value: "3.7.0-rc.0"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT


### PR DESCRIPTION
https://github.com/kubernetes/kops/pull/18557 defaults all tests to etcd 3.7, so this override is unnecessary and technically breaking since it replaces the released 3.7 with the 3.7 rc.