### PR TITLE
node-readiness-controller: move to kubekind-e2e-v2 image

### DIFF
--- a/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-periodics.yaml
@@ -21,7 +21,7 @@ periodics:
       timeout: 2h
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260708-267b57c4ed-master
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-1.36
           env:
             - name: E2E_KIND_VERSION
               value: v1.36
@@ -61,7 +61,7 @@ periodics:
       timeout: 2h
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260708-267b57c4ed-master
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-1.35
           env:
             - name: E2E_KIND_VERSION
               value: v1.35
@@ -101,7 +101,7 @@ periodics:
       timeout: 2h
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260708-267b57c4ed-master
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-1.34
           env:
             - name: E2E_KIND_VERSION
               value: v1.34
@@ -141,7 +141,7 @@ periodics:
       timeout: 2h
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260708-267b57c4ed-master
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-1.33
           env:
             - name: E2E_KIND_VERSION
               value: v1.33


### PR DESCRIPTION
ref: https://github.com/kubernetes/test-infra/tree/master/images/kubekins-e2e#deprecated

update the node-readiness-controller periodic jobs to use the new recommended `kubekins-e2e-v2` image