### PR TITLE
Build images for VPA release branches

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
+++ b/config/jobs/image-pushing/k8s-staging-autoscaling.yaml
@@ -28,6 +28,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
+        - ^vpa-release-
       run_if_changed: "^vertical-pod-autoscaler/"
       spec:
         serviceAccountName: gcb-builder


### PR DESCRIPTION
Relates to https://github.com/kubernetes/autoscaler/issues/10054

The current release process for patch releases is to build on our local laptops. We don't want to do this.

This PR allows prow to build from our release branches.