### PR TITLE
agent-sandbox: setting kwok job to not always run

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -223,7 +223,8 @@ presubmits:
       testgrid-tab-name: presubmit-test-skill-eval
   - name: presubmit-agent-sandbox-test-e2e-scalability-kwok
     cluster: eks-prow-build-cluster
-    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    # skip_if_only_changed overrides always_run: false, so we can't use both. commenting out until we merge https://github.com/kubernetes-sigs/agent-sandbox/pull/1269
+    # skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     always_run: false
     optional: true


### PR DESCRIPTION
commenting skip_if_only_changed as it overrides always_run: false