### PR TITLE
agent-sandbox: set kwok presubmit to always run with optional

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -223,10 +223,8 @@ presubmits:
       testgrid-tab-name: presubmit-test-skill-eval
   - name: presubmit-agent-sandbox-test-e2e-scalability-kwok
     cluster: eks-prow-build-cluster
-    # skip_if_only_changed overrides always_run: false, so we can't use both. commenting out until we merge https://github.com/kubernetes-sigs/agent-sandbox/pull/1269
-    # skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
-    always_run: false
     optional: true
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Setting kwok presubmit to always run while having the optional param, this will make the presubmit to run on every PR, but still will not block PRs on failures.

Please don't merge before merging https://github.com/kubernetes-sigs/agent-sandbox/pull/1269