### PR TITLE
agent-sandbox: add warm-pool claim-adoption benchmark jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
@@ -74,9 +74,9 @@ periodics:
     base_ref: main
   labels:
     preset-dind-enabled: "true"
-    preset-service-account: "true"
     preset-k8s-ssh: "true"
   spec:
+    serviceAccountName: prow-build
     containers:
     - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-master
       command:
@@ -106,9 +106,9 @@ periodics:
     base_ref: main
   labels:
     preset-dind-enabled: "true"
-    preset-service-account: "true"
     preset-k8s-ssh: "true"
   spec:
+    serviceAccountName: prow-build
     containers:
     - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-master
       command:
@@ -138,9 +138,9 @@ periodics:
     base_ref: main
   labels:
     preset-dind-enabled: "true"
-    preset-service-account: "true"
     preset-k8s-ssh: "true"
   spec:
+    serviceAccountName: prow-build
     containers:
     - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-master
       command:

--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
@@ -94,6 +94,38 @@ periodics:
       env:
       - name: BOSKOS_HOST
         value: boskos.test-pods.svc.cluster.local
+- name: periodic-benchmarks-kops-gcp-claims
+  cluster: k8s-infra-prow-build
+  interval: 24h
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-apps-agent-sandbox
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: agent-sandbox
+    base_ref: main
+  labels:
+    preset-dind-enabled: "true"
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-master
+      command:
+      - runner.sh
+      - dev/ci/periodics/benchmarks-kops-gcp-claims
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 7
+          memory: 14Gi
+        limits:
+          cpu: 7
+          memory: 14Gi
+      env:
+      - name: BOSKOS_HOST
+        value: boskos.test-pods.svc.cluster.local
 - name: periodic-benchmarks-kops-gcp-kindnet
   cluster: k8s-infra-prow-build
   interval: 24h

--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -140,6 +140,36 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-apps-agent-sandbox
       testgrid-tab-name: presubmit-benchmarks-kops-gcp-cilium
+  - name: presubmit-agent-sandbox-benchmarks-kops-gcp-claims
+    cluster: k8s-infra-prow-build
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    decorate: true
+    optional: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-master
+        command:
+        - runner.sh
+        - dev/ci/presubmits/benchmarks-kops-gcp-claims
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7
+            memory: 14Gi
+          limits:
+            cpu: 7
+            memory: 14Gi
+        env:
+        - name: BOSKOS_HOST
+          value: boskos.test-pods.svc.cluster.local
+    annotations:
+      testgrid-dashboards: sig-apps-agent-sandbox
+      testgrid-tab-name: presubmit-benchmarks-kops-gcp-claims
   - name: presubmit-agent-sandbox-benchmarks-kops-gcp-kindnet
     cluster: k8s-infra-prow-build
     skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"

--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -142,7 +142,7 @@ presubmits:
       testgrid-tab-name: presubmit-benchmarks-kops-gcp-cilium
   - name: presubmit-agent-sandbox-benchmarks-kops-gcp-claims
     cluster: k8s-infra-prow-build
-    run_if_changed: ^extensions/|^test/stress/|^test/benchmarks/|^dev/ci/(presubmits|periodics)/benchmarks-kops-gcp
+    run_if_changed: ^extensions/|^cmd/|^controllers/|^internal/|^test/stress/|^test/benchmarks/|^dev/ci/(presubmits|periodics)/benchmarks-kops-gcp
     decorate: true
     optional: true
     labels:

--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -117,9 +117,9 @@ presubmits:
     optional: true
     labels:
       preset-dind-enabled: "true"
-      preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
+      serviceAccountName: prow-build
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-master
         command:
@@ -142,14 +142,14 @@ presubmits:
       testgrid-tab-name: presubmit-benchmarks-kops-gcp-cilium
   - name: presubmit-agent-sandbox-benchmarks-kops-gcp-claims
     cluster: k8s-infra-prow-build
-    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    run_if_changed: ^extensions/|^test/stress/|^test/benchmarks/|^dev/ci/(presubmits|periodics)/benchmarks-kops-gcp
     decorate: true
     optional: true
     labels:
       preset-dind-enabled: "true"
-      preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
+      serviceAccountName: prow-build
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-master
         command:
@@ -177,9 +177,9 @@ presubmits:
     optional: true
     labels:
       preset-dind-enabled: "true"
-      preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
+      serviceAccountName: prow-build
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-master
         command:

--- a/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
@@ -132,6 +132,7 @@ PRESUBMIT_OVERRIDES = {
     "test-e2e": presubmit_test_e2e,
     # Expensive full-cluster benchmarks.
     "benchmarks-kops-gcp-cilium": optional_presubmit,
+    "benchmarks-kops-gcp-claims": optional_presubmit,
     "benchmarks-kops-gcp-kindnet": optional_presubmit,
     # Not wired up in prow before this generator existed; keep manual until
     # its credential requirements are sorted out.
@@ -154,6 +155,10 @@ def periodic_benchmarks_kops_gcp_cilium(job):
     job["interval"] = "24h"
 
 
+def periodic_benchmarks_kops_gcp_claims(job):
+    job["interval"] = "24h"
+
+
 def periodic_benchmarks_kops_gcp_kindnet(job):
     job["interval"] = "24h"
 
@@ -162,6 +167,7 @@ PERIODIC_OVERRIDES = {
     "test-load-test": periodic_test_load_test,
     "test-migration": periodic_test_migration,
     "benchmarks-kops-gcp-cilium": periodic_benchmarks_kops_gcp_cilium,
+    "benchmarks-kops-gcp-claims": periodic_benchmarks_kops_gcp_claims,
     "benchmarks-kops-gcp-kindnet": periodic_benchmarks_kops_gcp_kindnet,
 }
 

--- a/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
@@ -131,7 +131,7 @@ def presubmit_benchmarks_kops_gcp_claims(job):
     -- or the benchmark itself; anything else can still trigger it with
     /test."""
     optional_presubmit(job)
-    set_run_if_changed(job, r"^extensions/|^cmd/|^controllers/|^internal/|^test/stress/|^test/benchmarks/|^dev/ci/(presubmits|periodics)/benchmarks-kops-gcp")
+    set_run_if_changed(job, r"^extensions/|^cmd/|^controllers/|^internal/|^test/stress/|^test/benchmarks/|^dev/ci/(presubmits|periodics)/benchmarks-kops-gcp")  # pylint: disable=line-too-long
 
 
 PRESUBMIT_OVERRIDES = {

--- a/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
@@ -126,10 +126,12 @@ def optional_presubmit(job):
 
 def presubmit_benchmarks_kops_gcp_claims(job):
     """Optional, and auto-runs only on PRs that can affect warm-pool claim
-    adoption (extensions controllers/APIs) or the benchmark itself; anything
-    else can still trigger it with /test."""
+    adoption -- the extensions controllers/APIs plus the controller binary,
+    shared controllers, and internal packages the adoption path runs through
+    -- or the benchmark itself; anything else can still trigger it with
+    /test."""
     optional_presubmit(job)
-    set_run_if_changed(job, r"^extensions/|^test/stress/|^test/benchmarks/|^dev/ci/(presubmits|periodics)/benchmarks-kops-gcp")
+    set_run_if_changed(job, r"^extensions/|^cmd/|^controllers/|^internal/|^test/stress/|^test/benchmarks/|^dev/ci/(presubmits|periodics)/benchmarks-kops-gcp")
 
 
 PRESUBMIT_OVERRIDES = {

--- a/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
@@ -124,6 +124,14 @@ def optional_presubmit(job):
     job["optional"] = True
 
 
+def presubmit_benchmarks_kops_gcp_claims(job):
+    """Optional, and auto-runs only on PRs that can affect warm-pool claim
+    adoption (extensions controllers/APIs) or the benchmark itself; anything
+    else can still trigger it with /test."""
+    optional_presubmit(job)
+    set_run_if_changed(job, r"^extensions/|^test/stress/|^test/benchmarks/|^dev/ci/(presubmits|periodics)/benchmarks-kops-gcp")
+
+
 PRESUBMIT_OVERRIDES = {
     "test-autogen-up-to-date": presubmit_test_autogen_up_to_date,
     "test-unit": presubmit_test_unit,
@@ -132,7 +140,7 @@ PRESUBMIT_OVERRIDES = {
     "test-e2e": presubmit_test_e2e,
     # Expensive full-cluster benchmarks.
     "benchmarks-kops-gcp-cilium": optional_presubmit,
-    "benchmarks-kops-gcp-claims": optional_presubmit,
+    "benchmarks-kops-gcp-claims": presubmit_benchmarks_kops_gcp_claims,
     "benchmarks-kops-gcp-kindnet": optional_presubmit,
     # Not wired up in prow before this generator existed; keep manual until
     # its credential requirements are sorted out.
@@ -151,24 +159,16 @@ def periodic_test_migration(job):
     job["decoration_config"] = {"timeout": "30m"}
 
 
-def periodic_benchmarks_kops_gcp_cilium(job):
-    job["interval"] = "24h"
-
-
-def periodic_benchmarks_kops_gcp_claims(job):
-    job["interval"] = "24h"
-
-
-def periodic_benchmarks_kops_gcp_kindnet(job):
+def periodic_24h(job):
     job["interval"] = "24h"
 
 
 PERIODIC_OVERRIDES = {
     "test-load-test": periodic_test_load_test,
     "test-migration": periodic_test_migration,
-    "benchmarks-kops-gcp-cilium": periodic_benchmarks_kops_gcp_cilium,
-    "benchmarks-kops-gcp-claims": periodic_benchmarks_kops_gcp_claims,
-    "benchmarks-kops-gcp-kindnet": periodic_benchmarks_kops_gcp_kindnet,
+    "benchmarks-kops-gcp-cilium": periodic_24h,
+    "benchmarks-kops-gcp-claims": periodic_24h,
+    "benchmarks-kops-gcp-kindnet": periodic_24h,
 }
 
 DEFAULT_PERIODIC_INTERVAL = "24h"
@@ -235,7 +235,6 @@ def build_presubmit(script_name, override_func=None):
     if e2e:
         labels = {"preset-dind-enabled": "true"}
         if gcp:
-            labels["preset-service-account"] = "true"  # boskos GCE resources
             labels["preset-k8s-ssh"] = "true"  # node access
         else:
             labels["preset-kind-volume-mounts"] = "true"
@@ -256,7 +255,11 @@ def build_presubmit(script_name, override_func=None):
     c = container(f"dev/ci/presubmits/{script_name}", e2e, resources)
     if gcp:
         c["env"] = [{"name": "BOSKOS_HOST", "value": "boskos.test-pods.svc.cluster.local"}]
-    job["spec"] = {"containers": [c]}
+        # GCP credentials via workload identity on k8s-infra-prow-build
+        # (replaces the key-based preset-service-account preset).
+        job["spec"] = {"serviceAccountName": "prow-build", "containers": [c]}
+    else:
+        job["spec"] = {"containers": [c]}
 
     tab_name = f"presubmit-{script_name}"
     job["annotations"] = {
@@ -276,7 +279,6 @@ def build_periodic(script_name, override_func=None):
 
     labels = {"preset-dind-enabled": "true"}
     if gcp:
-        labels["preset-service-account"] = "true"
         labels["preset-k8s-ssh"] = "true"
     else:
         labels["preset-kind-volume-mounts"] = "true"
@@ -294,7 +296,11 @@ def build_periodic(script_name, override_func=None):
     c = container(f"dev/ci/periodics/{script_name}", e2e=True, resources=resources_for_e2e())
     if gcp:
         c["env"] = [{"name": "BOSKOS_HOST", "value": "boskos.test-pods.svc.cluster.local"}]
-    job["spec"] = {"containers": [c]}
+        # GCP credentials via workload identity on k8s-infra-prow-build
+        # (replaces the key-based preset-service-account preset).
+        job["spec"] = {"serviceAccountName": "prow-build", "containers": [c]}
+    else:
+        job["spec"] = {"containers": [c]}
 
     if override_func:
         override_func(job)


### PR DESCRIPTION
Adds prow jobs for the new warm-pool SandboxClaim adoption benchmark in kubernetes-sigs/agent-sandbox:

- **`presubmit-agent-sandbox-benchmarks-kops-gcp-claims`** — optional (non-blocking) presubmit, same shape/cluster/presets as the existing `benchmarks-kops-gcp-{cilium,kindnet}` jobs (k8s-infra-prow-build, Boskos GCE project, DinD).
- **`periodic-benchmarks-kops-gcp-claims`** — 24h periodic for a continuous adoption-latency baseline.

The job scripts (`dev/ci/{presubmits,periodics}/benchmarks-kops-gcp-claims`) are added in kubernetes-sigs/agent-sandbox#1236. The benchmark fires a burst of SandboxClaims against a pre-provisioned SandboxWarmPool and reports claim-adoption latency percentiles, giving controller changes on the claim/adoption path a dedicated per-PR signal.

Both YAML files are regenerated with `generate_jobs.py` against an agent-sandbox checkout that includes #1236; the diff is purely additive (the two new jobs plus their generator override entries).

**Merge order**: hold until kubernetes-sigs/agent-sandbox#1236 merges — the presubmit auto-runs (though non-blocking), so landing this first would make it fail on every agent-sandbox PR until the scripts exist.
