### PR TITLE
Split cri-o serial job to filter out slow/disruptive tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -275,7 +275,7 @@ periodics:
     testgrid-dashboards: sig-node-cri-o
     testgrid-tab-name: ci-node-crio-kubelet-serial
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
-    description: "OWNER: sig-node; runs serial node-e2e tests with CRI-O (+Serial, -Flaky|Benchmark|Node*Feature|Feature:OffByDefault)"
+    description: "OWNER: sig-node; runs serial node-e2e tests with CRI-O (+Serial, -Flaky|Slow|Disruptive|Benchmark|Node*Feature|Feature:OffByDefault)"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260720-39d457d26c-master
@@ -290,6 +290,66 @@ periodics:
         - --gcp-zone=us-central1-b
         - --parallelism=1
         - --focus-regex=\[Serial\]
+        # *Manager jobs are skipped because they have corresponding test lanes with the right image
+        # These jobs in serial get partially skipped and are long jobs.
+        # Slow and Disruptive tests are skipped here and run in ci-node-crio-kubelet-serial-slow-disruptive.
+        - --skip-regex=\[Flaky\]|\[Slow\]|\[Disruptive\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:OffByDefault\]
+        - '--test-args=--ginkgo.timeout=3h --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}" --service-feature-gates="PodLevelResources=true" --feature-gates="PodLevelResources=true"'
+        - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-serial.yaml
+        - --timeout=300m
+      env:
+      - name: GOPATH
+        value: /go
+      - name: KUBE_SSH_USER
+        value: core
+      - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+        value: "1"
+      resources:
+        limits:
+          cpu: 4
+          memory: 12Gi
+        requests:
+          cpu: 4
+          memory: 12Gi
+
+- name: ci-node-crio-kubelet-serial-slow-disruptive
+  cluster: k8s-infra-prow-build
+  interval: 12h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 360m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  annotations:
+    testgrid-dashboards: sig-node-cri-o
+    testgrid-tab-name: ci-node-crio-kubelet-serial-slow-disruptive
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
+    description: "OWNER: sig-node; runs slow and disruptive serial node-e2e tests with CRI-O (+Serial+Slow|Disruptive, -Flaky|Benchmark|Node*Feature|Feature:OffByDefault)"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260720-39d457d26c-master
+      command:
+        - runner.sh
+      args:
+        - kubetest2
+        - noop
+        - --test=node
+        - --
+        - --repo-root=.
+        - --gcp-zone=us-central1-b
+        - --parallelism=1
+        - --focus-regex=\[Serial\].*(\[Slow\]|\[Disruptive\])|((\[Slow\]|\[Disruptive\]).*\[Serial\])
         # *Manager jobs are skipped because they have corresponding test lanes with the right image
         # These jobs in serial get partially skipped and are long jobs.
         - --skip-regex=\[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:OffByDefault\]

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1814,6 +1814,66 @@ presubmits:
               - --focus-regex=\[Serial\]
               # *Manager jobs are skipped because they have corresponding test lanes with the right image
               # These jobs in serial get partially skipped and are long jobs.
+              # Slow and Disruptive tests are skipped here and run in pull-node-crio-kubelet-serial-slow-disruptive.
+              - --skip-regex=\[Flaky\]|\[Slow\]|\[Disruptive\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:OffByDefault\]
+              - '--test-args=--ginkgo.timeout=3h --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}" --service-feature-gates="PodLevelResources=true" --feature-gates="PodLevelResources=true"'
+              - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-serial.yaml
+            resources:
+              limits:
+                cpu: 4
+                memory: 12Gi
+              requests:
+                cpu: 4
+                memory: 12Gi
+            env:
+              - name: KUBE_SSH_KEY_PATH
+                value: /etc/ssh-key-secret/ssh-private
+              - name: KUBE_SSH_USER
+                value: core
+              - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+                value: "1"
+    - name: pull-node-crio-kubelet-serial-slow-disruptive
+      cluster: k8s-infra-prow-build
+      # explicitly needs /test pull-node-crio-kubelet-serial-slow-disruptive to run
+      always_run: false
+      optional: true
+      skip_report: false
+      max_concurrency: 12
+      skip_branches:
+        - release-\d+\.\d+ # per-release image
+      decorate: true
+      path_alias: k8s.io/kubernetes
+      extra_refs:
+        - org: kubernetes
+          repo: test-infra
+          base_ref: master
+          path_alias: k8s.io/test-infra
+      decoration_config:
+        timeout: 4h
+      labels:
+        preset-service-account: "true"
+        preset-k8s-ssh: "true"
+        preset-pull-kubernetes-e2e: "true"
+        preset-pull-kubernetes-e2e-gce: "true"
+      annotations:
+        testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
+        testgrid-tab-name: pull-node-crio-kubelet-serial-slow-disruptive
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260720-39d457d26c-master
+            command:
+              - runner.sh
+            args:
+              - kubetest2
+              - noop
+              - --test=node
+              - --
+              - --repo-root=.
+              - --gcp-zone=us-central1-b
+              - --parallelism=1
+              - --focus-regex=\[Serial\].*(\[Slow\]|\[Disruptive\])|((\[Slow\]|\[Disruptive\]).*\[Serial\])
+              # *Manager jobs are skipped because they have corresponding test lanes with the right image
+              # These jobs in serial get partially skipped and are long jobs.
               - --skip-regex=\[Flaky\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:OffByDefault\]
               - '--test-args=--ginkgo.timeout=3h --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}" --service-feature-gates="PodLevelResources=true" --feature-gates="PodLevelResources=true"'
               - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-serial.yaml


### PR DESCRIPTION
## What this PR does / why we need it

Fix the CRI-O serial job (`ci-node-crio-kubelet-serial`) by filtering out `[Slow]` and `[Disruptive]` tests that were causing timeouts and instability. A new dedicated job is created for those tests.

## Changes

### Existing jobs modified
- **`ci-node-crio-kubelet-serial`** (periodic) and **`pull-node-crio-kubelet-serial`** (presubmit): Added `\[Slow\]` and `\[Disruptive\]` to `--skip-regex` to exclude slow/disruptive tests from the main serial lane.

### New jobs created
- **`ci-node-crio-kubelet-serial-slow-disruptive`** (periodic, 12h interval): Runs serial tests that are also tagged `[Slow]` or `[Disruptive]`.
- **`pull-node-crio-kubelet-serial-slow-disruptive`** (presubmit, optional, manually triggered): Presubmit equivalent for the same test set.

Both new jobs use the same configuration (image, feature gates, feature skip-regex, image-config, timeout) as the original serial job but with a focus-regex that matches tests tagged with both `[Serial]` and either `[Slow]` or `[Disruptive]`.

## Which issue(s) this PR fixes

Fixes CRI-O serial job reliability by splitting slow/disruptive tests into a separate lane.

## Special notes for your reviewer

This PR was generated with AI assistance (Claude). All changes have been reviewed and validated.

/sig node
/area test
/kind cleanup
/cc @kubernetes/sig-node-pr-reviews