### PR TITLE
kops: fix ipv6 karpenter jobs passing flags nothing reads

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -922,9 +922,7 @@ def generate_misc():
                    kops_channel="alpha",
                    runs_per_day=1,
                    scenario="karpenter",
-                   env = {
-                    "OVERRIDES": "--ipv6 --topology=private --bastion",
-                   },
+                   extra_flags=["--ipv6", "--topology=private", "--bastion"],
                    extra_dashboards=["kops-misc", "kops-ipv6"]),
 
         # [sig-storage, @jsafrane] Test SELinux features, because kops
@@ -2562,9 +2560,7 @@ def generate_presubmits_e2e():
             networking="cilium",
             kops_channel="alpha",
             scenario="karpenter",
-            env = {
-                "OVERRIDES": "--ipv6 --topology=private --bastion",
-            },
+            extra_flags=["--ipv6", "--topology=private", "--bastion"],
         ),
         presubmit_test(
             name="pull-kops-aws-upgrade-k134-ko134-to-k136-kolatest-many-addons",

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -1438,7 +1438,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-aws-karpenter
 
-# {"cloud": "aws", "distro": "u2404arm64", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
+# {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion", "k8s_version": "stable", "kops_channel": "alpha", "kops_version": "latest", "networking": "cilium"}
 - name: e2e-kops-aws-ipv6-karpenter
   cluster: k8s-infra-kops-prow-build
   cron: '55 7-23/24 * * *'
@@ -1466,8 +1466,6 @@ periodics:
       env:
       - name: GINKGO_NO_COLOR
         value: "TRUE"
-      - name: OVERRIDES
-        value: "--ipv6 --topology=private --bastion"
       - name: KOPS_STATE_STORE
         value: "s3://k8s-kops-ci-prow-state-store"
       - name: KOPS_DNS_DOMAIN
@@ -1478,6 +1476,8 @@ periodics:
         value: "ubuntu"
       - name: CLUSTER_NAME
         value: "e2e-6e00e57ddb-8c03f.tests-kops-aws.k8s.io"
+      - name: KOPS_EXTRA_FLAGS
+        value: "--ipv6 --topology=private --bastion"
       image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
       imagePullPolicy: Always
       resources:
@@ -1492,6 +1492,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: u2404arm64
+    test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion
     test.kops.k8s.io/k8s_version: stable
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -1935,7 +1935,7 @@ presubmits:
       testgrid-days-of-results: '90'
       testgrid-tab-name: pull-kops-e2e-aws-karpenter
 
-  # {"cloud": "aws", "distro": "u2404arm64", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
+  # {"cloud": "aws", "distro": "u2404arm64", "extra_flags": "--ipv6 --topology=private --bastion", "k8s_version": "stable", "kops_channel": "alpha", "networking": "cilium"}
   - name: pull-kops-e2e-aws-ipv6-karpenter
     cluster: k8s-infra-kops-prow-build
     branches:
@@ -1971,10 +1971,10 @@ presubmits:
           value: "TRUE"
         - name: GOPATH
           value: /home/prow/go
-        - name: OVERRIDES
-          value: "--ipv6 --topology=private --bastion"
         - name: CLOUD_PROVIDER
           value: "aws"
+        - name: KOPS_EXTRA_FLAGS
+          value: "--ipv6 --topology=private --bastion"
         resources:
           requests:
             cpu: "6"
@@ -1985,6 +1985,7 @@ presubmits:
     annotations:
       test.kops.k8s.io/cloud: aws
       test.kops.k8s.io/distro: u2404arm64
+      test.kops.k8s.io/extra_flags: --ipv6 --topology=private --bastion
       test.kops.k8s.io/k8s_version: stable
       test.kops.k8s.io/kops_channel: alpha
       test.kops.k8s.io/networking: cilium


### PR DESCRIPTION
`e2e-kops-aws-ipv6-karpenter` and `pull-kops-e2e-aws-ipv6-karpenter` both set:

```yaml
- name: OVERRIDES
  value: "--ipv6 --topology=private --bastion"
```

but the karpenter scenario never reads `OVERRIDES`. `tests/e2e/scenarios/karpenter/run-test.sh` builds `CREATE_ARGS` entirely from hardcoded values; the only script in kops that reads `OVERRIDES` is `splitkcp/run-test.sh`, and it sets its own value locally.

So both jobs have been creating plain IPv4 karpenter clusters — behaviorally identical to `e2e-kops-aws-karpenter` / `pull-kops-e2e-aws-karpenter` — while reporting to the `kops-ipv6` dashboard.

This switches them to `extra_flags`, which is the mechanism the scenario job path already provides: `build_jobs.py` joins `extra_flags` into `KOPS_EXTRA_FLAGS` (the same variable the `upgrade-ab` scenario already consumes), and kubernetes/kops#18681 teaches the karpenter scenario to append it to its create args. Using `extra_flags` rather than hand-setting the env var also populates the `test.kops.k8s.io/extra_flags` annotation, so the job metadata now matches what the job does.

## Ordering

kubernetes/kops#18681 must merge before these jobs actually exercise IPv6. Until then they keep behaving exactly as they do today (the env var is simply ignored under a different name), so this is safe to merge in either order.

Worth flagging for reviewers: once both land, the ipv6 karpenter presubmit will be doing real work for the first time, so it may surface pre-existing IPv6 + karpenter issues rather than failing on anything introduced here.

## Testing

- Regenerated with `build_jobs.py` against the existing `pinned.list`; the diff touches only the two ipv6 karpenter jobs — no image or cron churn.
- `go test ./config/tests/jobs/...` passes.
- `OVERRIDES` no longer appears anywhere in `config/jobs/kubernetes/kops/`.

/sig testing
/area jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)