### PR TITLE
Drop --with-git-dir from k8s-website-hugo image push

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-docs.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-docs.yaml
@@ -20,5 +20,4 @@ postsubmits:
               - --project=k8s-staging-sig-docs
               - --scratch-bucket=gs://k8s-staging-sig-docs-gcb
               - --env-passthrough=PULL_BASE_REF
-              - --with-git-dir
               - .


### PR DESCRIPTION
While verifying other recent website build changes I noticed warnings about large uploads in the log files. While the log suggestions don't make sense in our case, it did lead to noticing some optimization.

The website image build never reads the `.git` directory. The image tag is computed locally by the builder tool (`git describe`) and passed to Cloud Build as the `_GIT_TAG` substitution.

The `--with-git-dir` flag only controls whether the `.git` directory tree is included in the uploaded source tarball. The Cloud Build step (`cloudbuild.yaml` -> `make docker-push` -> `buildx`) copies only `package.json` and `package-lock.json` into the image and never touches git.

Including `.git` added ~600 MiB of (already-compressed, so ~incompressible) packfiles to the source tarball on every run, inflating both tar creation and the gsutil upload. Removing the flag leaves tagging unchanged.