### PR TITLE
Cleanup: Fix Python 2 print statement syntax in `gubernator/filters_test.py`

### DIFF
--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -90,7 +90,7 @@ class HelperTest(unittest.TestCase):
             ('//pkg/foo/bar:go_default_test',
             'bazel test //pkg/foo/bar:go_default_test'),
             ('verify typecheck', 'make verify WHAT=typecheck')):
-            print 'test name:', name
+            print('test name:', name)
             self.assertEqual(filters.do_testcmd(name), expected)
 
     def test_classify_size(self):


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a legacy Python 2 `print` statement found in `gubernator/filters_test.py` by converting it to the Python 3 `print()` function syntax. The project uses Python 3, so this syntax would otherwise throw a `SyntaxError` if this test case is ever executed.

**Which issue(s) this PR fixes**:
Fixes #37541 

**Special notes for your reviewer**:

