### PR TITLE
Exclude minCompatibilityVersion feature specs from emulated version tests

### DIFF
--- a/experiment/compatibility-versions/test_versioned_specs_util.sh
+++ b/experiment/compatibility-versions/test_versioned_specs_util.sh
@@ -79,6 +79,25 @@ run_tests() {
     echo "PASS: get_exact_version_spec for non-existent version"
   fi
 
+  local mock_specs='[{"default":false,"preRelease":"Beta","version":"1.37"},{"default":true,"preRelease":"Beta","version":"1.37","minCompatibilityVersion":"1.37"}]'
+  # Test get_target_spec
+  local got
+  got=$(get_target_spec "$mock_specs" "1.37")
+  if [[ "$got" != *'"default": false'* ]]; then
+    echo "FAIL: get_target_spec expected false default considering minCompatibilityVersion, got: $got"
+    failures=$((failures+1))
+  else
+    echo "PASS: get_target_spec considering minCompatibilityVersion"
+  fi
+  # Test get_prev_target_spec
+  got=$(get_prev_target_spec "$mock_specs" "1.37")
+  if [[ "$got" != "null" ]]; then
+    echo "FAIL: get_prev_target_spec (first element) expected null considering minCompatibilityVersion, got: $got"
+    failures=$((failures+1))
+  else
+    echo "PASS: get_prev_target_spec (first element) considering minCompatibilityVersion"
+  fi
+
   if [[ $failures -gt 0 ]]; then
     echo "Tests failed ($failures failures)."
     exit 1

--- a/experiment/compatibility-versions/versioned_specs_util.sh
+++ b/experiment/compatibility-versions/versioned_specs_util.sh
@@ -16,13 +16,14 @@
 set -o errexit -o nounset -o pipefail
 
 # get_target_spec takes two arguments: specs_json and emulated_version
-# Returns the highest spec strictly less than or equal to the emulated_version.
+# Returns the highest spec strictly less than or equal to the emulated_version (excluding specs which set minCompatibilityVersion).
 function get_target_spec() {
   local specs_json="$1"
   local emulated_version="$2"
 
   echo "${specs_json}" | jq -r --arg ver "${emulated_version}" '
         [ .[]
+          | select(has("minCompatibilityVersion") | not)
           | select(
               ( .version | sub("^v"; "") | tonumber )
               <=
@@ -34,7 +35,7 @@ function get_target_spec() {
 }
 
 # get_prev_target_spec takes two arguments: specs_json and emulated_version
-# Returns the spec immediately preceding target_spec in the original sorted array.
+# Returns the spec immediately preceding target_spec in the original sorted array (excluding specs which set minCompatibilityVersion).
 function get_prev_target_spec() {
   local specs_json="$1"
   local emulated_version="$2"
@@ -42,6 +43,7 @@ function get_prev_target_spec() {
   echo "${specs_json}" | jq -r --arg ver "${emulated_version}" '
         . as $arr |
         [ range(length)
+          | select($arr[.] | has("minCompatibilityVersion") | not)
           | select(
               ( $arr[.] | .version | sub("^v"; "") | tonumber )
               <=


### PR DESCRIPTION
The test-infra portion of fixing https://github.com/kubernetes/kubernetes/issues/141283

requires https://github.com/kubernetes/kubernetes/pull/141324 to merge to master and fast-forward to release-1.37 before this info will exist in the files this test uses for 1.38 / 1.37
