### PR TITLE
cloud-provider-vsphere: add boilerplate verification job

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -206,6 +206,36 @@ presubmits:
       testgrid-tab-name: pr-verify-staticheck
       description: Verifies the Golang sources pass a static source checker
 
+  - name: pull-cloud-provider-vsphere-verify-boilerplate
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    branches:
+    - ^master$
+    - ^release-1.2[7-9]$
+    - ^release-1.[3-9]\d$
+    path_alias: k8s.io/cloud-provider-vsphere
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260713-9909545e89-master
+        command:
+        - runner.sh
+        args:
+        - python3
+        - hack/verify-boilerplate.py
+        resources:
+          limits:
+            cpu: 1
+            memory: 4Gi
+          requests:
+            cpu: 1
+            memory: 4Gi
+    annotations:
+      testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
+      testgrid-tab-name: pr-verify-boilerplate
+      testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
+      description: Verifies the copyright boilerplate headers of the source files
+
   # Builds the CCM and CSI binaries.
   - name: pull-cloud-provider-vsphere-build
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
This adds a new dedicated presubmit job `pull-cloud-provider-vsphere-verify-boilerplate` to verify the copyright boilerplate of source files on PR creation.

CPI PR: https://github.com/kubernetes/cloud-provider-vsphere/pull/1814