### PR TITLE
kops: use KOPS_CONTROL_PLANE_COUNT and drop unused preset-e2e-platform-aws

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -668,7 +668,7 @@ def generate_misc():
                        'KOPS_VERSION': "v1.33.1",
                        'K8S_VERSION': "v1.33.5",
                        'KOPS_SKIP_E2E': '1',
-                       'KOPS_CONTROL_PLANE_SIZE': '3',
+                       'KOPS_CONTROL_PLANE_COUNT': '3',
                    }),
 
         # Test Cilium against ci k8s test suite
@@ -828,7 +828,7 @@ def generate_misc():
                    runs_per_day=1,
                    test_timeout_minutes=240,
                    scenario="keypair-rotation",
-                   env={'KOPS_CONTROL_PLANE_SIZE': '3'},
+                   env={'KOPS_CONTROL_PLANE_COUNT': '3'},
                    extra_dashboards=['kops-misc']),
 
         build_test(name_override="kops-aws-metrics-server",
@@ -1612,7 +1612,7 @@ def generate_upgrades():
             'K8S_VERSION_B': k8s_b,
             'KOPS_SKIP_E2E': '1',
             'KOPS_TEMPLATE': 'tests/e2e/templates/many-addons.yaml.tmpl',
-            'KOPS_CONTROL_PLANE_SIZE': '3',
+            'KOPS_CONTROL_PLANE_COUNT': '3',
         }
 
         results.append(
@@ -1677,7 +1677,7 @@ def generate_periodics_upgrades_dns_none():
                     'KOPS_VERSION_B': kops_b,
                     'K8S_VERSION_B': k8s_b,
                     'KOPS_SKIP_E2E': '1',
-                    'KOPS_CONTROL_PLANE_SIZE': '3',
+                    'KOPS_CONTROL_PLANE_COUNT': '3',
                 },
             ))
     return results
@@ -1807,7 +1807,7 @@ def generate_presubmits_upgrades_dns_none():
                     'KOPS_VERSION_B': kops_b,
                     'K8S_VERSION_B': k8s_b,
                     'KOPS_SKIP_E2E': '1',
-                    'KOPS_CONTROL_PLANE_SIZE': '3',
+                    'KOPS_CONTROL_PLANE_COUNT': '3',
                 },
             ))
     return results
@@ -2583,7 +2583,7 @@ def generate_presubmits_e2e():
                 'K8S_VERSION_B': "v1.36.0",
                 'KOPS_SKIP_E2E': '1',
                 'KOPS_TEMPLATE': 'tests/e2e/templates/many-addons.yaml.tmpl',
-                'KOPS_CONTROL_PLANE_SIZE': '3',
+                'KOPS_CONTROL_PLANE_COUNT': '3',
             }
         ),
         presubmit_test(
@@ -2603,7 +2603,7 @@ def generate_presubmits_e2e():
                 'K8S_VERSION_B': "v1.36.0",
                 'KOPS_SKIP_E2E': '1',
                 'KOPS_TEMPLATE': 'tests/e2e/templates/many-addons.yaml.tmpl',
-                'KOPS_CONTROL_PLANE_SIZE': '3',
+                'KOPS_CONTROL_PLANE_COUNT': '3',
             }
         ),
         presubmit_test(

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -38,7 +38,7 @@ periodics:
         value: "v1.33.5"
       - name: KOPS_SKIP_E2E
         value: "1"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -960,7 +960,7 @@ periodics:
       env:
       - name: GINKGO_NO_COLOR
         value: "TRUE"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades-dns-none.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades-dns-none.yaml
@@ -40,7 +40,7 @@ periodics:
         value: "v1.36.1"
       - name: KOPS_SKIP_E2E
         value: "1"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -116,7 +116,7 @@ periodics:
         value: "v1.36.1"
       - name: KOPS_SKIP_E2E
         value: "1"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: CLOUD_PROVIDER
         value: "azure"
@@ -185,7 +185,7 @@ periodics:
         value: "v1.36.1"
       - name: KOPS_SKIP_E2E
         value: "1"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: CLOUD_PROVIDER
         value: "gce"

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades.yaml
@@ -110,7 +110,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -252,7 +252,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -394,7 +394,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -536,7 +536,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -678,7 +678,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -820,7 +820,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -962,7 +962,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -1104,7 +1104,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -1246,7 +1246,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -1388,7 +1388,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -1530,7 +1530,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -1672,7 +1672,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -1814,7 +1814,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -1956,7 +1956,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -2098,7 +2098,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -2240,7 +2240,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -2382,7 +2382,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -2524,7 +2524,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -2666,7 +2666,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
@@ -2808,7 +2808,7 @@ periodics:
         value: "1"
       - name: KOPS_TEMPLATE
         value: "tests/e2e/templates/many-addons.yaml.tmpl"
-      - name: KOPS_CONTROL_PLANE_SIZE
+      - name: KOPS_CONTROL_PLANE_COUNT
         value: "3"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"

--- a/config/jobs/kubernetes/kops/kops-presets.yaml
+++ b/config/jobs/kubernetes/kops/kops-presets.yaml
@@ -1,35 +1,5 @@
 presets:
 - labels:
-    preset-e2e-platform-aws: "true"
-  env:
-  # TODO(zmerlynn): Eliminate the other uses of this env variable
-  - name: KUBE_SSH_USER
-    value: ubuntu
-  # Log dump for kops (relies on kops-e2e-runner.sh support)
-  - name: LOG_DUMP_SSH_KEY
-    value: /workspace/.ssh/kube_aws_rsa
-  - name: LOG_DUMP_SSH_USER
-    value: ubuntu
-  - name: LOG_DUMP_SAVE_LOGS
-    value: cloud-init-output
-  - name: LOG_DUMP_SAVE_SERVICES
-    value: protokube
-  # kops testing only ever uses Cloud SDK for status and uploads
-  - name: CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK
-    value: "true"
-  - name: CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE
-    value: "false"
-    # Ignore version-we-pass vs version-kops-expects
-  - name: KOPS_RUN_OBSOLETE_VERSION
-    value: "true"
-    # Except for the updown job itself, use a version of kops that's
-    # passed updown.
-  - name: KOPS_LATEST
-    value: latest-ci-updown-green.txt
-  - name: KOPS_DEPLOY_LATEST_KUBE
-    value: "y"
-
-- labels:
     preset-storage-e2e-service-account: "true"
   env:
   # storage e2e tests borrow this as a preconfigured key instead of creating and

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -2041,7 +2041,7 @@ presubmits:
           value: "1"
         - name: KOPS_TEMPLATE
           value: "tests/e2e/templates/many-addons.yaml.tmpl"
-        - name: KOPS_CONTROL_PLANE_SIZE
+        - name: KOPS_CONTROL_PLANE_COUNT
           value: "3"
         - name: CLOUD_PROVIDER
           value: "aws"
@@ -2111,7 +2111,7 @@ presubmits:
           value: "1"
         - name: KOPS_TEMPLATE
           value: "tests/e2e/templates/many-addons.yaml.tmpl"
-        - name: KOPS_CONTROL_PLANE_SIZE
+        - name: KOPS_CONTROL_PLANE_COUNT
           value: "3"
         - name: CLOUD_PROVIDER
           value: "aws"

--- a/config/jobs/kubernetes/kops/kops-presubmits-upgrades-dns-none.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-upgrades-dns-none.yaml
@@ -49,7 +49,7 @@ presubmits:
           value: "v1.36.1"
         - name: KOPS_SKIP_E2E
           value: "1"
-        - name: KOPS_CONTROL_PLANE_SIZE
+        - name: KOPS_CONTROL_PLANE_COUNT
           value: "3"
         - name: CLOUD_PROVIDER
           value: "aws"
@@ -117,7 +117,7 @@ presubmits:
           value: "v1.36.1"
         - name: KOPS_SKIP_E2E
           value: "1"
-        - name: KOPS_CONTROL_PLANE_SIZE
+        - name: KOPS_CONTROL_PLANE_COUNT
           value: "3"
         - name: CLOUD_PROVIDER
           value: "azure"
@@ -187,7 +187,7 @@ presubmits:
           value: "v1.36.1"
         - name: KOPS_SKIP_E2E
           value: "1"
-        - name: KOPS_CONTROL_PLANE_SIZE
+        - name: KOPS_CONTROL_PLANE_COUNT
           value: "3"
         - name: CLOUD_PROVIDER
           value: "gce"


### PR DESCRIPTION
Two independent cleanups to the kops job configs, both no-ops at runtime.

**1. `KOPS_CONTROL_PLANE_SIZE` -> `KOPS_CONTROL_PLANE_COUNT`** (30 jobs)

The kops e2e scenario scripts have accepted `KOPS_CONTROL_PLANE_COUNT` since kubernetes/kops#15628 (July 2023). Today `tests/e2e/scenarios/lib/common.sh` and `lib/upgrade.sh` keep the old name working only to print:

```
Recognized (deprecated) KOPS_CONTROL_PLANE_SIZE=3, please set KOPS_CONTROL_PLANE_COUNT instead
```

before reassigning it. Setting the supported name here silences that warning and lets the two compat shims be deleted from kops in kubernetes/kops#18682.

That kops PR is held until this one merges: once the fallback is gone, any job still setting only `KOPS_CONTROL_PLANE_SIZE` would silently drop to the `:-1` default and create one control plane node instead of three. This PR is safe to merge on its own — both names work on kops master today.

All 30 affected jobs run against kops master (`base_ref: master` for the periodics, `branches: [master]` for the presubmits) so there is no release-branch compatibility concern. Both names are accepted on master regardless, so this can merge in either order relative to the kops-side cleanup.

**2. Remove the `preset-e2e-platform-aws` preset**

The label is defined in `kops-presets.yaml` but referenced by **zero jobs anywhere in test-infra**. Its env vars target `kops-e2e-runner.sh` — `LOG_DUMP_SSH_KEY`, `LOG_DUMP_SSH_USER`, `LOG_DUMP_SAVE_LOGS`, `LOG_DUMP_SAVE_SERVICES`, `KOPS_LATEST`, `KOPS_DEPLOY_LATEST_KUBE`, `KOPS_RUN_OBSOLETE_VERSION`, the `CLOUDSDK_*` pair, and a hardcoded `KUBE_SSH_USER=ubuntu` — a runner that no longer exists now that kops e2e jobs run through `kubetest2-kops`. The file's own comment gives it away: "Log dump for kops (relies on kops-e2e-runner.sh support)".

The other two presets in that file (`preset-storage-e2e-service-account`, `preset-kops-azure-cred-wi`) are still in use and are left alone.

## Testing

- Jobs regenerated with `build_jobs.py` using the existing `pinned.list`, so the diff contains no image or cron churn — only the 30 renamed env vars and the preset removal.
- `go test ./config/tests/jobs/...` passes.
- Confirmed `grep -r preset-e2e-platform-aws` returns nothing repo-wide after the change.

/sig testing
/area jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
