### PR TITLE
integration-race: bump timeout from 30 to 40 minutes

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -97,7 +97,7 @@ presubmits:
         - runner.sh
         env:
         - name: KUBE_TIMEOUT
-          value: "-timeout=30m"
+          value: "-timeout=40m"
         - name: KUBE_RACE
           value: "-race"
         args:
@@ -263,7 +263,7 @@ periodics:
       - name: SHORT
         value: --short=false
       - name: KUBE_TIMEOUT
-        value: "-timeout=30m"
+        value: "-timeout=40m"
       - name: KUBE_RACE
         value: "-race"
       # docker-in-docker needs privileged mode


### PR DESCRIPTION
test/integration/scheduler_perf/dra and affinity have been close to the 30 minute limit for a while and something slowed them down a bit more between Kubernetes 3bd2928d6..7e8950f1e such that they time out.

Nothing obvious stands out in that commit range. Perfdash also shows nothing. We might simply need a bit more time.