### PR TITLE
Add v1.37 and remove v1.33 milestone_applier rules

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -514,10 +514,10 @@ milestone_applier:
     master: v1.37
   kubernetes/kubernetes:
     master: v1.37
+    release-1.37: v1.37
     release-1.36: v1.36
     release-1.35: v1.35
     release-1.34: v1.34
-    release-1.33: v1.33
   kubernetes/org:
     main: v1.37
   kubernetes/release:


### PR DESCRIPTION
Add v1.37 and remove v1.33 milestone_applier rules

/hold
The hold should only be cancelled once v1.37.0-rc.0 is released and post-release branch creation tasks start

/sig release
/area release-eng