### PR TITLE
Increase memory for ci-cloud-provider-aws-e2e-with-kubernetes-master to 8Gi

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-periodics.yaml
@@ -73,10 +73,10 @@ periodics:
       resources:
         limits:
           cpu: 2
-          memory: 4Gi
+          memory: 8Gi
         requests:
           cpu: 2
-          memory: 4Gi
+          memory: 8Gi
       command:
       - runner.sh
       args:


### PR DESCRIPTION
The dep bump in cloud-provider-aws [PR #1476](https://github.com/kubernetes/cloud-provider-aws/pull/1476) (k8s 1.37-beta.0) enlarged the build's dependency set. Compiling `github.com/aws/aws-sdk-go-v2/service/ec2` and `k8s.io/apiserver/pkg/admission/plugin/policy/validating` now intermittently kills the Go compiler with SIGKILL because the container only has 4Gi of memory.

Increasing to 8Gi makes the build reliable again.

Failing job: https://testgrid.k8s.io/amazon-ec2#ci-cloud-provider-aws-e2e-with-kubernetes-master
Example failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-cloud-provider-aws-e2e-with-kubernetes-master/2083990747803029504