### PR TITLE
fix(cloud-provider-azure): actually not always run for euap checkin

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -798,7 +798,6 @@ presubmits:
     cluster: eks-prow-build-cluster
     optional: true
     always_run: false
-    skip_if_only_changed: "^docs/|^site/|^helm/|^pkg/azclient/|^pkg/provider/storage/|^kubetest2-aks/|^.pipelines/|^\\.github/|\\.(md|adoc)$|^(README|LICENSE)|^examples/|^tests/k8s-azure/manifest$|netlify.toml|.codespellignore|go.sum"
     decorate: true
     decoration_config:
       timeout: 5h


### PR DESCRIPTION
The skip_if_only_changed field is checked first before always_run. https://github.com/kubernetes-sigs/prow/blob/0633879af8026d056e1a5dbe1e29f5a98f6acec3/pkg/config/jobs.go#L487-L502

This change should make the test run manual.

/area provider/azure