### PR TITLE
Skip LocalhostNodePorts tests for cloud-provider-kind IPv6

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-periodic.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-periodic.yaml
@@ -80,7 +80,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]|\[Conformance\]
       - name: SKIP
-        value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv4|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|Internet.connection|loadbalancer.source.ranges|SCTPConnectivity
+        value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv4|DualStack|LocalhostNodePorts|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|Internet.connection|loadbalancer.source.ranges|SCTPConnectivity
       command:
         - wrapper.sh
         - bash

--- a/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-kind/cloud-provider-kind-presubmits.yaml
@@ -85,7 +85,7 @@ presubmits:
         - name: FOCUS
           value: \[sig-network\]|\[Conformance\]
         - name: SKIP
-          value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv4|DualStack|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|Internet.connection|loadbalancer.source.ranges|SCTPConnectivity
+          value: Alpha|Beta|NetworkPolicy|Disruptive|Flaky|IPv4|DualStack|LocalhostNodePorts|LoadBalancer.Service.without.NodePort|type.and.ports.of.a.TCP.service|Internet.connection|loadbalancer.source.ranges|SCTPConnectivity
         command:
         - wrapper.sh
         - bash


### PR DESCRIPTION
kube-proxy recently [added the ability to serve localhost NodePorts](https://github.com/kubernetes/kubernetes/pull/138427), but only in nftables mode. This also introduced an e2e test to cover this scenario. The test checks for the availability of IPv6, but not the mode it is running in.

However, cloud-provider-kind runs in iptables mode, and does not support this access to localhost. The LocalhostNodePorts job is now failing across all PRs. This adds an explicit skip to the cloud-provider-kind IPv6 tests so it does not attempt to run this e2e test.