### PR TITLE
bump docker to v29 for gcb-gcloud-docker image

### DIFF
--- a/images/gcb-docker-gcloud/buildx-entrypoint.sh
+++ b/images/gcb-docker-gcloud/buildx-entrypoint.sh
@@ -15,7 +15,7 @@
 
 set -eo pipefail
 
-docker run --privileged --rm tonistiigi/binfmt:qemu-v10.0.4 --install all
+docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.3 --install all
 if [ -z "${BUILDX_NO_DEFAULT_ATTESTATIONS}" ]; then
     export BUILDX_NO_DEFAULT_ATTESTATIONS=1
 fi

--- a/images/gcb-docker-gcloud/cloudbuild.yaml
+++ b/images/gcb-docker-gcloud/cloudbuild.yaml
@@ -34,7 +34,7 @@ steps:
       - --no-trunc 
 substitutions:
   _GIT_TAG: '12345'
-  _DOCKER_VERSION: '28' # Docker v29+ doesn't work in GCP Cloud Build because its stuck on 20.10.x
+  _DOCKER_VERSION: '29'
   _GO_VERSION: '1.26.5'
 tags:
   - gcb-docker-gcloud

--- a/images/gcb-docker-gcloud/runner.sh
+++ b/images/gcb-docker-gcloud/runner.sh
@@ -30,7 +30,7 @@ set +o errexit
 if [ -z "${BUILDX_NO_DEFAULT_ATTESTATIONS}" ]; then
     export BUILDX_NO_DEFAULT_ATTESTATIONS=1
 fi
-docker run --privileged --rm tonistiigi/binfmt:qemu-v10.0.4 --install all
+docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.3 --install all
 
 docker buildx create \
     --name multiarch-multiplatform-builder \


### PR DESCRIPTION
#37568 didn't work because docker v28 isn't available on alpine v23 or 24 which is the version supported by golang image.

Google fixed the issue that blocked Docker v29 from working correctly in Cloud Build, and it works now. 

https://console.cloud.google.com/cloud-build/builds/dac0add3-7e9f-4b17-b6f0-5c0391d60f07?project=855765450555 