### PR TITLE
Bump 1.34 go-compatibility jobs to Go 1.25

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -3040,7 +3040,7 @@ presubmits:
         - runner.sh
         env:
         - name: GO_VERSION
-          value: 1.24.5
+          value: 1.25.4
         - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
           value: auto
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
@@ -3209,7 +3209,7 @@ presubmits:
         - runner.sh
         env:
         - name: GO_VERSION
-          value: 1.24.5
+          value: 1.25.4
         - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
           value: auto
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34
@@ -3387,7 +3387,7 @@ presubmits:
         - test
         env:
         - name: GO_VERSION
-          value: 1.24.5
+          value: 1.25.4
         - name: KUBE_HACK_TOOLS_GOTOOLCHAIN
           value: auto
         image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260803-75cc24a334-1.34


### PR DESCRIPTION
Security updates for dependencies on release-1.34 require a minimum of Go 1.25 (xref https://github.com/kubernetes/kubernetes/pull/141224). This bumps the 1.34 go-compatibility jobs to Go 1.25.4 levels matching the minimum version we shipped any Kubernetes release with (Kubernetes 1.35).

Go 1.24 is now unsupported, downstreams who wish to continue building client-go with Go 1.24 can pin to current v0.34.x releases.

/cc @dims