### PR TITLE
Add post-filtering to commenter bot for API review

### DIFF
--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -20,6 +20,11 @@ limitations under the License.
 // By default commenter runs in dry mode, add --confirm to make it leave comments.
 // The --updated, --include-closed, --ceiling options provide minor safeguards
 // around leaving excessive comments.
+//
+// Commenter also skips any matched issue that already has an identical comment,
+// so it is idempotent and will not repeat a comment even if the --query text
+// filter fails to exclude the issue (GitHub search does not reliably match
+// free-text phrases, especially inside existing comments).
 package main
 
 import (
@@ -153,6 +158,13 @@ func makeQuery(query string, includeArchived, includeClosed, includeLocked bool,
 type client interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	FindIssues(query, sort string, asc bool) ([]github.Issue, error)
+	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
+}
+
+// normalizeComment makes comment bodies comparable across GitHub round-trips,
+// which can differ in line endings and surrounding whitespace.
+func normalizeComment(s string) string {
+	return strings.TrimSpace(strings.ReplaceAll(s, "\r\n", "\n"))
 }
 
 func main() {
@@ -252,6 +264,25 @@ func run(c client, query, sort string, asc, random bool, commenter func(meta) (s
 			msg := fmt.Sprintf("Failed to create comment for %s/%s#%d: %v", org, repo, number, err)
 			log.Print(msg)
 			problems = append(problems, msg)
+			continue
+		}
+		existing, err := c.ListIssueComments(org, repo, number)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to list comments for %s/%s#%d: %v", org, repo, number, err)
+			log.Print(msg)
+			problems = append(problems, msg)
+			continue
+		}
+		want := normalizeComment(comment)
+		commented := false
+		for _, ec := range existing {
+			if normalizeComment(ec.Body) == want {
+				commented = true
+				break
+			}
+		}
+		if commented {
+			log.Printf("Skipping %s: an identical comment already exists", i.HTMLURL)
 			continue
 		}
 		if err := c.CreateComment(org, repo, number, comment); err != nil {

--- a/robots/commenter/main_test.go
+++ b/robots/commenter/main_test.go
@@ -210,6 +210,8 @@ func makeIssue(owner, repo string, number int, title string) github.Issue {
 type fakeClient struct {
 	comments []int
 	issues   []github.Issue
+	// existingComments maps an issue number to the comments already on it.
+	existingComments map[int][]github.IssueComment
 }
 
 // Fakes Creating a client, using the same signature as github.Client
@@ -219,6 +221,14 @@ func (c *fakeClient) CreateComment(owner, repo string, number int, comment strin
 	}
 	c.comments = append(c.comments, number)
 	return nil
+}
+
+// Fakes listing an issue's comments, using the same signature as github.Client
+func (c *fakeClient) ListIssueComments(owner, repo string, number int) ([]github.IssueComment, error) {
+	if repo == "list-error" {
+		return nil, errors.New("list error")
+	}
+	return c.existingComments[number], nil
 }
 
 // Fakes searching for issues, using the same signature as github.Client
@@ -288,6 +298,37 @@ func TestRun(t *testing.T) {
 			client: fakeClient{issues: []github.Issue{
 				makeIssue("o", "r", 1, "problematic this should work"),
 				makeIssue("o", "error", 2, "problematic expect an error"),
+				makeIssue("o", "r", 3, "problematic works as well"),
+			}},
+			err:      true,
+			expected: []int{1, 3},
+		},
+		{
+			name:    "skip issues that already have an identical comment",
+			query:   "dup",
+			comment: "found you",
+			client: fakeClient{
+				issues: []github.Issue{
+					makeIssue("o", "r", 1, "dup one"),
+					makeIssue("o", "r", 2, "dup two"),
+					makeIssue("o", "r", 3, "dup three"),
+				},
+				existingComments: map[int][]github.IssueComment{
+					// Different line endings/whitespace must still count as a match.
+					2: {{Body: "found you\r\n"}},
+					// A non-matching comment should not prevent commenting.
+					3: {{Body: "something else"}},
+				},
+			},
+			expected: []int{1, 3},
+		},
+		{
+			name:    "list comments error",
+			query:   "problematic",
+			comment: "hey",
+			client: fakeClient{issues: []github.Issue{
+				makeIssue("o", "r", 1, "problematic this should work"),
+				makeIssue("o", "list-error", 2, "problematic expect a list error"),
 				makeIssue("o", "r", 3, "problematic works as well"),
 			}},
 			err:      true,


### PR DESCRIPTION
The commenter bot will post a message to a PR when an API review may be needed. This runs regularly and uses a GitHub query filter to get the list of PRs to comment on, filtering out ones that already have the string that's present in its own API review comment.

For whatever reason, this filtering is not always reliable. It filters out some PRs that have already received the comment, but there are a few where it does not. These PRs end up receiving the same comment over and over.

Since this is filtering on the GitHub side, there's not really much we can do. So to avoid the repeated comments, this PR adds post-filtering to the list of PRs that are returned from the GitHub query to do our own checking for the expected strings. Iterating through the comments we will find the API review comment string and avoid posting another comment.

(LLM assistance was used in the creation of this PR)