### PR TITLE
switch kind job to eks and check sctp coverage

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-kind-dual-canary
-    cluster: k8s-infra-prow-build
+    cluster: eks-prow-build-cluster
     optional: true
     always_run: false
     skip_report: false
@@ -32,7 +32,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: Alpha|Beta|Disruptive|Flaky|Networking-IPv6|LoadBalancer|SCTPConnectivity
+          value: Alpha|Beta|Disruptive|Flaky|Networking-IPv6|LoadBalancer
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
Let's bring back the SCTP coverage , first let's figure out if just switching to the EKS cluster brings us an OS with the kernel modules available, once merged we just need to `/test pull-kubernetes-e2e-kind-dual-canary`

https://github.com/kubernetes/kubernetes/issues/140489#issuecomment-5035476205

/assign @danwinship 