### PR TITLE
Update kubernetes-csi manual job configs from 1.28 to 1.35

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-manual-job-config.yaml
@@ -2,8 +2,8 @@
 
 presubmits:
   kubernetes-csi/csi-driver-host-path:
-  # 1.28 is used because it is the (currently) latest stable release.
-  - name: pull-kubernetes-csi-csi-driver-host-distributed-on-kubernetes-1-28
+  # 1.35 is used because it is the (currently) latest stable release.
+  - name: pull-kubernetes-csi-csi-driver-host-distributed-on-kubernetes-1-35
     cluster: eks-prow-build-cluster
     always_run: true
     optional: true
@@ -16,8 +16,8 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-csi-driver-host-path
-      testgrid-tab-name: distributed-on-kubernetes-1-28
-      description: Kubernetes-CSI pull job in repo csi-driver-host-path for distributed deployment on Kubernetes 1.28, with CSIStorageCapacity
+      testgrid-tab-name: distributed-on-kubernetes-1-35
+      description: Kubernetes-CSI pull job in repo csi-driver-host-path for distributed deployment on Kubernetes 1.35, with CSIStorageCapacity
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
@@ -28,7 +28,7 @@ presubmits:
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.35.0"
         - name: CSI_PROW_DEPLOYMENT
           value: "kubernetes-distributed"
         - name: CSI_SNAPSHOTTER_VERSION
@@ -55,13 +55,13 @@ presubmits:
 
 periodics:
 - interval: 6h
-  # 1.28 is used because it is the (currently) latest stable
+  # 1.35 is used because it is the (currently) latest stable
   # release.
   #
   # This job is meant to detect regressions in upcoming releases
   # that slipped through pre-merge testing, so we have to use canary
   # images.
-  name: ci-kubernetes-csi-canary-distributed-on-kubernetes-1-28
+  name: ci-kubernetes-csi-canary-distributed-on-kubernetes-1-35
   cluster: eks-prow-build-cluster
   decorate: true
   extra_refs:
@@ -75,9 +75,9 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     testgrid-dashboards: sig-storage-csi-ci
-    testgrid-tab-name: distributed-on-1-26
+    testgrid-tab-name: distributed-on-1-35
     testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-    description: periodic Kubernetes-CSI job for distributed provisioning on Kubernetes 1.28, with CSIStorageCapacity
+    description: periodic Kubernetes-CSI job for distributed provisioning on Kubernetes 1.35, with CSIStorageCapacity
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
@@ -88,7 +88,7 @@ periodics:
       - ./.prow.sh
       env:
       - name: CSI_PROW_KUBERNETES_VERSION
-        value: "1.28.0"
+        value: "1.35.0"
       - name: CSI_PROW_USE_BAZEL
         value: "false"
       - name: CSI_SNAPSHOTTER_VERSION

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-manual-job-config.yaml
@@ -2,7 +2,7 @@
 
 presubmits:
   kubernetes-csi/external-provisioner:
-  - name: pull-kubernetes-csi-external-provisioner-distributed-on-kubernetes-1-26
+  - name: pull-kubernetes-csi-external-provisioner-distributed-on-kubernetes-1-35
     cluster: eks-prow-build-cluster
     always_run: true
     optional: false
@@ -15,7 +15,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       testgrid-dashboards: sig-storage-csi-external-provisioner
-      testgrid-tab-name: distributed-on-kubernetes-1-26
+      testgrid-tab-name: distributed-on-kubernetes-1-35
       description: Kubernetes-CSI pull job in repo external-provisioner for distributed provisioning, with CSIStorageCapacity
     spec:
       containers:
@@ -27,11 +27,11 @@ presubmits:
         - ./.prow.sh
         env:
         - name: CSI_PROW_KUBERNETES_VERSION
-          value: "1.28.0"
+          value: "1.35.0"
         - name: CSI_PROW_USE_BAZEL
           value: "true"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.10.0"
+          value: "v1.17.1"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS
@@ -82,7 +82,7 @@ presubmits:
         - name: CSI_PROW_USE_BAZEL
           value: "true"
         - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.10.0"
+          value: "v1.17.1"
         - name: CSI_SNAPSHOTTER_VERSION
           value: "v6.1.0"
         - name: CSI_PROW_TESTS


### PR DESCRIPTION
csi-driver-host-path and external-provisioner manual job configs were still pinned to Kubernetes 1.28 (and one job was mislabeled 1-26) while the generated jobs already track 1.34/1.35/1.36. Bump the manual jobs to 1.35, the current latest stable version used by gen-jobs.sh.

Also updates CSI_PROW_DRIVER_VERSION to v1.17.1.