### PR TITLE
Fix missing preset-kops-scalability-common when it was extracted from preset-kops-scalability-gce-common

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-presubmit-jobs.yaml
@@ -202,6 +202,7 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
+      preset-kops-scalability-common: "true"
       preset-kops-scalability-gce-common: "true"
       preset-kops-scalability-gce-5000-node: "true"
       preset-kops-scalability-gce-experimental: "true"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -649,6 +649,7 @@ periodics:
   cluster: k8s-infra-prow-build
   labels:
     preset-k8s-ssh: "true"
+    preset-kops-scalability-common: "true"
     preset-kops-scalability-gce-common: "true"
     preset-kops-scalability-gce-100-node: "true"
   decorate: true

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -664,6 +664,7 @@ presubmits:
     run_if_changed: ^clusterloader2/.*$
     labels:
       preset-k8s-ssh: "true"
+      preset-kops-scalability-common: "true"
       preset-kops-scalability-gce-common: "true"
       preset-kops-scalability-gce-100-node: "true"
     decorate: true
@@ -708,6 +709,7 @@ presubmits:
     optional: true
     labels:
       preset-k8s-ssh: "true"
+      preset-kops-scalability-common: "true"
       preset-kops-scalability-gce-common: "true"
       preset-kops-scalability-gce-100-node: "true"
       preset-kops-scalability-gce-experimental: "true"
@@ -752,6 +754,7 @@ presubmits:
     always_run: false
     labels:
       preset-k8s-ssh: "true"
+      preset-kops-scalability-common: "true"
       preset-kops-scalability-gce-common: "true"
       preset-kops-scalability-gce-5000-node: "true"
     decorate: true


### PR DESCRIPTION
Fixes jobs broken by https://github.com/kubernetes/test-infra/pull/37548#issuecomment-5180438107

/assign @upodroid 