### PR TITLE
Add presubmit e2e test job for kubernetes-sigs/node-readiness-controller

### DIFF
--- a/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-presubmits.yaml
@@ -48,3 +48,36 @@ presubmits:
       testgrid-dashboards: sig-node-node-readiness-controller
       testgrid-num-columns-recent: '30'
       testgrid-create-test-group: 'true'
+  - name: pull-node-readiness-controller-test-e2e
+    cluster: eks-prow-build-cluster
+    always_run: false
+    skip_if_only_changed: "^docs/|\\.md$|^(README|LICENSE|OWNERS|SECURITY_CONTACTS)$"
+    branches:
+    - ^main$
+    - ^release-v.*$
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    decoration_config:
+      timeout: 2h
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-master
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-kind
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+    annotations:
+      testgrid-dashboards: sig-node-node-readiness-controller
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'


### PR DESCRIPTION
This PR adds a presubmit job for running e2e tests on K8s 1.36 to kubernetes-sigs/node-readiness-controller.

Follow-up to https://github.com/kubernetes-sigs/node-readiness-controller/pull/307#issuecomment-4955201262