### PR TITLE
Increase s390x integration package timeout to 15m

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-s390x-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-s390x-periodics.yaml
@@ -57,6 +57,8 @@ periodics:
         args:
         - ./hack/jenkins/test-integration-dockerized.sh
         env:
+        - name: KUBE_TIMEOUT
+          value: "-timeout=15m"
         - name: SHORT
           value: --short=false
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
/kind failing-test

### What this changes

set `KUBE_TIMEOUT=-timeout=15m` for `ci-kubernetes-integration-master-s390x`

`KUBE_TIMEOUT` is passed to `go test` as the per-package timeout where the current integration default is 600s

### Why this is needed

recent s390x runs show `k8s.io/apiextensions-apiserver/test/integration` consistently completing close to the existing 10 minute limit:
- 8m51s – 9m06s across five recent runs
- only approximately 54 – 68 seconds of remaining timeout margin

[build 2086430699157458944](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-integration-master-s390x/2086430699157458944/build-log.txt)

### Related work

- Tracking issue:
  https://github.com/kubernetes/kubernetes/issues/141284
- Embedded API server readiness fix:
  https://github.com/kubernetes/kubernetes/pull/141313