### PR TITLE
sig-node: fix EC2 serial presubmit timeouts, add CRI-O serial presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -3328,7 +3328,10 @@ presubmits:
               - --gcp-zone=us-central1-b
               - --parallelism=1
               - --focus-regex=\[Serial\]
-              # Keep this in sync with ci-node-crio-kubelet-serial.
+              # This skip list is identical to ci-node-crio-kubelet-serial. The
+              # periodic also skips Slow and Disruptive; those tests run in its
+              # ci-node-crio-kubelet-serial-slow-disruptive sibling. Keep this
+              # line in sync with the periodic.
               - --skip-regex=\[Flaky\]|\[Slow\]|\[Disruptive\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:OffByDefault\]
               - '--test-args=--ginkgo.timeout=3h --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}" --service-feature-gates="PodLevelResources=true" --feature-gates="PodLevelResources=true"'
               - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-serial.yaml

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -313,6 +313,8 @@ presubmits:
       cluster: eks-prow-build-cluster
       max_concurrency: 50
       decorate: true
+      decoration_config:
+        timeout: 300m
       extra_refs:
         - org: kubernetes-sigs
           repo: provider-aws-test-infra
@@ -3252,6 +3254,8 @@ presubmits:
       cluster: eks-prow-build-cluster
       max_concurrency: 50
       decorate: true
+      decoration_config:
+        timeout: 300m
       extra_refs:
         - org: kubernetes-sigs
           repo: provider-aws-test-infra
@@ -3284,6 +3288,65 @@ presubmits:
               requests:
                 cpu: 7
                 memory: 10Gi
+    - name: pull-kubernetes-node-crio-kubelet-serial
+      cluster: k8s-infra-prow-build
+      skip_branches:
+        - release-\d+\.\d+ # per-release image
+      always_run: false
+      optional: true
+      skip_report: false
+      labels:
+        preset-service-account: "true"
+        preset-k8s-ssh: "true"
+      annotations:
+        testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
+        description: Presubmit twin of ci-node-crio-kubelet-serial, runs serial node e2e tests with CRI-O on Fedora CoreOS
+        testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
+        fork-per-release: "true"
+      decorate: true
+      decoration_config:
+        timeout: 360m
+      path_alias: k8s.io/kubernetes
+      extra_refs:
+        - org: kubernetes
+          repo: test-infra
+          base_ref: master
+          path_alias: k8s.io/test-infra
+          auxiliary: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260729-f0c41ad0b9-master
+            command:
+              - runner.sh
+            args:
+              - kubetest2
+              - noop
+              - --test=node
+              - --
+              - --build-binaries
+              - --repo-root=.
+              - --gcp-zone=us-central1-b
+              - --parallelism=1
+              - --focus-regex=\[Serial\]
+              # Keep this in sync with ci-node-crio-kubelet-serial.
+              - --skip-regex=\[Flaky\]|\[Slow\]|\[Disruptive\]|\[Benchmark\]|\[Feature:Eviction\]|\[Feature:CPUManager\]|\[Feature:MemoryManager\]|\[Feature:TopologyManager\]|\[Feature:NodeSwap\]|\[Feature:DynamicResourceAllocation\]|\[Feature:HugePages\]|\[Feature:OffByDefault\]
+              - '--test-args=--ginkgo.timeout=3h --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}" --service-feature-gates="PodLevelResources=true" --feature-gates="PodLevelResources=true"'
+              - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-serial.yaml
+              - --timeout=300m
+            env:
+              - name: GOPATH
+                value: /go
+              - name: KUBE_SSH_USER
+                value: core
+              - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+                value: "1"
+            resources:
+              limits:
+                cpu: 4
+                memory: 12Gi
+              requests:
+                cpu: 4
+                memory: 12Gi
     - name: pull-kubernetes-node-e2e-cri-proxy-serial
       cluster: k8s-infra-prow-build
       always_run: false


### PR DESCRIPTION
#### What this PR does:

Two changes so that node test regressions on the environments that broke the memory PSI test (kubernetes/kubernetes#141146) can be caught from a kubernetes/kubernetes PR instead of only after merge:

1. Give `pull-kubernetes-node-e2e-containerd-serial-ec2` and its arm64 twin a 300 minute timeout. These presubmits build kubernetes from source and then run the serial suite, which takes about 250 minutes end to end. The default timeout killed every run at 240 minutes, so neither job has ever passed (their retained history is only aborted and failed runs). They stay optional.

2. Add `pull-kubernetes-node-crio-kubelet-serial`, an optional presubmit twin of the `ci-node-crio-kubelet-serial` periodic, with the same focus, skip list, image config, and test args. CRI-O node coverage became periodic only in the node job reorganization, so there is currently no way to run node tests against CRI-O on Fedora CoreOS from a kubernetes/kubernetes PR. The lack of such a job is part of how kubernetes/kubernetes#134141 stayed unresolved for months.

/sig node
/cc @kannon92 @saschagrunert
