### PR TITLE
Graduate the HA experiment to the release-blocking and presubmit 5k jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/README.md
+++ b/config/jobs/kubernetes/sig-scalability/README.md
@@ -58,14 +58,17 @@ a run on TestGrid corresponds to.
 
 ### Promoting experimental -> release-blocking
 
+Edit the presets in `sig-scalability-presets.yaml`, not a job's own `env:`, so the
+jobs don't drift apart.
+
 1. Check with SIG Scalability on Slack first, to make sure the experiment slot
    isn't already in use by another contributor.
-2. Update the experiment behind `EXPERIMENT_VARIANT` on the experimental periodic
-   and presubmit, keeping the two in sync.
+2. Put the experiment, behind `EXPERIMENT_VARIANT`, in
+   `preset-kops-scalability-gce-experimental`.
 3. **Graduation bar:** once the experiment has 4 passing runs in a row, it is
    considered stable enough to graduate.
-4. Fold the variant's settings into the release-blocking job
-   `ci-kubernetes-e2e-gce-scale-performance-5000` and drop the variant.
+4. Move the settings to `preset-kops-scalability-gce-5000-node`, shared by all gce
+   5k jobs, and reset the experimental preset to `env: []`.
 
 ### Experiment history
 
@@ -74,7 +77,7 @@ track. Add new entries at the top.
 
 | Variant | Date | What it does | Owner | Status |
 | --- | --- | --- | --- | --- |
-| `HA` | 2026-08-03 | 3-replica control plane (`CONTROL_PLANE_COUNT=3`) on the 5k job, which today runs a single control plane. | @Jefftree | In Progress |
+| `HA` | 2026-08-03 | 3-replica control plane (`CONTROL_PLANE_COUNT=3`) on the 5k job, which previously ran a single control plane. | @Jefftree | Graduated |
 | `node-exporter` | 2026-07-24 | Scraping node exporter (`PROMETHEUS_SCRAPE_NODE_EXPORTER=true`) for per-node resource metrics. | @serathius | Graduated |
 | `restart-etcd36` | 2026-07-10 | RangeStream (`+EtcdRangeStream`) with HA control plane restart, on etcd 3.6.12, to gather data on RangeStream against etcd 3.6. Presubmit only. | @Jefftree | Completed |
 | `restart` | 2026-06-29 | HA control plane with restart, for tracking improvements with watch cache initialization. |  @Jefftree | In Progress |

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -408,6 +408,8 @@ presets:
   env:
   - name: KUBE_NODE_COUNT
     value: "5000"
+  - name: CONTROL_PLANE_COUNT
+    value: "3"
   - name: CONTROL_PLANE_SIZE
     value: "c4-standard-96"
   - name: ADDONS_NODE_SIZE
@@ -427,8 +429,4 @@ presets:
 
 - labels:
     preset-kops-scalability-gce-experimental: "true"
-  env:
-  - name: EXPERIMENT_VARIANT
-    value: "HA"
-  - name: CONTROL_PLANE_COUNT
-    value: "3"
+  env: []

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -789,9 +789,6 @@ presubmits:
         - ./tests/e2e/scenarios/scalability/run-test.sh
         securityContext:
           privileged: true
-        env:
-        - name: CONTROL_PLANE_COUNT
-          value: "1"
         resources:
           requests:
             cpu: 7


### PR DESCRIPTION
Graduates the `HA` experiment by moving `CONTROL_PLANE_COUNT: "3"` from `preset-kops-scalability-gce-experimental` into `preset-kops-scalability-gce-5000-node`, then clearing the experiment slot.

## Results

**HA** (3 masters): PR kubernetes/kubernetes#139476 [a](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-5000-experimental/2084665012042862592), [b](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-5000-experimental/2084750347196174336), [c](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-5000-experimental/2086916873177272320). Zero changed files, so master against master.
**Not HA** (1 master): periodic `ci-kubernetes-e2e-gce-scale-performance-5000`, 15 runs. All runs in both arms pass.

"Base" is the median of those 15 runs. Rows marked n=1 come from a single baseline Prometheus snapshot.

| | HA | base | ratio |
|---|---|---|---|
| API tail latency p99, worst verb | 483 ms | 1,202 ms | **0.40x** |
| service churn, steps 02+22+28 | 1,023 s | 1,549 s | **0.66x** |
| apiserver memory per box | 44 GB | 63 GB | **0.70x** |
| watch events per apiserver | 257M | 672M | **0.38x** |
| kubelet pod writes throttled (429) | 0 - 34,758 | 79,625 | n=1 |
| load overall | 3,925 s | 4,573 s | 0.86x, null |
| pod startup p99 | 1,110 ms | 1,167 ms | 0.95x, null |
| terminated pod watchers | 837 | 317 | **2.6x worse** |
| 403s on configmaps, secrets, SAs | 549 - 64,369 | 145 | **worse**, n=1 |

### 1. API tail latency

`APIResponsivenessPrometheus_load`, resource scope p99, ms.

| verb | HA a | HA b | HA c | **HA med** | **base med** | ratio |
|---|---|---|---|---|---|---|
| GET | 382 | 368 | 285 | **368** | **737** | **0.50x** |
| PUT | 471 | 325 | 324 | **325** | **963** | **0.34x** |
| PATCH | 698 | 391 | 353 | **391** | **895** | **0.44x** |
| DELETE | 618 | 356 | 314 | **356** | **1,202** | **0.30x** |
| POST | 483 | 333 | 570 | **483** | **1,055** | **0.46x** |

This is the non-enforcing artifact and reports roughly the worst 5-minute window. The enforced whole-run p99 moves the same way.

### 2. Wall clock and throughput

| | HA a | HA b | HA c | **HA med** | **base med** | base range | ratio |
|---|---|---|---|---|---|---|---|
| load overall | 3,925 s | 3,583 s | 4,984 s | 3,925 s | 4,573 s | 3,393 - 7,324 | 0.86x, null |
| write QPS | 2,369 | 2,374 | 1,738 | 2,369 | 1,735 | 1,358 - 2,105 | 1.37x |

Write QPS decomposes into 1.09x more write requests in a 1.165x shorter run. Neither factor is individually significant.

Where the extra writes are:

| whole run | single | HA a | HA b | HA c | base range |
|---|---|---|---|---|---|
| writes to pods | 1.65M | 2.16M | 2.34M | 2.46M | 1.58 - 1.75M |
| pods throttled, 429 | 79,625 | 34,758 | 8,147 | 0 | n=1 |
| pods/status PATCH, 200 | 1.05M | 1.54M | 1.71M | 1.84M | n=1 |
| `system` PL nominal seats, fleet | 103 | 309 | 309 | 309 | |

APF seats are allocated per apiserver. Every HA run is outside the baseline range on pod writes.

### 3. Fan-out

`apiserver_watch_events_total` per apiserver, whole run. Counts deliveries, so it falls whenever watchers split across replicas.

| | HA a | HA b | HA c | **HA med** | **base med** | ratio |
|---|---|---|---|---|---|---|
| all resources | 292M | 214M | 257M | **257M** | **672M** | **0.38x** |
| endpointslices | 222M | 146M | 186M | **186M** | **475M** | **0.39x** |
| pods | 7.7M | 8.4M | 6.4M | **7.7M** | **12M** | 0.64x |

### 4. Terminated watchers

`apiserver_terminated_watchers_total`, cluster total, whole run.

| | HA a | HA b | HA c | **HA med** | **base med** | base range |
|---|---|---|---|---|---|---|
| endpointslices | 820 | 182 | 2,048 | **820** | **20,442** | 0 - 57,583 |
| **pods, all unfiltered** | 1,597 | 837 | 424 | **837** | **317** | 111 - 437 |
| all resources | 2,427 | 1,021 | 2,475 | 2,427 | 20,735 | 132 - 58,085 |

Endpointslices down, pods up. The pod increase is likely the extra write traffic from the per-apiserver APF seats: pod changes reaching the watch cache are 2.45 / 2.63 / 2.75M per apiserver against a 1.95M baseline.

Pod kills by `len(c.input)`, the watcher's buffer depth at the moment it was closed. 1000 is `maxWatchChanSizeWithIndexWithoutTrigger`, the cap.

| `len(c.input)` | single | HA a |
|---|---|---|
| **1000, buffer full at the cap** | **5** | **763** |
| below the cap, 9 - 683 | 135 | 107 |
| total | 140 | 870 |

Below-cap kills barely move. All the growth is in full buffers. Probably just the higher pod write rate: 1000 events is about 370 ms at 2,700/s, so there is not much room to fall behind.

### 5. Node-authorizer 403s

| | single, n=1 | HA a | HA b | HA c |
|---|---|---|---|---|
| 403s on configmaps, secrets, serviceaccounts | **145** | 64,369 | 20,378 | 549 |
| LIST configmaps + secrets | **6,346** | 40,447 | 12,047 | 10,074 |

The authorizer graph is built off the same pod informer ([`graph_populator.go:42`](https://github.com/kubernetes/kubernetes/blob/v1.37.0-beta.0/plugin/pkg/auth/authorizer/node/graph_populator.go#L42)), so this is late pod events again, not a separate problem.

### 6. etcd

etcd performance is worse but that's expected given that HA needs raft consensus. It's interesting that it's sort of invisible at apiserver get p99 because the raft overhead is neglected by better performance due to less watchers

| metric (ms) | base med | HA med | HA vs base |
|---|---|---|---|
| apiserver GET p50 | 3.81 | 5.61 | 1.47x worse |
| apiserver GET p90 | 559.8 | 24.0 | 23x better |
| apiserver GET p99 | 2308 | 603 | 3.8x better |
| etcd Range request p50 | 2.52 | 7.25 | 2.87x worse |
| etcd Range request p99 | 11.64 | 31.9 | 2.74x worse |
| etcd mvcc Range p99 (storage only) | 2.45 | 5.18 | 2.12x worse |
| etcd Txn request p99 | 11.84 | 30.5 | 2.58x worse |
| etcd fsync p99, worst member | 3.31 | 7.91 | 2.39x worse (3 disks, not raft) |
| etcd fsync p99, leader | 3.31 | 3.19 | no change |
| etcd backend commit p99, leader | 9.32 | 12.13 | no change (overlap) |
| etcd CPU core-s per 1M puts | 737 | 730 | no change |
