### PR TITLE
Add periodic e2e-in-kind tests for gemini-cu-sandbox and python-runtime-sandbox

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
@@ -32,6 +32,72 @@ periodics:
         limits:
           cpu: 7
           memory: 14Gi
+- name: periodic-agent-sandbox-gemini-cu-sandbox-test
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-apps-agent-sandbox
+    testgrid-tab-name: periodic-gemini-cu-sandbox-test
+    description: Nightly end-to-end test for the gemini-cu-sandbox example using kind
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: agent-sandbox
+    base_ref: main
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+      command:
+      - runner.sh
+      - dev/ci/presubmits/test-e2e-gemini-cu-sandbox
+      env:
+      - name: GEMINI_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: gemini-api-key
+            key: key
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 4
+          memory: 8Gi
+        limits:
+          cpu: 4
+          memory: 8Gi
+- name: periodic-agent-sandbox-python-runtime-sandbox-test
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-apps-agent-sandbox
+    testgrid-tab-name: periodic-python-runtime-sandbox-test
+    description: Nightly end-to-end test for the python-runtime-sandbox example using kind
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: agent-sandbox
+    base_ref: main
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+      command:
+      - runner.sh
+      - dev/ci/presubmits/test-e2e-python-runtime-sandbox
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 4
+          memory: 8Gi
+        limits:
+          cpu: 4
+          memory: 8Gi
 - name: periodic-benchmarks-kops-gcp-cilium
   cluster: k8s-infra-prow-build
   interval: 24h

--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
@@ -27,6 +27,72 @@ periodics:
         limits:
           cpu: 7
           memory: 14Gi
+- name: periodic-agent-sandbox-gemini-cu-sandbox-test
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-apps-agent-sandbox
+    testgrid-tab-name: periodic-gemini-cu-sandbox-test
+    description: Nightly end-to-end test for the gemini-cu-sandbox example using kind
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: agent-sandbox
+    base_ref: main
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+      command:
+      - runner.sh
+      - dev/ci/presubmits/test-e2e-gemini-cu-sandbox
+      env:
+      - name: GEMINI_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: gemini-api-key
+            key: key
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 4
+          memory: 8Gi
+        limits:
+          cpu: 4
+          memory: 8Gi
+- name: periodic-agent-sandbox-python-runtime-sandbox-test
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-apps-agent-sandbox
+    testgrid-tab-name: periodic-python-runtime-sandbox-test
+    description: Nightly end-to-end test for the python-runtime-sandbox example using kind
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: agent-sandbox
+    base_ref: main
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260622-537e33cc05-master
+      command:
+      - runner.sh
+      - dev/ci/presubmits/test-e2e-python-runtime-sandbox
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 4
+          memory: 8Gi
+        limits:
+          cpu: 4
+          memory: 8Gi
 - name: periodic-agent-sandbox-migration-test
   cluster: eks-prow-build-cluster
   interval: 1h


### PR DESCRIPTION
Registers two nightly periodics for kubernetes-sigs/agent-sandbox that reuse
the existing e2e-in-kind presubmit scripts:

- `periodic-agent-sandbox-gemini-cu-sandbox-test`
- `periodic-agent-sandbox-python-runtime-sandbox-test`

**Why periodic, not just presubmit**: the matching presubmits added in
kubernetes-sigs/agent-sandbox#1273 only run when a PR touches the example's
own directory (`run_if_changed`). They're blind to breakage caused by
changes elsewhere in the repo -- controller/CRD changes, base image bumps,
SDK changes -- that don't touch the example's files but can still break it.
A nightly rerun independent of the diff catches that drift.

**No new scripts**: both `dev/ci/presubmits/test-e2e-gemini-cu-sandbox` and
`test-e2e-python-runtime-sandbox` are self-contained with no PR-specific
assumptions, so pointing a scheduled job at the same path guarantees the
periodic run exercises exactly what the presubmit exercises -- no duplicated
logic, no drift between the two triggers.

Same shape as `periodic-agent-sandbox-migration-test`: `runner.sh` +
`securityContext.privileged: true` + `preset-dind-enabled` /
`preset-kind-volume-mounts` labels, `extra_refs` pinned to `base_ref: main`
since periodics have no PR context. Resource sizing (`cpu: 4`, `memory: 8Gi`)
and the `GEMINI_API_KEY` `secretKeyRef` wiring are copied as-is from the
presubmit twins registered in #37536, so the same secret already provisioned
for those covers this too -- no new secret needed.

**Validated live**: manually ran `test-e2e-python-runtime-sandbox` against a
real cluster end-to-end (build, kind bring-up, Sandbox create, port-forward,
tester assertions) and confirmed it passes. That exercise also caught and
fixed two real bugs on the companion PR: `setup_cluster()` was building
every example image in the repo instead of just the controller image the
`k8s/` manifests actually need (cut a ~13-minute run down from 2+ hours),
and `tester.go`'s exists-check asserted the wrong expected path.

**Merge order**: hold until kubernetes-sigs/agent-sandbox#1273 merges --
these jobs invoke script paths that don't exist on agent-sandbox `main`
until that PR lands.