### PR TITLE
run full e2e etcd test suite

### DIFF
--- a/config/jobs/etcd/etcd-presubmits.yaml
+++ b/config/jobs/etcd/etcd-presubmits.yaml
@@ -215,7 +215,7 @@ presubmits:
         - |
           set -euo pipefail
           make gofail-enable
-          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true E2E_TEST_MINIMAL=true make test-e2e-release
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
         resources:
           requests:
             cpu: "4"
@@ -246,7 +246,8 @@ presubmits:
         - -c
         - |
           set -euo pipefail
-          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true E2E_TEST_MINIMAL=true make test-e2e
+          make gofail-enable
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true make test-e2e
         resources:
           requests:
             cpu: "4"
@@ -276,7 +277,8 @@ presubmits:
         - -c
         - |
           set -euo pipefail
-          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true E2E_TEST_MINIMAL=true make test-e2e-release
+          make gofail-enable
+          TIMEOUT=60m VERBOSE=1 GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
Enable the full e2e suite for presubmits, as it's about 5 minutes longer than the shortened suite we run in PRs.

https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-e2e-amd64
https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-etcd-e2e-amd64

/cc @serathius @ahrtr @fuweid 