### PR TITLE
Update mdtoc CI image to go1.26-trixie

### DIFF
--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.26-trixie
         imagePullPolicy: Always
         command:
         - make
@@ -31,7 +31,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.24-bookworm
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.26-trixie
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
The `go1.24-bookworm` image is no longer available, causing all mdtoc presubmit jobs to fail with image pull errors.

Updates both `pull-mdtoc-test` and `pull-mdtoc-verify` to use `latest-go1.26-trixie`, consistent with other releng jobs.