### PR TITLE
pick the image mirror dynamically and fix missing cpu/metrics of dind

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -42,20 +42,6 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     echo "Docker in Docker enabled, initializing..."
     printf '=%.0s' {1..80}; echo
 
-    # optionally enable CDI in Docker/containerd (see https://github.com/cncf-tags/container-device-interface?tab=readme-ov-file#docker-configuration)
-    export CDI_IN_DOCKER_ENABLED=${CDI_IN_DOCKER_ENABLED:-false}
-    if [[ "${CDI_IN_DOCKER_ENABLED}" == "true" ]]; then
-        echo "Enabling CDI for Docker."
-        mkdir -p /etc/docker/
-        cat >/etc/docker/daemon.json <<EOF
-{
-  "features": {
-    "cdi": true
-  }
-}
-EOF
-    fi
-
     # docker v27+ has ipv6 by default, but not all e2e hosts have everything
     # we need enabled by default
     # enable ipv6
@@ -66,6 +52,24 @@ EOF
 
     # Fix ulimit issue
     sed -i 's|ulimit -Hn|ulimit -n|' /etc/init.d/docker || true
+
+    local docker_registry_mirror_url
+    if [[ "${PROW_CLOUD_PROVIDER:-}" == "amazon" ]]; then
+        echo "Configuring docker to use public.ecr.aws/docker/library"
+        docker_registry_mirror_url=https://public.ecr.aws/docker/library
+    else
+        echo "Configuring docker to use mirror.gcr.io"
+        docker_registry_mirror_url="https://mirror.gcr.io"
+    fi
+
+    mkdir -p /etc/docker
+    cat >/etc/docker/daemon.json <<EOF
+{
+  "registry-mirrors": ["${docker_registry_mirror_url}"],
+  "cgroup-parent": "dind",
+  "default-cgroupns-mode": "host"
+}
+EOF
 
     # start the docker daemon
     service docker start

--- a/images/kubekins-e2e-v2/Dockerfile
+++ b/images/kubekins-e2e-v2/Dockerfile
@@ -201,13 +201,6 @@ RUN if [ -n "${KUBETEST2_VERSION}" ]; then \
     rm linux-${TARGETARCH}.tgz; \
     fi
 
-# configure dockerd to use mirror.gcr.io
-# per instructions at https://cloud.google.com/container-registry/docs/pulling-cached-images
-ARG DOCKER_REGISTRY_MIRROR_URL=https://mirror.gcr.io
-RUN [ -n "${DOCKER_REGISTRY_MIRROR_URL}" ] && \
-    echo "DOCKER_OPTS=\"\${DOCKER_OPTS} --registry-mirror=${DOCKER_REGISTRY_MIRROR_URL}\"" | \
-    tee --append /etc/default/docker
-
 # note the runner is also responsible for making docker in docker function if
 # env DOCKER_IN_DOCKER_ENABLED is set
 COPY ["runner.sh", \

--- a/images/kubekins-e2e-v2/runner.sh
+++ b/images/kubekins-e2e-v2/runner.sh
@@ -48,6 +48,24 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     # Fix ulimit issue
     sed -i 's|ulimit -Hn|ulimit -n|' /etc/init.d/docker || true
 
+    local docker_registry_mirror_url
+    if [[ "${PROW_CLOUD_PROVIDER:-}" == "amazon" ]]; then
+        echo "Configuring docker to use public.ecr.aws/docker/library"
+        local docker_registry_mirror_url=https://public.ecr.aws/docker/library
+    else
+        echo "Configuring docker to use mirror.gcr.io"
+        local docker_registry_mirror_url="https://mirror.gcr.io"
+    fi
+
+    mkdir -p /etc/docker
+    cat >/etc/docker/daemon.json <<EOF
+{
+  "registry-mirrors": ["${docker_registry_mirror_url}"],
+  "cgroup-parent": "dind",
+  "default-cgroupns-mode": "host"
+}
+EOF
+
     # start the docker daemon
     service docker start
     # the service can be started but the docker socket not ready, wait for ready

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -101,13 +101,6 @@ RUN if [ -n "${KUBETEST2_VERSION}" ]; then \
     cd /tmp/kubetest2 && make install-all && rm -rf /tmp/kubetest2; \
     fi
 
-# configure dockerd to use mirror.gcr.io
-# per instructions at https://cloud.google.com/container-registry/docs/pulling-cached-images
-ARG DOCKER_REGISTRY_MIRROR_URL=https://mirror.gcr.io
-RUN [ -n "${DOCKER_REGISTRY_MIRROR_URL}" ] && \
-    echo "DOCKER_OPTS=\"\${DOCKER_OPTS} --registry-mirror=${DOCKER_REGISTRY_MIRROR_URL}\"" | \
-    tee --append /etc/default/docker
-
 # add env we can debug with the image name:tag
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}


### PR DESCRIPTION
- cdi has been enabled by default since v28, and no jobs are setting that env variable
- We want to set the mirrors dynamically based on a new env variable called `PROW_CLOUD_PROVIDER` that will use the correct mirrors for AWS and GCP and defaults to the current one if unset.
- Setting `default-cgroupns-mode` to `host` should allow us to see cpu/metrics of DIND correctly in Datadog/Prometheus


/cc @dims @BenTheElder @pohly 

