### PR TITLE
prow: migrate transfer issue plugin to issue-management

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ccm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ccm-presubmits.yaml
@@ -2,7 +2,7 @@ presubmits:
   kubernetes-sigs/cluster-api-provider-ibmcloud:
   - name: pull-cluster-api-provider-ccm-image
     cluster: eks-prow-build-cluster
-    run_if_changed: '^hack/ccm/'
+    run_if_changed: '^hack/release/ccm/'
     branches:
       - ^main$
     decorate: true
@@ -18,7 +18,7 @@ presubmits:
         - bash
         - -c
         - |
-          pushd hack/ccm
+          pushd hack/release/ccm
           make build-image-linux-amd64
           make build-image-linux-ppc64le
           popd

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
@@ -25,7 +25,7 @@ periodics:
         - -c
         - |
           result=0
-          ./scripts/ci-test-coverage.sh || result=$?
+          ./hack/scripts/ci/ci-test-coverage.sh || result=$?
           cp cover.* ${ARTIFACTS}
           cd ../../k8s.io/test-infra/gopherage
           GO111MODULE=on go build .

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1330,6 +1330,7 @@ plugins:
     - skip
     - slackevents
     - testfreeze
+    - issue-management
     - trick-or-treat
     - trigger
     - verify-owners
@@ -1550,6 +1551,7 @@ plugins:
     - shrug
     - size
     - skip
+    - issue-management
     - trick-or-treat
     - trigger
     - verify-owners


### PR DESCRIPTION
With the change introduced via https://github.com/kubernetes-sigs/prow/pull/702, migrate transfer-issue to issue-management for kubernetes and kubernetes-sigs.