### PR TITLE
fix(capibm): update job paths broken by hack/ refactor (kubernetes-sigs/cluster-api-provider-ibmcloud#2882)

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ccm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ccm-presubmits.yaml
@@ -2,7 +2,7 @@ presubmits:
   kubernetes-sigs/cluster-api-provider-ibmcloud:
   - name: pull-cluster-api-provider-ccm-image
     cluster: eks-prow-build-cluster
-    run_if_changed: '^hack/ccm/'
+    run_if_changed: '^hack/release/ccm/'
     branches:
       - ^main$
     decorate: true
@@ -18,7 +18,7 @@ presubmits:
         - bash
         - -c
         - |
-          pushd hack/ccm
+          pushd hack/release/ccm
           make build-image-linux-amd64
           make build-image-linux-ppc64le
           popd

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/cluster-api-provider-ibmcom-periodics-main.yaml
@@ -25,7 +25,7 @@ periodics:
         - -c
         - |
           result=0
-          ./scripts/ci-test-coverage.sh || result=$?
+          ./hack/scripts/ci/ci-test-coverage.sh || result=$?
           cp cover.* ${ARTIFACTS}
           cd ../../k8s.io/test-infra/gopherage
           GO111MODULE=on go build .


### PR DESCRIPTION
## What this does

`kubernetes-sigs/cluster-api-provider-ibmcloud` PR [#2882](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/2882) reorganised the `hack/` and `scripts/` trees **on main only**. Two job configs in this repo were left pointing at the old locations.

### Change 1 — `periodic-cluster-api-provider-ibmcloud-coverage`

```diff
-          ./scripts/ci-test-coverage.sh || result=$?
+          ./hack/scripts/ci/ci-test-coverage.sh || result=$?
```

This job was exiting 127 (`No such file or directory`) on every run since #2882 landed.

### Change 2 — `pull-cluster-api-provider-ccm-image` (scoped to `^main$`)

```diff
-    run_if_changed: '^hack/ccm/'
+    run_if_changed: '^hack/release/ccm/'
 ...
-          pushd hack/ccm
+          pushd hack/release/ccm
```

This was a **silent failure**: the `run_if_changed` regex no longer matched any path on main, so the job stopped triggering entirely — no red check, just missing coverage.

## What is not changed

Release-branch configs (`presubmits-release-0.11` through `0.14`) are **deliberately untouched**. The hack/ refactor is main-only and the existing paths are correct on those branches. They will need updating only if the refactor is ever backported.

## See also

- [ppc64le-cloud/test-infra#626](https://github.com/ppc64le-cloud/test-infra/pull/626) — companion PR fixing the e2e periodics

## Verification

- `hack/scripts/ci/ci-test-coverage.sh` confirmed to exist on CAPIBM main (HTTP 200 from raw.githubusercontent.com)
- Grep for old paths after edit returns zero hits in the CAPIBM job directory
- Both edited files parse cleanly with `python3 -c "import yaml; yaml.safe_load(...)"`
- `checkconfig` binary not available in this checkout (unverified at prow config level)