### PR TITLE
[sig-windows] Add Windows 2025 serial-slow periodic job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-master-windows.yaml
@@ -243,6 +243,65 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
     testgrid-dashboards: sig-windows-master-release, sig-windows-signal
     testgrid-tab-name: capz-windows-master-serial-slow
+- name: ci-kubernetes-e2e-capz-master-windows-2025-serial-slow
+  cluster: eks-prow-build-cluster
+  interval: 24h
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-community: "true"
+    preset-capz-windows-common: "true"
+    preset-capz-windows-2025: "true"
+    preset-capz-containerd-2-0-latest: "true"
+    preset-capz-serial-slow: "true"
+    preset-capz-gmsa-setup: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: sigs.k8s.io/windows-testing
+    workdir: true
+  - org: kubernetes-sigs
+    repo: cloud-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    workdir: false
+  spec:
+    serviceAccountName: azure
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260729-f0c41ad0b9-master
+        command:
+          - "runner.sh"
+          - "env"
+          - "KUBERNETES_VERSION=latest"
+          - "./capz/run-capz-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 2
+            memory: "9Gi"
+          limits:
+            cpu: 2
+            memory: "9Gi"
+        env:
+          - name: GINKGO_FOCUS
+            value: (\[sig-windows\]|\[sig-scheduling\].SchedulerPreemption|\[sig-apps\].CronJob).*(\[Serial\]|\[Slow\])|(\[Serial\]|\[Slow\]).*(\[Conformance\]|\[NodeConformance\])|\[sig-api-machinery\].Garbage.collector
+          - name: GINKGO_SKIP
+            value: \[LinuxOnly\]|device.plugin.for.Windows|\[sig-autoscaling\].\[Feature:HPA\]|\[Alpha\]|\[FeatureGate:SchedulerAsyncPreemption\]|\[Beta\]
+          - name: NODE_FEATURE_GATES
+            value: "WindowsGracefulNodeShutdown=true"
+  annotations:
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com, sig-windows-leads@kubernetes.io
+    testgrid-dashboards: sig-windows-master-release, sig-windows-signal
+    testgrid-tab-name: capz-windows-master-2025-serial-slow
 - name: ci-kubernetes-e2e-capz-master-windows-serial-slow-hpa
   cluster: eks-prow-build-cluster
   interval: 24h


### PR DESCRIPTION
## Summary

Adds `ci-kubernetes-e2e-capz-master-windows-2025-serial-slow`, a Windows Server 2025 counterpart to the existing Windows Server 2022 CAPZ serial/slow periodic job.

## Changes

- Copies the existing serial/slow job configuration, including its 24-hour interval, test filters, GMSA setup, resources, timeout, and alerting.
- Uses `preset-capz-windows-2025`, which selects the Windows Server 2025 CAPZ gallery image.
- Publishes results to the `sig-windows-master-release` and `sig-windows-signal` dashboards under `capz-windows-master-2025-serial-slow`.

## Context

The existing `capz-windows-master-serial-slow` job continues to run on Windows Server 2022 unchanged. This new periodic provides equivalent serial/slow coverage on Windows Server 2025 so results can be compared independently.

/sig windows
/area test