### PR TITLE
fix(postsubmit): bump post-push-kep-manifest image to gcb-docker-gcloud

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/enhancements-postsubmit.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/enhancements-postsubmit.yaml
@@ -8,7 +8,7 @@ postsubmits:
       max_concurrency: 1
       spec:
         containers:
-        - image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20230111-cd1b3caf9c
+        - image: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
           command:
             - sh
             - "-c"


### PR DESCRIPTION
Fixes #37469

**What changed**
Replaced the `gcloud-in-go:v20230111-cd1b3caf9c` image with `gcb-docker-gcloud:v20260205-38cfa9523f` per upodroids recommendation.

**Why**
The old image bundles Go 1.22 which cannot parse the `go 1.26.0` directive in kubernetes/enhancements/go.mod. The newer `gcb-docker-gcloud` image has Go 1.26+ and gcloud SDK.