### PR TITLE
Point 1.37 DRA node jobs at release-1.37 artifacts

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.37.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.37.yaml
@@ -859,7 +859,7 @@ periodics:
       - --
       - --use-binaries-from-package
       - --test-package-url=https://dl.k8s.io
-      - --test-package-dir=ci/fast
+      - --test-package-dir=ci
       - --test-package-marker=latest-1.37.txt
       - --gcp-zone=us-central1-b
       - --parallelism=1
@@ -915,7 +915,7 @@ periodics:
       - --
       - --use-binaries-from-package
       - --test-package-url=https://dl.k8s.io
-      - --test-package-dir=ci/fast
+      - --test-package-dir=ci
       - --test-package-marker=latest-1.37.txt
       - --gcp-zone=us-central1-b
       - --parallelism=1
@@ -964,7 +964,7 @@ periodics:
       - --
       - --use-binaries-from-package
       - --test-package-url=https://dl.k8s.io
-      - --test-package-dir=ci/fast
+      - --test-package-dir=ci
       - --test-package-marker=latest-1.37.txt
       - --gcp-zone=us-central1-b
       - --parallelism=1
@@ -1016,7 +1016,7 @@ periodics:
       - --
       - --use-binaries-from-package
       - --test-package-url=https://dl.k8s.io
-      - --test-package-dir=ci/fast
+      - --test-package-dir=ci
       - --test-package-marker=latest-1.37.txt
       - --gcp-zone=us-central1-b
       - --parallelism=1
@@ -1068,7 +1068,7 @@ periodics:
       - --
       - --use-binaries-from-package
       - --test-package-url=https://dl.k8s.io
-      - --test-package-dir=ci/fast
+      - --test-package-dir=ci
       - --test-package-marker=latest-1.37.txt
       - --gcp-zone=us-central1-b
       - --parallelism=1
@@ -5454,8 +5454,8 @@ presubmits:
         - --
         - --use-binaries-from-package
         - --test-package-url=https://dl.k8s.io
-        - --test-package-dir=ci/fast
-        - --test-package-marker=latest-fast.txt
+        - --test-package-dir=ci
+        - --test-package-marker=latest-1.37.txt
         - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow'
@@ -5505,8 +5505,8 @@ presubmits:
         - --
         - --use-binaries-from-package
         - --test-package-url=https://dl.k8s.io
-        - --test-package-dir=ci/fast
-        - --test-package-marker=latest-fast.txt
+        - --test-package-dir=ci
+        - --test-package-marker=latest-1.37.txt
         - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow'
@@ -5549,8 +5549,8 @@ presubmits:
         - --
         - --use-binaries-from-package
         - --test-package-url=https://dl.k8s.io
-        - --test-package-dir=ci/fast
-        - --test-package-marker=latest-fast.txt
+        - --test-package-dir=ci
+        - --test-package-marker=latest-1.37.txt
         - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow'
@@ -5597,8 +5597,8 @@ presubmits:
         - --
         - --use-binaries-from-package
         - --test-package-url=https://dl.k8s.io
-        - --test-package-dir=ci/fast
-        - --test-package-marker=latest-fast.txt
+        - --test-package-dir=ci
+        - --test-package-marker=latest-1.37.txt
         - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow'
@@ -5645,8 +5645,8 @@ presubmits:
         - --
         - --use-binaries-from-package
         - --test-package-url=https://dl.k8s.io
-        - --test-package-dir=ci/fast
-        - --test-package-marker=latest-fast.txt
+        - --test-package-dir=ci
+        - --test-package-marker=latest-1.37.txt
         - --gcp-zone=us-central1-b
         - --parallelism=1
         - '--label-filter=DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow'


### PR DESCRIPTION
The five DRA node jobs on the [sig-release-1.37-informing](https://testgrid.k8s.io/sig-release-1.37-informing) board fail on every run:

```
package.go:51]  Defaulting to version from latest-1.37.txt: <Error><Code>NoSuchKey</Code>
                  No such object: k8s-release-dev/ci/fast/latest-1.37.txt
package.go:182] Downloading tar ball from: https://dl.k8s.io/ci/fast/<error-XML>/kubernetes-test-linux-amd64.tar.gz
F node.go:498]  failed to get packages from published releases: failed to create gzip reader: EOF
```

`ci/fast/latest-1.37.txt` does not exist and never will. `krel ci-build --fast` publishes exactly one marker, and the name has no minor version in it ([`pkg/release/publish.go`](https://github.com/kubernetes/release/blob/master/pkg/release/publish.go#L216)):

```go
if fast {
    versionMarkers = append(versionMarkers, releaseType+"-fast")   // "latest-fast", always
}
```

So `gs://k8s-release-dev/ci/fast/` holds one marker, `latest-fast.txt`, for master. Every version directory under it is a master build. There is no `ci/fast/latest-1.34.txt`, `-1.35`, `-1.36` or `-1.37`.

1.36 was not affected because its DRA node jobs build from source. 1.37 is the first branch forked after master switched those jobs to pre-built packages.

## Change

Point the five periodics at `ci`, where the release branch marker does live.

Also fix the five forked `kubernetes/test-infra` presubmits, which read `latest-fast.txt` from `ci/fast`. A file scoped to `release-1.37` was pulling master artifacts.

## Verification

`ci-kubernetes-e2e-gce-device-plugin-gpu-1-37` already uses this exact path and is green, through the same resolver:

```
package.go:51]  Defaulting to version from latest-1.37.txt: v1.37.0-rc.0.8+b87623f93c36a3
package.go:201] Downloading test tar ball from: https://dl.k8s.io/ci/v1.37.0-rc.0.8+b87623f93c36a3/kubernetes-test-linux-amd64.tar.gz
```

The artifacts resolve: gzip magic `1f8b`, 126789769 bytes, extracts `kubernetes/test/bin/ginkgo`. `ci/` holds the same linux-amd64 files as `ci/fast` (420 objects against 96) plus every other platform.

`checkconfig` passes with the same args as `pull-test-infra-prow-checkconfig`.

A follow-up PR stops the forker producing this again.

/sig release
/sig node
/area release-eng
