### PR TITLE
Run the experimental 5k presubmit on the restart variant with default etcd

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -277,13 +277,11 @@ presubmits:
           privileged: true
         env:
         - name: EXPERIMENT_VARIANT
-          value: "restart-etcd36"
+          value: "restart"
         - name: CL2_ENABLE_INFORMER_LATENCY_TEST
           value: "false"
         - name: CL2_RESTART_APISERVER
           value: "true"
-        - name: KUBE_FEATURE_GATES
-          value: "+EtcdRangeStream"
         - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
           value: "21474836480"
         - name: CL2_EXECSERVICE_CPU_REQUESTS
@@ -305,8 +303,6 @@ presubmits:
           value: gce
         - name: KUBE_NODE_COUNT
           value: "5000"
-        - name: ETCD_VERSION
-          value: "3.6.12"
         - name: CL2_LOAD_TEST_THROUGHPUT
           value: "50"
         - name: CL2_DELETE_TEST_THROUGHPUT


### PR DESCRIPTION
Drops the ETCD_VERSION=3.6.12 pin and the +EtcdRangeStream gate from the experimental 5k presubmit. The data collection on RangeStream against etcd 3.6 is done, so the job goes back to the restart variant on the default etcd.