### PR TITLE
Add kubernetes/kubernetes presubmit for windows e2e node tests

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/windows-e2enode.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-e2enode.yaml
@@ -39,6 +39,52 @@ periodics:
     testgrid-tab-name: windows-e2e-node-master
 
 presubmits:
+  kubernetes/kubernetes:
+    - name: pull-kubernetes-e2enode-windows-master
+      always_run: false
+      branches:
+        - master
+        - main
+      cluster: eks-prow-build-cluster
+      decorate: true
+      decoration_config:
+        timeout: 4h
+      optional: true
+      labels:
+        preset-dind-enabled: "true"
+        preset-azure-community: "true"
+      extra_refs:
+        - org: kubernetes-sigs
+          repo: windows-testing
+          base_ref: master
+          path_alias: sigs.k8s.io/windows-testing
+          workdir: true
+      path_alias: k8s.io/kubernetes
+      run_if_changed: '.*windows\.go$|.*windows/.*\.go$'
+      spec:
+        serviceAccountName: azure
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260708-267b57c4ed-master
+            command:
+              - "runner.sh"
+              - "./scripts/ci-k8s-e2e-node-test.sh"
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 2
+                memory: "5Gi"
+              limits:
+                cpu: 2
+                memory: "5Gi"
+            env:
+              - name: VM_LOCATION
+                value: northeurope
+              - name: CONTAINERD_VERSION
+                value: "nightly"
+      annotations:
+        testgrid-dashboards: sig-windows-presubmit
+        testgrid-tab-name: pr-kubernetes-e2enode-windows-master
   kubernetes-sigs/windows-testing:
     - name: pull-kubernetes-e2enode-windows
       always_run: false

--- a/config/jobs/kubernetes-sigs/sig-windows/windows-e2enode.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/windows-e2enode.yaml
@@ -6,7 +6,6 @@ periodics:
   decoration_config:
     timeout: 4h
   labels:
-    preset-dind-enabled: "true"
     preset-azure-community: "true"
   extra_refs:
   - org: kubernetes-sigs
@@ -20,8 +19,6 @@ periodics:
         command:
           - "runner.sh"
           - "./scripts/ci-k8s-e2e-node-test.sh"
-        securityContext:
-          privileged: true
         resources:
           requests:
             cpu: 2
@@ -40,18 +37,22 @@ periodics:
 
 presubmits:
   kubernetes/kubernetes:
-    - name: pull-kubernetes-e2enode-windows-master
+    # Prow clones k/k into the build container (the primary repo), but
+    # ci-k8s-e2e-node-test.sh ignores that checkout and only forwards the
+    # PR-coordinate env vars (PULL_NUMBER / PULL_BASE_REF / REPO_OWNER /
+    # REPO_NAME) to k8s_e2e_node_windows.ps1. That script does a fresh shallow
+    # clone + PR fetch/checkout on the Windows test VM and builds kubelet there,
+    # so this invocation can be identical to the windows-testing job below.
+    - name: pull-kubernetes-e2enode-windows
       always_run: false
-      branches:
-        - master
-        - main
+      skip_branches:
+        - release-\d+\.\d+ # per-release image
       cluster: eks-prow-build-cluster
       decorate: true
       decoration_config:
         timeout: 4h
       optional: true
       labels:
-        preset-dind-enabled: "true"
         preset-azure-community: "true"
       extra_refs:
         - org: kubernetes-sigs
@@ -68,8 +69,6 @@ presubmits:
             command:
               - "runner.sh"
               - "./scripts/ci-k8s-e2e-node-test.sh"
-            securityContext:
-              privileged: true
             resources:
               requests:
                 cpu: 2
@@ -83,10 +82,18 @@ presubmits:
               - name: CONTAINERD_VERSION
                 value: "nightly"
       annotations:
+        fork-per-release: "true"
         testgrid-dashboards: sig-windows-presubmit
-        testgrid-tab-name: pr-kubernetes-e2enode-windows-master
+        testgrid-tab-name: pr-kubernetes-e2enode-windows
   kubernetes-sigs/windows-testing:
-    - name: pull-kubernetes-e2enode-windows
+    # This job validates changes to the windows-testing scripts themselves.
+    # ci-k8s-e2e-node-test.sh provisions a Windows Azure VM and runs
+    # k8s_e2e_node_windows.ps1 on it, which clones kubernetes/kubernetes
+    # (defaulting to master) directly on the VM and builds kubelet there.
+    # The k/k source is therefore never used inside the Prow build container,
+    # so it does not need to be an extra_ref here; only this repo's scripts are
+    # needed. As a result this job always tests against kubernetes/kubernetes master.
+    - name: pull-k8s-sig-windows-e2enode
       always_run: false
       cluster: eks-prow-build-cluster
       decorate: true
@@ -94,7 +101,6 @@ presubmits:
         timeout: 4h
       optional: true
       labels:
-        preset-dind-enabled: "true"
         preset-azure-community: "true"
       path_alias: sigs.k8s.io/windows-testing
       run_if_changed: '^scripts\/.*'
@@ -105,8 +111,6 @@ presubmits:
             command:
               - "runner.sh"
               - "./scripts/ci-k8s-e2e-node-test.sh"
-            securityContext:
-              privileged: true
             resources:
               requests:
                 cpu: 2
@@ -121,4 +125,4 @@ presubmits:
                 value: "nightly"
       annotations:
         testgrid-dashboards: sig-windows-presubmit
-        testgrid-tab-name: pr-windows-e2e-node-master
+        testgrid-tab-name: pr-k8s-sig-windows-e2enode

--- a/config/tests/jobs/policy/presubmit-jobs.yaml
+++ b/config/tests/jobs/policy/presubmit-jobs.yaml
@@ -104,6 +104,8 @@ optional_and_run_if_changed:
       run_if_changed: ^(pkg\/controller\/volume|pkg\/kubelet\/volumemanager|pkg\/volume|pkg\/util\/mount|test\/e2e\/storage|test\/e2e\/testing-manifests\/storage-csi)
     - name: pull-kubernetes-e2e-storage-kind-vac
       run_if_changed: ^(pkg\/controller\/volume|pkg\/kubelet\/volumemanager|pkg\/volume|pkg\/util\/mount|test\/e2e\/storage|test\/e2e\/testing-manifests\/storage-csi)
+    - name: pull-kubernetes-e2enode-windows-master
+      run_if_changed: .*windows\.go$|.*windows/.*\.go$
     - name: pull-kubernetes-kind-dra
       branches:
         - release-1.33

--- a/config/tests/jobs/policy/presubmit-jobs.yaml
+++ b/config/tests/jobs/policy/presubmit-jobs.yaml
@@ -104,7 +104,7 @@ optional_and_run_if_changed:
       run_if_changed: ^(pkg\/controller\/volume|pkg\/kubelet\/volumemanager|pkg\/volume|pkg\/util\/mount|test\/e2e\/storage|test\/e2e\/testing-manifests\/storage-csi)
     - name: pull-kubernetes-e2e-storage-kind-vac
       run_if_changed: ^(pkg\/controller\/volume|pkg\/kubelet\/volumemanager|pkg\/volume|pkg\/util\/mount|test\/e2e\/storage|test\/e2e\/testing-manifests\/storage-csi)
-    - name: pull-kubernetes-e2enode-windows-master
+    - name: pull-kubernetes-e2enode-windows
       run_if_changed: .*windows\.go$|.*windows/.*\.go$
     - name: pull-kubernetes-kind-dra
       branches:


### PR DESCRIPTION
Add pre-submit job on windows node level e2e test. this pre-submitted job will be triggered only when windows related code being changed