### PR TITLE
Enable etcd Prometheus scraping on the AWS kops scalability jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
@@ -97,6 +97,8 @@ periodics:
         value: "true"
       - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
         value: "false"
+      - name: PROMETHEUS_SCRAPE_ETCD
+        value: "true"
       - name: PROMETHEUS_PVC_STORAGE_CLASS
         value: "io2"
       - name: CLOUD_PROVIDER
@@ -216,6 +218,8 @@ periodics:
         value: "true"
       - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
         value: "false"
+      - name: PROMETHEUS_SCRAPE_ETCD
+        value: "true"
       - name: PROMETHEUS_PVC_STORAGE_CLASS
         value: "io2"
       - name: CLOUD_PROVIDER
@@ -310,6 +314,8 @@ presubmits:
           value: "true"
         - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
           value: "false"
+        - name: PROMETHEUS_SCRAPE_ETCD
+          value: "true"
         - name: PROMETHEUS_PVC_STORAGE_CLASS
           value: "io2"
         - name: CLOUD_PROVIDER

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -102,6 +102,10 @@ periodics:
         value: "1"
       - name: CONTROL_PLANE_SIZE
         value: "c8i.24xlarge"
+      - name: PROMETHEUS_SCRAPE_ETCD
+        value: "true"
+      - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
+        value: "false"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -202,6 +206,10 @@ periodics:
         value: "1"
       - name: CONTROL_PLANE_SIZE
         value: "c8a.8xlarge"
+      - name: PROMETHEUS_SCRAPE_ETCD
+        value: "true"
+      - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
+        value: "false"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -898,6 +898,10 @@ presubmits:
           value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c8i.8xlarge"
+        - name: PROMETHEUS_SCRAPE_ETCD
+          value: "true"
+        - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
+          value: "false"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -979,6 +983,10 @@ presubmits:
           value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c8i.12xlarge"
+        - name: PROMETHEUS_SCRAPE_ETCD
+          value: "true"
+        - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
+          value: "false"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -1061,6 +1069,10 @@ presubmits:
           value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c8a.24xlarge"
+        - name: PROMETHEUS_SCRAPE_ETCD
+          value: "true"
+        - name: PROMETHEUS_SCRAPE_APISERVER_ONLY
+          value: "false"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT


### PR DESCRIPTION
Verify that etcd scraping works on AWS before we default it on for all kops scalability tests.

/assign @serathius