### PR TITLE
Drop trailing slash from test-package-url in ec2-alpha-features

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml
@@ -178,7 +178,7 @@ periodics:
              --test=ginkgo \
              -- \
              --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
-             --test-package-url=https://dl.k8s.io/ \
+             --test-package-url=https://dl.k8s.io \
              --test-package-dir=ci/fast \
              --test-package-marker=latest-fast.txt \
              --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking" \


### PR DESCRIPTION
`ci-kubernetes-e2e-ec2-alpha-features` is the only job in the repo that passes `--test-package-url=https://dl.k8s.io/` with a trailing slash:

```
$ grep -rn "test-package-url=https://dl.k8s.io/" config/jobs/
config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml:181: --test-package-url=https://dl.k8s.io/ \
```

The kubetest2 ginkgo tester joins that base URL with `ci/fast/latest-fast.txt`, requests `https://dl.k8s.io//ci/fast/latest-fast.txt` (double slash), receives a NoSuchKey XML error, uses the XML body as the version string, and then fails to download the test tarball. From [today's run](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-ec2-alpha-features/2082585287875104768):

```
package.go:51] Test package version was not specified. Defaulting to version from latest-fast.txt:
  <?xml version='1.0' ...><Error><Code>NoSuchKey</Code>...
ginkgo.go:259] failed to run ginkgo tester: failed to get ginkgo test package
  from published releases: failed to create gzip reader: EOF
```

The sibling jobs `ci-kubernetes-e2e-ec2-alpha-enabled-default` and `ci-kubernetes-e2e-ec2-device-plugin-gpu` use `https://dl.k8s.io` without the slash and their testers work — `alpha-enabled-default` ran 1185 specs today.

The typo was latent for months because the job used to die earlier in an AMI build failure, fixed today in kubernetes-sigs/provider-aws-test-infra#582. With that merged, the cluster comes up and this trailing slash is the last blocker before the suite runs.

/sig cloud-provider
/area jobs