### PR TITLE
Reduce gce-cos e2e master periodics from 1h to 2h

### DIFF
--- a/config/jobs/kubernetes/sig-release/gce-cos-e2e-master.yaml
+++ b/config/jobs/kubernetes/sig-release/gce-cos-e2e-master.yaml
@@ -2,7 +2,7 @@ periodics:
 - annotations:
     fork-per-release: "true"
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: "1h 2h 6h 24h"
+    fork-per-release-periodic-interval: "6h 8h 12h 24h"
     fork-per-release-replacements: "extract=ci/latest -> extract=ci/latest-{{.Version}}"
     testgrid-alert-email: release-team@kubernetes.io
     testgrid-dashboards: sig-release-master-blocking
@@ -16,7 +16,7 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 1h
+  interval: 2h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -51,7 +51,7 @@ periodics:
 - annotations:
     fork-per-release: "true"
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: "1h 2h 6h 24h"
+    fork-per-release-periodic-interval: "6h 8h 12h 24h"
     fork-per-release-replacements: "extract=ci/latest -> extract=ci/latest-{{.Version}}"
     testgrid-alert-email: release-team@kubernetes.io
     testgrid-dashboards: sig-release-master-blocking
@@ -65,7 +65,7 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 1h
+  interval: 2h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -97,7 +97,7 @@ periodics:
 - annotations:
     fork-per-release: "true"
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: "1h 2h 6h 24h"
+    fork-per-release-periodic-interval: "6h 8h 12h 24h"
     fork-per-release-replacements: "extract=ci/latest -> extract=ci/latest-{{.Version}}"
     testgrid-dashboards: sig-release-master-informing
     testgrid-num-failures-to-alert: "6"
@@ -111,7 +111,7 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 1h
+  interval: 2h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -142,7 +142,7 @@ periodics:
 - annotations:
     fork-per-release: "true"
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: "1h 2h 6h 24h"
+    fork-per-release-periodic-interval: "6h 8h 12h 24h"
     fork-per-release-replacements: "extract=ci/latest -> extract=ci/latest-{{.Version}}"
     testgrid-dashboards: sig-release-master-informing
     testgrid-num-failures-to-alert: "6"
@@ -156,7 +156,7 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 1h
+  interval: 2h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -1131,7 +1131,7 @@ periodics:
     testgrid-tab-name: gce-cos-alphafeatures-1.34
   cluster: k8s-infra-prow-build
   decorate: true
-  interval: 6h
+  interval: 12h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1175,7 +1175,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h20m0s
-  interval: 6h
+  interval: 12h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1253,7 +1253,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 11h20m0s
-  interval: 6h
+  interval: 12h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1294,7 +1294,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h50m0s
-  interval: 6h
+  interval: 12h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -1250,14 +1250,14 @@ periodics:
       runAsUser: 2001
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 12h 24h
     testgrid-dashboards: sig-release-1.35-blocking
     testgrid-tab-name: gce-cos-alphafeatures-1.35
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 2h20m0s
-  interval: 2h
+  interval: 8h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1294,14 +1294,14 @@ periodics:
           memory: 3Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 12h 24h
     testgrid-dashboards: sig-release-1.35-blocking
     testgrid-tab-name: gce-cos-default-1.35
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 2h20m0s
-  interval: 2h
+  interval: 8h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1373,7 +1373,7 @@ periodics:
           memory: 3Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 12h 24h
     testgrid-dashboards: sig-release-1.35-informing
     testgrid-num-failures-to-alert: "6"
     testgrid-tab-name: gce-cos-serial-1.35
@@ -1381,7 +1381,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 11h20m0s
-  interval: 2h
+  interval: 8h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1414,7 +1414,7 @@ periodics:
           memory: 3Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 12h 24h
     testgrid-dashboards: sig-release-1.35-informing
     testgrid-num-failures-to-alert: "6"
     testgrid-tab-name: gce-cos-slow-1.35
@@ -1422,7 +1422,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h50m0s
-  interval: 2h
+  interval: 8h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.36.yaml
@@ -1016,7 +1016,7 @@ periodics:
           memory: 6Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 2h 6h 24h
+    fork-per-release-periodic-interval: 8h 12h 24h
     testgrid-alert-email: release-team@kubernetes.io
     testgrid-dashboards: sig-release-1.36-blocking
     testgrid-tab-name: gce-cos-alphafeatures-1.36
@@ -1024,7 +1024,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 2h20m0s
-  interval: 1h
+  interval: 6h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1061,7 +1061,7 @@ periodics:
           memory: 3Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 2h 6h 24h
+    fork-per-release-periodic-interval: 8h 12h 24h
     testgrid-alert-email: release-team@kubernetes.io
     testgrid-dashboards: sig-release-1.36-blocking
     testgrid-tab-name: gce-cos-default-1.36
@@ -1074,7 +1074,7 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 1h
+  interval: 6h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1148,7 +1148,7 @@ periodics:
           memory: 3Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 2h 6h 24h
+    fork-per-release-periodic-interval: 8h 12h 24h
     testgrid-dashboards: sig-release-1.36-informing
     testgrid-num-failures-to-alert: "6"
     testgrid-tab-name: gce-cos-serial-1.36
@@ -1161,7 +1161,7 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 1h
+  interval: 6h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -1192,7 +1192,7 @@ periodics:
           memory: 3Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 2h 6h 24h
+    fork-per-release-periodic-interval: 8h 12h 24h
     testgrid-dashboards: sig-release-1.36-informing
     testgrid-num-failures-to-alert: "6"
     testgrid-tab-name: gce-cos-slow-1.36
@@ -1205,7 +1205,7 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 1h
+  interval: 6h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"


### PR DESCRIPTION
The four gce-cos e2e jobs (alphafeatures, default, serial, slow) run every hour on master. These are release blocking jobs, so they keep a frequent cadence on master but slow down on older branches:

- master: 2h
- master-1 (1.36): 6h
- master-2 (1.35): 8h
- master-3 (1.34): 12h
- master-4 (1.33): 24h

The fork-per-release-periodic-interval annotation changes from `1h 2h 6h 24h` to `6h 8h 12h 24h`. config-forker and config-rotator read this list when a release branch is cut: the fork for the newest branch takes the first value, and each rotation to an older branch takes the next one.

The existing release-branch jobs in release-branch-jobs/1.3x.yaml are updated to the same spread, including the remaining values in their annotations so future rotations stay on this ladder. The 1.33 jobs already run every 24h and are unchanged.