### PR TITLE
Add pull-perf-tests-benchmark-list-proto presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -1359,3 +1359,70 @@ presubmits:
           limits:
             cpu: 7
             memory: "40Gi"
+
+  - name: pull-perf-tests-benchmark-list-proto
+    cluster: k8s-infra-prow-build
+    always_run: false
+    optional: true
+    max_concurrency: 1
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-e2e-scalability-common: "true"
+      preset-e2e-scalability-presubmits: "true"
+    decorate: true
+    decoration_config:
+      timeout: 90m
+    path_alias: k8s.io/perf-tests
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    annotations:
+      testgrid-dashboards: presubmits-kubernetes-scalability
+      testgrid-tab-name: pull-perf-tests-benchmark-list-proto
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260713-9909545e89-master
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --cluster=benchmark-list
+        - --extract=ci/latest
+        - --gcp-master-size=n2-standard-32
+        - --gcp-node-size=e2-standard-32
+        - --gcp-node-image=gci
+        - --gcp-nodes=1
+        - --gcp-project-type=scalability-project
+        - --gcp-zone=us-east1-b
+        - --provider=gce
+        - --metadata-sources=cl2-metadata.json
+        - --env=KUBE_FEATURE_GATES=DetectCacheInconsistency=false
+        - --env=KUBE_GCE_PRIVATE_CLUSTER=false
+        - --env=CL2_LIST_CONFIG_MAP_BYTES=100000
+        - --env=CL2_LIST_CONFIG_MAP_NUMBER=10000
+        - --env=CL2_LIST_BENCHMARK_PODS=10
+        - --env=CL2_LIST_BENCHMARK_CONTENT_TYPE=proto
+        - --test=false
+        - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+        - --test-cmd-args=cluster-loader2
+        - --test-cmd-args=--nodes=1
+        - --test-cmd-args=--provider=gce
+        - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
+        - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=$(JOB_NAME)-$(BUILD_ID)
+        - --test-cmd-args=--experimental-prometheus-snapshot-to-report-dir=true
+        - --test-cmd-args=--report-dir=$(ARTIFACTS)
+        - --test-cmd-args=--testconfig=testing/list/config.yaml
+        - --test-cmd-name=ClusterLoaderV2
+        - --timeout=60m
+        - --use-logexporter
+        - --logexporter-gcs-path=gs://k8s-infra-scalability-tests-logs/$(JOB_NAME)/$(BUILD_ID)
+        resources:
+          requests:
+            cpu: 3
+            memory: "8Gi"
+          limits:
+            cpu: 3
+            memory: "8Gi"


### PR DESCRIPTION
Optional presubmit mirroring the ci-kubernetes-benchmark-list-proto periodic, so perf-tests changes like https://github.com/kubernetes/perf-tests/pull/4183 can be confirmed in a presubmit via /test.

/assign @serathius