### PR TITLE
Update kubekins-e2e variants.yaml with v1.37 config

### DIFF
--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -5,6 +5,12 @@ variants:
     K8S_BRANCH: master
     BAZEL_VERSION: 3.4.1
     DOCKER_VERSION: 5:29.*
+  '1.37':
+    CONFIG: '1.37'
+    K8S_RELEASE: latest-1.37
+    K8S_BRANCH: release-1.37
+    BAZEL_VERSION: 3.4.1
+    DOCKER_VERSION: 5:28.*
   '1.36':
     CONFIG: '1.36'
     K8S_RELEASE: latest-1.36


### PR DESCRIPTION
Update kubekins-e2e variants.yaml with v1.37 config

/hold
The hold should only be cancelled once v1.37.0-rc.0 is released and post-release branch creation tasks start

/sig release
/area release-eng