### PR TITLE
Enable lgtm store_tree_hash for kubernetes-sigs/inference-perf

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -294,6 +294,7 @@ lgtm:
   - kubernetes-sigs/cluster-api-provider-aws
   - kubernetes-sigs/dra-driver-nvidia-gpu
   - kubernetes-sigs/dra-example-driver
+  - kubernetes-sigs/inference-perf
   - kubernetes-sigs/kjob
   - kubernetes-sigs/kueue
   store_tree_hash: true


### PR DESCRIPTION
Adds `kubernetes-sigs/inference-perf` to the `lgtm` plugin's `store_tree_hash: true` block.

The repo currently has no entry under `lgtm:`, so it runs on the defaults and the `lgtm` label is removed on every push, including force-pushes that leave the tree hash unchanged: a rebase onto main, or a commit message reword to clear `do-not-merge/invalid-commit-message`. Each one costs another round trip with a reviewer who has already read the identical diff.

inference-perf is a small subproject repo with a thin reviewer pool, so those round trips dominate merge latency rather than review time itself. Recent example: https://github.com/kubernetes-sigs/inference-perf/pull/693 was lgtm'd, lost the label to a rebase, waited five days for the re-lgtm, then lost it again to a message-only reword that changed no content.

This is the same behavior already enabled for kubernetes/kubernetes, cluster-api, kueue and others in this block. No other lgtm setting changes: `review_acts_as_lgtm` remains off for the repo.
