### PR TITLE
Bug: Fix missing Stdin mapping for build-release script prompt in kubetest

### DIFF
--- a/kubetest/build.go
+++ b/kubetest/build.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 
@@ -110,8 +111,9 @@ func (b *buildStrategy) Build() error {
 		return control.FinishRunning(cmd)
 	}
 
-	// TODO(fejta): FIX ME
 	// The build-release script needs stdin to ask the user whether
 	// it's OK to download the docker image.
-	return control.FinishRunning(exec.Command("make", "-C", util.K8s("kubernetes"), target))
+	cmd := exec.Command("make", "-C", util.K8s("kubernetes"), target)
+	cmd.Stdin = os.Stdin
+	return control.FinishRunning(cmd)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR resolves a `TODO(fejta): FIX ME` in `kubetest/build.go`. When executing the `make release` command, the build script occasionally needs `stdin` to ask the user whether it's OK to download a Docker image. Previously, `cmd.Stdin` wasn't mapped to `os.Stdin`, causing the prompt to hang or fail. This PR explicitly maps it.

**Which issue(s) this PR fixes**:
Fixes #37544 

**Special notes for your reviewer**:
/sig testing
/kind bug