### PR TITLE
DRA: increase resource requirements for E2E node jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -694,10 +694,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: ci-node-crio-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -753,10 +753,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: ci-node-e2e-containerd-1-7-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -808,10 +808,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: ci-node-e2e-containerd-1-7-cos-dra
     cluster: k8s-infra-prow-build
@@ -863,10 +863,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: ci-node-e2e-containerd-2-0-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -921,10 +921,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: ci-node-e2e-containerd-2-0-cos-dra
     cluster: k8s-infra-prow-build
@@ -979,10 +979,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: ci-node-e2e-containerd-1-7-ubuntu-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1031,10 +1031,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: ci-node-e2e-containerd-1-7-cos-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1083,10 +1083,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: ci-node-e2e-containerd-2-0-ubuntu-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1138,10 +1138,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: ci-node-e2e-containerd-2-0-cos-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1193,7 +1193,7 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi

--- a/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
@@ -57,10 +57,10 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: pull-test-infra-node-e2e-containerd-1-7-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -109,10 +109,10 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: pull-test-infra-node-e2e-containerd-1-7-cos-dra
     cluster: k8s-infra-prow-build
@@ -161,10 +161,10 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: pull-test-infra-node-e2e-containerd-2-0-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -216,10 +216,10 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
 
   - name: pull-test-infra-node-e2e-containerd-2-0-cos-dra
     cluster: k8s-infra-prow-build
@@ -271,7 +271,7 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -317,10 +317,10 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 0.5
-            memory: 1Gi
+            memory: 2Gi
           {%- else %}
           limits:
             cpu: 2


### PR DESCRIPTION
This is for periodics where 1Gi was not enough for Ubuntu-based VMs. It's unclear why those jobs need more memory *in the Prow pod* - maybe there are too many test failure. Let's bump up the limit, otherwise the jobs just fail badly due to OOM, then investigate further.

/assign @dims

https://github.com/kubernetes/kubernetes/issues/140701