### PR TITLE
Prow presubmit unit tests

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -87,7 +87,7 @@ presubmits:
       testgrid-tab-name: presubmit-lint-api
   - name: presubmit-agent-sandbox-gemini-cu-sandbox-test
     cluster: eks-prow-build-cluster
-    run_if_changed: "^examples/gemini-cu-sandbox/|^dev/ci/presubmits/test-gemini-cu-sandbox$"
+    run_if_changed: "^examples/gemini-cu-sandbox/|^dev/ci/presubmits/test-e2e-gemini-cu-sandbox$"
     decorate: true
     always_run: false
     optional: true
@@ -99,7 +99,7 @@ presubmits:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
         command:
         - runner.sh
-        - dev/ci/presubmits/test-gemini-cu-sandbox
+        - dev/ci/presubmits/test-e2e-gemini-cu-sandbox
         env:
         - name: GEMINI_API_KEY
           valueFrom:
@@ -122,7 +122,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   - name: presubmit-agent-sandbox-python-runtime-sandbox-test
     cluster: eks-prow-build-cluster
-    run_if_changed: "^examples/python-runtime-sandbox/|^dev/ci/presubmits/test-python-runtime-sandbox$"
+    run_if_changed: "^examples/python-runtime-sandbox/|^dev/ci/presubmits/test-e2e-python-runtime-sandbox$"
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -132,7 +132,7 @@ presubmits:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
         command:
         - runner.sh
-        - dev/ci/presubmits/test-python-runtime-sandbox
+        - dev/ci/presubmits/test-e2e-python-runtime-sandbox
         securityContext:
           privileged: true
         resources:

--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -147,6 +147,69 @@ presubmits:
       testgrid-tab-name: presubmit-python-runtime-sandbox-test
       description: End-to-end test for the python-runtime-sandbox example using kind
       testgrid-num-columns-recent: '30'
+  - name: presubmit-agent-sandbox-mcp-server-sandbox-test
+    cluster: eks-prow-build-cluster
+    run_if_changed: "^examples/mcp-server-sandbox/|^dev/ci/presubmits/test-mcp-server-sandbox$"
+    decorate: true
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+        command:
+        - dev/ci/presubmits/test-mcp-server-sandbox
+        resources:
+          requests:
+            cpu: 1
+            memory: 2Gi
+          limits:
+            cpu: 1
+            memory: 2Gi
+    annotations:
+      testgrid-dashboards: sig-apps-agent-sandbox
+      testgrid-tab-name: presubmit-mcp-server-sandbox-test
+      description: Unit tests for the mcp-server-sandbox example
+      testgrid-num-columns-recent: '30'
+  - name: presubmit-agent-sandbox-analytics-tool-test
+    cluster: eks-prow-build-cluster
+    run_if_changed: "^examples/analytics-tool/analytics-tool/|^dev/ci/presubmits/test-analytics-tool$"
+    decorate: true
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+        command:
+        - dev/ci/presubmits/test-analytics-tool
+        resources:
+          requests:
+            cpu: 1
+            memory: 2Gi
+          limits:
+            cpu: 1
+            memory: 2Gi
+    annotations:
+      testgrid-dashboards: sig-apps-agent-sandbox
+      testgrid-tab-name: presubmit-analytics-tool-test
+      description: Unit tests for the analytics-tool example
+      testgrid-num-columns-recent: '30'
+  - name: presubmit-agent-sandbox-langchain-test
+    cluster: eks-prow-build-cluster
+    run_if_changed: "^examples/langchain/|^dev/ci/presubmits/test-langchain$"
+    decorate: true
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+        command:
+        - dev/ci/presubmits/test-langchain
+        resources:
+          requests:
+            cpu: 1
+            memory: 2Gi
+          limits:
+            cpu: 1
+            memory: 2Gi
+    annotations:
+      testgrid-dashboards: sig-apps-agent-sandbox
+      testgrid-tab-name: presubmit-langchain-test
+      description: Unit tests for the langchain (coding_agent) example
+      testgrid-num-columns-recent: '30'
   - name: presubmit-agent-sandbox-test-e2e
     cluster: eks-prow-build-cluster
     skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"

--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -85,6 +85,41 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-apps-agent-sandbox
       testgrid-tab-name: presubmit-lint-api
+  - name: presubmit-agent-sandbox-gemini-cu-sandbox-test
+    cluster: eks-prow-build-cluster
+    run_if_changed: "^examples/gemini-cu-sandbox/|^dev/ci/presubmits/test-gemini-cu-sandbox$"
+    decorate: true
+    always_run: false
+    optional: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+        command:
+        - runner.sh
+        - dev/ci/presubmits/test-gemini-cu-sandbox
+        env:
+        - name: GEMINI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: gemini-api-key
+              key: key
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 4
+            memory: 8Gi
+          limits:
+            cpu: 4
+            memory: 8Gi
+    annotations:
+      testgrid-dashboards: sig-apps-agent-sandbox
+      testgrid-tab-name: presubmit-gemini-cu-sandbox-test
+      description: End-to-end test for the gemini-cu-sandbox example using kind
+      testgrid-num-columns-recent: '30'
   - name: presubmit-agent-sandbox-test-e2e
     cluster: eks-prow-build-cluster
     skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"

--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -120,6 +120,33 @@ presubmits:
       testgrid-tab-name: presubmit-gemini-cu-sandbox-test
       description: End-to-end test for the gemini-cu-sandbox example using kind
       testgrid-num-columns-recent: '30'
+  - name: presubmit-agent-sandbox-python-runtime-sandbox-test
+    cluster: eks-prow-build-cluster
+    run_if_changed: "^examples/python-runtime-sandbox/|^dev/ci/presubmits/test-python-runtime-sandbox$"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+        command:
+        - runner.sh
+        - dev/ci/presubmits/test-python-runtime-sandbox
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 4
+            memory: 8Gi
+          limits:
+            cpu: 4
+            memory: 8Gi
+    annotations:
+      testgrid-dashboards: sig-apps-agent-sandbox
+      testgrid-tab-name: presubmit-python-runtime-sandbox-test
+      description: End-to-end test for the python-runtime-sandbox example using kind
+      testgrid-num-columns-recent: '30'
   - name: presubmit-agent-sandbox-test-e2e
     cluster: eks-prow-build-cluster
     skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"


### PR DESCRIPTION
Registers five new presubmits for kubernetes-sigs/agent-sandbox, generated by `generate_jobs.py` from the matching `dev/ci/presubmits/*` scripts (companion PR: kubernetes-sigs/agent-sandbox#1273):

- `presubmit-agent-sandbox-test-gemini-cu-sandbox`
- `presubmit-agent-sandbox-test-python-runtime-sandbox`
- `presubmit-agent-sandbox-test-mcp-server-sandbox`
- `presubmit-agent-sandbox-test-analytics-tool`
- `presubmit-agent-sandbox-test-langchain`

**Generator change**: `test-gemini-cu-sandbox` and `test-python-runtime-sandbox` build a runtime image and load it into a kind cluster, but their names don't contain "e2e" or "benchmark", so `generate_jobs.py`'s naming heuristic would otherwise classify them as plain unprivileged jobs. Added an explicit `E2E_PRESUBMITS` allowlist so the generator gives them the privileged kind/docker profile. The other three are genuinely unit-tests-only and correctly fall through to the default local-test profile without any override.

**Why this is a hand-splice, not a full regen**: the five new entries were produced by running `generate_jobs.py` against an agent-sandbox checkout containing the new scripts, then added to the current config by hand rather than committing a full regeneration. A full regen right now would have (a) rolled back the image tag on every existing job, since the generator's checked-in `IMAGE` constant lags the tag already live in this file (autobumped separately), and (b) dropped `presubmit-agent-sandbox-test-e2e-scalability-kwok`, which is intentionally staged ahead of kubernetes-sigs/agent-sandbox#1269 (still open) and doesn't correspond to a script in agent-sandbox `main` yet. Both are pre-existing, unrelated conditions this PR leaves untouched — the diff here is purely additive.

**Merge order**: hold until kubernetes-sigs/agent-sandbox#1273 merges, same as the pattern in #37499 — these presubmits reference scripts that need to exist on `main` first.