### PR TITLE
Add perodic and presubmit job for CAPI main with kubekins-e2e-v2 image

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-v2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-periodics-v2.yaml
@@ -1,0 +1,57 @@
+# Additional periodic jobs for CAPI main branch using the kubekins-e2e-v2 image
+# These jobs are intentionally
+# separate from the generated jobs so that we can validate the new image works
+# correctly on main before rolling it out to release branches.
+periodics:
+- name: periodic-cluster-api-e2e-main-v2
+  cluster: eks-prow-build-cluster
+  interval: 3h
+  decorate: true
+  decoration_config:
+    timeout: 180m
+  rerun_auth_config:
+    github_team_slugs:
+    - org: kubernetes-sigs
+      slug: cluster-api-maintainers
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: main
+    path_alias: sigs.k8s.io/cluster-api
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.36
+        args:
+          - runner.sh
+          - ./hack/scripts/ci/ci-e2e.sh
+        env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
+          - name: GINKGO_LABEL_FILTER
+            value: "!Conformance"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 4000m
+            memory: 16Gi
+          limits:
+            cpu: 4000m
+            memory: 16Gi
+  annotations:
+    testgrid-dashboards: cluster-api-core-main
+    testgrid-tab-name: capi-e2e-main-v2
+    testgrid-alert-email: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    testgrid-num-failures-to-alert: "4"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits-v2.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-main-presubmits-v2.yaml
@@ -1,0 +1,52 @@
+# Additional pre-submit jobs for CAPI main branch using the kubekins-e2e-v2 image
+# These jobs are intentionally
+# separate from the generated jobs so that we can validate the new image works
+# correctly on main before rolling it out to release branches.
+presubmits:
+  kubernetes-sigs/cluster-api:
+  - name: pull-cluster-api-e2e-main-v2
+    cluster: eks-prow-build-cluster
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    decorate: true
+    decoration_config:
+      timeout: 180m
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^main$
+    path_alias: sigs.k8s.io/cluster-api
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260803-75cc24a334-1.36
+        args:
+          - runner.sh
+          - ./hack/scripts/ci/ci-e2e.sh
+        env:
+          # enable IPV6 in bootstrap image
+          - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+            value: "true"
+          - name: GINKGO_LABEL_FILTER
+            value: "!Conformance"
+          # Ensure required kind images get built.
+          - name: KIND_BUILD_IMAGES
+            value: "KUBERNETES_VERSION,KUBERNETES_VERSION_LATEST_CI,KUBERNETES_VERSION_UPGRADE_TO,KUBERNETES_VERSION_UPGRADE_FROM"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 4000m
+            memory: 16Gi
+          limits:
+            cpu: 4000m
+            memory: 16Gi
+    annotations:
+      testgrid-dashboards: cluster-api-core-main
+      testgrid-tab-name: capi-pr-e2e-main-v2


### PR DESCRIPTION
This PR contains changes to add periodic and presubmit job for CAPI main branch using kubekins-v2 image, The goal is to evaluate the impact of using the new images for the job.

Related https://github.com/kubernetes/test-infra/pull/37620