### PR TITLE
Set tide merge_method to squash for kubernetes-sigs/inference-perf

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -869,6 +869,7 @@ tide:
     kubernetes-sigs/devops-bench: squash
     kubernetes-sigs/external-dns: squash
     kubernetes-sigs/ibm-vpc-block-csi-driver: squash
+    kubernetes-sigs/inference-perf: squash
     kubernetes-sigs/jobset: squash
     kubernetes-sigs/karpenter: squash
     kubernetes-sigs/kernel-module-management: rebase


### PR DESCRIPTION
kubernetes-sigs/inference-perf only allows squash merges (merge commits and rebase merges are disabled in repo settings), so tide fails to merge approved PRs with:

> Not mergeable. Merge type "merge" disallowed by repo settings

Example: https://github.com/kubernetes-sigs/inference-perf/pull/625 has both `lgtm` and `approved` but the tide context is in error state.

This adds the repo to the `tide.merge_method` map, matching other squash-only kubernetes-sigs repos.