### PR TITLE
Scrape etcd metrics in pull-perf-tests-gce-master-scale-performance-100-experimental

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -1244,6 +1244,8 @@ presubmits:
           value: "c4-standard-32"
         - name: PROMETHEUS_SCRAPE_KUBE_PROXY
           value: "true"
+        - name: PROMETHEUS_SCRAPE_ETCD
+          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT


### PR DESCRIPTION
The job runs a Prometheus server but never scraped etcd, so etcd metrics were missing from its snapshots. Want to test https://github.com/kubernetes/perf-tests/pull/4184 in perf-tests before merging. 