### PR TITLE
e2e_node: drop the vestigial GPU host from the containerd serial image config

### DIFF
--- a/jobs/e2e_node/containerd/image-config-serial.yaml
+++ b/jobs/e2e_node/containerd/image-config-serial.yaml
@@ -7,15 +7,6 @@ images:
     image_regex: ".*[^-cgroupsv1]$"
     machine: e2-standard-2 # These tests need a lot of memory
     metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
-  cos-2:
-    image_family: cos-129-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
-    project: cos-cloud
-    machine: n1-standard-4 # These tests need a lot of memory
-    metadata: "user-data</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/init.yaml,cni-template</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cni.template,containerd-config</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/config.toml,registry-config-docker</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/hosts-docker.toml"
-    resources:
-      accelerators:
-        - type: nvidia-tesla-t4
-          count: 2
   cos-1:
     image_family: cos-129-lts # keep in sync with jobs/e2e_node/containerd/image-config.yaml
     project: cos-cloud


### PR DESCRIPTION
#### What this PR does:

Removes the `cos-2` host from `jobs/e2e_node/containerd/image-config-serial.yaml`. That host requests an `n1-standard-4` with two `nvidia-tesla-t4` accelerators.

Three reasons:

1. **Nothing uses the GPUs.** The GPU device plugin tests were removed from `test/e2e_node` in September 2024 (kubernetes/kubernetes@2fbbca62791), so every run since then has provisioned two T4s for a suite with no GPU test in it. The stanza dates from 2021 (55700509af, K80 era) and was kept looking current by the K80 to T4 EOL swap in 2024 (ff132e27d5).
2. **The GPU is a reliability tax.** T4 capacity in us-central1-b runs out regularly; each `ZONE_RESOURCE_POOL_EXHAUSTED` stockout fails the whole job while the other hosts pass everything. Two of three runs of `pull-kubernetes-node-kubelet-serial-containerd` on kubernetes/kubernetes#141146 failed exactly this way (builds 2084468173834293248 and 2084642507584442368).
3. **No coverage is lost.** Apart from the GPU, `cos-2` is byte for byte the same as `cos-1` (same `cos-129-lts` family, same metadata), so the job was testing the identical image twice.

After this change the job tests `cos-129-lts` and the `pipeline-1-34-amd64` Ubuntu image, once each.

/sig node
