### PR TITLE
etcd: bump grpcproxy-integration-amd64 memory to 6Gi

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -752,10 +752,10 @@ presubmits:
         resources:
           requests:
             cpu: "6"
-            memory: "4Gi"
+            memory: "6Gi"
           limits:
             cpu: "6"
-            memory: "4Gi"
+            memory: "6Gi"
 
   - name: pull-etcd-grpcproxy-e2e-amd64
     cluster: eks-prow-build-cluster


### PR DESCRIPTION
Bumps the memory to 6Gi after getting OOMs for the release-3.5 branch.

/cc @ahrtr @fuweid 