### PR TITLE
skip slow jobs for gotooltip containerd jobs

### DIFF
--- a/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
+++ b/config/jobs/kubernetes/sig-arch/kubernetes-code-organization.yaml
@@ -456,7 +456,7 @@ periodics:
           - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service"'
           - --node-tests=true
           - --provider=gce
-          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
+          - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
           - --timeout=65m
         resources:
           limits:


### PR DESCRIPTION
Fixes: #https://github.com/kubernetes/kubernetes/issues/140553