### PR TITLE
Revert Migrate CAPI release-1.12/1.11 to kubekins-e2e-v2

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-prowjob-gen.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-prowjob-gen.yaml
@@ -91,7 +91,7 @@ prow_ignored:
         - from: "1.36"
           to: "1.37"
     release-1.12:
-      testImage: "us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34"
+      testImage: "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34"
       interval: "4h"
       upgradesInterval: "24h"
       kubernetesVersionManagement: "v1.31.12"
@@ -112,7 +112,7 @@ prow_ignored:
         - from: "1.35"
           to: "1.36"
     release-1.11:
-      testImage: "us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33"
+      testImage: "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33"
       interval: "4h"
       upgradesInterval: "24h"
       kubernetesVersionManagement: "v1.30.10"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-11-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-11-periodics-upgrades.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -81,7 +81,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -138,7 +138,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -195,7 +195,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -252,7 +252,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -309,7 +309,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-11-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-11-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
       command:
       - runner.sh
       - ./scripts/ci-test.sh
@@ -50,7 +50,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
       command:
       - runner.sh
       - ./scripts/ci-test.sh
@@ -100,7 +100,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -152,7 +152,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -212,7 +212,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -261,7 +261,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-11-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-11-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^release-1.11$
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -44,7 +44,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         resources:
           requests:
             cpu: 6000m
@@ -69,7 +69,7 @@ presubmits:
     - ^release-1.11$
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         command:
         - "runner.sh"
         - ./scripts/ci-verify.sh
@@ -98,7 +98,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|core|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -124,7 +124,7 @@ presubmits:
     - ^release-1.11$
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -168,7 +168,7 @@ presubmits:
     - ^release-1.11$
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         args:
         - runner.sh
         - ./scripts/ci-e2e.sh
@@ -223,7 +223,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|core|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -266,7 +266,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -312,7 +312,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -362,7 +362,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -405,7 +405,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.33
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.33
         args:
         - runner.sh
         - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-12-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-12-periodics-upgrades.yaml
@@ -24,7 +24,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -81,7 +81,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -138,7 +138,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -195,7 +195,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -252,7 +252,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -309,7 +309,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -366,7 +366,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-12-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-12-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       command:
       - runner.sh
       - ./scripts/ci-test.sh
@@ -50,7 +50,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       command:
       - runner.sh
       - ./scripts/ci-test.sh
@@ -100,7 +100,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -152,7 +152,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -212,7 +212,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"
@@ -261,7 +261,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
       args:
       - runner.sh
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-12-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-release-1-12-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^release-1.12$
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -44,7 +44,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+        image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         resources:
           requests:
             cpu: 6000m
@@ -69,7 +69,7 @@ presubmits:
     - ^release-1.12$
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         command:
         - "runner.sh"
         - ./scripts/ci-verify.sh
@@ -98,7 +98,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|core|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -124,7 +124,7 @@ presubmits:
     - ^release-1.12$
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -168,7 +168,7 @@ presubmits:
     - ^release-1.12$
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         args:
         - runner.sh
         - ./scripts/ci-e2e.sh
@@ -223,7 +223,7 @@ presubmits:
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|core|errors|exp|feature|hack|internal|scripts|test|util|webhooks|version)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -266,7 +266,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -312,7 +312,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -362,7 +362,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         args:
         - runner.sh
         - "./scripts/ci-e2e.sh"
@@ -405,7 +405,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.34
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
         args:
         - runner.sh
         - "./scripts/ci-e2e.sh"


### PR DESCRIPTION
kubekins-e2e-v2 didn't work for us, so have to revert for now (CAPI controller didn't come up anymore in kind)

xref: https://github.com/kubernetes/test-infra/issues/36065