### PR TITLE
Bump resources for cluster-api-provider-openstack e2e jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.12.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.12.yaml
@@ -31,14 +31,13 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "3Gi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          # The kind management clusters and all CAPI/CAPO controllers run
+          # inside the pod cgroup, so this needs to cover them too.
+          memory: "6Gi"
+          cpu: 4000m
         limits:
-          memory: "3Gi"
-          cpu: 2000m
+          memory: "6Gi"
+          cpu: 4000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
     testgrid-tab-name: periodic-e2e-test-release-0.12
@@ -91,14 +90,13 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "3Gi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          # The kind management clusters and all CAPI/CAPO controllers run
+          # inside the pod cgroup, so this needs to cover them too.
+          memory: "6Gi"
+          cpu: 4000m
         limits:
-          memory: "3Gi"
-          cpu: 2000m
+          memory: "6Gi"
+          cpu: 4000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
     testgrid-tab-name: periodic-e2e-full-test-release-0.12

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.13.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.13.yaml
@@ -31,14 +31,13 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "3Gi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          # The kind management clusters and all CAPI/CAPO controllers run
+          # inside the pod cgroup, so this needs to cover them too.
+          memory: "6Gi"
+          cpu: 4000m
         limits:
-          memory: "3Gi"
-          cpu: 2000m
+          memory: "6Gi"
+          cpu: 4000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
     testgrid-tab-name: periodic-e2e-test-release-0.13
@@ -91,14 +90,13 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "3Gi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          # The kind management clusters and all CAPI/CAPO controllers run
+          # inside the pod cgroup, so this needs to cover them too.
+          memory: "6Gi"
+          cpu: 4000m
         limits:
-          memory: "3Gi"
-          cpu: 2000m
+          memory: "6Gi"
+          cpu: 4000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
     testgrid-tab-name: periodic-e2e-full-test-release-0.13

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.14.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics-release-0.14.yaml
@@ -31,14 +31,13 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "3Gi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          # The kind management clusters and all CAPI/CAPO controllers run
+          # inside the pod cgroup, so this needs to cover them too.
+          memory: "6Gi"
+          cpu: 4000m
         limits:
-          memory: "3Gi"
-          cpu: 2000m
+          memory: "6Gi"
+          cpu: 4000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
     testgrid-tab-name: periodic-e2e-test-release-0.14
@@ -91,14 +90,13 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "3Gi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          # The kind management clusters and all CAPI/CAPO controllers run
+          # inside the pod cgroup, so this needs to cover them too.
+          memory: "6Gi"
+          cpu: 4000m
         limits:
-          memory: "3Gi"
-          cpu: 2000m
+          memory: "6Gi"
+          cpu: 4000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
     testgrid-tab-name: periodic-e2e-full-test-release-0.14

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-periodics.yaml
@@ -31,14 +31,13 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "3Gi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          # The kind management clusters and all CAPI/CAPO controllers run
+          # inside the pod cgroup, so this needs to cover them too.
+          memory: "6Gi"
+          cpu: 4000m
         limits:
-          memory: "3Gi"
-          cpu: 2000m
+          memory: "6Gi"
+          cpu: 4000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
     testgrid-tab-name: periodic-e2e-test-main
@@ -83,14 +82,13 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "3Gi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          # The kind management clusters and all CAPI/CAPO controllers run
+          # inside the pod cgroup, so this needs to cover them too.
+          memory: "6Gi"
+          cpu: 4000m
         limits:
-          memory: "3Gi"
-          cpu: 2000m
+          memory: "6Gi"
+          cpu: 4000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
     testgrid-tab-name: periodic-conformance-test-main
@@ -135,14 +133,13 @@ periodics:
         privileged: true
       resources:
         requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
-          memory: "3Gi"
-          # during the tests more like 3-20m is used
-          cpu: 2000m
+          # The kind management clusters and all CAPI/CAPO controllers run
+          # inside the pod cgroup, so this needs to cover them too.
+          memory: "6Gi"
+          cpu: 4000m
         limits:
-          memory: "3Gi"
-          cpu: 2000m
+          memory: "6Gi"
+          cpu: 4000m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
     testgrid-tab-name: periodic-e2e-full-test-main

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -80,14 +80,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "3Gi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            # The kind management clusters and all CAPI/CAPO controllers run
+            # inside the pod cgroup, so this needs to cover them too.
+            memory: "6Gi"
+            cpu: 4000m
           limits:
-            memory: "3Gi"
-            cpu: 2000m
+            memory: "6Gi"
+            cpu: 4000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-e2e-test
@@ -126,14 +125,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "3Gi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            # The kind management clusters and all CAPI/CAPO controllers run
+            # inside the pod cgroup, so this needs to cover them too.
+            memory: "6Gi"
+            cpu: 4000m
           limits:
-            memory: "3Gi"
-            cpu: 2000m
+            memory: "6Gi"
+            cpu: 4000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-conformance-test
@@ -176,14 +174,13 @@ presubmits:
           privileged: true
         resources:
           requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "3Gi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            # The kind management clusters and all CAPI/CAPO controllers run
+            # inside the pod cgroup, so this needs to cover them too.
+            memory: "6Gi"
+            cpu: 4000m
           limits:
-            memory: "3Gi"
-            cpu: 2000m
+            memory: "6Gi"
+            cpu: 4000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-openstack
       testgrid-tab-name: pr-e2e-full-test


### PR DESCRIPTION
Since kubekins-e2e `v20260713-9909545e89` (b09c569af) the DinD cgroup is nested under the pod cgroup, so the CAPO e2e jobs' 2 CPU / 3Gi limits are now enforced on the kind management clusters and CAPI/CAPO/ORC controllers running inside the pod. The kind apiserver/etcd get CPU-starved (leader-election lease timeouts, webhook connection refused) and the e2e-full-test periodics have failed every run since 2026-07-15, always in the clusterctl-upgrade resourceVersion stability check.

Bump the DinD e2e/conformance jobs (periodics, release branches, presubmits) to 4 CPU / 6Gi. Same class of fix as #37461.

Fixes kubernetes-sigs/cluster-api-provider-openstack#3275