### PR TITLE
Revert "Skip Kuberay test in periodic dra test"

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics-main.yaml
@@ -124,8 +124,6 @@ periodics:
           value: latest
         - name: AZURE_CONTROL_PLANE_MACHINE_TYPE
           value: Standard_D8s_v3
-        - name: GINKGO_SKIP
-          value: \[KubeRay\]
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Reverts kubernetes/test-infra#37593. The problem is actually with the new DRA workload resource claim flags which will be fixed in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6538