### PR TITLE
ci-kubernetes-cross-canary: move to eks-prow-build-cluster

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/periodics.yaml
@@ -28,7 +28,7 @@ periodics:
               cpu: 100m
               memory: 512Mi
   - name: ci-kubernetes-cross-canary
-    cluster: k8s-infra-aks-prow-build
+    cluster: eks-prow-build-cluster
     interval: 2h
     decorate: true
     max_concurrency: 1


### PR DESCRIPTION
## What

Moves `ci-kubernetes-cross-canary` from `k8s-infra-aks-prow-build` to `eks-prow-build-cluster`. One-line cluster change; resources and command are unchanged.

## Why

The job has not completed a single run since **2026-07-21 ~10:00 UTC** ([testgrid](https://testgrid.k8s.io/sig-k8s-infra-canaries#ci-k8s-cross-canary)). Triage findings:

- Every pod is SIGTERMed ~25–29 min in, always during the 8-platform parallel `e2e.test` build — the peak disk-write phase of `make release` (e.g. [build 2082991726103891968](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-cross-canary/2082991726103891968)). Not a build error, not the 2h timeout.
- The AKS nodepools ([aks.tf](https://github.com/kubernetes/k8s.io/blob/main/infra/azure/terraform/k8s-infra-prow-build/aks.tf)) run `Standard_D8ads_v6` with `os_disk_size_gb = 100`, `kubelet_disk_type = "OS"` — images, dind emptyDirs, and all build output share a 100GB disk, while the VM's 440GiB local NVMe goes unused. A full `make release` needs ~60–90GB of scratch, so the pod is disk-pressure evicted at a deterministic point. Other jobs on the same cluster that write less (verify-master-canary 43min, kind-ipv6-canary 33–38min) run fine.
- plank (`error_on_eviction: false`) recreates the evicted pod with a fresh build ID every ~30 min, so one ProwJob (`48ca6355-5c6b-4248-a1a5-20aac59cb38f`, pending since 07-24, generation 869) has produced hundreds of ABORTED builds and horologium never schedules a new run.
- This was chronic before going terminal: 3–13 evicted attempts/day since at least 07-10, retries used to squeak through (~28.5 min success vs ~25–29 min kill point); the margin ran out on 07-21. Both boundary builds ran the same kubekins image, and the k8s commit window contains nothing relevant — this is infra, not a k8s or image regression.

The EKS build cluster provisions CI nodes via Karpenter with [`instanceStorePolicy: RAID0`](https://github.com/kubernetes/k8s.io/blob/main/kubernetes/eks-prow-build/kube-system/ec2nodeclass.yaml) (kubelet/containerd on local NVMe RAID) — the same pattern as the GKE build nodepools (`-lssd` machine types with `ephemeral_storage_config`), so the cross build has the disk it needs there. A green run on EKS also confirms the AKS disk diagnosis while the terraform fix (e.g. `kubelet_disk_type = "Temporary"`) is pursued separately in kubernetes/k8s.io.


/sig k8s-infra
/area jobs