### PR TITLE
CAPO: Update test timeout for CAPO presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -54,11 +54,12 @@ presubmits:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-openstack"
+    always_run: false
     skip_if_only_changed: '^(docs/|LICENSE|netlify.toml|OWNERS|OWNERS_ALIASES|SECURITY_CONTACTS|tilt-provider.json|.github/|.gitignore|.golangci.yml)|\\.md$'
     optional: false
     decorate: true
     decoration_config:
-      timeout: 5h
+      timeout: 3h
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
@@ -100,7 +101,7 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      timeout: 5h
+      timeout: 3h
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder
@@ -145,7 +146,7 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      timeout: 5h
+      timeout: 3h
     extra_refs:
     - org: kubernetes-sigs
       repo: image-builder


### PR DESCRIPTION
We want to decrease the test timeout and build job for CAPO presubmit jobs. Currently it has 5h timeout which is too long for presubmit jobs. We want to decrease it to 3h so that we don't need to wait for 5h timeout. Also adding `always_run: false` for openstack e2e test in presubmit jobs. We don't want this job to run during changes in md files or docs.