### PR TITLE
Adding New Functional Tests

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -31,7 +31,7 @@ periodics:
     testgrid-tab-name: ci-unit-test
     description: aws ebs csi driver unit test, continuous
     testgrid-num-columns-recent: '30'
-- name: ci-aws-ebs-csi-driver-e2e-single-az
+- name: ci-aws-ebs-csi-driver-e2e-functional
   cluster: eks-prow-build-cluster
   decorate: true
   decoration_config:
@@ -52,7 +52,7 @@ periodics:
       - runner.sh
       args:
       - make
-      - test-e2e-single-az
+      - test-e2e-functional
       securityContext:
         privileged: true
       resources:
@@ -64,44 +64,8 @@ periodics:
           memory: "8Gi"
   annotations:
     testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-periodics
-    testgrid-tab-name: ci-e2e-test-single-az
-    description: aws ebs csi driver e2e test on single az, continuous
-    testgrid-num-columns-recent: '30'
-- name: ci-aws-ebs-csi-driver-e2e-multi-az
-  cluster: eks-prow-build-cluster
-  decorate: true
-  decoration_config:
-    timeout: 1h20m
-  interval: 6h
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-    preset-aws-credential-aws-shared-testing: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: aws-ebs-csi-driver
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260729-f0c41ad0b9-master
-      command:
-      - runner.sh
-      args:
-      - make
-      - test-e2e-multi-az
-      securityContext:
-        privileged: true
-      resources:
-        limits:
-          cpu: "2"
-          memory: "8Gi"
-        requests:
-          cpu: "2"
-          memory: "8Gi"
-  annotations:
-    testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-periodics
-    testgrid-tab-name: ci-e2e-test-multi-az
-    description: aws ebs csi driver e2e test on mutiple AZs, continuous
+    testgrid-tab-name: ci-e2e-test-functional
+    description: aws ebs csi driver functional e2e test, continuous
     testgrid-num-columns-recent: '30'
 - name: ci-aws-ebs-csi-driver-external-test
   cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -156,7 +156,7 @@ presubmits:
       testgrid-tab-name: pull-ebs-unit-test
       description: aws ebs csi driver unit test on pull request
       testgrid-num-columns-recent: '30'
-  - name: pull-aws-ebs-csi-driver-e2e-single-az
+  - name: pull-aws-ebs-csi-driver-e2e-functional
     cluster: eks-prow-build-cluster
     decorate: true
     optional: false
@@ -174,7 +174,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - test-e2e-single-az
+        - test-e2e-functional
         securityContext:
           privileged: true
         resources:
@@ -186,41 +186,8 @@ presubmits:
             memory: "8Gi"
     annotations:
       testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
-      testgrid-tab-name: pull-e2e-test-single-az
-      description: aws ebs csi driver e2e test on single az on pull request
-      testgrid-num-columns-recent: '30'
-  - name: pull-aws-ebs-csi-driver-e2e-multi-az
-    cluster: eks-prow-build-cluster
-    decorate: true
-    optional: false
-    skip_branches:
-    - gh-pages
-    skip_if_only_changed: "^docs/|^examples/|.md$|OWNERS$|^.github/"
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-aws-credential-aws-shared-testing: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260729-f0c41ad0b9-master
-        command:
-        - runner.sh
-        args:
-        - make
-        - test-e2e-multi-az
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: "2"
-            memory: "8Gi"
-          requests:
-            cpu: "2"
-            memory: "8Gi"
-    annotations:
-      testgrid-dashboards: provider-aws-ebs-csi-driver, amazon-ec2-presubmits
-      testgrid-tab-name: pull-e2e-test-multi-az
-      description: aws ebs csi driver e2e test on mutiple AZs on pull request
+      testgrid-tab-name: pull-e2e-test-functional
+      description: aws ebs csi driver functional e2e tests on pull request
       testgrid-num-columns-recent: '30'
   - name: pull-aws-ebs-csi-driver-e2e-disruptive
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
Adding new functional e2e tests for EBS CSI Driver. This is a unification of what was previously single-az and multi-az tests. 

This is PR # 2 out of the three necessary. See https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2964#issue-4904510314 for more details.

/hold 

Holding until https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2964 is merged 
