### PR TITLE
Re-enable node-exporter scraping on GCE scalability jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -74,6 +74,8 @@ presubmits:
           value: "3"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-32"
+        - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
+          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -318,6 +320,8 @@ presubmits:
         - name: KUBE_PROXY_MODE
           value: "nftables"
         - name: PROMETHEUS_SCRAPE_ETCD
+          value: "true"
+        - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1271,6 +1271,8 @@ periodics:
         value: "nftables"
       - name: PROMETHEUS_SCRAPE_ETCD
         value: "true"
+      - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
+        value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -1369,6 +1371,8 @@ periodics:
         value: "1"
       - name: CONTROL_PLANE_SIZE
         value: "c4-standard-32"
+      - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
+        value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -152,6 +152,8 @@ presubmits:
           value: "c4-standard-32"
         - name: PROMETHEUS_SCRAPE_ETCD
           value: "true"
+        - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
+          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -487,6 +489,8 @@ presubmits:
         - name: KUBE_PROXY_MODE
           value: "nftables"
         - name: PROMETHEUS_SCRAPE_ETCD
+          value: "true"
+        - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
@@ -1145,6 +1149,8 @@ presubmits:
           value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-32"
+        - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
+          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -1231,6 +1237,8 @@ presubmits:
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-32"
         - name: PROMETHEUS_SCRAPE_ETCD
+          value: "true"
+        - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
@@ -1334,6 +1342,8 @@ presubmits:
           value: "c3-standard-44"
         - name: KUBE_PROXY_MODE
           value: "nftables"
+        - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
+          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -159,6 +159,8 @@ periodics:
         value: "nftables"
       - name: PROMETHEUS_SCRAPE_ETCD
         value: "true"
+      - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
+        value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -257,6 +259,8 @@ periodics:
         value: "1"
       - name: CONTROL_PLANE_SIZE
         value: "c4-standard-32"
+      - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
+        value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT


### PR DESCRIPTION
Restores node-exporter scraping on the GCE kops scalability jobs, dropped in https://github.com/kubernetes/test-infra/commit/5a4e42717f when moving to kops.

don't actually know if this works. I'm assuming you ran into trouble with this @serathius?