### PR TITLE
cluster-api-provider-gcp: bump make job memory to 8Gi

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-main.yaml
@@ -74,10 +74,10 @@ presubmits:
         resources:
           limits:
             cpu: 4
-            memory: 4Gi
+            memory: 8Gi
           requests:
             cpu: 4
-            memory: 4Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-make

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-10.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-10.yaml
@@ -69,10 +69,10 @@ presubmits:
         resources:
           limits:
             cpu: 4
-            memory: 4Gi
+            memory: 8Gi
           requests:
             cpu: 4
-            memory: 4Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-make-release-1-10

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-11.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits-release-1-11.yaml
@@ -69,10 +69,10 @@ presubmits:
         resources:
           limits:
             cpu: 4
-            memory: 4Gi
+            memory: 8Gi
           requests:
             cpu: 4
-            memory: 4Gi
+            memory: 8Gi
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-make-release-1-11


### PR DESCRIPTION
The `pull-cluster-api-provider-gcp-make` job is OOM killed during
`go build` of the large `google.golang.org/api/compute/v0.alpha`
package inside Docker-in-Docker under the current 4Gi memory limit.

Example failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-gcp/1713/pull-cluster-api-provider-gcp-make/2084652683678978048

This bumps memory requests/limits from 4Gi to 8Gi for the make
job across all branches (main, release-1.10, release-1.11).

/cc @kubernetes-sigs/cluster-api-provider-gcp-maintainers