### PR TITLE
Bump AKS mgmt cluster version for CAPZ test

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -383,6 +383,8 @@ periodics:
           value: ""
         - name: MGMT_CLUSTER_TYPE
           value: "aks"
+        - name: AKS_MGMT_KUBERNETES_VERSION
+          value: "1.36"
       securityContext:
         privileged: true
       resources:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits-main.yaml
@@ -875,6 +875,8 @@ presubmits:
             value: ""
           - name: MGMT_CLUSTER_TYPE
             value: "aks"
+          - name: AKS_MGMT_KUBERNETES_VERSION
+            value: "1.36"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
AKS v1.33 is now LTS. Set the aks management cluster version to 1.36