### PR TITLE
Fix config-rotator and config-forker bugs found in the 1.37 cut

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -67,13 +67,23 @@ var buildClusters = []string{
 
 // These are special prowjobs that can't fit on our standard build nodes
 // They should be be configured with appropriate nodeSelectors/tolerations
-var jobsExemptFromResourceLimits = []string{
-	"ci-kubernetes-build",
-	"ci-kubernetes-e2e-gce-scale-performance-5000",
-	"ci-kubernetes-e2e-gce-scale-performance-5000-experimental",
-	"pull-kubernetes-gce-master-scale-performance-5000",
-	"pull-kubernetes-gce-master-scale-performance-5000-experimental",
-	"pull-perf-tests-gce-master-scale-performance-5000",
+// Each entry must match the whole job name. Use a pattern for a job that
+// is forked per release, so a new branch does not need a new entry.
+var jobsExemptFromResourceLimits = []*regexp.Regexp{
+	// Also matches the release forks, such as ci-kubernetes-build-1-37.
+	regexp.MustCompile(`^ci-kubernetes-build(-1-\d+)?$`),
+	regexp.MustCompile(`^ci-kubernetes-e2e-gce-scale-performance-5000$`),
+	regexp.MustCompile(`^ci-kubernetes-e2e-gce-scale-performance-5000-experimental$`),
+	regexp.MustCompile(`^pull-kubernetes-gce-master-scale-performance-5000$`),
+	regexp.MustCompile(`^pull-kubernetes-gce-master-scale-performance-5000-experimental$`),
+	regexp.MustCompile(`^pull-perf-tests-gce-master-scale-performance-5000$`),
+}
+
+func isExemptFromResourceLimits(jobName string) bool {
+	return slices.ContainsFunc(
+		jobsExemptFromResourceLimits,
+		func(re *regexp.Regexp) bool { return re.MatchString(jobName) },
+	)
 }
 
 func TestMain(m *testing.M) {
@@ -1201,7 +1211,7 @@ func verifyPodQOSGuaranteed(spec *coreapi.PodSpec, required bool, jobName string
 			} else if limit.Cmp(request) != 0 {
 				errs = append(errs, fmt.Errorf("resources.limits[%v] (%v) %v match resources.request[%v] (%v)", r, limit.String(), should, r, request.String()))
 			} else if r == coreapi.ResourceMemory {
-				if slices.Contains(jobsExemptFromResourceLimits, jobName) {
+				if isExemptFromResourceLimits(jobName) {
 					continue
 				}
 				// Enforce a maximum memory limit to allow jobs to fit in an 8 core, 30G Node
@@ -1210,7 +1220,7 @@ func verifyPodQOSGuaranteed(spec *coreapi.PodSpec, required bool, jobName string
 					errs = append(errs, fmt.Errorf("container '%v' resources.limits[%v] (%v) %v be at most %v", c.Name, r, limit.String(), should, maxMem.String()))
 				}
 			} else if r == coreapi.ResourceCPU {
-				if slices.Contains(jobsExemptFromResourceLimits, jobName) {
+				if isExemptFromResourceLimits(jobName) {
 					continue
 				}
 				// Enforce a maximum CPU limit to allow jobs to fit in an 8 core, 30G Node

--- a/releng/config-forker/pkg/forker.go
+++ b/releng/config-forker/pkg/forker.go
@@ -323,9 +323,15 @@ func generatePresubmits(
 			job.SkipBranches = nil
 			job.Branches = []string{"release-" + vars.Version}
 
-			job.Context = generatePresubmitContextVariant(
-				job.Name, job.Context, vars.Version,
-			)
+			// Presubmits keep their master name, so the default context
+			// has to keep it too. An explicit context is versioned.
+			if job.Context == "" {
+				job.Context = job.Name
+			} else {
+				job.Context = replaceAllMaster(
+					job.Context, "-"+vars.Version,
+				)
+			}
 
 			if err := processContainers(
 				ctx, job.Spec, vars,
@@ -813,18 +819,6 @@ func generateNameVariant(
 
 	if !strings.HasSuffix(name, masterSuffix) {
 		return name + suffix
-	}
-
-	return replaceAllMaster(name, suffix)
-}
-
-func generatePresubmitContextVariant(
-	name, context, version string,
-) string {
-	suffix := "-" + version
-
-	if context != "" {
-		return replaceAllMaster(context, suffix)
 	}
 
 	return replaceAllMaster(name, suffix)

--- a/releng/config-forker/pkg/forker_test.go
+++ b/releng/config-forker/pkg/forker_test.go
@@ -645,7 +645,9 @@ func TestGeneratePresubmits(t *testing.T) {
 					Branches: []string{"release-1.15"},
 				},
 				Reporter: config.Reporter{
-					Context: "pull-kubernetes-e2e-branch-in-name-1.15",
+					// The forker does not version presubmit names, so
+					// the default context has to match the name.
+					Context: "pull-kubernetes-e2e-branch-in-name-master",
 				},
 			},
 			{

--- a/releng/config-rotator/pkg/rotator.go
+++ b/releng/config-rotator/pkg/rotator.go
@@ -100,20 +100,32 @@ func updateString(s, old, replacement string) string {
 	return strings.ReplaceAll(s, old, replacement)
 }
 
-func updateJobBase(job *config.JobBase, old, replacement string) {
-	job.Name = updateString(job.Name, old, replacement)
+// rotateSuffix replaces a trailing "-<old>" tier marker with "-<replacement>".
+// The tier is only ever a suffix. The "beta" in
+// pull-kubernetes-e2e-kind-alpha-beta-features means beta feature gates.
+func rotateSuffix(s, old, replacement string) string {
+	suffix := "-" + old
+	if !strings.HasSuffix(s, suffix) {
+		return s
+	}
 
+	return strings.TrimSuffix(s, suffix) + "-" + replacement
+}
+
+func updateJobBase(job *config.JobBase, old, replacement string) {
+	job.Name = rotateSuffix(job.Name, old, replacement)
+
+	// Args carry the tier only as a "k8s-" marker. A plain replace also hits
+	// unrelated values such as --runtime-config=api/beta=true.
 	for idx := range job.Spec.Containers {
 		container := &job.Spec.Containers[idx]
 
 		for argIdx := range container.Args {
 			container.Args[argIdx] = updateGenericVersionMarker(container.Args[argIdx])
-			container.Args[argIdx] = updateString(container.Args[argIdx], old, replacement)
 		}
 
 		for cmdIdx := range container.Command {
 			container.Command[cmdIdx] = updateGenericVersionMarker(container.Command[cmdIdx])
-			container.Command[cmdIdx] = updateString(container.Command[cmdIdx], old, replacement)
 		}
 	}
 }
@@ -141,7 +153,7 @@ func updatePeriodicAnnotations(periodic *config.Periodic, old, replacement strin
 
 	for key, val := range periodic.Annotations {
 		if key == "testgrid-tab-name" || key == "testgrid-dashboards" {
-			periodic.Annotations[key] = updateString(val, old, replacement)
+			periodic.Annotations[key] = rotateSuffix(val, old, replacement)
 		}
 	}
 }
@@ -151,7 +163,7 @@ func updatePeriodic(periodic *config.Periodic, old, replacement string) {
 	updatePeriodicAnnotations(periodic, old, replacement)
 
 	for tagIdx := range periodic.Tags {
-		periodic.Tags[tagIdx] = updateString(periodic.Tags[tagIdx], old, replacement)
+		periodic.Tags[tagIdx] = rotateSuffix(periodic.Tags[tagIdx], old, replacement)
 	}
 }
 
@@ -159,6 +171,10 @@ func updateEverything(jobConfig *config.JobConfig, old, replacement string) {
 	for _, presubmits := range jobConfig.PresubmitsStatic {
 		for idx := range presubmits {
 			updateJobBase(&presubmits[idx].JobBase, old, replacement)
+			// The context must keep matching the name.
+			presubmits[idx].Context = rotateSuffix(
+				presubmits[idx].Context, old, replacement,
+			)
 		}
 	}
 

--- a/releng/config-rotator/pkg/rotator_test.go
+++ b/releng/config-rotator/pkg/rotator_test.go
@@ -16,7 +16,79 @@ limitations under the License.
 
 package rotator
 
-import "testing"
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/prow/pkg/config"
+)
+
+func TestRotateSuffix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "tier suffix rotates",
+			in:   "ci-kubernetes-e2e-gce-cos-default-beta",
+			want: "ci-kubernetes-e2e-gce-cos-default-stable1",
+		},
+		{
+			name: "beta feature gates stay",
+			in:   "pull-kubernetes-e2e-kind-alpha-beta-features",
+			want: "pull-kubernetes-e2e-kind-alpha-beta-features",
+		},
+		{
+			name: "beta without a dash stays",
+			in:   "pull-kubernetes-betabeta",
+			want: "pull-kubernetes-betabeta",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := rotateSuffix(tt.in, "beta", "stable1"); got != tt.want {
+				t.Errorf("rotateSuffix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateJobBaseArgs(t *testing.T) {
+	t.Parallel()
+
+	job := config.JobBase{
+		Name: "ci-kubernetes-e2e-gce-cos-default-beta",
+		Spec: &v1.PodSpec{
+			Containers: []v1.Container{{
+				Args: []string{
+					"--extra-version-markers=k8s-beta",
+					"--runtime-config=api/alpha=true,api/beta=true",
+				},
+			}},
+		},
+	}
+
+	updateJobBase(&job, "beta", "stable1")
+
+	if want := "ci-kubernetes-e2e-gce-cos-default-stable1"; job.Name != want {
+		t.Errorf("Name = %v, want %v", job.Name, want)
+	}
+
+	want := []string{
+		"--extra-version-markers=k8s-stable1",
+		"--runtime-config=api/alpha=true,api/beta=true",
+	}
+	for idx, arg := range job.Spec.Containers[0].Args {
+		if arg != want[idx] {
+			t.Errorf("Args[%d] = %v, want %v", idx, arg, want[idx])
+		}
+	}
+}
 
 func TestUpdateGenericVersionMarker(t *testing.T) {
 	t.Parallel()

--- a/releng/prepare-release-branch/internal/run/run.go
+++ b/releng/prepare-release-branch/internal/run/run.go
@@ -23,7 +23,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -57,9 +60,17 @@ func RotateFiles(branchDir string, version release.Version) error {
 
 	for index := range len(suffixes) - 1 {
 		target := release.Version{Major: version.Major, Minor: version.Minor - index}
+		configFile := filepath.Join(branchDir, target.Filename())
+
+		// Configs for releases that are out of support get deleted.
+		if _, err := os.Stat(configFile); errors.Is(err, fs.ErrNotExist) {
+			log.Printf("Skipping %s, no config file", target.Filename())
+
+			continue
+		}
 
 		if err := rotator.Run(rotator.Options{
-			ConfigFile: filepath.Join(branchDir, target.Filename()),
+			ConfigFile: configFile,
 			OldVersion: suffixes[index],
 			NewVersion: suffixes[index+1],
 		}); err != nil {

--- a/releng/prepare-release-branch/internal/run/run_test.go
+++ b/releng/prepare-release-branch/internal/run/run_test.go
@@ -39,6 +39,16 @@ func TestSuffixes(t *testing.T) {
 	}
 }
 
+func TestRotateFilesSkipsMissingConfigs(t *testing.T) {
+	t.Parallel()
+
+	// An empty directory stands in for a repo where every out of support
+	// release config was deleted.
+	if err := run.RotateFiles(t.TempDir(), release.Version{Major: 1, Minor: 36}); err != nil {
+		t.Errorf("RotateFiles() = %v, want nil", err)
+	}
+}
+
 func TestFetchGoVersion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Three fixes found while cutting the 1.37 release branch jobs. All three are
in the generators and the test policy. No job config changes.

Depends on #37642, which adds `skip_branches` to
`pull-kubernetes-e2e-gce-cos-serial`. Without that, generation produces a
duplicate presubmit and checkconfig fails.

### config-rotator renamed unrelated jobs

The rotator replaced the tier name anywhere it appeared in a job name or a
container arg. The tier is only ever a suffix, so the plain replace also
hit:

- job names where `beta` means beta feature gates, such as
  `pull-kubernetes-e2e-kind-alpha-beta-features`, which became
  `pull-kubernetes-e2e-kind-alpha-stable1-features` while the job kept
  `FEATURE_GATES: {"AllBeta":true}`. The rotator does not update the
  `context` field, so the name and the context stopped matching and
  `config/tests/jobs` failed.
- the `--runtime-config=api/beta=true` flag, which became
  `api/stable1=true`.

The tier is now matched as a suffix. Container args carry the tier only as
a `k8s-` version marker, which `updateGenericVersionMarker` already
rotates, so the plain replace there is gone. The presubmit context now
rotates with the name.

### prepare-release-branch failed on a deleted config

```
rotating 1.33.yaml (stable3 to stable4): failed to load job config:
stat config/jobs/kubernetes/sig-release/release-branch-jobs/1.33.yaml:
no such file or directory
```

Configs for releases that are out of support get deleted, so the oldest
tiers often have no file left. Skip them and log each skip.

This one caused real damage. `RotateFiles` writes each file as it goes, so
it had already rewritten 1.36, 1.35 and 1.34 before it stopped. Running the
command again rotated those three a second time. Two field types advance
from their own current value:

- `cron` and `interval` come from a queue in the `fork-per-release-cron`
  and `fork-per-release-periodic-interval` annotations. Each run pops the
  head.
- `--extra-version-markers` reads the current tier and moves to the next.

So a branch can end up testing less often than intended, and a tier marker
can end up published by no branch at all.

### config-forker versioned the presubmit context

The forker does not version presubmit names. Release branch presubmits keep
the master name and the branch filter tells them apart. The context was
versioned anyway, so `pull-kubernetes-e2e-gce-master-scale-performance-100`
got the context `pull-kubernetes-e2e-gce-1.37-scale-performance-100` and
failed `TestContextMatches`.

The default context now follows the job name. An explicit context is still
versioned, since it is set on purpose.

### Resource limit exemptions are now patterns

`ci-kubernetes-build` is exempt from the standard node limits because it
runs on the build node pool. Every cut forks it again as
`ci-kubernetes-build-1-37`, and the fork keeps the same nodeSelector and
toleration but needed its own entry. The list now holds anchored patterns,
so a new release branch does not need a new entry.

### Testing

- `make go-unit` passes, 8201 tests.
- Ran `make -C releng prepare-release-branch` on a clean tree with these
  fixes plus #37642. It completed, skipped the missing 1.33.yaml, and left
  only the usual per cut steps: add the two 1.37 testgrid dashboards and
  run `make update-config-fixture`.
- The generated `1.37.yaml` is byte for byte the same as the file in
  #37641, and the rotated 1.34, 1.35 and 1.36 come out correct instead of
  one tier too far.
- `checkconfig` passes on that generated tree using the CI image.
