### PR TITLE
Enforce v1.37 Code Freeze

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -748,6 +748,31 @@ tide:
     - do-not-merge/work-in-progress
   - repos:
     - kubernetes/kubernetes
+    excludedBranches:
+    - master
+    - release-1.37
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
+    - do-not-merge/needs-sig
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+  - repos:
+    - kubernetes/kubernetes
+    milestone: v1.37
+    includedBranches:
+    - master
+    - release-1.37
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
The Kubernetes v1.37 Code and Test Freeze is scheduled to start Wednesday 22nd July 2026 (AoE) / Thursday 23rd July 2026, 12:00 UTC.

/hold

The hold should ONLY be cancelled by the Release Team Leads when the v1.37 Release Team is ready around the Code Freeze deadline, ensuring that everything in the [merge queue](https://prow.k8s.io/tide) is merged before unhold

cc: @dipesh-rawat
/priority critical-urgent
/cc @kubernetes/release-team-leads
/cc @kubernetes/release-engineering