### PR TITLE
audit: ignore group discovery ops for groups with no GA version

### DIFF
--- a/experiment/audit/audit_log_parser.py
+++ b/experiment/audit/audit_log_parser.py
@@ -161,6 +161,7 @@ class SwaggerEndpointMapper:
         self.swagger_spec = None
         self.path_to_operation = {}
         self.deprecated_operations = set()
+        self.pre_ga_group_operations = set()
         self.known_resource_types = set()
         self.load_swagger_spec()
 
@@ -231,6 +232,44 @@ class SwaggerEndpointMapper:
         print(f"Loaded {len(self.path_to_operation)} API operations from Swagger spec")
         if self.deprecated_operations:
             print(f"Found {len(self.deprecated_operations)} deprecated operations")
+
+        self._build_pre_ga_group_operations()
+
+    def _build_pre_ga_group_operations(self):
+        """Collect group discovery operations whose group serves no GA version.
+
+        A group discovery path, /apis/<group>/, carries no version, because it
+        is what you call to find out what the versions are. The alpha/beta
+        check on the operation id therefore never matches, and an alpha only
+        group's discovery operation reads as stable. A group is only as stable
+        as the most stable version it actually serves.
+        """
+        if not self.swagger_spec or 'paths' not in self.swagger_spec:
+            return
+
+        group_versions = {}
+        for path in self.swagger_spec['paths']:
+            parts = path.strip('/').split('/')
+            if len(parts) >= 3 and parts[0] == 'apis':
+                group_versions.setdefault(parts[1], set()).add(parts[2])
+
+        for path, methods in self.swagger_spec['paths'].items():
+            parts = path.strip('/').split('/')
+            if len(parts) != 2 or parts[0] != 'apis':
+                continue
+            versions = group_versions.get(parts[1], set())
+            # no versions at all, or the group already serves a GA one
+            if not versions or any(
+                    'alpha' not in v and 'beta' not in v for v in versions):
+                continue
+            for method, operation in methods.items():
+                if (method.lower() in ['get', 'post', 'put', 'patch', 'delete']
+                        and 'operationId' in operation):
+                    self.pre_ga_group_operations.add(operation['operationId'])
+
+        if self.pre_ga_group_operations:
+            print(f"Found {len(self.pre_ga_group_operations)} group discovery "
+                  "operations for groups with no GA version")
 
     def _extract_resource_types(self):
         """Extract resource types from Swagger paths to avoid hardcoding."""
@@ -877,6 +916,8 @@ def warn_on_missing_stable_endpoints(deprecated_operations, endpoint_counts, ine
         if not any(version in op for version in
                    ['V1alpha', 'V1beta', 'V2alpha', 'V2beta', 'V3alpha', 'V3beta', 'alpha', 'beta'])
     }
+    # Filter out group discovery operations for groups with no GA version
+    stable_missing_operations = stable_missing_operations - swagger_mapper.pre_ga_group_operations
     # Filter out ineligible endpoints from missing operations
     if ineligible_endpoints:
         stable_missing_operations = stable_missing_operations - ineligible_endpoints


### PR DESCRIPTION
Related:  Related: https://github.com/kubernetes/kubernetes/issues/141065

warn_on_missing_stable_endpoints decides alpha/beta/stable by looking for those substrings in the operation id. That works for versioned operations because the version is in the name, but a group discovery operation is named for its group only, and its path, /apis/<group>/, carries no version either. It is the operation you call to find out what the versions are. So getLifecycleAPIGroup reads as stable even though lifecycle.k8s.io only serves v1alpha1, and the check fails on it.

A group is only as stable as the most stable version it actually serves. Collect the discovery operations of groups with no GA version and filter them out alongside the deprecated, ineligible and pending lists.

This is the same rule as the one in kubernetes-sigs/apisnoop, which classifies from the path rather than the operation id and had the same blind spot. Both were checked against api/openapi-spec/swagger.json from v1.5.0, v1.20.0, v1.27.0 and master, and select the same operations in every case:

  v1.5.0   8  getAppsAPIGroup, getAuthenticationAPIGroup,
              getAuthorizationAPIGroup, getCertificatesAPIGroup,
              getExtensionsAPIGroup, getPolicyAPIGroup,
              getRbacAuthorizationAPIGroup, getStorageAPIGroup
  v1.20.0  5  getDiscoveryAPIGroup, getExtensionsAPIGroup,
              getFlowcontrolApiserverAPIGroup,
              getInternalApiserverAPIGroup, getPolicyAPIGroup
  v1.27.0  3  getFlowcontrolApiserverAPIGroup,
              getInternalApiserverAPIGroup, getResourceAPIGroup
  master   2  getInternalApiserverAPIGroup, getLifecycleAPIGroup

Groups drop off that list on their own as they go GA, so nothing needs maintaining by hand as new alpha groups arrive or graduate.

Once this lands, getLifecycleAPIGroup no longer needs its entry in test/conformance/testdata/pending_eligible_endpoints.yaml.