### PR TITLE
Update gcb-docker-gcloud to v20260729-0b834bafc6

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/enhancements-postsubmit.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/enhancements-postsubmit.yaml
@@ -8,7 +8,7 @@ postsubmits:
       max_concurrency: 1
       spec:
         containers:
-        - image: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+        - image: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6
           command:
             - sh
             - "-c"

--- a/images/alpine/cloudbuild.yaml
+++ b/images/alpine/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6
     entrypoint: /buildx-entrypoint
     args:
     - build
@@ -9,7 +9,7 @@ steps:
     - --push
     - .
     dir: .
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6
     entrypoint: gcloud
     args:
     - container

--- a/images/git-custom-k8s-auth/cloudbuild.yaml
+++ b/images/git-custom-k8s-auth/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6
     entrypoint: /buildx-entrypoint
     args:
       - build
@@ -12,7 +12,7 @@ steps:
       - --push
       - .
     dir: .
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6
     entrypoint: gcloud
     args:
       - container

--- a/images/git/cloudbuild.yaml
+++ b/images/git/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6
     entrypoint: /buildx-entrypoint
     args:
     - build
@@ -9,7 +9,7 @@ steps:
     - --push
     - .
     dir: .
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6
     entrypoint: gcloud
     args:
     - container

--- a/images/krte/cloudbuild.yaml
+++ b/images/krte/cloudbuild.yaml
@@ -1,6 +1,6 @@
 timeout: 1800s
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6
     entrypoint: /buildx-entrypoint
     args:
     - build

--- a/images/kubekins-e2e-v2/cloudbuild.yaml
+++ b/images/kubekins-e2e-v2/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
       dnf update -y && dnf install docker -y -q > /dev/null 2>&1
       aws sts get-caller-identity --profile cloudbuild
       aws ecr get-login-password --profile cloudbuild | docker login --username AWS --password-stdin "$_AWS_ECR_REGISTRY"
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6
     args:
     - bash
     - -c

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -30,7 +30,7 @@ steps:
     - GO111MODULE=on
     - GOPROXY=https://proxy.golang.org
     - GOSUMDB=sum.golang.org
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6
     args:
     - docker
     - buildx


### PR DESCRIPTION
Older tags of `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud` get pruned from the registry — the January tag disappearing broke the kubernetes/kubernetes test-image postsubmits (see kubernetes/kubernetes#141034). Our pins are on the February tag, which survived this round but will be pruned eventually.

This bumps all pins (6 image cloudbuild.yamls + enhancements-postsubmit job) to the latest tag `v20260729-0b834bafc6` (built 2026-07-29).

The config-forker test fixtures also mention the February tag, but those are parsing examples that never touch the registry, so they're left alone.