### PR TITLE
config-forker: fail on a replacement that matches nothing

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -17,7 +17,6 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
-      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -217,7 +216,6 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
-      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -345,7 +343,6 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
-      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -473,7 +470,6 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
-      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -599,7 +595,6 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
-      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -649,7 +644,7 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
-      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, ci/fast -> ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -770,7 +765,7 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
-      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, ci/fast -> ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -825,7 +820,7 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
-      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, ci/fast -> ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -880,7 +875,7 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
-      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, ci/fast -> ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -938,7 +933,7 @@ periodics:
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com, release-team@kubernetes.io
       fork-per-release: "true"
       fork-per-release-periodic-interval: 24h
-      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, ci/fast -> ci
     decorate: true
     decoration_config:
       timeout: 90m

--- a/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
@@ -19,6 +19,7 @@ presubmits:
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with CRI-O
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, ci/fast -> ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -78,6 +79,7 @@ presubmits:
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 1.7 on Ubuntu
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, ci/fast -> ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -130,6 +132,7 @@ presubmits:
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 1.7 on COS
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, ci/fast -> ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -182,6 +185,7 @@ presubmits:
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 2.1 on Ubuntu
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, ci/fast -> ci
     decorate: true
     decoration_config:
       timeout: 90m
@@ -237,6 +241,7 @@ presubmits:
       description: Runs E2E node tests for Dynamic Resource Allocation on-by-default features with containerd 2.1 on COS
       testgrid-alert-email: eduard.bartosh@intel.com, patrick.ohly@intel.com
       fork-per-release: "true"
+      fork-per-release-replacements: latest-fast.txt -> latest-{{.Version}}.txt, ci/fast -> ci
     decorate: true
     decoration_config:
       timeout: 90m

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -65,7 +65,13 @@ presubmits:
       fork-per-release: "true"
       {%- if ci %}
       fork-per-release-periodic-interval: 24h
-      fork-per-release-replacements: latest-fast.txt -> latest-{% raw %}{{.Version}}{% endraw %}.txt, https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
+      {%- endif %}
+      {#- Only the jobs that download a package need the marker rewritten, and
+          the rules must match how the args are written: the URL and the
+          directory are separate args, so "ci/fast" cannot be spelled as a
+          full URL here. Master keeps ci/fast; only the fork moves to ci. #}
+      {%- if job_type == "node" and ( ci or testinfra ) %}
+      fork-per-release-replacements: latest-fast.txt -> latest-{% raw %}{{.Version}}{% endraw %}.txt, ci/fast -> ci
       {%- endif %}
       {%- endif %}
     decorate: true

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -84,7 +84,10 @@ periodics:
         slug: release-managers
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "k8s-master -> k8s-beta, latest-default -> latest-{{.Version}}"
+    # No replacements. "k8s-master" stopped matching when b7f6021f2a dropped
+    # --extra-version-markers, and "latest-default" names the image tag, which
+    # this annotation does not rewrite. To give the newest release branch the
+    # k8s-beta marker again, put the arg back first.
     testgrid-dashboards: sig-release-master-blocking, sig-release-releng-blocking
     testgrid-tab-name: build-master
     testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io

--- a/releng/config-forker/pkg/forker.go
+++ b/releng/config-forker/pkg/forker.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -55,6 +56,7 @@ var (
 	ErrEnvReplacementResult   = errors.New("expected a single string result replacing env var")
 	ErrEnvReplacementFormat   = errors.New("expected NAME=VALUE format replacing env var")
 	ErrReplacementParse       = errors.New("failed to parse replacement")
+	ErrReplacementUnmatched   = errors.New("replacement matches nothing in the job")
 	ErrImageResolve           = errors.New("image resolution failed")
 )
 
@@ -283,6 +285,13 @@ func generatePostsubmits(
 			job.SkipBranches = nil
 			job.Branches = []string{"release-" + vars.Version}
 
+			if err := verifyReplacements(
+				job.Spec, nil,
+				job.Annotations[replacementAnnotation], postsubmit.Name,
+			); err != nil {
+				return nil, err
+			}
+
 			if err := processContainers(
 				ctx, job.Spec, vars,
 				job.Annotations[replacementAnnotation],
@@ -331,6 +340,13 @@ func generatePresubmits(
 				job.Context = replaceAllMaster(
 					job.Context, "-"+vars.Version,
 				)
+			}
+
+			if err := verifyReplacements(
+				job.Spec, nil,
+				job.Annotations[replacementAnnotation], presubmit.Name,
+			); err != nil {
+				return nil, err
 			}
 
 			if err := processContainers(
@@ -477,6 +493,13 @@ func generatePeriodics(
 			periodic.Annotations[suffixAnnotation] == annotationTrue,
 		)
 
+		if err := verifyReplacements(
+			job.Spec, job.Tags,
+			job.Annotations[replacementAnnotation], periodic.Name,
+		); err != nil {
+			return nil, err
+		}
+
 		if err := processPeriodicContainers(
 			ctx, job.Spec, &conf, job.UtilityConfig, vars,
 			job.Annotations[replacementAnnotation], periodic.Name,
@@ -590,6 +613,68 @@ func performEnvReplacement(
 	}
 
 	return parts[0], parts[1], nil
+}
+
+// replacementKeys returns the search strings of a fork-per-release-replacements
+// annotation. Malformed entries are skipped, because performReplacement reports
+// those with a better message.
+func replacementKeys(replacementStr string) []string {
+	var keys []string
+
+	for entry := range strings.SplitSeq(replacementStr, ", ") {
+		parts := strings.Split(entry, " -> ")
+		if len(parts) == replacementParts {
+			keys = append(keys, parts[0])
+		}
+	}
+
+	return keys
+}
+
+// verifyReplacements reports replacement rules that match nothing in the job.
+// A rule that matches nothing is a stale annotation: the forked job silently
+// keeps the master value the rule was written to rewrite. Call this before the
+// job is processed, so the rules are tested against the strings their author
+// wrote them against.
+func verifyReplacements(
+	spec *v1.PodSpec, tags []string, replacementStr, jobName string,
+) error {
+	if replacementStr == "" {
+		return nil
+	}
+
+	haystack := slices.Clone(tags)
+
+	if spec != nil {
+		for idx := range spec.Containers {
+			container := &spec.Containers[idx]
+			haystack = append(haystack, container.Command...)
+			haystack = append(haystack, container.Args...)
+
+			for _, env := range container.Env {
+				// performEnvReplacement joins the pair before replacing.
+				haystack = append(haystack, env.Name+"="+env.Value)
+			}
+		}
+	}
+
+	var unmatched []string
+
+	for _, key := range replacementKeys(replacementStr) {
+		if !slices.ContainsFunc(haystack, func(straw string) bool {
+			return strings.Contains(straw, key)
+		}) {
+			unmatched = append(unmatched, key)
+		}
+	}
+
+	if len(unmatched) > 0 {
+		return fmt.Errorf(
+			"%s: %w: %q", jobName, ErrReplacementUnmatched, unmatched,
+		)
+	}
+
+	return nil
 }
 
 func performReplacement(

--- a/releng/config-forker/pkg/forker_test.go
+++ b/releng/config-forker/pkg/forker_test.go
@@ -18,6 +18,7 @@ package forker
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"reflect"
 	"testing"
@@ -194,6 +195,94 @@ func TestPerformArgReplacements(t *testing.T) {
 
 			if !reflect.DeepEqual(result, test.expected) {
 				t.Errorf("Expected result %v, but got %v instead", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestVerifyReplacements(t *testing.T) {
+	t.Parallel()
+
+	spec := func(cmd, args []string, env ...v1.EnvVar) *v1.PodSpec {
+		return &v1.PodSpec{Containers: []v1.Container{{
+			Command: cmd, Args: args, Env: env,
+		}}}
+	}
+
+	tests := []struct {
+		name         string
+		spec         *v1.PodSpec
+		tags         []string
+		replacements string
+		expectErr    bool
+	}{
+		{
+			name:         "no replacements is fine",
+			spec:         spec(nil, []string{"--foo=bar"}),
+			replacements: "",
+		},
+		{
+			name:         "rule matching an arg is fine",
+			spec:         spec(nil, []string{"--test-package-dir=ci/fast"}),
+			replacements: "ci/fast -> ci",
+		},
+		{
+			name:         "rule matching a command is fine",
+			spec:         spec([]string{"run --marker=latest-fast.txt"}, nil),
+			replacements: "latest-fast.txt -> latest-{{.Version}}.txt",
+		},
+		{
+			name:         "rule matching an env pair is fine",
+			spec:         spec(nil, nil, v1.EnvVar{Name: "MARKER", Value: "latest-fast.txt"}),
+			replacements: "MARKER=latest-fast.txt -> MARKER=latest-{{.Version}}.txt",
+		},
+		{
+			name:         "rule matching a tag is fine",
+			spec:         spec(nil, nil),
+			tags:         []string{"latest-fast.txt"},
+			replacements: "latest-fast.txt -> latest-{{.Version}}.txt",
+		},
+		{
+			// The bug this guard exists for: the job splits the URL across
+			// --test-package-url and --test-package-dir, so a rule written
+			// against the joined URL silently rewrites nothing.
+			name: "rule matching nothing is an error",
+			spec: spec(nil, []string{
+				"--test-package-url=https://dl.k8s.io",
+				"--test-package-dir=ci/fast",
+			}),
+			replacements: "https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci",
+			expectErr:    true,
+		},
+		{
+			name:         "one good rule does not excuse a dead one",
+			spec:         spec(nil, []string{"--marker=latest-fast.txt"}),
+			replacements: "latest-fast.txt -> latest-{{.Version}}.txt, ci/fast -> ci",
+			expectErr:    true,
+		},
+		{
+			name:         "nil spec with a rule is an error",
+			spec:         nil,
+			replacements: "ci/fast -> ci",
+			expectErr:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifyReplacements(test.spec, test.tags, test.replacements, "some-job")
+			if test.expectErr {
+				if !errors.Is(err, ErrReplacementUnmatched) {
+					t.Fatalf("Expected ErrReplacementUnmatched, but got %v", err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
Follow-up to #37644, which fixed the symptom by hand. This stops the forker producing it again.

## The defect

`config-forker` applies `fork-per-release-replacements` through `strings.NewReplacer`. A rule that matches nothing is applied silently, so a stale annotation looks exactly like a working one. The forked job keeps the master value the rule was written to rewrite and nothing reports it.

That is how #37644 happened. The rule read:

```
https://dl.k8s.io/ci/fast -> https://dl.k8s.io/ci
```

It matched while the job passed one joined URL. When the job split the URL into `--test-package-url=https://dl.k8s.io` and `--test-package-dir=ci/fast`, the rule stopped matching. Nothing failed, and four months later the 1.37 fork shipped with `ci/fast` and five jobs red on every run.

## Change

Check every rule against the job before the job is processed, and fail the fork naming the job and the dead rules.

Run against the current master configs for 1.38, this finds three stale annotations and no false positives:

| Job | Dead rule | Why |
|---|---|---|
| `ci-node-crio-dra` + 4 containerd | `https://dl.k8s.io/ci/fast` | the URL was split into two args |
| `ci-dra-integration` | both rules | builds from source, never downloaded a package |
| `ci-kubernetes-build` | `k8s-master` | b7f6021f2a dropped `--extra-version-markers` |
| `ci-kubernetes-build` | `latest-default` | names the image tag, which this annotation does not rewrite |

All three are fixed here, because the guard makes them fatal.

**`dra.jinja`** — write the rule as the bare fragment `ci/fast -> ci` so it matches both the standalone `--test-package-dir` arg and the inline URLs in the kind job. Scope the rules to the jobs that download a package: `ci-dra-integration` never needed them, and the `test-infra` presubmits did need them but sat outside the `ci` guard, which is why their 1.37 fork kept master markers.

**`kubernetes-builds.yaml`** — drop the two dead rules from `ci-kubernetes-build` and record why. This also explains why `ci-kubernetes-build-1-37` forked with no `--extra-version-markers` and `gs://k8s-release-dev/ci/k8s-beta.txt` has had no writer since April. Restoring that marker needs the arg back first, which is a separate change and a release-engineering call.

Master job behaviour does not change. All ten master DRA jobs still use `ci/fast` and `latest-fast.txt`; only the fork-time rules moved.

## Verification

- `go test ./releng/...` passes, including a new `TestVerifyReplacements` with 8 cases
- forking 1.38 end to end now exits 0, and every DRA node job, periodic and presubmit, gets `--test-package-dir=ci` with `--test-package-marker=latest-1.38.txt`
- `checkconfig` passes with the same args as `pull-test-infra-prow-checkconfig`

/sig release
/sig node
/area release-eng
