### PR TITLE
Remove no-op PROMETHEUS_SCRAPE_KUBE_PROXY from the scalability jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -74,8 +74,6 @@ presubmits:
           value: "3"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-32"
-        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -319,8 +317,6 @@ presubmits:
           value: "c3-standard-44"
         - name: KUBE_PROXY_MODE
           value: "nftables"
-        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-          value: "true"
         - name: PROMETHEUS_SCRAPE_ETCD
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-networking.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-networking.yaml
@@ -237,8 +237,6 @@ periodics:
         value: "false"
       - name: NODE_MODE
         value: "master"
-      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-        value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-ec2.yaml
@@ -102,8 +102,6 @@ periodics:
         value: "1"
       - name: CONTROL_PLANE_SIZE
         value: "c8i.24xlarge"
-      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-        value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -204,8 +202,6 @@ periodics:
         value: "1"
       - name: CONTROL_PLANE_SIZE
         value: "c8a.8xlarge"
-      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-        value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1269,8 +1269,6 @@ periodics:
         value: "c3-standard-44"
       - name: KUBE_PROXY_MODE
         value: "nftables"
-      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-        value: "true"
       - name: PROMETHEUS_SCRAPE_ETCD
         value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
@@ -1371,8 +1369,6 @@ periodics:
         value: "1"
       - name: CONTROL_PLANE_SIZE
         value: "c4-standard-32"
-      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-        value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -150,8 +150,6 @@ presubmits:
           value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-32"
-        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-          value: "true"
         - name: PROMETHEUS_SCRAPE_ETCD
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
@@ -488,8 +486,6 @@ presubmits:
           value: "c3-standard-44"
         - name: KUBE_PROXY_MODE
           value: "nftables"
-        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-          value: "true"
         - name: PROMETHEUS_SCRAPE_ETCD
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
@@ -902,8 +898,6 @@ presubmits:
           value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c8i.8xlarge"
-        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -985,8 +979,6 @@ presubmits:
           value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c8i.12xlarge"
-        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -1069,8 +1061,6 @@ presubmits:
           value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c8a.24xlarge"
-        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -1155,8 +1145,6 @@ presubmits:
           value: "1"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-32"
-        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
@@ -1242,8 +1230,6 @@ presubmits:
           value: "3"
         - name: CONTROL_PLANE_SIZE
           value: "c4-standard-32"
-        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-          value: "true"
         - name: PROMETHEUS_SCRAPE_ETCD
           value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
@@ -1348,8 +1334,6 @@ presubmits:
           value: "c3-standard-44"
         - name: KUBE_PROXY_MODE
           value: "nftables"
-        - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-          value: "true"
         - name: CL2_ENABLE_DNS_PROGRAMMING
           value: "true"
         - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -157,8 +157,6 @@ periodics:
         value: "c3-standard-44"
       - name: KUBE_PROXY_MODE
         value: "nftables"
-      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-        value: "true"
       - name: PROMETHEUS_SCRAPE_ETCD
         value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
@@ -259,8 +257,6 @@ periodics:
         value: "1"
       - name: CONTROL_PLANE_SIZE
         value: "c4-standard-32"
-      - name: PROMETHEUS_SCRAPE_KUBE_PROXY
-        value: "true"
       - name: CL2_ENABLE_DNS_PROGRAMMING
         value: "true"
       - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT


### PR DESCRIPTION
These lines set the value the CL2 flag already has by default: https://github.com/kubernetes/perf-tests/blob/b54a5367e15ceb96ece567b0a1fc5edabb9d18c6/clusterloader2/pkg/prometheus/prometheus.go#L92

/assign @serathius