### PR TITLE
remove jobset 1.33 jobs as 1.33 is out of support

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -69,46 +69,6 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-e2e-main-1-33
-    cluster: eks-prow-build-cluster
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: jobset
-        base_ref: main
-        path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps-jobset, sig-apps-jobset-periodics
-      testgrid-tab-name: periodic-jobset-test-e2e-main-1-33
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset end to end tests for Kubernetes 1.33"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-    decorate: true
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260720-39d457d26c-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.33.1
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.26
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - test-e2e-kind
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 3
-              memory: 10Gi
-            requests:
-              cpu: 3
-              memory: 10Gi
-  - interval: 12h
     name: periodic-jobset-test-e2e-main-1-34
     cluster: eks-prow-build-cluster
     extra_refs:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-release-0-12.yaml
@@ -69,46 +69,6 @@ periodics:
             cpu: 3
             memory: 10Gi
   - interval: 12h
-    name: periodic-jobset-test-e2e-release-0-12-1-33
-    cluster: eks-prow-build-cluster
-    extra_refs:
-      - org: kubernetes-sigs
-        repo: jobset
-        base_ref: release-0.12
-        path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps-jobset-periodics
-      testgrid-tab-name: periodic-jobset-test-e2e-release-0-12-1-33
-      testgrid-num-failures-to-alert: '1'
-      description: "Run periodic jobset end to end tests for Kubernetes 1.33 on release 0.12"
-      testgrid-num-columns-recent: '30'
-    labels:
-      preset-dind-enabled: "true"
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260720-39d457d26c-master
-        env:
-        - name: E2E_KIND_VERSION
-          value: kindest/node:v1.33.1
-        - name: BUILDER_IMAGE
-          value: public.ecr.aws/docker/library/golang:1.26
-        command:
-        # generic runner script, handles DIND, bazelrc for caching, etc.
-        - runner.sh
-        args:
-        - make
-        - test-e2e-kind
-        securityContext:
-          privileged: true
-        resources:
-          limits:
-            cpu: 3
-            memory: 10Gi
-          requests:
-            cpu: 3
-            memory: 10Gi
-  - interval: 12h
     name: periodic-jobset-test-e2e-release-0-12-1-34
     cluster: eks-prow-build-cluster
     extra_refs:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -59,43 +59,6 @@ presubmits:
           requests:
             cpu: 3
             memory: 10Gi
-  - name: pull-jobset-test-e2e-main-1-33
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^main
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps-jobset-presubmits
-      testgrid-tab-name: pull-jobset-test-e2e-main-1-33
-      description: "Run jobset end to end tests for Kubernetes 1.33"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260720-39d457d26c-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.33.1
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.26
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - test-e2e-kind
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 3
-              memory: 10Gi
-            requests:
-              cpu: 3
-              memory: 10Gi
   - name: pull-jobset-test-e2e-main-1-34
     cluster: eks-prow-build-cluster
     branches:

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-12.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-release-0-12.yaml
@@ -57,42 +57,6 @@ presubmits:
           requests:
             cpu: 3
             memory: 10Gi
-  - name: pull-jobset-test-e2e-release-0-12-1-33
-    cluster: eks-prow-build-cluster
-    branches:
-    - ^release-0.12
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/jobset
-    annotations:
-      testgrid-dashboards: sig-apps-jobset-presubmits
-      description: "Run jobset end to end tests for Kubernetes 1.33"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260720-39d457d26c-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.33.1
-            - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.26
-          command:
-            # generic runner script, handles DIND, bazelrc for caching, etc.
-            - runner.sh
-          args:
-            - make
-            - test-e2e-kind
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 3
-              memory: 10Gi
-            requests:
-              cpu: 3
-              memory: 10Gi
   - name: pull-jobset-test-e2e-release-0-12-1-34
     cluster: eks-prow-build-cluster
     branches:


### PR DESCRIPTION
1.33 went out of support on June 28th so we should stop testing 1.33 jobs.

https://kubernetes.io/releases/