### PR TITLE
SIG testing: add pull-kubernetes-e2e-kind-alpha-beta-features-others

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -433,7 +433,7 @@ presubmits:
 
   - name: pull-kubernetes-e2e-kind-alpha-beta-features
     annotations:
-      description: Runs tests with no special requirements other than alpha or beta feature gates in a KinD cluster where alpha and beta feature gates and APIs are enabled.
+      description: Runs tests with no special requirements other than alpha or beta feature gates in a KinD cluster where alpha and beta feature gates and APIs are enabled, excluding slow or disruptive tests.
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
@@ -466,6 +466,53 @@ presubmits:
           value: '{"api/all":"true"}'
         - name: LABEL_FILTER
           value: "Feature: isSubsetOf OffByDefault && !Deprecated && !Slow && !Disruptive && !Flaky"
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 7
+            memory: 9000Mi
+          requests:
+            cpu: 7
+            memory: 9000Mi
+
+  - name: pull-kubernetes-e2e-kind-alpha-beta-features-others
+    annotations:
+      description: Runs tests with no special requirements other than alpha or beta feature gates in a KinD cluster where alpha and beta feature gates and APIs are enabled, focusing on slow or disruptive tests.
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'
+      fork-per-release: "true"
+    cluster: k8s-infra-prow-build
+    optional: true
+    decorate: true
+    skip_branches:
+    - release-\d+\.\d+ # per-release settings
+    labels:
+      preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20260713-c0336204b2-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        # EventedPLEG is disabled temporarily for https://github.com/kubernetes/kubernetes/issues/122721
+        - name: FEATURE_GATES
+          value: '{"AllAlpha":true,"AllBeta":true,"EventedPLEG":false}'
+        - name: RUNTIME_CONFIG
+          value: '{"api/all":"true"}'
+        - name: LABEL_FILTER
+          value: "Feature: isSubsetOf OffByDefault && !Deprecated && (Slow || Disruptive) && !Flaky"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -121,6 +121,9 @@ dashboards:
   - name: pull-kubernetes-e2e-kind-alpha-beta-features
     test_group_name: pull-kubernetes-e2e-kind-alpha-beta-features
     base_options: width=10
+  - name: pull-kubernetes-e2e-kind-alpha-beta-features-others
+    test_group_name: pull-kubernetes-e2e-kind-alpha-beta-features-others
+    base_options: width=10
   - name: pull-kubernetes-e2e-kind-alpha-beta-enabled
     test_group_name: pull-kubernetes-e2e-kind-alpha-beta-enabled
     base_options: width=10


### PR DESCRIPTION
Disruptive or slow tests were impossible to test on kind because all presubmits skip them. Let's add a variant of pull-kubernetes-e2e-kind-alpha-beta-features because that'll enable the largest range of new tests.

This change was triggered by the observation that we cannot test the SIG Storage "GenericPersistentVolume" and "NFSPersistentVolume" tests in any (?!) presubmit because they are marked disruptive. They probably still won't run on kind because they skip themselves at runtime when no ssh access is available, but other tests might work, so adding the job is still worthwhile.

/assign @gnufied 