### PR TITLE
Right-size CPU requests/limits for kueue periodic-*-main jobs to test…

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -364,13 +364,13 @@ periodics:
             - test-performance-scheduler
           env:
             - name: GOMAXPROCS
-              value: "5"
+              value: "7"
           resources:
             requests:
-              cpu: "2200m"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "2200m"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-tas-scheduling-perf-main
@@ -403,13 +403,13 @@ periodics:
             - test-tas-performance-scheduler
           env:
             - name: GOMAXPROCS
-              value: "6"
+              value: "7"
           resources:
             requests:
-              cpu: "2400m"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "2400m"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-large-scale-scheduling-perf-main

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -39,10 +39,10 @@ periodics:
             - test
           resources:
             requests:
-              cpu: "4000m"
+              cpu: "2800m"
               memory: "6Gi"
             limits:
-              cpu: "4000m"
+              cpu: "2800m"
               memory: "6Gi"
   - interval: 12h
     name: periodic-kueue-test-unit-shard-1-main
@@ -84,10 +84,10 @@ periodics:
             - test
           resources:
             requests:
-              cpu: "1800m"
+              cpu: "1600m"
               memory: "6Gi"
             limits:
-              cpu: "1800m"
+              cpu: "1600m"
               memory: "6Gi"
   - interval: 24h
     name: periodic-kueue-test-fuzz-main
@@ -120,10 +120,10 @@ periodics:
             - test-fuzz
           resources:
             requests:
-              cpu: "1"
+              cpu: "400m"
               memory: "6Gi"
             limits:
-              cpu: "1"
+              cpu: "400m"
               memory: "6Gi"
   - interval: 24h
     name: periodic-kueue-verify-website-links-main
@@ -289,10 +289,10 @@ periodics:
               value: "3"
           resources:
             requests:
-              cpu: "7000m"
+              cpu: "3500m"
               memory: "14Gi"
             limits:
-              cpu: "7000m"
+              cpu: "3500m"
               memory: "14Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-multikueue-main
@@ -328,10 +328,10 @@ periodics:
               value: "4"
           resources:
             requests:
-              cpu: "3800m"
+              cpu: "2500m"
               memory: "12Gi"
             limits:
-              cpu: "3800m"
+              cpu: "2500m"
               memory: "12Gi"
   - interval: 12h
     name: periodic-kueue-test-scheduling-perf-main
@@ -367,10 +367,10 @@ periodics:
               value: "5"
           resources:
             requests:
-              cpu: "4500m"
+              cpu: "2200m"
               memory: "10Gi"
             limits:
-              cpu: "4500m"
+              cpu: "2200m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-tas-scheduling-perf-main
@@ -406,10 +406,10 @@ periodics:
               value: "6"
           resources:
             requests:
-              cpu: "5100m"
+              cpu: "2400m"
               memory: "10Gi"
             limits:
-              cpu: "5100m"
+              cpu: "2400m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-large-scale-scheduling-perf-main
@@ -492,10 +492,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "5200m"
+              cpu: "3800m"
               memory: "10Gi"
             limits:
-              cpu: "5200m"
+              cpu: "3800m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-extended-shard-0-main-1-34
@@ -539,10 +539,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "4500m"
+              cpu: "3400m"
               memory: "10Gi"
             limits:
-              cpu: "4500m"
+              cpu: "3400m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-extended-shard-1-main-1-34
@@ -586,10 +586,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "3900m"
+              cpu: "3800m"
               memory: "10Gi"
             limits:
-              cpu: "3900m"
+              cpu: "3800m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-extended-shard-2-main-1-34
@@ -633,10 +633,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "4900m"
+              cpu: "3400m"
               memory: "10Gi"
             limits:
-              cpu: "4900m"
+              cpu: "3400m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-baseline-main-1-35
@@ -680,10 +680,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "5600m"
+              cpu: "3800m"
               memory: "10Gi"
             limits:
-              cpu: "5600m"
+              cpu: "3800m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-extended-shard-0-main-1-35
@@ -727,10 +727,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "5000m"
+              cpu: "3400m"
               memory: "10Gi"
             limits:
-              cpu: "5000m"
+              cpu: "3400m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-extended-shard-1-main-1-35
@@ -774,10 +774,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "4500m"
+              cpu: "3700m"
               memory: "10Gi"
             limits:
-              cpu: "4500m"
+              cpu: "3700m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-extended-shard-2-main-1-35
@@ -821,10 +821,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "5000m"
+              cpu: "3500m"
               memory: "10Gi"
             limits:
-              cpu: "5000m"
+              cpu: "3500m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-baseline-main-1-36
@@ -868,10 +868,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "6400m"
+              cpu: "4200m"
               memory: "10Gi"
             limits:
-              cpu: "6400m"
+              cpu: "4200m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-extended-shard-0-main-1-36
@@ -915,10 +915,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "5200m"
+              cpu: "4900m"
               memory: "10Gi"
             limits:
-              cpu: "5200m"
+              cpu: "4900m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-extended-shard-1-main-1-36
@@ -962,10 +962,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "7000m"
+              cpu: "5100m"
               memory: "10Gi"
             limits:
-              cpu: "7000m"
+              cpu: "5100m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-extended-shard-2-main-1-36
@@ -1009,10 +1009,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "6600m"
+              cpu: "4900m"
               memory: "10Gi"
             limits:
-              cpu: "6600m"
+              cpu: "4900m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-multikueue-baseline-main
@@ -1103,10 +1103,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "6600m"
+              cpu: "4900m"
               memory: "10Gi"
             limits:
-              cpu: "6600m"
+              cpu: "4900m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-multikueue-extended-shard-1-main
@@ -1150,10 +1150,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "6700m"
+              cpu: "4200m"
               memory: "10Gi"
             limits:
-              cpu: "6700m"
+              cpu: "4200m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-multikueue-sequential-shard-0-main
@@ -1291,10 +1291,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "6000m"
+              cpu: "4000m"
               memory: "10Gi"
             limits:
-              cpu: "6000m"
+              cpu: "4000m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-tas-extended-shard-0-main
@@ -1338,10 +1338,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "4100m"
+              cpu: "3700m"
               memory: "10Gi"
             limits:
-              cpu: "4100m"
+              cpu: "3700m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-tas-extended-shard-1-main
@@ -1385,10 +1385,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "6500m"
+              cpu: "4800m"
               memory: "10Gi"
             limits:
-              cpu: "6500m"
+              cpu: "4800m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-sequential-baseline-shard-0-main
@@ -1526,10 +1526,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "4500m"
+              cpu: "3200m"
               memory: "10Gi"
             limits:
-              cpu: "4500m"
+              cpu: "3200m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-sequential-extended-shard-1-main
@@ -1573,10 +1573,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "5200m"
+              cpu: "3100m"
               memory: "10Gi"
             limits:
-              cpu: "5200m"
+              cpu: "3100m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-certmanager-main
@@ -1620,10 +1620,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "3500m"
+              cpu: "3700m"
               memory: "10Gi"
             limits:
-              cpu: "3500m"
+              cpu: "3700m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-dra-main
@@ -1667,10 +1667,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "3900m"
+              cpu: "4100m"
               memory: "10Gi"
             limits:
-              cpu: "3900m"
+              cpu: "4100m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-multikueue-dra-main
@@ -1714,10 +1714,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "6600m"
+              cpu: "5000m"
               memory: "10Gi"
             limits:
-              cpu: "6600m"
+              cpu: "5000m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-dra-counter-main
@@ -1761,10 +1761,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "3300m"
+              cpu: "4000m"
               memory: "10Gi"
             limits:
-              cpu: "3300m"
+              cpu: "4000m"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-e2e-k8s-main-was
@@ -1851,10 +1851,10 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: "3700m"
+              cpu: "3600m"
               memory: "10Gi"
             limits:
-              cpu: "3700m"
+              cpu: "3600m"
               memory: "10Gi"
   - interval: 24h
     name: periodic-kueue-verify-ci-build-times-main


### PR DESCRIPTION
… the measured recommendations

# CPU right-sizing recommendations (49 jobs)

CPU values are cores. request == limit (Guaranteed QoS), so only the request is shown. rec cpu req is rounded up to a full 7-core node once it already exceeds 85% of one.

| job | builds | p50 dur (min) | p95 dur (min) | now cpu req | rec cpu req | diff |
|---|--:|--:|--:|--:|--:|--:|
| pull-kueue-build-image-main | 447 | 10 | 11.5 | 4.7 | 3.7 | 1 |
| pull-kueue-populator-test-e2e-main | 444 | 9.5 | 11 | 3.7 | 2.8 | 0.9 |
| pull-kueue-populator-test-integration-main | 447 | 8 | 9.5 | 1 | 0.7 | 0.3 |
| pull-kueue-populator-test-unit-main | 455 | 7 | 8 | 0.6 | 0.4 | 0.2 |
| pull-kueue-populator-verify-main | 449 | 7.5 | 8.5 | 1.1 | 0.7 | 0.4 |
| pull-kueue-priority-booster-test-integration-main | 447 | 8.5 | 9.5 | 0.9 | 0.7 | 0.2 |
| pull-kueue-priority-booster-test-unit-main | 444 | 10 | 11.5 | 0.4 | 0.5 | -0.1 |
| pull-kueue-test-e2e-baseline-main-1-34 | 449 | 9.5 | 11 | 5.2 | 3.8 | 1.4 |
| pull-kueue-test-e2e-baseline-main-1-35 | 447 | 9 | 11 | 5.6 | 3.8 | 1.8 |
| pull-kueue-test-e2e-baseline-main-1-36 | 457 | 8.5 | 11 | 6.4 | 4.2 | 2.2 |
| pull-kueue-test-e2e-certmanager-main | 447 | 10.5 | 12 | 3.5 | 3.7 | -0.2 |
| pull-kueue-test-e2e-certmanager-upgrade-main | 447 | 11 | 12 | 2.5 | 2.8 | -0.3 |
| pull-kueue-test-e2e-dra-counter-main | 447 | 10.5 | 12.5 | 3.3 | 4 | -0.7 |
| pull-kueue-test-e2e-dra-main | 453 | 10.5 | 12 | 3.9 | 4.1 | -0.2 |
| pull-kueue-test-e2e-extended-shard-0-main-1-34 | 452 | 9.5 | 11 | 4.5 | 3.4 | 1.1 |
| pull-kueue-test-e2e-extended-shard-0-main-1-35 | 445 | 9.5 | 11 | 5 | 3.4 | 1.6 |
| pull-kueue-test-e2e-extended-shard-0-main-1-36 | 448 | 9.5 | 12 | 5.2 | 4.9 | 0.3 |
| pull-kueue-test-e2e-extended-shard-1-main-1-34 | 449 | 10 | 11.82 | 3.9 | 3.8 | 0.1 |
| pull-kueue-test-e2e-extended-shard-1-main-1-35 | 452 | 9 | 11.5 | 4.5 | 3.7 | 0.8 |
| pull-kueue-test-e2e-extended-shard-1-main-1-36 | 449 | 9.5 | 11.5 | 7 | 5.1 | 1.9 |
| pull-kueue-test-e2e-extended-shard-2-main-1-34 | 450 | 9.5 | 11 | 4.9 | 3.4 | 1.5 |
| pull-kueue-test-e2e-extended-shard-2-main-1-35 | 450 | 9.5 | 11 | 5 | 3.5 | 1.5 |
| pull-kueue-test-e2e-extended-shard-2-main-1-36 | 453 | 9 | 11.5 | 6.6 | 4.9 | 1.7 |
| pull-kueue-test-e2e-kueueviz-main | 451 | 9 | 12 | 3.7 | 3.6 | 0.1 |
| pull-kueue-test-e2e-multikueue-baseline-main | 442 | 11 | 11.5 | 3.1 | 3.1 | 0 |
| pull-kueue-test-e2e-multikueue-dra-main | 448 | 9.5 | 11 | 6.6 | 5 | 1.6 |
| pull-kueue-test-e2e-multikueue-extended-shard-0-main | 449 | 9.5 | 11.5 | 6.6 | 4.9 | 1.7 |
| pull-kueue-test-e2e-multikueue-extended-shard-1-main | 450 | 9.5 | 11 | 6.7 | 4.2 | 2.5 |
| pull-kueue-test-e2e-multikueue-sequential-shard-0-main | 441 | 10.5 | 12 | 7 | 7 | 0 |
| pull-kueue-test-e2e-multikueue-sequential-shard-1-main | 441 | 11 | 12.5 | 7 | 7 | 0 |
| pull-kueue-test-e2e-sequential-baseline-shard-0-main | 442 | 10.5 | 12 | 7 | 7 | 0 |
| pull-kueue-test-e2e-sequential-baseline-shard-1-main | 438 | 11 | 12.57 | 7 | 7 | 0 |
| pull-kueue-test-e2e-sequential-extended-shard-0-main | 453 | 9.5 | 11 | 4.5 | 3.2 | 1.3 |
| pull-kueue-test-e2e-sequential-extended-shard-1-main | 452 | 9 | 10.5 | 5.2 | 3.1 | 2.1 |
| pull-kueue-test-e2e-tas-baseline-main | 449 | 9.5 | 11 | 6 | 4 | 2 |
| pull-kueue-test-e2e-tas-extended-shard-0-main | 451 | 10 | 11.5 | 4.1 | 3.7 | 0.4 |
| pull-kueue-test-e2e-tas-extended-shard-1-main | 455 | 9 | 11.5 | 6.5 | 4.8 | 1.7 |
| pull-kueue-test-e2e-upgrade-main | 446 | 11 | 12 | 2.4 | 2.9 | -0.5 |
| pull-kueue-test-fuzz-main | 413 | 4 | 5 | 1 | 0.4 | 0.6 |
| pull-kueue-test-integration-multikueue-main | 443 | 10 | 10.5 | 3.8 | 2.5 | 1.3 |
| pull-kueue-test-integration-shard-0-main | 441 | 12 | 13 | 7 | 7 | 0 |
| pull-kueue-test-integration-shard-1-main | 449 | 11 | 12 | 7 | 7 | 0 |
| pull-kueue-test-integration-shard-2-main | 456 | 9 | 10 | 7 | 3.5 | 3.5 |
| pull-kueue-test-scheduling-perf-main | 445 | 9 | 10 | 4.5 | 2.2 | 2.3 |
| pull-kueue-test-tas-scheduling-perf-main | 449 | 9 | 10 | 5.1 | 2.4 | 2.7 |
| pull-kueue-test-unit-shard-0-main | 448 | 9.5 | 10 | 4 | 2.8 | 1.2 |
| pull-kueue-test-unit-shard-1-main | 442 | 9.5 | 10.5 | 1.8 | 1.6 | 0.2 |
| pull-kueue-verify-main | 559 | 9 | 10.5 | 6.3 | 5.3 | 1 |
| pull-kueue-verify-website-links-preview-main | 143 | 4 | 11.5 | 6 | 0.2 | 5.8 |

Potentially saved cpu req: 48.9 cores

Target duration: 12 min (pull-kueue-test-integration-shard-0-main, p50 duration)

Binpackability (7-core nodes, first-fit-decreasing):
- now: 38 nodes (85.1% packed)
- recommended: 28 nodes (90.5% packed)
