### PR TITLE
Bump security-profiles-operator dind job memory to 4Gi

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -78,11 +78,11 @@ presubmits:
           privileged: true  # for dind
         resources:
           requests:
-            memory: 2Gi
-            cpu: 2
+            memory: 4Gi
+            cpu: 6
           limits:
-            memory: 2Gi
-            cpu: 2
+            memory: 4Gi
+            cpu: 6
         command:
         - runner.sh
         args:
@@ -108,11 +108,11 @@ presubmits:
           privileged: true  # for dind
         resources:
           requests:
-            memory: 2Gi
-            cpu: 5
+            memory: 4Gi
+            cpu: 6
           limits:
-            memory: 2Gi
-            cpu: 5
+            memory: 4Gi
+            cpu: 6
         command:
         - runner.sh
         args:


### PR DESCRIPTION
The build-image and test-e2e jobs are OOM killed with 2Gi after the recent kubekins-e2e image bump. Bump memory to 4Gi and CPU to 6 for both.