### PR TITLE
Lower frequency of compatibility-versions-feature-gate-test

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/compatibility-versions-e2e.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/compatibility-versions-e2e.yaml
@@ -170,7 +170,7 @@ periodics:
           # this is mostly for building kubernetes
           memory: 9Gi
           cpu: 7
-- interval: 1h
+- interval: 12h
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-e2e-kind-compatibility-versions-feature-gate-test
   annotations:
@@ -224,7 +224,7 @@ periodics:
           # this is mostly for building kubernetes
           memory: 14Gi
           cpu: 7
-- interval: 1h
+- interval: 12h
   cluster: k8s-infra-prow-build
   name: ci-kubernetes-e2e-kind-compatibility-versions-feature-gate-test-n-2
   annotations:


### PR DESCRIPTION
Noticed these jobs were running hourly... running twice a day is more than sufficient

/hold until we get a green run with https://github.com/kubernetes/kubernetes/issues/141283 fixed

/cc @dims