### PR TITLE
Upgrade node e2e COS image family to cos-129-lts

### DIFF
--- a/jobs/e2e_node/containerd/containerd-main-presubmit/image-config-presubmit.yaml
+++ b/jobs/e2e_node/containerd/containerd-main-presubmit/image-config-presubmit.yaml
@@ -1,5 +1,5 @@
 images:
   cos:
-    image_family: cos-125-lts # keep as close to the COS version that has containerd version closest to the main branch as possible
+    image_family: cos-129-lts # keep as close to the COS version that has containerd version closest to the main branch as possible
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main-presubmit/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/image-config.yaml
@@ -7,6 +7,6 @@ images:
     image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env"
   cos:
-    image_family: cos-125-lts # keep as close to the COS version that has containerd version closest to the main branch as possible
+    image_family: cos-129-lts # keep as close to the COS version that has containerd version closest to the main branch as possible
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/perf-image-config.yaml
@@ -8,7 +8,7 @@ images:
     machine: e2-standard-16  # node performance tests will be skipped on smaller machines
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env"
   cos:
-    image_family: cos-125-lts # keep as close to the COS version that has containerd version closest to the main branch as possible
+    image_family: cos-129-lts # keep as close to the COS version that has containerd version closest to the main branch as possible
     project: cos-cloud
     machine: e2-standard-16 # node performance tests will be skipped on smaller machines
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/systemd/image-config-serial.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/systemd/image-config-serial.yaml
@@ -1,6 +1,6 @@
 images:
   cos:
-    image_family: cos-125-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
+    image_family: cos-129-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
     project: cos-cloud
     machine: e2-standard-2 # These tests need a lot of memory
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-main/systemd/image-config.yaml
@@ -1,5 +1,5 @@
 images:
   cos:
-    image_family: cos-125-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
+    image_family: cos-129-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-main/systemd/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/image-config-serial-eviction.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-eviction.yaml
@@ -1,6 +1,6 @@
 images:
   cos:
-    image_family: cos-125-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
+    image_family: cos-129-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
     project: cos-cloud
     machine: e2-standard-2 # These tests need a lot of memory
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init-eviction.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"

--- a/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial-resource-managers.yaml
@@ -12,7 +12,7 @@ images:
     machine: n2d-standard-32
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
   cos:
-    image_family: cos-125-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
+    image_family: cos-129-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
     # Using `n2d-standard-32` that has 2 numa nodes to enable resource managers node e2e tests.

--- a/jobs/e2e_node/containerd/image-config-serial.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial.yaml
@@ -8,7 +8,7 @@ images:
     machine: e2-standard-2 # These tests need a lot of memory
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
   cos-2:
-    image_family: cos-125-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
+    image_family: cos-129-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
     project: cos-cloud
     machine: n1-standard-4 # These tests need a lot of memory
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
@@ -17,7 +17,7 @@ images:
         - type: nvidia-tesla-t4
           count: 2
   cos-1:
-    image_family: cos-125-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
+    image_family: cos-129-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
     project: cos-cloud
     machine: e2-standard-2 # These tests need a lot of memory
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"

--- a/jobs/e2e_node/containerd/image-config.yaml
+++ b/jobs/e2e_node/containerd/image-config.yaml
@@ -7,6 +7,6 @@ images:
     image_regex: ".*[^-cgroupsv1]$"
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
   cos:
-    image_family: cos-125-lts
+    image_family: cos-129-lts
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"

--- a/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+++ b/jobs/e2e_node/image-config-serial-cpu-manager.yaml
@@ -11,7 +11,7 @@ images:
     # Using `e2-standard-4` to enable CPU manager node e2e tests.
     machine: e2-standard-4
   cos:
-    image_family: cos-125-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
+    image_family: cos-129-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
     # Using `e2-standard-4` to enable CPU manager node e2e tests.

--- a/jobs/e2e_node/image-config-serial.yaml
+++ b/jobs/e2e_node/image-config-serial.yaml
@@ -10,7 +10,7 @@ images:
     image_regex: ".*[^-cgroupsv1]$"
     machine: e2-standard-2 # These tests need a lot of memory
   cos:
-    image_family: cos-125-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
+    image_family: cos-129-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
     project: cos-cloud
     machine: e2-standard-2 # These tests need a lot of memory
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Update the COS image family from cos-125-lts to cos-129-lts across all node e2e image configs. COS M129 ships containerd v2.2.5, which implements ListPodSandboxMetrics with per-container metrics needed to test the CRI stats path.

Release branch configs (1.34, 1.35) and the containerd-release-2.1 config are left on cos-125-lts as they pin specific containerd versions.

Align with https://github.com/kubernetes/kubernetes/pull/141049 for https://github.com/kubernetes/kubernetes/pull/140786