### PR TITLE
Update go version for 1.26.5 in kustomize

### DIFF
--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-presubmit-master.yaml
@@ -9,7 +9,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25.7
+      - image: public.ecr.aws/docker/library/golang:1.26.5
         command:
         - make
         args:


### PR DESCRIPTION
Update golang version in prow that is used in tests for https://github.com/kubernetes-sigs/kustomize