### PR TITLE
Align configs for kops scalability tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -238,8 +238,6 @@ presubmits:
         env:
         - name: CONTROL_PLANE_COUNT
           value: "3"
-        - name: PROMETHEUS_SCRAPE_ETCD
-          value: "true"
         resources:
           requests:
             cpu: 7

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -1228,8 +1228,6 @@ periodics:
       env:
       - name: CONTROL_PLANE_COUNT
         value: "3"
-      - name: PROMETHEUS_SCRAPE_ETCD
-        value: "true"
       resources:
         requests:
           cpu: 7

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -352,6 +352,8 @@ presets:
     value: "true"
   - name: PROMETHEUS_PVC_STORAGE_CLASS
     value: "ssd-csi"
+  - name: PROMETHEUS_SCRAPE_ETCD
+    value: "true"
   - name: KUBE_SSH_KEY_PATH
     value: "/etc/ssh-key-secret/ssh-private"
   - name: KUBE_SSH_USER

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -127,9 +127,6 @@ presubmits:
         - ./tests/e2e/scenarios/scalability/run-test.sh
         securityContext:
           privileged: true
-        env:
-        - name: PROMETHEUS_SCRAPE_ETCD
-          value: "true"
         resources:
           requests:
             cpu: 5
@@ -412,9 +409,6 @@ presubmits:
         - ./tests/e2e/scenarios/scalability/run-test.sh
         securityContext:
           privileged: true
-        env:
-        - name: PROMETHEUS_SCRAPE_ETCD
-          value: "true"
         resources:
           requests:
             cpu: 7
@@ -1047,6 +1041,7 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-kops-scalability-gce-common: "true"
       preset-kops-scalability-gce-100-node: "true"
+      preset-kops-scalability-gce-experimental: "true"
     decorate: true
     max_concurrency: 3
     decoration_config:
@@ -1078,8 +1073,6 @@ presubmits:
         env:
         - name: CONTROL_PLANE_COUNT
           value: "3"
-        - name: PROMETHEUS_SCRAPE_ETCD
-          value: "true"
         resources:
           requests:
             cpu: 5

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -124,11 +124,6 @@ periodics:
       - ./tests/e2e/scenarios/scalability/run-test.sh
       securityContext:
         privileged: true
-      env:
-      - name: CONTROL_PLANE_COUNT
-        value: "1"
-      - name: PROMETHEUS_SCRAPE_ETCD
-        value: "true"
       resources:
         requests:
           cpu: 7


### PR DESCRIPTION
Here is the complete diff of rendered environment variables across all 12 target jobs comparing the **Un-refactored state (baseline before preset refactoring)** vs **Current refactored & aligned state**:

1. ci-kubernetes-e2e-gce-scale-performance-5000

```diff
- CONTROL_PLANE_COUNT=1   # Removed redundant default (1 control plane node is default)
```

2. ci-kubernetes-e2e-gce-scale-performance-100

```diff
- CONTROL_PLANE_COUNT=1   # Removed redundant default
+ PROMETHEUS_SCRAPE_ETCD=true # Aligned: Inherited from preset-kops-scalability-gce-common
```

3. pull-perf-tests-gce-master-scale-performance-5000

```diff
- CONTROL_PLANE_COUNT=1   # Removed redundant default
+ PROMETHEUS_SCRAPE_ETCD=true # Aligned: Inherited from preset-kops-scalability-gce-common
```

4. pull-perf-tests-gce-master-scale-performance-100

```diff
- CONTROL_PLANE_COUNT=1   # Removed redundant default
+ PROMETHEUS_SCRAPE_ETCD=true # Aligned: Inherited from preset-kops-scalability-gce-common
```

5. pull-kubernetes-gce-master-scale-performance-100-experimental

```diff
+ PROMETHEUS_SCRAPE_ETCD=true # Aligned: Inherited from preset-kops-scalability-gce-common
```

6. pull-perf-tests-gce-master-scale-performance-100-experimental

```diff
+ EXPERIMENT_VARIANT=restart          # Standardized via preset-kops-scalability-gce-experimental
+ CL2_RESTART_APISERVER=true          # Standardized via preset-kops-scalability-gce-experimental
+ CL2_HEAP_PROFILE_INTERVAL=5m        # Standardized via preset-kops-scalability-gce-experimental
+ PROMETHEUS_SCRAPE_ETCD=true         # Aligned: Inherited from preset-kops-scalability-gce-common
```

/cc @Jefftree 