### PR TITLE
Add presubmit prow jobs for kubernetes-sigs/devops-bench

### DIFF
--- a/config/jobs/kubernetes-sigs/devops-bench/OWNERS
+++ b/config/jobs/kubernetes-sigs/devops-bench/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - janetkuo

--- a/config/jobs/kubernetes-sigs/devops-bench/devops-bench-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/devops-bench/devops-bench-presubmits.yaml
@@ -1,0 +1,111 @@
+presubmits:
+  kubernetes-sigs/devops-bench:
+  - name: pull-devops-bench-verify
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|\\.md$|^(\\.gitignore|\\.editorconfig|LICENSE|OWNERS|SECURITY_CONTACTS)$|^\\.github/"
+    decorate: true
+    spec:
+      containers:
+      - image: python:3.14
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          pip install --quiet uv
+          uv sync --frozen
+          uv run ruff check .
+          uv run ruff format --check .
+        resources:
+          requests:
+            cpu: 1
+            memory: 2Gi
+          limits:
+            cpu: 1
+            memory: 2Gi
+    annotations:
+      description: ruff lint and format check (ruff is pinned exactly in pyproject.toml)
+  - name: pull-devops-bench-unit-py312
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|\\.md$|^(\\.gitignore|\\.editorconfig|LICENSE|OWNERS|SECURITY_CONTACTS)$|^\\.github/"
+    decorate: true
+    spec:
+      containers:
+      - image: python:3.12
+        env:
+        # Pin uv to the container interpreter; otherwise uv downloads the
+        # .python-version (3.14) default and every matrix job tests the same
+        # interpreter.
+        - name: UV_PYTHON
+          value: "3.12"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          pip install --quiet uv
+          uv sync --frozen
+          uv run pytest -q
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+          limits:
+            cpu: 2
+            memory: 4Gi
+    annotations:
+      description: unit tests on Python 3.12 (the requires-python floor)
+  - name: pull-devops-bench-unit-py313
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|\\.md$|^(\\.gitignore|\\.editorconfig|LICENSE|OWNERS|SECURITY_CONTACTS)$|^\\.github/"
+    decorate: true
+    spec:
+      containers:
+      - image: python:3.13
+        env:
+        - name: UV_PYTHON
+          value: "3.13"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          pip install --quiet uv
+          uv sync --frozen
+          uv run pytest -q
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+          limits:
+            cpu: 2
+            memory: 4Gi
+    annotations:
+      description: unit tests on Python 3.13
+  - name: pull-devops-bench-unit-py314
+    cluster: eks-prow-build-cluster
+    skip_if_only_changed: "^docs/|\\.md$|^(\\.gitignore|\\.editorconfig|LICENSE|OWNERS|SECURITY_CONTACTS)$|^\\.github/"
+    decorate: true
+    spec:
+      containers:
+      - image: python:3.14
+        env:
+        - name: UV_PYTHON
+          value: "3.14"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          pip install --quiet uv
+          uv sync --frozen
+          uv run pytest -q
+        resources:
+          requests:
+            cpu: 2
+            memory: 4Gi
+          limits:
+            cpu: 2
+            memory: 4Gi
+    annotations:
+      description: unit tests on Python 3.14 (the .python-version dev default)

--- a/config/jobs/kubernetes-sigs/devops-bench/devops-bench-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/devops-bench/devops-bench-presubmits.yaml
@@ -16,6 +16,7 @@ presubmits:
           uv sync --frozen
           uv run ruff check .
           uv run ruff format --check .
+          uv run python hack/boilerplate.py --dry-run
         resources:
           requests:
             cpu: 1
@@ -26,7 +27,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-apps-devops-bench
       testgrid-tab-name: presubmit-verify
-      description: ruff lint and format check (ruff is pinned exactly in pyproject.toml)
+      description: ruff lint, format check, and license header check (hack/boilerplate.py)
   - name: pull-devops-bench-unit-py312
     cluster: eks-prow-build-cluster
     skip_if_only_changed: "^docs/|\\.md$|^(\\.gitignore|\\.editorconfig|LICENSE|OWNERS|SECURITY_CONTACTS)$|^\\.github/"

--- a/config/jobs/kubernetes-sigs/devops-bench/devops-bench-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/devops-bench/devops-bench-presubmits.yaml
@@ -24,6 +24,8 @@ presubmits:
             cpu: 1
             memory: 2Gi
     annotations:
+      testgrid-dashboards: sig-apps-devops-bench
+      testgrid-tab-name: presubmit-verify
       description: ruff lint and format check (ruff is pinned exactly in pyproject.toml)
   - name: pull-devops-bench-unit-py312
     cluster: eks-prow-build-cluster
@@ -54,6 +56,8 @@ presubmits:
             cpu: 2
             memory: 4Gi
     annotations:
+      testgrid-dashboards: sig-apps-devops-bench
+      testgrid-tab-name: presubmit-unit-py312
       description: unit tests on Python 3.12 (the requires-python floor)
   - name: pull-devops-bench-unit-py313
     cluster: eks-prow-build-cluster
@@ -81,6 +85,8 @@ presubmits:
             cpu: 2
             memory: 4Gi
     annotations:
+      testgrid-dashboards: sig-apps-devops-bench
+      testgrid-tab-name: presubmit-unit-py313
       description: unit tests on Python 3.13
   - name: pull-devops-bench-unit-py314
     cluster: eks-prow-build-cluster
@@ -108,4 +114,6 @@ presubmits:
             cpu: 2
             memory: 4Gi
     annotations:
+      testgrid-dashboards: sig-apps-devops-bench
+      testgrid-tab-name: presubmit-unit-py314
       description: unit tests on Python 3.14 (the .python-version dev default)

--- a/config/testgrids/kubernetes/sig-apps/config.yaml
+++ b/config/testgrids/kubernetes/sig-apps/config.yaml
@@ -2,6 +2,7 @@ dashboard_groups:
 - name: sig-apps
   dashboard_names:
     - sig-apps-agent-sandbox
+    - sig-apps-devops-bench
     - sig-apps-mcp-lifecycle-operator
     - sig-apps-examples
     - sig-apps-jobset
@@ -15,6 +16,7 @@ dashboard_groups:
 
 dashboards:
 - name: sig-apps-agent-sandbox
+- name: sig-apps-devops-bench
 - name: sig-apps-mcp-lifecycle-operator
 - name: sig-apps-examples
 - name: sig-apps-jobset


### PR DESCRIPTION
Adds presubmit job config for the new [kubernetes-sigs/devops-bench](https://github.com/kubernetes-sigs/devops-bench) repo, modeled on `config/jobs/kubernetes-sigs/agent-sandbox`.

This replaces the GitHub Actions workflow proposed in kubernetes-sigs/devops-bench#18, per review feedback there that SIG repos should use Prow for CI.

Jobs (devops-bench is a Python 3.12+ / uv project):

- **pull-devops-bench-verify** — `ruff check` + `ruff format --check` (ruff is pinned exactly in the repo's pyproject.toml so formatter style cannot drift) + `hack/boilerplate.py --dry-run` for license-header compliance.
- **pull-devops-bench-unit-py312 / py313 / py314** — `uv sync --frozen` + `pytest` across the supported interpreter range

All four presubmits are annotated onto a new `sig-apps-devops-bench` dashboard.
`go test ./config/tests/...` passes locally.

/cc @janetkuo

