### PR TITLE
Require CI status checks for kubernetes-sigs/inference-perf

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -615,6 +615,13 @@ branch-protection:
         hydrophone:
           exclude:
             - "^dependencies/" # don't protect branches created by github action that updates dependencies
+        inference-perf:
+          required_status_checks:
+            contexts:
+            - unit-test (3.13)
+            - coverage (3.13)
+            - lint (3.13)
+            - e2e-tests
         kernel-module-management:
           required_status_checks:
             contexts:
@@ -910,6 +917,8 @@ tide:
           cluster-api-provider-kubevirt:
             from-branch-protection: true
           cluster-api-provider-vsphere:
+            from-branch-protection: true
+          inference-perf:
             from-branch-protection: true
           kubespray:
             from-branch-protection: true


### PR DESCRIPTION
## What this does

Adds required status checks for `kubernetes-sigs/inference-perf` `main`:

- `unit-test (3.13)`, `coverage (3.13)`, `lint (3.13)`, `e2e-tests` (GitHub Actions workflows in the repo)

and registers the repo in tide's `context_options` with `from-branch-protection: true` so tide waits for these contexts before merging.

## Why

Currently only `EasyCLA` is required, so tide merges inference-perf PRs as soon as `lgtm` + `approved` land, without waiting for any CI. This bit us on kubernetes-sigs/inference-perf#651, which merged after only EasyCLA + tide.

## Dependency

⚠️ Depends on kubernetes-sigs/inference-perf#652, which renames the workflow jobs to produce these distinct context names (they currently collide as `format-check (3.13)`). This PR must not merge before that one.

/hold
/hold reason: waiting for kubernetes-sigs/inference-perf#652 to merge

/cc @jjk-g