### PR TITLE
sig-node: skip [Slow] tests in containerd NodeConformance lanes

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -125,7 +125,7 @@ periodics:
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=false --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
+      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
       - --timeout=65m
       env:
       - name: GOPATH
@@ -177,7 +177,7 @@ periodics:
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-driver=systemd --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
           - --timeout=65m
         env:
           - name: GOPATH
@@ -510,7 +510,7 @@ periodics:
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
+      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
       - --timeout=65m
       env:
       - name: GOPATH
@@ -714,7 +714,7 @@ periodics:
       - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
       - --node-tests=true
       - --provider=gce
-      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
+      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
       - --timeout=65m
       resources:
         limits:

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -2900,7 +2900,7 @@ presubmits:
               - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--fail-cgroupv1=false --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
               - --node-tests=true
               - --provider=gce
-              - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
+              - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
               - --timeout=65m
             env:
               - name: GOPATH


### PR DESCRIPTION
## What this PR does / why we need it

Several containerd NodeConformance node-e2e jobs (periodic and presubmit)
were not excluding `[Slow]` tests from their focus/skip filters, unlike
sibling jobs in the same files. Given the tight timeouts (65m) on these
1h/24h-interval lanes, this was causing frequent job timeouts in sig-node.

This adds `[Slow]` to the `--skip` filter for:
- `ci-cos-cgroupv1-containerd-node-e2e`
- `ci-containerd-node-e2e-1-7`
- `ci-cos-containerd-node-e2e`
- `ci-cgroup-systemd-containerd-node-e2e`
- `pull-kubernetes-cos-cgroupv1-containerd-node-e2e` (presubmit)

Slow test coverage is not lost: the existing dedicated
`ci-kubernetes-node-e2e-containerd-slow` periodic job
(`config/jobs/kubernetes/sig-node/node-kubelet.yaml`) already runs with a
`Slow && NodeConformance` label-filter and a longer timeout, so it
continues to exercise these tests separately.

## Which issue(s) this PR fixes

Fixes frequent timeouts in sig-node containerd CI lanes.

## Special notes for your reviewer

Part of these changes were AI-assisted using the pi coding agent
(with human review of the diff before submission).

## Does this PR introduce a user-facing change?

```release-note
NONE
```