### PR TITLE
Bump snoopdb image to v20260803-auditlogger-1.2.13-261-ge6f4338

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -15,7 +15,7 @@ periodics:
   spec:
     containers:
     - name: apisnoop-gate
-      image: gcr.io/k8s-staging-apisnoop/snoopdb:v20250906-auditlogger-1.2.13-125-ga6fd3d3
+      image: gcr.io/k8s-staging-apisnoop/snoopdb:v20260803-auditlogger-1.2.13-261-ge6f4338
       env:
         - name: LOAD_K8S_DATA
           value: "true"


### PR DESCRIPTION
Updates the snoopdb image used by the conformance-gate job to the latest build:

`gcr.io/k8s-staging-apisnoop/snoopdb:v20250906-auditlogger-1.2.13-125-ga6fd3d3` → `gcr.io/k8s-staging-apisnoop/snoopdb:v20260803-auditlogger-1.2.13-261-ge6f4338`