### PR TITLE
kueue: auto-run website link preview check on site/ changes

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -1938,6 +1938,7 @@ presubmits:
       cluster: eks-prow-build-cluster
       optional: true
       always_run: false
+      run_if_changed: "^(site/|netlify\\.toml)"
       branches:
         - ^main
       decorate: true


### PR DESCRIPTION
## Summary

- Adds `run_if_changed: "^(site/|netlify\\.toml)"` to `pull-kueue-verify-website-links-preview-main`
- Keeps the job `optional: true` so it remains non-blocking during soak time

## Context

kubernetes-sigs/kueue#12472 introduced an on-demand presubmit that checks links on Netlify deploy previews. Maintainers asked to start with on-demand triggering, then enable automatic runs on website PRs without blocking merge. This change implements that next step.

Companion docs PR: kubernetes-sigs/kueue (docs/website-link-check-guide)

## Test plan

- [ ] Confirm prow job YAML validates
- [ ] On a kueue `site/` PR, verify the job is triggered automatically after merge of this config

Part of kubernetes-sigs/kueue#12472