### PR TITLE
spyglass: highlight FAILED in buildlog output

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -103,7 +103,7 @@ deck:
           - FAILED. See logs
           - failed to acquire k8s binaries
           - failed to solve
-          - (FAIL|Failure \[)\b
+          - (FAIL|FAILED|Failure \[)\b
           - fatal error
           - flag provided but not defined
           - Full Stack Trace


### PR DESCRIPTION
The buildlog lens highlight regex `(FAIL|Failure \[)\b` was matching
"FAIL" but not "FAILED" because the word boundary `\b` requires the
match to end at a non-word character.

In "[FAIL]" the boundary exists (L followed by ]), but in "[FAILED]"
there is no boundary (L followed by E).

This caused Ginkgo test output containing "[FAILED]" to not be
highlighted or displayed in the filtered log view, while "[FAIL]"
and "error" keywords were shown correctly.

Changed the regex to `(FAIL|FAILED|Failure \[)\b` to match both
"FAIL" and "FAILED" as complete words.

Fixes highlighting of Ginkgo test failures in prow.k8s.io job views.

see https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/cloud-provider-openstack/3153/openstack-cloud-controller-manager-e2e-test/2082505813812842496