### PR TITLE
agent-sandbox: increase KWOK scalability presubmit resources

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -240,10 +240,10 @@ presubmits:
         resources:
           requests:
             cpu: 7
-            memory: 14Gi
+            memory: 27Gi
           limits:
             cpu: 7
-            memory: 14Gi
+            memory: 27Gi
     annotations:
       testgrid-dashboards: sig-apps-agent-sandbox
       testgrid-tab-name: presubmit-test-e2e-scalability-kwok

--- a/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
@@ -134,6 +134,15 @@ def presubmit_benchmarks_kops_gcp_claims(job):
     set_run_if_changed(job, r"^extensions/|^cmd/|^controllers/|^internal/|^test/stress/|^test/benchmarks/|^dev/ci/(presubmits|periodics)/benchmarks-kops-gcp")  # pylint: disable=line-too-long
 
 
+def presubmit_test_e2e_scalability_kwok(job):
+    optional_presubmit(job)
+    for c in job["spec"]["containers"]:
+        c["resources"] = {
+            "requests": {"cpu": 7, "memory": "27Gi"},
+            "limits": {"cpu": 7, "memory": "27Gi"},
+        }
+
+
 PRESUBMIT_OVERRIDES = {
     "test-autogen-up-to-date": presubmit_test_autogen_up_to_date,
     "test-unit": presubmit_test_unit,
@@ -147,6 +156,7 @@ PRESUBMIT_OVERRIDES = {
     # Not wired up in prow before this generator existed; keep manual until
     # its credential requirements are sorted out.
     "test-skill-eval": manual_presubmit,
+    "test-e2e-scalability-kwok": presubmit_test_e2e_scalability_kwok,
 }
 
 


### PR DESCRIPTION
Increase memory from 14Gi to 27Gi for presubmit-agent-sandbox-test-e2e-scalability-kwok to avoid throttling during local cluster stress tests.