### PR TITLE
bump kubekins docker version to v29

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-releng.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-releng.yaml
@@ -115,7 +115,6 @@ postsubmits:
             args:
               - --project=k8s-staging-releng
               - --scratch-bucket=gs://k8s-staging-releng-gcb
-              - --env-passthrough=PULL_BASE_REF,REGISTRY
               - --build-dir=.
               - images/releng/gcb-docker-gcloud
             env:

--- a/images/kubekins-e2e-v2/variants.yaml
+++ b/images/kubekins-e2e-v2/variants.yaml
@@ -4,7 +4,7 @@ variants:
     K8S_RELEASE: stable
     K8S_BRANCH: master
     BAZEL_VERSION: 3.4.1
-    DOCKER_VERSION: 5:28.*
+    DOCKER_VERSION: 5:29.*
   '1.36':
     CONFIG: '1.36'
     K8S_RELEASE: latest-1.36


### PR DESCRIPTION
krte and gcb-docker-gcloud have been running docker v29 fine for a while