### PR TITLE
Increase memory of CAPI jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics.yaml
@@ -119,10 +119,10 @@ periodics:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-main
     testgrid-tab-name: capi-e2e-main
@@ -179,10 +179,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-main
     testgrid-tab-name: capi-e2e-mink8s-main
@@ -228,10 +228,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-main
     testgrid-tab-name: capi-e2e-conformance-main
@@ -277,10 +277,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-main
     testgrid-tab-name: capi-e2e-conformance-ci-latest-main
@@ -342,10 +342,10 @@ periodics:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-main
     testgrid-tab-name: capi-e2e-latestk8s-main

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits.yaml
@@ -195,10 +195,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-main
       testgrid-tab-name: capi-pr-e2e-mink8s-main
@@ -285,10 +285,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-main
       testgrid-tab-name: capi-pr-e2e-main
@@ -331,10 +331,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-main
       testgrid-tab-name: capi-pr-e2e-main-gke
@@ -424,10 +424,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-main
       testgrid-tab-name: capi-pr-e2e-conformance-main
@@ -467,10 +467,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-main
       testgrid-tab-name: capi-pr-e2e-conformance-ci-latest-main
@@ -526,10 +526,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-main
       testgrid-tab-name: capi-pr-e2e-latestk8s-main

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-11-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-11-periodics.yaml
@@ -119,10 +119,10 @@ periodics:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.11
     testgrid-tab-name: capi-e2e-release-1-11
@@ -179,10 +179,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.11
     testgrid-tab-name: capi-e2e-mink8s-release-1-11
@@ -228,10 +228,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.11
     testgrid-tab-name: capi-e2e-conformance-release-1-11
@@ -277,10 +277,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.11
     testgrid-tab-name: capi-e2e-conformance-ci-latest-release-1-11

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-11-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-11-presubmits.yaml
@@ -195,10 +195,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.11
       testgrid-tab-name: capi-pr-e2e-mink8s-release-1-11
@@ -285,10 +285,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.11
       testgrid-tab-name: capi-pr-e2e-release-1-11
@@ -378,10 +378,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.11
       testgrid-tab-name: capi-pr-e2e-conformance-release-1-11
@@ -421,10 +421,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.11
       testgrid-tab-name: capi-pr-e2e-conformance-ci-latest-release-1-11

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-12-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-12-periodics.yaml
@@ -119,10 +119,10 @@ periodics:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.12
     testgrid-tab-name: capi-e2e-release-1-12
@@ -179,10 +179,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.12
     testgrid-tab-name: capi-e2e-mink8s-release-1-12
@@ -228,10 +228,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.12
     testgrid-tab-name: capi-e2e-conformance-release-1-12
@@ -277,10 +277,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.12
     testgrid-tab-name: capi-e2e-conformance-ci-latest-release-1-12

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-12-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-12-presubmits.yaml
@@ -195,10 +195,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.12
       testgrid-tab-name: capi-pr-e2e-mink8s-release-1-12
@@ -285,10 +285,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.12
       testgrid-tab-name: capi-pr-e2e-release-1-12
@@ -378,10 +378,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.12
       testgrid-tab-name: capi-pr-e2e-conformance-release-1-12
@@ -421,10 +421,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.12
       testgrid-tab-name: capi-pr-e2e-conformance-ci-latest-release-1-12

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-13-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-13-periodics.yaml
@@ -119,10 +119,10 @@ periodics:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.13
     testgrid-tab-name: capi-e2e-release-1-13
@@ -179,10 +179,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.13
     testgrid-tab-name: capi-e2e-mink8s-release-1-13
@@ -228,10 +228,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.13
     testgrid-tab-name: capi-e2e-conformance-release-1-13
@@ -277,10 +277,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.13
     testgrid-tab-name: capi-e2e-conformance-ci-latest-release-1-13

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-13-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-13-presubmits.yaml
@@ -195,10 +195,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.13
       testgrid-tab-name: capi-pr-e2e-mink8s-release-1-13
@@ -285,10 +285,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.13
       testgrid-tab-name: capi-pr-e2e-release-1-13
@@ -378,10 +378,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.13
       testgrid-tab-name: capi-pr-e2e-conformance-release-1-13
@@ -421,10 +421,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.13
       testgrid-tab-name: capi-pr-e2e-conformance-ci-latest-release-1-13

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-14-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-14-periodics.yaml
@@ -119,10 +119,10 @@ periodics:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.14
     testgrid-tab-name: capi-e2e-release-1-14
@@ -179,10 +179,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.14
     testgrid-tab-name: capi-e2e-mink8s-release-1-14
@@ -228,10 +228,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.14
     testgrid-tab-name: capi-e2e-conformance-release-1-14
@@ -277,10 +277,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-1.14
     testgrid-tab-name: capi-e2e-conformance-ci-latest-release-1-14

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-14-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-14-presubmits.yaml
@@ -195,10 +195,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.14
       testgrid-tab-name: capi-pr-e2e-mink8s-release-1-14
@@ -285,10 +285,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.14
       testgrid-tab-name: capi-pr-e2e-release-1-14
@@ -378,10 +378,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.14
       testgrid-tab-name: capi-pr-e2e-conformance-release-1-14
@@ -421,10 +421,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-1.14
       testgrid-tab-name: capi-pr-e2e-conformance-ci-latest-release-1-14

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics.yaml.tpl
@@ -135,10 +135,10 @@ periodics:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-{{ TrimPrefix $.branch "release-" }}
     testgrid-tab-name: capi-e2e-{{ ReplaceAll $.branch "." "-" }}
@@ -204,10 +204,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-{{ TrimPrefix $.branch "release-" }}
     testgrid-tab-name: capi-e2e-mink8s-{{ ReplaceAll $.branch "." "-" }}
@@ -262,10 +262,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-{{ TrimPrefix $.branch "release-" }}
     testgrid-tab-name: capi-e2e-conformance-{{ ReplaceAll $.branch "." "-" }}
@@ -320,10 +320,10 @@ periodics:
       resources:
         requests:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
         limits:
           cpu: 4000m
-          memory: 12Gi
+          memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-{{ TrimPrefix $.branch "release-" }}
     testgrid-tab-name: capi-e2e-conformance-ci-latest-{{ ReplaceAll $.branch "." "-" }}
@@ -394,10 +394,10 @@ periodics:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
   annotations:
     testgrid-dashboards: cluster-api-core-{{ TrimPrefix $.branch "release-" }}
     testgrid-tab-name: capi-e2e-latestk8s-{{ ReplaceAll $.branch "." "-" }}

--- a/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
+++ b/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-presubmits.yaml.tpl
@@ -223,10 +223,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-{{ TrimPrefix $.branch "release-" }}
       testgrid-tab-name: capi-pr-e2e-mink8s-{{ ReplaceAll $.branch "." "-" }}
@@ -336,10 +336,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-{{ TrimPrefix .branch "release-" }}
       testgrid-tab-name: capi-pr-e2e-{{ ReplaceAll .branch "." "-" }}{{ $jobSuffix }}
@@ -453,10 +453,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-{{ TrimPrefix $.branch "release-" }}
       testgrid-tab-name: capi-pr-e2e-conformance-{{ ReplaceAll $.branch "." "-" }}
@@ -505,10 +505,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-{{ TrimPrefix $.branch "release-" }}
       testgrid-tab-name: capi-pr-e2e-conformance-ci-latest-{{ ReplaceAll $.branch "." "-" }}
@@ -573,10 +573,10 @@ presubmits:
         resources:
           requests:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
           limits:
             cpu: 4000m
-            memory: 12Gi
+            memory: 16Gi
     annotations:
       testgrid-dashboards: cluster-api-core-{{ TrimPrefix $.branch "release-" }}
       testgrid-tab-name: capi-pr-e2e-latestk8s-{{ ReplaceAll $.branch "." "-" }}


### PR DESCRIPTION
CAPI needs more memory now after https://github.com/kubernetes-sigs/cluster-api/pull/13898

But the upside is that jobs are now *much* faster (~ -30min)