### PR TITLE
Use presets for kops gce jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -18,6 +18,9 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
+      preset-kops-scalability-gce-common: "true"
+      preset-kops-scalability-gce-100-node: "true"
+      preset-kops-scalability-gce-experimental: "true"
     decoration_config:
       timeout: 100m
     extra_refs:
@@ -44,54 +47,10 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: CL2_RESTART_APISERVER
-          value: "true"
         - name: KUBE_FEATURE_GATES
           value: "+EtcdRangeStream"
-        - name: CL2_HEAP_PROFILE_INTERVAL
-          value: "1m"
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
-        - name: GOPATH
-          value: /home/prow/go
-        - name: CNI_PLUGIN
-          value: gce
-        - name: KUBE_NODE_COUNT
-          value: "100"
-        - name: CL2_LOAD_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_DELETE_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_RATE_LIMIT_POD_CREATION
-          value: "false"
-        - name: NODE_MODE
-          value: "master"
-        - name: KUBE_PROXY_MODE
-          value: "nftables"
         - name: CONTROL_PLANE_COUNT
           value: "3"
-        - name: CONTROL_PLANE_SIZE
-          value: "c4-standard-32"
-        - name: CL2_ENABLE_DNS_PROGRAMMING
-          value: "true"
-        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-          value: "true"
-        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-          value: "99.5"
-        - name: CL2_ALLOWED_SLOW_API_CALLS
-          value: "1"
-        - name: ENABLE_PROMETHEUS_SERVER
-          value: "true"
-        - name: TEAR_DOWN_PROMETHEUS_SERVER
-          value: "false"
-        - name: PROMETHEUS_PVC_STORAGE_CLASS
-          value: "ssd-csi"
-        - name: CLOUD_PROVIDER
-          value: "gce"
-        - name: BOSKOS_RESOURCE_TYPE
-          value: "scalability-project"
         resources:
           requests:
             cpu: 5
@@ -244,6 +203,9 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
+      preset-kops-scalability-gce-common: "true"
+      preset-kops-scalability-gce-5000-node: "true"
+      preset-kops-scalability-gce-experimental: "true"
     job_queue_name: "5k-gce-scale-test" # DON'T REMOVE THIS
     decoration_config:
       timeout: 450m
@@ -274,69 +236,10 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: EXPERIMENT_VARIANT
-          value: "restart"
-        - name: CL2_ENABLE_INFORMER_LATENCY_TEST
-          value: "false"
-        - name: CL2_RESTART_APISERVER
-          value: "true"
-        - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
-          value: "21474836480"
-        - name: CL2_EXECSERVICE_CPU_REQUESTS
-          value: "8"
-        - name: CL2_EXECSERVICE_MEMORY_REQUESTS
-          value: "16Gi"
-        - name: CL2_REALISTIC_POD
-          value: "true"
-        - name: CL2_HEAP_PROFILE_INTERVAL
-          value: "5m"
-        #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
-        - name: GOPATH
-          value: /home/prow/go
-        - name: CNI_PLUGIN
-          value: gce
-        - name: KUBE_NODE_COUNT
-          value: "5000"
-        - name: CL2_LOAD_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_DELETE_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_RATE_LIMIT_POD_CREATION
-          value: "false"
-        - name: NODE_MODE
-          value: "master"
         - name: CONTROL_PLANE_COUNT
           value: "3"
-        - name: CONTROL_PLANE_SIZE
-          value: "c4-standard-96"
-        - name: ADDONS_NODE_SIZE
-          value: "c3-standard-44"
-        - name: KUBE_PROXY_MODE
-          value: "nftables"
         - name: PROMETHEUS_SCRAPE_ETCD
           value: "true"
-        - name: CL2_ENABLE_DNS_PROGRAMMING
-          value: "true"
-        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-          value: "true"
-        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-          value: "99.5"
-        - name: CL2_ALLOWED_SLOW_API_CALLS
-          value: "1"
-        - name: ENABLE_PROMETHEUS_SERVER
-          value: "true"
-        - name: TEAR_DOWN_PROMETHEUS_SERVER
-          value: "false"
-        - name: PROMETHEUS_PVC_STORAGE_CLASS
-          value: "ssd-csi"
-        - name: CLOUD_PROVIDER
-          value: "gce"
-        - name: BOSKOS_RESOURCE_TYPE
-          value: "scalability-scale-project"
         resources:
           requests:
             cpu: 7

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1187,6 +1187,9 @@ periodics:
   cluster: k8s-infra-prow-build
   labels:
     preset-k8s-ssh: "true"
+    preset-kops-scalability-gce-common: "true"
+    preset-kops-scalability-gce-5000-node: "true"
+    preset-kops-scalability-gce-experimental: "true"
   job_queue_name: "5k-gce-scale-test" # DON'T REMOVE THIS
   decorate: true
   decoration_config:
@@ -1223,72 +1226,10 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: EXPERIMENT_VARIANT
-        value: "restart"
-      - name: CL2_ENABLE_INFORMER_LATENCY_TEST
-        value: "false"
-      # Disabled: see https://github.com/kubernetes/test-infra/pull/37027
-      # - name: CL2_INFORMER_RUN_ON_CONTROL_PLANE
-      #   value: "true"
-      - name: CL2_RESTART_APISERVER
-        value: "true"
-      - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
-        value: "21474836480"
-      - name: CL2_EXECSERVICE_CPU_REQUESTS
-        value: "8"
-      - name: CL2_EXECSERVICE_MEMORY_REQUESTS
-        value: "16Gi"
-      - name: CL2_REALISTIC_POD
-        value: "true"
-      - name: CL2_HEAP_PROFILE_INTERVAL
-        value: "5m"
-      #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/ssh-key-secret/ssh-private
-      - name: KUBE_SSH_USER
-        value: prow
-      - name: GOPATH
-        value: /home/prow/go
-      - name: CNI_PLUGIN
-        value: gce
-      - name: KUBE_NODE_COUNT
-        value: "5000"
-      - name: CL2_LOAD_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_DELETE_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_RATE_LIMIT_POD_CREATION
-        value: "false"
-      - name: NODE_MODE
-        value: "master"
       - name: CONTROL_PLANE_COUNT
         value: "3"
-      - name: CONTROL_PLANE_SIZE
-        value: "c4-standard-96"
-      - name: ADDONS_NODE_SIZE
-        value: "c3-standard-44"
-      - name: KUBE_PROXY_MODE
-        value: "nftables"
       - name: PROMETHEUS_SCRAPE_ETCD
         value: "true"
-      - name: CL2_ENABLE_DNS_PROGRAMMING
-        value: "true"
-      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-        value: "true"
-      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-        value: "99.5"
-      - name: CL2_ALLOWED_SLOW_API_CALLS
-        value: "1"
-      - name: ENABLE_PROMETHEUS_SERVER
-        value: "true"
-      - name: TEAR_DOWN_PROMETHEUS_SERVER
-        value: "false"
-      - name: PROMETHEUS_PVC_STORAGE_CLASS
-        value: "ssd-csi"
-      - name: CLOUD_PROVIDER
-        value: "gce"
-      - name: BOSKOS_RESOURCE_TYPE
-        value: "scalability-scale-project"
       resources:
         requests:
           cpu: 7
@@ -1309,6 +1250,8 @@ periodics:
   cluster: k8s-infra-prow-build
   labels:
     preset-k8s-ssh: "true"
+    preset-kops-scalability-gce-common: "true"
+    preset-kops-scalability-gce-100-node: "true"
   decorate: true
   decoration_config:
     timeout: 1h
@@ -1341,52 +1284,10 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/ssh-key-secret/ssh-private
-      - name: KUBE_SSH_USER
-        value: prow
-      - name: GOPATH
-        value: /home/prow/go
       - name: GOFLAGS
         value: "-tags=fieldsv1string"
       - name: KUBERNETES_VERSION
         value: master
-      - name: CNI_PLUGIN
-        value: gce
-      - name: KUBE_NODE_COUNT
-        value: "100"
-      - name: CL2_LOAD_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_DELETE_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_RATE_LIMIT_POD_CREATION
-        value: "false"
-      - name: NODE_MODE
-        value: "master"
-      - name: KUBE_PROXY_MODE
-        value: "nftables"
-      - name: CONTROL_PLANE_COUNT
-        value: "1"
-      - name: CONTROL_PLANE_SIZE
-        value: "c4-standard-32"
-      - name: CL2_ENABLE_DNS_PROGRAMMING
-        value: "true"
-      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-        value: "true"
-      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-        value: "99.5"
-      - name: CL2_ALLOWED_SLOW_API_CALLS
-        value: "1"
-      - name: ENABLE_PROMETHEUS_SERVER
-        value: "true"
-      - name: TEAR_DOWN_PROMETHEUS_SERVER
-        value: "false"
-      - name: PROMETHEUS_PVC_STORAGE_CLASS
-        value: "ssd-csi"
-      - name: CLOUD_PROVIDER
-        value: "gce"
-      - name: BOSKOS_RESOURCE_TYPE
-        value: "scalability-project"
       resources:
         requests:
           cpu: 2

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -336,3 +336,83 @@ presets:
 - labels:
     preset-e2e-scalability-periodics-master: "true"
   env:
+
+- labels:
+    preset-kops-scalability-gce-common: "true"
+  env:
+  - name: CLOUD_PROVIDER
+    value: "gce"
+  - name: CNI_PLUGIN
+    value: "gce"
+  - name: KUBE_PROXY_MODE
+    value: "nftables"
+  - name: NODE_MODE
+    value: "master"
+  - name: ENABLE_PROMETHEUS_SERVER
+    value: "true"
+  - name: PROMETHEUS_PVC_STORAGE_CLASS
+    value: "ssd-csi"
+  - name: KUBE_SSH_KEY_PATH
+    value: "/etc/ssh-key-secret/ssh-private"
+  - name: KUBE_SSH_USER
+    value: "prow"
+  - name: GOPATH
+    value: "/home/prow/go"
+  - name: CL2_LOAD_TEST_THROUGHPUT
+    value: "50"
+  - name: CL2_DELETE_TEST_THROUGHPUT
+    value: "50"
+  - name: CL2_RATE_LIMIT_POD_CREATION
+    value: "false"
+  - name: CL2_ENABLE_DNS_PROGRAMMING
+    value: "true"
+  - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
+    value: "true"
+  - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
+    value: "99.5"
+  - name: CL2_ALLOWED_SLOW_API_CALLS
+    value: "1"
+  - name: TEAR_DOWN_PROMETHEUS_SERVER
+    value: "false"
+
+- labels:
+    preset-kops-scalability-gce-100-node: "true"
+  env:
+  - name: KUBE_NODE_COUNT
+    value: "100"
+  - name: CONTROL_PLANE_SIZE
+    value: "c4-standard-32"
+  - name: BOSKOS_RESOURCE_TYPE
+    value: "scalability-project"
+
+- labels:
+    preset-kops-scalability-gce-5000-node: "true"
+  env:
+  - name: KUBE_NODE_COUNT
+    value: "5000"
+  - name: CONTROL_PLANE_SIZE
+    value: "c4-standard-96"
+  - name: ADDONS_NODE_SIZE
+    value: "c3-standard-44"
+  - name: BOSKOS_RESOURCE_TYPE
+    value: "scalability-scale-project"
+  - name: CL2_ENABLE_INFORMER_LATENCY_TEST
+    value: "false"
+  - name: ETCD_QUOTA_BACKEND_BYTES
+    value: "21474836480"
+  - name: CL2_EXECSERVICE_CPU_REQUESTS
+    value: "8"
+  - name: CL2_EXECSERVICE_MEMORY_REQUESTS
+    value: "16Gi"
+  - name: CL2_REALISTIC_POD
+    value: "true"
+
+- labels:
+    preset-kops-scalability-gce-experimental: "true"
+  env:
+  - name: EXPERIMENT_VARIANT
+    value: "restart"
+  - name: CL2_RESTART_APISERVER
+    value: "true"
+  - name: CL2_HEAP_PROFILE_INTERVAL
+    value: "5m"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -97,6 +97,8 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
+      preset-kops-scalability-gce-common: "true"
+      preset-kops-scalability-gce-100-node: "true"
     decorate: true
     path_alias: k8s.io/kubernetes
     decoration_config:
@@ -126,50 +128,8 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
-        - name: GOPATH
-          value: /home/prow/go
-        - name: CNI_PLUGIN
-          value: gce
-        - name: KUBE_NODE_COUNT
-          value: "100"
-        - name: CL2_LOAD_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_DELETE_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_RATE_LIMIT_POD_CREATION
-          value: "false"
-        - name: NODE_MODE
-          value: "master"
-        - name: KUBE_PROXY_MODE
-          value: "nftables"
-        - name: CONTROL_PLANE_COUNT
-          value: "1"
-        - name: CONTROL_PLANE_SIZE
-          value: "c4-standard-32"
         - name: PROMETHEUS_SCRAPE_ETCD
           value: "true"
-        - name: CL2_ENABLE_DNS_PROGRAMMING
-          value: "true"
-        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-          value: "true"
-        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-          value: "99.5"
-        - name: CL2_ALLOWED_SLOW_API_CALLS
-          value: "1"
-        - name: ENABLE_PROMETHEUS_SERVER
-          value: "true"
-        - name: TEAR_DOWN_PROMETHEUS_SERVER
-          value: "false"
-        - name: PROMETHEUS_PVC_STORAGE_CLASS
-          value: "ssd-csi"
-        - name: CLOUD_PROVIDER
-          value: "gce"
-        - name: BOSKOS_RESOURCE_TYPE
-          value: "scalability-project"
         resources:
           requests:
             cpu: 5
@@ -421,6 +381,8 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
+      preset-kops-scalability-gce-common: "true"
+      preset-kops-scalability-gce-5000-node: "true"
     job_queue_name: "5k-gce-scale-test" # DON'T REMOVE THIS
     decoration_config:
       timeout: 480m
@@ -451,61 +413,8 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        #  Remaining parameters should match ci-kubernetes-e2e-gce-scale-performance-5000
-        - name: CL2_ENABLE_INFORMER_LATENCY_TEST
-          value: "false"
-        - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
-          value: "21474836480"
-        - name: CL2_EXECSERVICE_CPU_REQUESTS
-          value: "8"
-        - name: CL2_EXECSERVICE_MEMORY_REQUESTS
-          value: "16Gi"
-        - name: CL2_REALISTIC_POD
-          value: "true"
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
-        - name: GOPATH
-          value: /home/prow/go
-        - name: CNI_PLUGIN
-          value: gce
-        - name: KUBE_NODE_COUNT
-          value: "5000"
-        - name: CL2_LOAD_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_DELETE_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_RATE_LIMIT_POD_CREATION
-          value: "false"
-        - name: NODE_MODE
-          value: "master"
-        - name: CONTROL_PLANE_SIZE
-          value: "c4-standard-96"
-        - name: ADDONS_NODE_SIZE
-          value: "c3-standard-44"
-        - name: KUBE_PROXY_MODE
-          value: "nftables"
         - name: PROMETHEUS_SCRAPE_ETCD
           value: "true"
-        - name: CL2_ENABLE_DNS_PROGRAMMING
-          value: "true"
-        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-          value: "true"
-        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-          value: "99.5"
-        - name: CL2_ALLOWED_SLOW_API_CALLS
-          value: "1"
-        - name: ENABLE_PROMETHEUS_SERVER
-          value: "true"
-        - name: TEAR_DOWN_PROMETHEUS_SERVER
-          value: "false"
-        - name: PROMETHEUS_PVC_STORAGE_CLASS
-          value: "ssd-csi"
-        - name: CLOUD_PROVIDER
-          value: "gce"
-        - name: BOSKOS_RESOURCE_TYPE
-          value: "scalability-scale-project"
         resources:
           requests:
             cpu: 7
@@ -1092,6 +1001,8 @@ presubmits:
     run_if_changed: ^clusterloader2/.*$
     labels:
       preset-k8s-ssh: "true"
+      preset-kops-scalability-gce-common: "true"
+      preset-kops-scalability-gce-100-node: "true"
     decorate: true
     max_concurrency: 3
     decoration_config:
@@ -1120,49 +1031,6 @@ presubmits:
         - ./tests/e2e/scenarios/scalability/run-test.sh
         securityContext:
           privileged: true
-        env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
-        - name: GOPATH
-          value: /home/prow/go
-        - name: CNI_PLUGIN
-          value: gce
-        - name: KUBE_NODE_COUNT
-          value: "100"
-        - name: CL2_LOAD_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_DELETE_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_RATE_LIMIT_POD_CREATION
-          value: "false"
-        - name: NODE_MODE
-          value: "master"
-        - name: KUBE_PROXY_MODE
-          value: "nftables"
-        - name: CONTROL_PLANE_COUNT
-          value: "1"
-        - name: CONTROL_PLANE_SIZE
-          value: "c4-standard-32"
-        - name: CL2_ENABLE_DNS_PROGRAMMING
-          value: "true"
-        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-          value: "true"
-        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-          value: "99.5"
-        - name: CL2_ALLOWED_SLOW_API_CALLS
-          value: "1"
-        - name: ENABLE_PROMETHEUS_SERVER
-          value: "true"
-        - name: TEAR_DOWN_PROMETHEUS_SERVER
-          value: "false"
-        - name: PROMETHEUS_PVC_STORAGE_CLASS
-          value: "ssd-csi"
-        - name: CLOUD_PROVIDER
-          value: "gce"
-        - name: BOSKOS_RESOURCE_TYPE
-          value: "scalability-project"
         resources:
           requests:
             cpu: 5
@@ -1177,6 +1045,8 @@ presubmits:
     optional: true
     labels:
       preset-k8s-ssh: "true"
+      preset-kops-scalability-gce-common: "true"
+      preset-kops-scalability-gce-100-node: "true"
     decorate: true
     max_concurrency: 3
     decoration_config:
@@ -1206,50 +1076,10 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
-        - name: GOPATH
-          value: /home/prow/go
-        - name: CNI_PLUGIN
-          value: gce
-        - name: KUBE_NODE_COUNT
-          value: "100"
-        - name: CL2_LOAD_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_DELETE_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_RATE_LIMIT_POD_CREATION
-          value: "false"
-        - name: NODE_MODE
-          value: "master"
-        - name: KUBE_PROXY_MODE
-          value: "nftables"
         - name: CONTROL_PLANE_COUNT
           value: "3"
-        - name: CONTROL_PLANE_SIZE
-          value: "c4-standard-32"
         - name: PROMETHEUS_SCRAPE_ETCD
           value: "true"
-        - name: CL2_ENABLE_DNS_PROGRAMMING
-          value: "true"
-        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-          value: "true"
-        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-          value: "99.5"
-        - name: CL2_ALLOWED_SLOW_API_CALLS
-          value: "1"
-        - name: ENABLE_PROMETHEUS_SERVER
-          value: "true"
-        - name: TEAR_DOWN_PROMETHEUS_SERVER
-          value: "false"
-        - name: PROMETHEUS_PVC_STORAGE_CLASS
-          value: "ssd-csi"
-        - name: CLOUD_PROVIDER
-          value: "gce"
-        - name: BOSKOS_RESOURCE_TYPE
-          value: "scalability-project"
         resources:
           requests:
             cpu: 5
@@ -1263,6 +1093,8 @@ presubmits:
     always_run: false
     labels:
       preset-k8s-ssh: "true"
+      preset-kops-scalability-gce-common: "true"
+      preset-kops-scalability-gce-5000-node: "true"
     decorate: true
     decoration_config:
       timeout: 480m
@@ -1296,62 +1128,8 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: CL2_ENABLE_INFORMER_LATENCY_TEST
-          value: "false"
-        # - name: CL2_INFORMER_RUN_ON_CONTROL_PLANE
-        #   value: "true"
-        - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
-          value: "21474836480"
-        - name: CL2_EXECSERVICE_CPU_REQUESTS
-          value: "8"
-        - name: CL2_EXECSERVICE_MEMORY_REQUESTS
-          value: "16Gi"
-        - name: CL2_REALISTIC_POD
-          value: "true"
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
-        - name: GOPATH
-          value: /home/prow/go
-        - name: CNI_PLUGIN
-          value: gce
-        - name: KUBE_NODE_COUNT
-          value: "5000"
-        - name: CL2_LOAD_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_DELETE_TEST_THROUGHPUT
-          value: "50"
-        - name: CL2_RATE_LIMIT_POD_CREATION
-          value: "false"
-        - name: NODE_MODE
-          value: "master"
         - name: CONTROL_PLANE_COUNT
           value: "1"
-        - name: CONTROL_PLANE_SIZE
-          value: "c4-standard-96"
-        - name: ADDONS_NODE_SIZE
-          value: "c3-standard-44"
-        - name: KUBE_PROXY_MODE
-          value: "nftables"
-        - name: CL2_ENABLE_DNS_PROGRAMMING
-          value: "true"
-        - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-          value: "true"
-        - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-          value: "99.5"
-        - name: CL2_ALLOWED_SLOW_API_CALLS
-          value: "1"
-        - name: ENABLE_PROMETHEUS_SERVER
-          value: "true"
-        - name: TEAR_DOWN_PROMETHEUS_SERVER
-          value: "false"
-        - name: PROMETHEUS_PVC_STORAGE_CLASS
-          value: "ssd-csi"
-        - name: CLOUD_PROVIDER
-          value: "gce"
-        - name: BOSKOS_RESOURCE_TYPE
-          value: "scalability-scale-project"
         resources:
           requests:
             cpu: 7

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -83,6 +83,8 @@ periodics:
   cluster: k8s-infra-prow-build
   labels:
     preset-k8s-ssh: "true"
+    preset-kops-scalability-gce-common: "true"
+    preset-kops-scalability-gce-5000-node: "true"
   decorate: true
   job_queue_name: "5k-gce-scale-test" # DON'T REMOVE THIS
   decoration_config:
@@ -123,62 +125,10 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: CL2_ENABLE_INFORMER_LATENCY_TEST
-        value: "false"
-      - name: ETCD_QUOTA_BACKEND_BYTES # 20GB
-        value: "21474836480"
-      - name: CL2_EXECSERVICE_CPU_REQUESTS
-        value: "8"
-      - name: CL2_EXECSERVICE_MEMORY_REQUESTS
-        value: "16Gi"
-      - name: CL2_REALISTIC_POD
-        value: "true"
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/ssh-key-secret/ssh-private
-      - name: KUBE_SSH_USER
-        value: prow
-      - name: GOPATH
-        value: /home/prow/go
-      - name: CNI_PLUGIN
-        value: gce
-      - name: KUBE_NODE_COUNT
-        value: "5000"
-      - name: CL2_LOAD_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_DELETE_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_RATE_LIMIT_POD_CREATION
-        value: "false"
-      - name: NODE_MODE
-        value: "master"
       - name: CONTROL_PLANE_COUNT
         value: "1"
-      - name: CONTROL_PLANE_SIZE
-        value: "c4-standard-96"
-      - name: ADDONS_NODE_SIZE
-        value: "c3-standard-44"
-      - name: KUBE_PROXY_MODE
-        value: "nftables"
       - name: PROMETHEUS_SCRAPE_ETCD
         value: "true"
-      - name: CL2_ENABLE_DNS_PROGRAMMING
-        value: "true"
-      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-        value: "true"
-      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-        value: "99.5"
-      - name: CL2_ALLOWED_SLOW_API_CALLS
-        value: "1"
-      - name: ENABLE_PROMETHEUS_SERVER
-        value: "true"
-      - name: TEAR_DOWN_PROMETHEUS_SERVER
-        value: "false"
-      - name: PROMETHEUS_PVC_STORAGE_CLASS
-        value: "ssd-csi"
-      - name: CLOUD_PROVIDER
-        value: "gce"
-      - name: BOSKOS_RESOURCE_TYPE
-        value: "scalability-scale-project"
       resources:
         requests:
           cpu: 7
@@ -196,6 +146,8 @@ periodics:
   interval: 30m
   labels:
     preset-k8s-ssh: "true"
+    preset-kops-scalability-gce-common: "true"
+    preset-kops-scalability-gce-100-node: "true"
   decorate: true
   decoration_config:
     timeout: 1h
@@ -233,50 +185,8 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/ssh-key-secret/ssh-private
-      - name: KUBE_SSH_USER
-        value: prow
-      - name: GOPATH
-        value: /home/prow/go
       - name: KUBERNETES_VERSION
         value: master
-      - name: CNI_PLUGIN
-        value: gce
-      - name: KUBE_NODE_COUNT
-        value: "100"
-      - name: CL2_LOAD_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_DELETE_TEST_THROUGHPUT
-        value: "50"
-      - name: CL2_RATE_LIMIT_POD_CREATION
-        value: "false"
-      - name: NODE_MODE
-        value: "master"
-      - name: KUBE_PROXY_MODE
-        value: "nftables"
-      - name: CONTROL_PLANE_COUNT
-        value: "1"
-      - name: CONTROL_PLANE_SIZE
-        value: "c4-standard-32"
-      - name: CL2_ENABLE_DNS_PROGRAMMING
-        value: "true"
-      - name: CL2_ENABLE_API_AVAILABILITY_MEASUREMENT
-        value: "true"
-      - name: CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD
-        value: "99.5"
-      - name: CL2_ALLOWED_SLOW_API_CALLS
-        value: "1"
-      - name: ENABLE_PROMETHEUS_SERVER
-        value: "true"
-      - name: TEAR_DOWN_PROMETHEUS_SERVER
-        value: "false"
-      - name: PROMETHEUS_PVC_STORAGE_CLASS
-        value: "ssd-csi"
-      - name: CLOUD_PROVIDER
-        value: "gce"
-      - name: BOSKOS_RESOURCE_TYPE
-        value: "scalability-project"
       resources:
         requests:
           cpu: 2


### PR DESCRIPTION
Trying to use presets more as the list envs became unmanageable.

This is purely refactor, I tried not to change anything even if imperfect, so the review is simpler and we can do cleanup in followups. 

Validated that nothing changed via a test that simulates presetting. Might contribute it later, but I will figure out how to integrate it in the repo later.
```
package tests

import (
	"encoding/json"
	"os"
	"path/filepath"
	"sort"
	"testing"

	"github.com/google/go-cmp/cmp"
	coreapi "k8s.io/api/core/v1"
)

type EnvVarDump struct {
	Name  string `json:"name"`
	Value string `json:"value,omitempty"`
}

var targetJobs = map[string]bool{
	// 5000-node GCE kops jobs
	"ci-kubernetes-e2e-gce-scale-performance-5000":                             true,
	"pull-kubernetes-gce-master-scale-performance-5000":                         true,
	"pull-perf-tests-gce-master-scale-performance-5000":                         true,
	"ci-kubernetes-e2e-gce-scale-performance-5000-experimental":                true,
	"pull-kubernetes-gce-master-scale-performance-5000-experimental":           true,
	"ci-kubernetes-e2e-kops-gce-5000-node-dra-with-workload-ipalias-using-cl2": true,

	// 100-node GCE kops jobs
	"ci-kubernetes-e2e-gce-scale-performance-100":                      true,
	"ci-kubernetes-e2e-gce-scale-performance-100-fieldsv1string":       true,
	"pull-kubernetes-e2e-gce-master-scale-performance-100":              true,
	"pull-perf-tests-gce-master-scale-performance-100":                  true,
	"pull-perf-tests-gce-master-scale-performance-100-experimental":   true,
	"pull-kubernetes-gce-master-scale-performance-100-experimental":    true,
}

func TestRenderGoldenDataset(t *testing.T) {
	if os.Getenv("GENERATE_GOLDEN") != "true" && os.Getenv("VERIFY_GOLDEN") != "true" {
		t.Skip("Skipping golden dataset test (set GENERATE_GOLDEN=true or VERIFY_GOLDEN=true)")
	}

	jobEnvs := make(map[string][]EnvVarDump)

	extractEnvs := func(name string, spec *coreapi.PodSpec) {
		if !targetJobs[name] || spec == nil {
			return
		}
		var envs []EnvVarDump
		for _, container := range spec.Containers {
			for _, e := range container.Env {
				envs = append(envs, EnvVarDump{
					Name:  e.Name,
					Value: e.Value,
				})
			}
		}
		sort.Slice(envs, func(i, j int) bool {
			return envs[i].Name < envs[j].Name
		})
		jobEnvs[name] = envs
	}

	for _, p := range c.Periodics {
		extractEnvs(p.Name, p.Spec)
	}
	for _, presubmits := range c.PresubmitsStatic {
		for _, p := range presubmits {
			extractEnvs(p.Name, p.Spec)
		}
	}

	if len(jobEnvs) != len(targetJobs) {
		t.Fatalf("Expected %d target jobs, found %d", len(targetJobs), len(jobEnvs))
	}

	outDir := os.Getenv("GOLDEN_OUT_DIR")
	if outDir == "" {
		outDir = "."
	}
	outPath := filepath.Join(outDir, "golden_job_envs.json")

	currentData, err := json.MarshalIndent(jobEnvs, "", "  ")
	if err != nil {
		t.Fatalf("Failed to marshal rendered envs: %v", err)
	}

	if os.Getenv("GENERATE_GOLDEN") == "true" {
		if err := os.WriteFile(outPath, currentData, 0644); err != nil {
			t.Fatalf("Failed to write golden file: %v", err)
		}
		t.Logf("Golden dataset successfully written to %s", outPath)
	}

	if os.Getenv("VERIFY_GOLDEN") == "true" {
		goldenData, err := os.ReadFile(outPath)
		if err != nil {
			t.Fatalf("Failed to read golden file: %v", err)
		}
		var expected map[string][]EnvVarDump
		if err := json.Unmarshal(goldenData, &expected); err != nil {
			t.Fatalf("Failed to unmarshal golden dataset: %v", err)
		}

		if diff := cmp.Diff(expected, jobEnvs); diff != "" {
			t.Fatalf("Job environment variables mismatch against golden dataset (-want +got):\n%s", diff)
		}
		t.Logf("Golden dataset verification PASSED: 100%% match!")
	}
}

```

/cc @Jefftree 