### PR TITLE
Drop node-exporter variant and stage the HA experiment

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/README.md
+++ b/config/jobs/kubernetes/sig-scalability/README.md
@@ -74,6 +74,8 @@ track. Add new entries at the top.
 
 | Variant | Date | What it does | Owner | Status |
 | --- | --- | --- | --- | --- |
+| `HA` | 2026-08-03 | 3-replica control plane (`CONTROL_PLANE_COUNT=3`) on the 5k job, which today runs a single control plane. | @Jefftree | In Progress |
+| `node-exporter` | 2026-07-24 | Scraping node exporter (`PROMETHEUS_SCRAPE_NODE_EXPORTER=true`) for per-node resource metrics. | @serathius | Graduated |
 | `restart-etcd36` | 2026-07-10 | RangeStream (`+EtcdRangeStream`) with HA control plane restart, on etcd 3.6.12, to gather data on RangeStream against etcd 3.6. Presubmit only. | @Jefftree | Completed |
 | `restart` | 2026-06-29 | HA control plane with restart, for tracking improvements with watch cache initialization. |  @Jefftree | In Progress |
 | `etcd36` | 2026-06-26 | Testing the 5k job on etcd 3.6.12. | @Jefftree | Completed |

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -50,8 +50,6 @@ presubmits:
         env:
         - name: KUBE_FEATURE_GATES
           value: "+EtcdRangeStream"
-        - name: CONTROL_PLANE_COUNT
-          value: "3"
         resources:
           requests:
             cpu: 5
@@ -236,9 +234,6 @@ presubmits:
         - ./tests/e2e/scenarios/scalability/run-test.sh
         securityContext:
           privileged: true
-        env:
-        - name: CONTROL_PLANE_COUNT
-          value: "3"
         resources:
           requests:
             cpu: 7

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -629,9 +629,6 @@ periodics:
       - ./tests/e2e/scenarios/scalability/run-test.sh
       securityContext:
         privileged: true
-      env:
-      - name: CONTROL_PLANE_COUNT
-        value: "3"
       resources:
         requests:
           cpu: 7

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -390,8 +390,6 @@ presets:
     value: "1"
   - name: TEAR_DOWN_PROMETHEUS_SERVER
     value: "false"
-  - name: EXPERIMENT_VARIANT
-    value: "node-exporter"
   - name: PROMETHEUS_SCRAPE_NODE_EXPORTER
     value: "true"
 
@@ -429,4 +427,8 @@ presets:
 
 - labels:
     preset-kops-scalability-gce-experimental: "true"
-  env: []
+  env:
+  - name: EXPERIMENT_VARIANT
+    value: "HA"
+  - name: CONTROL_PLANE_COUNT
+    value: "3"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -739,9 +739,6 @@ presubmits:
         - ./tests/e2e/scenarios/scalability/run-test.sh
         securityContext:
           privileged: true
-        env:
-        - name: CONTROL_PLANE_COUNT
-          value: "3"
         resources:
           requests:
             cpu: 5


### PR DESCRIPTION
The node-exporter graduation in #37551 left `EXPERIMENT_VARIANT: node-exporter` on every kops scalability job and reset the experimental preset to empty, dropping the HA variant.