### PR TITLE
Increase Cluster Autoscaler memory limit

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -650,10 +650,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 2
-            memory: 6Gi
+            memory: 8Gi
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
For the last few days, the test pull-autoscaling-e2e-gci-gce-ca-test has been failing due to running out of memory. Let's see if an increase fixes it or if we have a runaway test memory leak.