### PR TITLE
sig-node: enable AllAlpha/AllBeta service feature gates for pull-kubernetes-node-e2e-containerd-alpha-features

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -653,7 +653,7 @@ presubmits:
               - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/image-config.yaml
               - --deployment=node
               - --gcp-zone=us-central1-b
-              - '--node-test-args=--feature-gates=AllAlpha=true,EventedPLEG=false,PodAndContainerStatsFromCRI=true,GenericWorkload=true --service-feature-gates=ResourceHealthStatus=true,GenericWorkload=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --feature-gates=PodAndContainerStatsFromCRI=true"'
+              - '--node-test-args=--feature-gates=AllAlpha=true,EventedPLEG=false,PodAndContainerStatsFromCRI=true,GenericWorkload=true --service-feature-gates=AllAlpha=true,AllBeta=true --runtime-config=api/all=true --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --feature-gates=PodAndContainerStatsFromCRI=true"'
               - --node-tests=true
               - --provider=gce
               - --test_args=--nodes=8 --focus="\[Feature:.+\]" --skip="\[Flaky\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]"


### PR DESCRIPTION
The non-serial alpha-features node lane runs its **kubelet** with `AllAlpha=true`, but the **in-process control plane** started by the e2e_node harness gets a hand-maintained named list:

```yaml
--node-test-args=--feature-gates=AllAlpha=true,...
                 --service-feature-gates=ResourceHealthStatus=true,GenericWorkload=true
```

As a result, any alpha feature that adds apiserver-validated API surface (a new field or resource name) cannot be exercised on this lane: the apiserver rejects the test pods at creation because its gate is off, even though the kubelet and the test selection (`--focus="\[Feature:.+\]"`, which opts into `[Feature:OffByDefault]` tests) both declare the lane alpha-capable. Example run, failing with `spec.resources.limits[pids]: ... pids resource requires PerPodPIDLimit feature gate` at pod creation:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/140889/pull-kubernetes-node-e2e-containerd-alpha-features/2080399557874683904

The current named list is itself the accumulation of previous features hitting this: `ResourceHealthStatus` and `GenericWorkload` were each appended after their k/k merges. That per-feature ritual also means the lane can never provide pre-merge signal for such features — the gate name can't be referenced in test-infra before it exists in k/k master.

This PR aligns the lane with its serial sibling, `pull-kubernetes-node-kubelet-serial-containerd-alpha-features`, which already runs with `--service-feature-gates=AllAlpha=true,AllBeta=true` and has been stable that way:

https://github.com/kubernetes/test-infra/blob/8bd0b2446470a3c9af092b8b8b5e339ce48ae1d3/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml#L799

AI usage: AI was used in diagnosing this issue.

/sig node
/area jobs

