### PR TITLE
Unprotect gh-pages branch for aws-fsx-openzfs-csi-driver

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -548,6 +548,10 @@ branch-protection:
           branches:
             gh-pages:
               protect: false
+        aws-fsx-openzfs-csi-driver:
+          branches:
+            gh-pages:
+              protect: false
         cluster-api:
           required_status_checks:
             contexts:


### PR DESCRIPTION
The gh-pages branch only receives automated index.yaml commits from the chart-releaser bot, which cannot satisfy the required EasyCLA status check. This matches the existing configuration of aws-ebs-csi-driver, aws-efs-csi-driver, and aws-fsx-csi-driver.