### PR TITLE
apisnoop: shorten pushed image tags so the autobumper can read them

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
+++ b/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
@@ -21,6 +21,7 @@ postsubmits:
               - --project=k8s-staging-apisnoop
               - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --version-tag-filter=no-such-tag-*
               - apps/auditlogger
     - name: apisnoop-push-snoopdb-images
       cluster: k8s-infra-prow-build-trusted
@@ -43,6 +44,7 @@ postsubmits:
               - --project=k8s-staging-apisnoop
               - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --version-tag-filter=no-such-tag-*
               - apps/snoopdb
   kubernetes-sigs/verify-conformance:
     - name: post-verify-conformance-push-images


### PR DESCRIPTION
image-builder derives the version with `git describe --tags`, which picks up whichever tag in kubernetes-sigs/apisnoop is nearest, regardless of which image is being built. Both images therefore end up tagged from the auditlogger series, giving tags like

  v20250906-auditlogger-1.2.13-125-ga6fd3d3

The autobumper matches tags against

  (v?\d{8}-(?:v\d(?:[.-]\d+)*-g)?[0-9a-f]{6,10}|latest)(-.+)?

This uses --version-tag-filter with a glob that deliberately matches no tag, so git describe --always falls through to the bare commit. That's the only way I found to get "just the date and commit" — image-builder has no explicit option for it, and v* doesn't work here because of the old v2020.*/v2021.* tags (and would break anyway on a build made exactly at a release tag). Happy to spell it differently, or to add a proper flag to image-builder instead, if either is preferred. 

Fixes kubernetes-sigs/apisnoop#962