### PR TITLE
ci-kubernetes-e2e-node-canary: bump timeout 90m→120m

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -64,7 +64,7 @@ periodics:
       - --node-tests=true
       - --provider=gce
       - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]"
-      - --timeout=90m
+      - --timeout=120m
       env:
       - name: GOPATH
         value: /go


### PR DESCRIPTION
NodeConformance suite has grown to 1283 specs; recent green runs consume 97%+ of the 75m ginkgo budget (worst observed: 4396s out of 4500s), making pass/fail a coin flip on timing noise rather than code correctness.

120m outer timeout gives ginkgo ~105m, dropping worst-case utilization to ~70% and providing ~30m of real headroom.

This is a stopgap — sharding is the durable fix as the suite continues to grow — but this unblocks the job now.

Ref: https://github.com/kubernetes/kubernetes/issues/140943#issuecomment-5083170348