### PR TITLE
Prow: fix agentic AI authentication

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
@@ -19,7 +19,7 @@ periodics:
       - --print
       - Respond with exactly "k8s-infra-agentic-ai is ready".
       env:
-      - name: GOOGLE_SERVICE_ACCOUNT_AUTH
+      - name: GOOGLE_GENAI_USE_VERTEXAI
         value: "true"
       - name: GOOGLE_CLOUD_PROJECT
         value: k8s-infra-agentic-ai


### PR DESCRIPTION
Use Antigravity’s Vertex AI authentication mode so the periodic uses Workload Identity instead of falling back to interactive OAuth.