### PR TITLE
Make mcp-lifecycle-operator e2e presubmit required

### DIFF
--- a/config/jobs/kubernetes-sigs/mcp-lifecycle-operator/mcp-lifecycle-operator-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/mcp-lifecycle-operator/mcp-lifecycle-operator-presubmits-main.yaml
@@ -24,7 +24,7 @@ presubmits:
   - name: presubmit-mcp-lifecycle-operator-e2e-test
     cluster: eks-prow-build-cluster
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Change `optional: true` to `optional: false` for the
`presubmit-mcp-lifecycle-operator-e2e-test` Prow job, making e2e
tests a required check for PRs on kubernetes-sigs/mcp-lifecycle-operator.

/sig apps

Assisted-by: 🤖 claude-opus-4-6@default