### PR TITLE
Restore 6 CPU cores for kueue website-links preview presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -1965,8 +1965,8 @@ presubmits:
               privileged: true
             resources:
               requests:
-                cpu: "100m"
+                cpu: "6"
                 memory: "6Gi"
               limits:
-                cpu: "100m"
+                cpu: "6"
                 memory: "6Gi"

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
@@ -1964,8 +1964,8 @@ presubmits:
               privileged: true
             resources:
               requests:
-                cpu: "100m"
+                cpu: "6"
                 memory: "6Gi"
               limits:
-                cpu: "100m"
+                cpu: "6"
                 memory: "6Gi"


### PR DESCRIPTION
The 100m right-sizing starved the Netlify deploy-preview link check, because of that pull-kueue-verify-website-links-preview-{main,release-0-19} runs for 30 min 