### PR TITLE
kubernetes/examples: create e2e test job

### DIFF
--- a/config/jobs/kubernetes/examples/OWNERS
+++ b/config/jobs/kubernetes/examples/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - soltysh
+  - justinsb
+  - janetkuo
+  - sig-apps-leads
+labels:
+- sig/apps

--- a/config/jobs/kubernetes/examples/examples-presubmits.yaml
+++ b/config/jobs/kubernetes/examples/examples-presubmits.yaml
@@ -1,0 +1,36 @@
+# github.com/kubernetes/examples presubmits
+presubmits:
+  kubernetes/examples:
+  - name: pull-examples-e2e-kind
+    cluster: k8s-infra-prow-build
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    # Run on every PR, but non-blocking for now.
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 30m
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20260706-7056f81a85-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - tests/e2e/e2e-kind
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "4"
+            memory: 9000Mi
+          requests:
+            cpu: "4"
+            memory: 9000Mi
+    annotations:
+      testgrid-dashboards: sig-apps-examples
+      testgrid-tab-name: pull-examples-e2e-kind
+      description: Runs the tests/e2e/e2e-kind test.

--- a/config/testgrids/kubernetes/sig-apps/config.yaml
+++ b/config/testgrids/kubernetes/sig-apps/config.yaml
@@ -3,6 +3,7 @@ dashboard_groups:
   dashboard_names:
     - sig-apps-agent-sandbox
     - sig-apps-mcp-lifecycle-operator
+    - sig-apps-examples
     - sig-apps-jobset
     - sig-apps-jobset-periodics
     - sig-apps-jobset-presubmits
@@ -15,6 +16,7 @@ dashboard_groups:
 dashboards:
 - name: sig-apps-agent-sandbox
 - name: sig-apps-mcp-lifecycle-operator
+- name: sig-apps-examples
 - name: sig-apps-jobset
 - name: sig-apps-jobset-periodics
 - name: sig-apps-jobset-presubmits


### PR DESCRIPTION
We create a generic tests/e2e/e2e-with-kind entrypoint to avoid
having to create a new job for each example.
