### PR TITLE
Kueue: enable override

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1301,6 +1301,11 @@ cherry_pick_approved:
   - Verolop
   - xmudrii
 
+override:
+  allowed_github_teams:
+    kubernetes-sigs/kueue:
+    - kueue-maintainers
+
 # Enabled plugins per repo.
 # Keys: Full repo name: "org/repo".
 # Values: List of plugins to run against the repo.
@@ -1641,6 +1646,7 @@ plugins:
     plugins:
     - milestone
     - milestonestatus
+    - override
     - release-note
 
   kubernetes-sigs/kustomize:


### PR DESCRIPTION
Enables the Prow override plugin for `kueue-maintainers` so that when a job gets stuck, maintainers can unblock the PR without requiring a push from PR owner.

[docs](https://prow.k8s.io/command-help#override):

| Command | Example | Description |
| --- | --- | --- |
| `/override [context1] [context2]` | `/override pull-kueue-verify-website-links-preview-main` | Forces github status contexts to green (multiple can be given). Overrides expire when the base branch moves. |
| `/override-sticky [context1] [context2]` | `/override-sticky pull-kueue-verify-website-links-preview-main` | Like /override, but the override persists across retests on the current HEAD SHA even when the base branch moves. Pushing a new commit clears them. Use /override-cancel to remove. |
| `/override-cancel [context]` | `/override-cancel pull-kueue-verify-website-links-preview-main` | Removes overrides by setting the status back to failure. Works on both regular and sticky overrides. If a context is given, only that override is removed. If no context is given, all overrides on the PR are removed. |

Part of [kubernetes-sigs/kueue#13474](https://github.com/kubernetes-sigs/kueue/issues/13474).