### PR TITLE
config: add lws upgrade e2e presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -208,6 +208,43 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-lws-test-e2e-upgrade-main
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^main
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      pod_unscheduled_timeout: 10m
+    path_alias: sigs.k8s.io/lws
+    annotations:
+      testgrid-dashboards: sig-apps-lws-presubmits
+      testgrid-tab-name: pull-lws-test-e2e-upgrade-main
+      description: "Run lws upgrade end to end tests"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260729-f0c41ad0b9-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.36.1
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-upgrade
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-lws-test-e2e-main-gang-scheduling
     cluster: eks-prow-build-cluster
     always_run: true


### PR DESCRIPTION
## Summary

Add an optional, manually triggered LWS upgrade E2E presubmit, following the Kueue upgrade job pattern.

This is a follow-up to https://github.com/kubernetes-sigs/lws/pull/928, which merged on July 21, 2026. After this job is deployed, trigger it on an open LWS PR with:

`/test pull-lws-test-e2e-upgrade-main`

## Testing

- `go test ./config/tests/jobs/...`
- `go test ./config/tests/testgrids/...`
- `hack/make-rules/verify/yamllint.sh`
- Generated the local ProwJob and Pod with `mkpj` and `mkpod`