### PR TITLE
Add pull-kubernetes-e2e-ec2-alpha-canary presubmit for provider-aws-test-infra

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -618,7 +618,8 @@ presubmits:
       preset-e2e-containerd-ec2: "true"
       preset-dind-enabled: "true"
     path_alias: sigs.k8s.io/provider-aws-test-infra
-    always_run: false
+    # Run automatically when the deployer or its build inputs change; stay non-blocking.
+    run_if_changed: '^(kubetest2-ec2/|go\.mod|go\.sum|vendor/)'
     optional: true
     cluster: eks-prow-build-cluster
     decorate: true

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml
@@ -605,6 +605,67 @@ presubmits:
             requests:
               cpu: 7
               memory: 10Gi
+  - name: pull-kubernetes-e2e-ec2-alpha-canary
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: presubmits-ec2
+      description: duplicate of ci-kubernetes-e2e-ec2-alpha-features that builds kubetest2-ec2 from the PR
+    labels:
+      preset-e2e-containerd-ec2: "true"
+      preset-dind-enabled: "true"
+    path_alias: sigs.k8s.io/provider-aws-test-infra
+    always_run: false
+    optional: true
+    cluster: eks-prow-build-cluster
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    spec:
+      serviceAccountName: node-e2e-tests
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260729-f0c41ad0b9-master
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              source $(go env GOPATH)/src/sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/scripts/check-ami.sh
+              cd kubetest2-ec2 && GOPROXY=direct go install .
+              VERSION=$(curl -Ls --retry 5 --retry-delay 10 --retry-all-errors https://dl.k8s.io/ci/fast/latest-fast.txt)
+              kubetest2 ec2 \
+               --stage https://dl.k8s.io/ci/fast \
+               --version $VERSION \
+               --feature-gates="AllAlpha=true,AllBeta=true,EventedPLEG=false" \
+               --runtime-config="api/all=true" \
+               --up \
+               --down \
+               --test=ginkgo \
+               -- \
+               --test-args="--node-os-arch=$NODE_OS_ARCH --provider=aws --minStartupPods=8" \
+               --test-package-url=https://dl.k8s.io \
+               --test-package-dir=ci/fast \
+               --test-package-marker=latest-fast.txt \
+               --focus-regex="\[Feature:(AdmissionWebhookMatchConditions|InPlacePodVerticalScaling|StorageVersionAPI|PodPreset|StatefulSetAutoDeletePVC)\]|Networking" \
+               --skip-regex="\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Example)\]|IPv6|csi-hostpath-v0" \
+               --parallel=25
+          env:
+            - name: USE_DOCKERIZED_BUILD
+              value: "true"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 7
+              memory: 10Gi
+            requests:
+              cpu: 7
+              memory: 10Gi
   - name: pull-kubernetes-e2e-ec2-cloud-provider-canary
     skip_branches:
       - release-\d+\.\d+  # per-release image


### PR DESCRIPTION
kubernetes-sigs/provider-aws-test-infra has no presubmit that runs the tests of the periodic job ci-kubernetes-e2e-ec2-alpha-features.

The comment on pull-kubernetes-node-e2e-alpha-ec2 describes that job as a duplicate of the periodic for testing provider-aws-test-infra changes. The job cannot test provider-aws-test-infra pull requests, because it is a kubernetes/kubernetes presubmit and it installs kubetest2-ec2 with "go install ...@latest", so it always tests the merged main branch of provider-aws-test-infra and never a pull request.

The presubmits that do run on provider-aws-test-infra pull requests build kubetest2-ec2 from the pull request checkout, but none of them run the tests the periodic runs. The quick jobs run one pod test. The canary jobs skip tests labeled [Disruptive]. The conformance jobs run only tests labeled [Conformance].

A recent deployer change (kubernetes-sigs/provider-aws-test-infra@848d043d12b7970ffda244a3a85380c1eedac27c) broke the test "[sig-network] Networking should recreate its iptables rules if they are deleted" in the periodic, and no presubmit ran that test, so the break only showed up after merge.

The new job copies the feature gates, focus regex, and skip regex from the periodic, and builds kubetest2-ec2 from the pull request checkout like the other canary jobs. It does not run automatically. Run it with /test pull-kubernetes-e2e-ec2-alpha-canary.

go test ./config/tests/jobs/ and go test ./config/tests/testgrids/ both pass.
