### PR TITLE
Marking Parameter Tests As Required

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -518,8 +518,7 @@ presubmits:
   - name: pull-aws-ebs-csi-driver-e2e-parameters
     cluster: eks-prow-build-cluster
     decorate: true
-    optional: true
-    skip_report: true
+    optional: false
     skip_branches:
     - gh-pages
     skip_if_only_changed: "^docs/|^examples/|.md$|OWNERS$|^.github/"


### PR DESCRIPTION
Parameter tests have been running [with no flakes for a while](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-aws-ebs-csi-driver-e2e-parameters?buildId=), flipping to required. 