### PR TITLE
Kueue: make website link preview check required

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -1968,7 +1968,6 @@ presubmits:
                 memory: "6Gi"
     - name: pull-kueue-verify-website-links-preview-main
       cluster: eks-prow-build-cluster
-      optional: true
       always_run: false
       run_if_changed: "^(site/|netlify\\.toml)"
       branches:
@@ -1981,7 +1980,7 @@ presubmits:
       annotations:
         testgrid-dashboards: sig-scheduling
         testgrid-tab-name: pull-kueue-verify-website-links-preview-main
-        description: "Check links on a PR's Netlify deploy preview, on demand (non-blocking)"
+        description: "Check links on a PR's Netlify deploy preview"
       labels:
         preset-dind-enabled: "true"
         preset-kind-volume-mounts: "true"

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -936,6 +936,12 @@ tide:
             from-branch-protection: true
           cluster-api-provider-vsphere:
             from-branch-protection: true
+          kueue:
+            optional-contexts:
+            - deploy/netlify
+            - Header rules
+            - Pages changed
+            - Redirect rules
           kubespray:
             from-branch-protection: true
   batch_size_limit:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -938,6 +938,8 @@ tide:
             from-branch-protection: true
           kueue:
             optional-contexts:
+            # Netlify checks can fail intermittently, making the PR stuck and requiring a push from the PR owner.
+            # Website changes remain gated by pull-kueue-verify-website-links-preview-main.
             - deploy/netlify
             - Header rules
             - Pages changed

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1301,6 +1301,11 @@ cherry_pick_approved:
   - Verolop
   - xmudrii
 
+override:
+  allowed_github_teams:
+    kubernetes-sigs/kueue:
+    - kueue-maintainers
+
 # Enabled plugins per repo.
 # Keys: Full repo name: "org/repo".
 # Values: List of plugins to run against the repo.
@@ -1641,6 +1646,7 @@ plugins:
     plugins:
     - milestone
     - milestonestatus
+    - override
     - release-note
 
   kubernetes-sigs/kustomize:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1301,11 +1301,6 @@ cherry_pick_approved:
   - Verolop
   - xmudrii
 
-override:
-  allowed_github_teams:
-    kubernetes-sigs/kueue:
-    - kueue-maintainers
-
 # Enabled plugins per repo.
 # Keys: Full repo name: "org/repo".
 # Values: List of plugins to run against the repo.
@@ -1646,7 +1641,6 @@ plugins:
     plugins:
     - milestone
     - milestonestatus
-    - override
     - release-note
 
   kubernetes-sigs/kustomize:


### PR DESCRIPTION
Makes `pull-kueue-verify-website-links-preview-main` required and the Netlify contexts optional in Tide.

Fixes kubernetes-sigs/kueue#13474.
