### PR TITLE
Bump security-profiles-operator build-image memory to 2Gi

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -78,10 +78,10 @@ presubmits:
           privileged: true  # for dind
         resources:
           requests:
-            memory: 1Gi
+            memory: 2Gi
             cpu: 2
           limits:
-            memory: 1Gi
+            memory: 2Gi
             cpu: 2
         command:
         - runner.sh


### PR DESCRIPTION
The `pull-security-profiles-operator-build-image` Prow job is consistently OOM killed after the recent kubekins-e2e image bump (`v20260713-9909545e89-master`) which added dind cgroup delegation overhead in `runner.sh`.

Bumps memory from 1Gi to 2Gi to match the e2e job which also uses dind.
