### PR TITLE
Add prow presubmits for sig-security srctl tool

### DIFF
--- a/config/jobs/kubernetes/sig-security/srctl-tests.yaml
+++ b/config/jobs/kubernetes/sig-security/srctl-tests.yaml
@@ -1,0 +1,56 @@
+presubmits:
+  kubernetes/sig-security:
+  - name: pull-sig-security-srctl-unit-tests
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-security-srctl
+      testgrid-create-test-group: "true"
+      description: Run srctl unit tests when sig-security-tooling/srctl changes
+    run_if_changed: "^sig-security-tooling/srctl/"
+    branches:
+    - main
+    decorate: true
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260729-f0c41ad0b9-master
+        command: ['runner.sh']
+        args:
+        - bash
+        - -ec
+        - |
+          cd sig-security-tooling/srctl
+          go test -v -cover ./...
+        resources:
+          limits:
+            cpu: 2
+            memory: "2Gi"
+          requests:
+            cpu: 2
+            memory: "2Gi"
+
+  - name: pull-sig-security-srctl-golangci-lint
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-security-srctl
+      testgrid-create-test-group: "true"
+      description: Run golangci-lint on srctl when sig-security-tooling/srctl changes
+    run_if_changed: "^sig-security-tooling/srctl/"
+    branches:
+    - main
+    decorate: true
+    spec:
+      containers:
+      - image: golangci/golangci-lint:v2.12.1
+        command:
+        - bash
+        - -ec
+        - |
+          cd sig-security-tooling/srctl
+          golangci-lint run ./...
+        resources:
+          limits:
+            cpu: 2
+            memory: "2Gi"
+          requests:
+            cpu: 2
+            memory: "2Gi"

--- a/config/testgrids/kubernetes/sig-security/config.yaml
+++ b/config/testgrids/kubernetes/sig-security/config.yaml
@@ -5,9 +5,11 @@ dashboard_groups:
   dashboard_names:
   - sig-security-snyk-scan
   - sig-security-cve-feed
+  - sig-security-srctl
 
 # Dashboards
 #
 dashboards:
 - name: sig-security-snyk-scan
 - name: sig-security-cve-feed
+- name: sig-security-srctl


### PR DESCRIPTION
# WARNING! AI assisted PR

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds presubmit jobs for `kubernetes/sig-security` that run when `sig-security-tooling/srctl` changes:

1. **pull-sig-security-srctl-unit-tests** — `go test -v -cover ./...` (kubekins image)
2. **pull-sig-security-srctl-golangci-lint** — `golangci-lint run ./...` (golangci-lint v2.12.1, matches the project's golangci v2 config)

Pattern mirrors the existing `cve-feed-tests.yaml` presubmit. Also registers a `sig-security-srctl` Testgrid dashboard under the sig-security group.

Verified locally:
- `go test -v -cover ./...` passes
- `golangci-lint` v2.12.1 reports 0 issues

#### Which issue(s) this PR fixes:

Fixes kubernetes/sig-security#175

#### Special notes for your reviewer:

/sig security
/sig testing

#### Does this PR introduce a user-facing change?

```release-note
NONE
```