### PR TITLE
sig-storage-local-static-provisioner e2e: pin COS master/node image (temporary workaround)

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/OWNERS
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/OWNERS
@@ -7,6 +7,7 @@ reviewers:
   - jsafrane
   - cofyc
   - xing-yang
+  - andyzhangx
 approvers:
   - msau42
   - saad-ali
@@ -14,3 +15,4 @@ approvers:
   - jsafrane
   - cofyc
   - xing-yang
+  - andyzhangx

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -89,6 +89,21 @@ presubmits:
         args:
         - make
         - e2e
+        # Workaround: kubetest's kube-up (cluster/gce/util.sh) resolves the COS
+        # image family via `gcloud compute images list --filter=family:...`,
+        # which currently returns multiple images and gets its output line-split
+        # by kube-up. Pin the master/node image explicitly so kube-up skips the
+        # buggy lookup. Track fix: kubernetes/kubernetes#141067. Remove once
+        # that fix is present in ci/latest.
+        env:
+        - name: KUBE_GCE_MASTER_IMAGE
+          value: cos-129-19506-299-61
+        - name: KUBE_GCE_MASTER_PROJECT
+          value: cos-cloud
+        - name: KUBE_GCE_NODE_IMAGE
+          value: cos-129-19506-299-61
+        - name: KUBE_GCE_NODE_PROJECT
+          value: cos-cloud
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
### What this PR does / why we need it

The `pull-sig-storage-local-static-provisioner-e2e` presubmit currently fails at cluster bring-up on every PR ([recent failure log](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_sig-storage-local-static-provisioner/604/pull-sig-storage-local-static-provisioner-e2e/2083011217974104064/build-log.txt)).

The job runs:

```
kubetest --provider gce --extract ci/latest --deployment bash --up --down ...
```

That invokes `kube-up` (`cluster/gce/util.sh`) from the extracted `ci/latest` k/k tarball, which resolves the COS master/node image with:

```
gcloud compute images list \
  --project="${MASTER_IMAGE_PROJECT}" \
  --no-standard-images \
  --filter="family:${MASTER_IMAGE_FAMILY} architecture:X86_64" \
  --format 'value(name)'
```

There is no `--sort-by` / `--limit`, so gcloud now returns two images from family `cos-129-lts` (`cos-129-19506-299-60` and `cos-129-19506-299-61`) as two separate output lines. `kube-up` then concatenates that multi-line string into a single `MASTER_IMAGE` env value and passes it to `gcloud compute instance-templates create`, which fails.

Log excerpt:

```
Using image: cos-129-19506-299-60
cos-129-19506-299-61 from project: cos-cloud as master image
```

The underlying fix lives in `cluster/gce/util.sh` in k/k (`--sort-by=~creationTimestamp --limit=1`) and is being addressed in **[kubernetes/kubernetes#141067](https://github.com/kubernetes/kubernetes/pull/141067)**. Until that fix rides into `ci/latest`, this job (and any other GCE e2e job that uses `--extract ci/latest --deployment bash`) is red for reasons unrelated to the PR under test.

This PR is a temporary workaround: set `KUBE_GCE_MASTER_IMAGE` / `KUBE_GCE_NODE_IMAGE` (and matching PROJECT overrides) on the job so `kube-up` skips the buggy `gcloud` lookup entirely (`cluster/gce/util.sh` honors those env vars).

Scope is intentionally narrow — only `pull-sig-storage-local-static-provisioner-e2e`. The Windows variant already pins its own image via the `preset-common-gce-windows` preset and is unaffected.

### Which issue(s) this PR fixes

Related: kubernetes/kubernetes#141067

### Special notes for your reviewer

Please revert this once kubernetes/kubernetes#141067 merges and rides into `ci/latest`.

### Does this PR introduce a user-facing change?

```release-note
NONE
```
