### PR TITLE
5k experimental presubmit: switch HA with restart to HA no restart

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -413,6 +413,8 @@ presets:
     preset-kops-scalability-gce-experimental: "true"
   env:
   - name: EXPERIMENT_VARIANT
-    value: "node-exporter"
-  - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
-    value: "true"
+    value: "HA"
+  - name: CL2_RESTART_APISERVER
+    value: "false"
+  - name: CL2_HEAP_PROFILE_INTERVAL
+    value: "5m"


### PR DESCRIPTION
Switch the 5k experimental presubmit from HA with restart to HA no restart.