### PR TITLE
Reduce pull 5k experimental CL2 pod to 27Gi and drop highmem toleration

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -262,9 +262,6 @@ presubmits:
       testgrid-tab-name: pull-kubernetes-gce-master-scale-performance-5000-experimental
     spec:
       serviceAccountName: prow-build
-      tolerations:
-        - key: highmem
-          operator: Exists
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260720-39d457d26c-master
         command:
@@ -340,7 +337,7 @@ presubmits:
         resources:
           requests:
             cpu: 7
-            memory: "40Gi"
+            memory: "27Gi"
           limits:
             cpu: 7
-            memory: "40Gi"
+            memory: "27Gi"


### PR DESCRIPTION
So we don't have RSS numbers without messing with the test config a lot more. CL2 profiling can miss max, and RSS is probably higher, but I kind of doubt we need like 40G from a peak heap of ~8G? Given that we optimized CL2 recently, I want to see if we can lower the memory requirement so we can actually run 5k tests in parallel. This only applies to the experimental pull job just to test it out.