### PR TITLE
Prow: add agentic AI canary

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
@@ -1,0 +1,34 @@
+periodics:
+- name: ci-k8s-infra-agentic-ai
+  interval: 24h
+  cluster: k8s-infra-prow-build
+  decorate: true
+  decoration_config:
+    timeout: 10m
+  annotations:
+    testgrid-dashboards: sig-k8s-infra-canaries
+    testgrid-tab-name: agentic-ai
+    description: Verifies that Prow can run Antigravity using k8s-infra-agentic-ai.
+  spec:
+    serviceAccountName: agy-agent
+    containers:
+    - image: gcr.io/k8s-staging-infra-tools/antigravity@sha256:4ec6e2e3817472fc0914393126a793029ded042d8c5978bc9bec833b6fda6116
+      command:
+      - agy
+      args:
+      - --print
+      - Respond with exactly "k8s-infra-agentic-ai is ready".
+      env:
+      - name: GOOGLE_SERVICE_ACCOUNT_AUTH
+        value: "true"
+      - name: GOOGLE_CLOUD_PROJECT
+        value: k8s-infra-agentic-ai
+      - name: GOOGLE_CLOUD_LOCATION
+        value: global
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: "1"
+          memory: 2Gi


### PR DESCRIPTION
Verifies that Prow can run Antigravity using k8s infra

Related to:
  - https://github.com/kubernetes/k8s.io/issues/9606