### PR TITLE
cloud-provider-openstack: increase memory to solve OOM kills during tests

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
@@ -19,10 +19,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
 
   - name: pull-cloud-provider-openstack-test
     cluster: eks-prow-build-cluster
@@ -43,7 +43,7 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-master-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test
@@ -66,10 +66,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-ovn-e2e-test
@@ -135,10 +135,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test
@@ -171,10 +171,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test
@@ -197,10 +197,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test
@@ -224,10 +224,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test
@@ -261,10 +261,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-keystone-authentication-authorization
       testgrid-tab-name: presubmit-e2e-test

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.25-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.25-config.yaml
@@ -18,10 +18,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-1.25
@@ -55,10 +55,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.25
@@ -91,10 +91,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.25
@@ -127,10 +127,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.25
@@ -153,10 +153,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.25

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.26-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.26-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.26
@@ -64,10 +64,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.26
@@ -100,10 +100,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.26
@@ -126,10 +126,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-1.26
@@ -153,10 +153,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.26

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.27-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.27-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.27
@@ -64,10 +64,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.27
@@ -100,10 +100,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.27
@@ -126,10 +126,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-1.27
@@ -153,10 +153,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.27

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.28-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.28-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.28
@@ -64,10 +64,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.28
@@ -100,10 +100,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.28
@@ -126,10 +126,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-128
@@ -153,10 +153,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.28
@@ -190,10 +190,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-keystone-authentication-authorization
       testgrid-tab-name: presubmit-e2e-test-release-1.28

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.29-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.29-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.29
@@ -64,10 +64,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.29
@@ -100,10 +100,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.29
@@ -126,10 +126,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-129
@@ -153,10 +153,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.29
@@ -190,10 +190,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-keystone-authentication-authorization
       testgrid-tab-name: presubmit-e2e-test-release-1.29

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.30-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.30-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.30
@@ -64,10 +64,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.30
@@ -100,10 +100,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.30
@@ -126,10 +126,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-130
@@ -153,10 +153,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.30
@@ -190,10 +190,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-keystone-authentication-authorization
       testgrid-tab-name: presubmit-e2e-test-release-1.30

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.31-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.31-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.31
@@ -64,10 +64,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.31
@@ -100,10 +100,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.31
@@ -126,10 +126,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-131
@@ -153,10 +153,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.31
@@ -190,10 +190,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-keystone-authentication-authorization
       testgrid-tab-name: presubmit-e2e-test-release-1.31

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.32-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.32-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.32
@@ -66,10 +66,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-ovn-e2e-test-release-132
@@ -102,10 +102,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.32
@@ -138,10 +138,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.32
@@ -164,10 +164,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-132
@@ -191,10 +191,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.32
@@ -228,10 +228,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-keystone-authentication-authorization
       testgrid-tab-name: presubmit-e2e-test-release-1.32

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.33-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.33-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.33
@@ -66,10 +66,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-ovn-e2e-test-release-133
@@ -102,10 +102,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.33
@@ -138,10 +138,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.33
@@ -164,10 +164,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-133
@@ -191,10 +191,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.33
@@ -228,10 +228,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-keystone-authentication-authorization
       testgrid-tab-name: presubmit-e2e-test-release-1.33

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.34-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.34-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.34
@@ -66,10 +66,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-ovn-e2e-test-release-134
@@ -102,10 +102,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.34
@@ -138,10 +138,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.34
@@ -164,10 +164,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-134
@@ -191,10 +191,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.34
@@ -228,10 +228,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-keystone-authentication-authorization
       testgrid-tab-name: presubmit-e2e-test-release-1.34

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.35-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.35-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.35
@@ -66,10 +66,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-ovn-e2e-test-release-135
@@ -102,10 +102,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.35
@@ -138,10 +138,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.35
@@ -164,10 +164,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-135
@@ -191,10 +191,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.35
@@ -228,10 +228,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-keystone-authentication-authorization
       testgrid-tab-name: presubmit-e2e-test-release-1.35

--- a/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.36-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/provider-openstack-presubmits-release-v1.36-config.yaml
@@ -28,10 +28,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-e2e-test-release-1.36
@@ -66,10 +66,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-cloud-controller-manager
       testgrid-tab-name: presubmit-ovn-e2e-test-release-136
@@ -102,10 +102,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-e2e-test-release-1.36
@@ -138,10 +138,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-e2e-test-release-1.36
@@ -164,10 +164,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-openstack-csi-cinder
       testgrid-tab-name: presubmit-sanity-test-release-136
@@ -191,10 +191,10 @@ presubmits:
         resources:
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 2
-            memory: 4Gi
+            memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-manila-csi-plugin
       testgrid-tab-name: presubmit-sanity-test-release-1.36
@@ -228,10 +228,10 @@ presubmits:
           resources:
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
             requests:
               cpu: 2
-              memory: 4Gi
+              memory: 5Gi
     annotations:
       testgrid-dashboards: provider-openstack-keystone-authentication-authorization
       testgrid-tab-name: presubmit-e2e-test-release-1.36


### PR DESCRIPTION
addressing OOM kills like https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/cloud-provider-openstack/3146/pull-cloud-provider-openstack-check/2076627454247571456