### PR TITLE
Pin kueue scheduling-perf jobs to 7 CPU cores (max) to avoid threshold flakes

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -364,13 +364,13 @@ periodics:
             - test-performance-scheduler
           env:
             - name: GOMAXPROCS
-              value: "5"
+              value: "7"
           resources:
             requests:
-              cpu: "4500m"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "4500m"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-tas-scheduling-perf-main
@@ -403,13 +403,13 @@ periodics:
             - test-tas-performance-scheduler
           env:
             - name: GOMAXPROCS
-              value: "6"
+              value: "7"
           resources:
             requests:
-              cpu: "5100m"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "5100m"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-large-scale-scheduling-perf-main

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -288,13 +288,13 @@ periodics:
             - test-performance-scheduler
           env:
             - name: GOMAXPROCS
-              value: "5"
+              value: "7"
           resources:
             requests:
-              cpu: "4500m"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "4500m"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-tas-scheduling-perf-release-0-18
@@ -327,13 +327,13 @@ periodics:
             - test-tas-performance-scheduler
           env:
             - name: GOMAXPROCS
-              value: "6"
+              value: "7"
           resources:
             requests:
-              cpu: "5100m"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "5100m"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-large-scale-scheduling-perf-release-0-18

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
@@ -328,13 +328,13 @@ periodics:
             - test-performance-scheduler
           env:
             - name: GOMAXPROCS
-              value: "5"
+              value: "7"
           resources:
             requests:
-              cpu: "4500m"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "4500m"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-tas-scheduling-perf-release-0-19
@@ -367,13 +367,13 @@ periodics:
             - test-tas-performance-scheduler
           env:
             - name: GOMAXPROCS
-              value: "6"
+              value: "7"
           resources:
             requests:
-              cpu: "5100m"
+              cpu: "7"
               memory: "10Gi"
             limits:
-              cpu: "5100m"
+              cpu: "7"
               memory: "10Gi"
   - interval: 12h
     name: periodic-kueue-test-large-scale-scheduling-perf-release-0-19

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -1615,13 +1615,13 @@ presubmits:
               - test-performance-scheduler
             env:
               - name: GOMAXPROCS
-                value: "5"
+                value: "7"
             resources:
               requests:
-                cpu: "4500m"
+                cpu: "7"
                 memory: "10Gi"
               limits:
-                cpu: "4500m"
+                cpu: "7"
                 memory: "10Gi"
     - name: pull-kueue-test-tas-scheduling-perf-main
       cluster: eks-prow-build-cluster
@@ -1646,13 +1646,13 @@ presubmits:
               - test-tas-performance-scheduler
             env:
               - name: GOMAXPROCS
-                value: "6"
+                value: "7"
             resources:
               requests:
-                cpu: "5100m"
+                cpu: "7"
                 memory: "10Gi"
               limits:
-                cpu: "5100m"
+                cpu: "7"
                 memory: "10Gi"
     - name: pull-kueue-populator-verify-main
       cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -1582,13 +1582,13 @@ presubmits:
               - test-performance-scheduler
             env:
               - name: GOMAXPROCS
-                value: "5"
+                value: "7"
             resources:
               requests:
-                cpu: "4500m"
+                cpu: "7"
                 memory: "10Gi"
               limits:
-                cpu: "4500m"
+                cpu: "7"
                 memory: "10Gi"
     - name: pull-kueue-test-tas-scheduling-perf-release-0-18
       cluster: eks-prow-build-cluster
@@ -1613,13 +1613,13 @@ presubmits:
               - test-tas-performance-scheduler
             env:
               - name: GOMAXPROCS
-                value: "6"
+                value: "7"
             resources:
               requests:
-                cpu: "5100m"
+                cpu: "7"
                 memory: "10Gi"
               limits:
-                cpu: "5100m"
+                cpu: "7"
                 memory: "10Gi"
     - name: pull-kueue-populator-verify-release-0-18
       cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
@@ -1582,13 +1582,13 @@ presubmits:
               - test-performance-scheduler
             env:
               - name: GOMAXPROCS
-                value: "5"
+                value: "7"
             resources:
               requests:
-                cpu: "4500m"
+                cpu: "7"
                 memory: "10Gi"
               limits:
-                cpu: "4500m"
+                cpu: "7"
                 memory: "10Gi"
     - name: pull-kueue-test-tas-scheduling-perf-release-0-19
       cluster: eks-prow-build-cluster
@@ -1613,13 +1613,13 @@ presubmits:
               - test-tas-performance-scheduler
             env:
               - name: GOMAXPROCS
-                value: "6"
+                value: "7"
             resources:
               requests:
-                cpu: "5100m"
+                cpu: "7"
                 memory: "10Gi"
               limits:
-                cpu: "5100m"
+                cpu: "7"
                 memory: "10Gi"
     - name: pull-kueue-populator-verify-release-0-19
       cluster: eks-prow-build-cluster


### PR DESCRIPTION
## Summary
- Sets `cpu` (requests/limits) and `GOMAXPROCS` to `7` (a full node) for `test-scheduling-perf` and `test-tas-scheduling-perf` periodic and presubmit jobs, across `main`, `release-0.18`, and `release-0.19`.
- `large-scale-scheduling-perf` jobs were already at `7` and are unchanged.


## Fix

Fix for https://github.com/kubernetes-sigs/kueue/issues/14077