### PR TITLE
kops: drop redundant KUBE_SSH_KEY_PATH from AWS jobs

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-conformance.yaml
@@ -45,8 +45,6 @@ periodics:
           --skip-regex="\[NoSkip\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -115,8 +113,6 @@ periodics:
           --skip-regex="\[NoSkip\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -252,8 +248,6 @@ periodics:
           --skip-regex="\[NoSkip\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -322,8 +316,6 @@ periodics:
           --skip-regex="\[NoSkip\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -459,8 +451,6 @@ periodics:
           --skip-regex="\[NoSkip\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -529,8 +519,6 @@ periodics:
           --skip-regex="\[NoSkip\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -666,8 +654,6 @@ periodics:
           --skip-regex="\[NoSkip\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -736,8 +722,6 @@ periodics:
           --skip-regex="\[NoSkip\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -41,8 +41,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -106,8 +104,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -171,8 +167,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -236,8 +230,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -301,8 +293,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -367,8 +357,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -432,8 +420,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -498,8 +484,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -563,8 +547,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -629,8 +611,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -694,8 +674,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -760,8 +738,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -825,8 +801,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -891,8 +865,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -956,8 +928,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -1022,8 +992,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -1087,8 +1055,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -1154,8 +1120,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-periodics-dns-none.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-dns-none.yaml
@@ -41,8 +41,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -301,8 +299,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -43,8 +43,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -111,8 +109,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -179,8 +175,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -247,8 +241,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -315,8 +307,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -383,8 +373,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -451,8 +439,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -519,8 +505,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -587,8 +571,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -655,8 +637,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -723,8 +703,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -791,8 +769,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -859,8 +835,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -927,8 +901,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -995,8 +967,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -1063,8 +1033,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -1131,8 +1099,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -1199,8 +1165,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -1267,8 +1231,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -1335,8 +1297,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -1403,8 +1363,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -1471,8 +1429,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -1539,8 +1495,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -1607,8 +1561,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -1675,8 +1627,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -1743,8 +1693,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -1811,8 +1759,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -1879,8 +1825,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -1947,8 +1891,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2015,8 +1957,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2083,8 +2023,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2151,8 +2089,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2219,8 +2155,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2287,8 +2221,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2355,8 +2287,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2423,8 +2353,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2491,8 +2419,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2559,8 +2485,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2627,8 +2551,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2695,8 +2617,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2763,8 +2683,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2831,8 +2749,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2899,8 +2815,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -2967,8 +2881,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3035,8 +2947,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3103,8 +3013,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3171,8 +3079,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3239,8 +3145,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3307,8 +3211,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3375,8 +3277,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3443,8 +3343,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3511,8 +3409,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3579,8 +3475,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3647,8 +3541,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3715,8 +3607,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3783,8 +3673,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3851,8 +3739,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3919,8 +3805,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -3987,8 +3871,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4055,8 +3937,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4123,8 +4003,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4191,8 +4069,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4259,8 +4135,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4327,8 +4201,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4395,8 +4267,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4463,8 +4333,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4531,8 +4399,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4599,8 +4465,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4667,8 +4531,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4735,8 +4597,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4803,8 +4663,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4871,8 +4729,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -4939,8 +4795,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5007,8 +4861,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5075,8 +4927,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5143,8 +4993,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5211,8 +5059,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5279,8 +5125,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5347,8 +5191,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5415,8 +5257,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5483,8 +5323,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5551,8 +5389,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5619,8 +5455,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5687,8 +5521,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5755,8 +5587,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5823,8 +5653,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5891,8 +5719,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -5959,8 +5785,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -6027,8 +5851,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -6095,8 +5917,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -6163,8 +5983,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -6231,8 +6049,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -6299,8 +6115,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -6367,8 +6181,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -6435,8 +6247,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -6503,8 +6313,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -6571,8 +6379,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -6639,8 +6445,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -6707,8 +6511,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -6775,8 +6577,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -6843,8 +6643,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -6911,8 +6709,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -6979,8 +6775,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7047,8 +6841,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7115,8 +6907,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7183,8 +6973,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7251,8 +7039,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7319,8 +7105,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7387,8 +7171,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7455,8 +7237,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7523,8 +7303,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7591,8 +7369,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7659,8 +7435,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7727,8 +7501,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7795,8 +7567,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7863,8 +7633,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7931,8 +7699,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -7999,8 +7765,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -8067,8 +7831,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -8135,8 +7897,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -8203,8 +7963,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -8271,8 +8029,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -8339,8 +8095,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -8407,8 +8161,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -8475,8 +8227,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -8543,8 +8293,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -8612,8 +8360,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -8681,8 +8427,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -8750,8 +8494,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -8819,8 +8561,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -8888,8 +8628,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -8957,8 +8695,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -9026,8 +8762,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -9095,8 +8829,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -9164,8 +8896,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -9232,8 +8962,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -9299,8 +9027,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -9366,8 +9092,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -9433,8 +9157,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -9500,8 +9222,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -9567,8 +9287,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -9634,8 +9352,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -9701,8 +9417,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -9768,8 +9482,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -9835,8 +9547,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -9902,8 +9612,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -9969,8 +9677,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10036,8 +9742,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10103,8 +9807,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10170,8 +9872,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10237,8 +9937,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10304,8 +10002,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10371,8 +10067,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10438,8 +10132,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10505,8 +10197,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10572,8 +10262,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10639,8 +10327,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10706,8 +10392,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10773,8 +10457,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10840,8 +10522,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10907,8 +10587,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -10974,8 +10652,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -11041,8 +10717,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11108,8 +10782,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11175,8 +10847,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11242,8 +10912,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11309,8 +10977,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11376,8 +11042,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11443,8 +11107,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11510,8 +11172,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11577,8 +11237,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11644,8 +11302,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11712,8 +11368,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11780,8 +11434,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11848,8 +11500,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11916,8 +11566,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -11984,8 +11632,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12052,8 +11698,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12120,8 +11764,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12188,8 +11830,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12256,8 +11896,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12323,8 +11961,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12390,8 +12026,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12457,8 +12091,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12524,8 +12156,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12591,8 +12221,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12658,8 +12286,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12725,8 +12351,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12792,8 +12416,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12859,8 +12481,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12927,8 +12547,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -12995,8 +12613,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13063,8 +12679,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13131,8 +12745,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13199,8 +12811,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13267,8 +12877,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13335,8 +12943,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13403,8 +13009,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13471,8 +13075,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13538,8 +13140,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13605,8 +13205,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13672,8 +13270,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13739,8 +13335,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13806,8 +13400,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13873,8 +13465,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -13940,8 +13530,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14007,8 +13595,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14075,8 +13661,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14143,8 +13727,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14211,8 +13793,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14279,8 +13859,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14347,8 +13925,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14415,8 +13991,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14483,8 +14057,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14551,8 +14123,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14618,8 +14188,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14685,8 +14253,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14752,8 +14318,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14819,8 +14383,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14886,8 +14448,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -14953,8 +14513,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -15020,8 +14578,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -15087,8 +14643,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -15155,8 +14709,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -15223,8 +14775,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -15291,8 +14841,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -15359,8 +14907,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -15427,8 +14973,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -15495,8 +15039,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -15563,8 +15105,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -15631,8 +15171,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -15698,8 +15236,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -15765,8 +15301,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -15832,8 +15366,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -15899,8 +15431,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -15966,8 +15496,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16033,8 +15561,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16100,8 +15626,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16167,8 +15691,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16234,8 +15756,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16302,8 +15822,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16370,8 +15888,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16438,8 +15954,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16506,8 +16020,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16574,8 +16086,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16642,8 +16152,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16710,8 +16218,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16778,8 +16284,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16846,8 +16350,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16913,8 +16415,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -16980,8 +16480,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17047,8 +16545,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17114,8 +16610,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17181,8 +16675,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17248,8 +16740,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17315,8 +16805,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17382,8 +16870,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17449,8 +16935,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17517,8 +17001,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17585,8 +17067,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17653,8 +17133,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17721,8 +17199,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17789,8 +17265,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17857,8 +17331,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17925,8 +17397,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -17993,8 +17463,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18060,8 +17528,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18127,8 +17593,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18194,8 +17658,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18261,8 +17723,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18328,8 +17788,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18395,8 +17853,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18462,8 +17918,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18529,8 +17983,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18596,8 +18048,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18664,8 +18114,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18732,8 +18180,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18800,8 +18246,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18868,8 +18312,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -18936,8 +18378,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -19004,8 +18444,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -19072,8 +18510,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -19141,8 +18577,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -19209,8 +18643,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -19277,8 +18709,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -19345,8 +18775,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -19413,8 +18841,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -19481,8 +18907,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -19549,8 +18973,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -19617,8 +19039,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -19685,8 +19105,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -19752,8 +19170,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -19819,8 +19235,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -19886,8 +19300,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -19953,8 +19365,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20020,8 +19430,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20087,8 +19495,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20154,8 +19560,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20221,8 +19625,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20288,8 +19690,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20355,8 +19755,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20422,8 +19820,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20489,8 +19885,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20556,8 +19950,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20623,8 +20015,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20690,8 +20080,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20757,8 +20145,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20824,8 +20210,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20891,8 +20275,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -20958,8 +20340,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -21025,8 +20405,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -21092,8 +20470,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -21159,8 +20535,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -21226,8 +20600,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -21293,8 +20665,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -21360,8 +20730,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -21427,8 +20795,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -21494,8 +20860,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -21561,8 +20925,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -21628,8 +20990,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -21695,8 +21055,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -21762,8 +21120,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -21829,8 +21185,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -21896,8 +21250,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -21963,8 +21315,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22030,8 +21380,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22097,8 +21445,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22164,8 +21510,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22232,8 +21576,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22300,8 +21642,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22368,8 +21708,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22436,8 +21774,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22504,8 +21840,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22572,8 +21906,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22640,8 +21972,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22708,8 +22038,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22776,8 +22104,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22843,8 +22169,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22910,8 +22234,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -22977,8 +22299,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23044,8 +22364,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23111,8 +22429,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23178,8 +22494,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23245,8 +22559,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23312,8 +22624,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23379,8 +22689,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23447,8 +22755,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23515,8 +22821,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23583,8 +22887,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23651,8 +22953,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23719,8 +23019,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23787,8 +23085,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23855,8 +23151,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23923,8 +23217,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -23991,8 +23283,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24058,8 +23348,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24125,8 +23413,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24192,8 +23478,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24259,8 +23543,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24326,8 +23608,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24393,8 +23673,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24460,8 +23738,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24527,8 +23803,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24595,8 +23869,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24663,8 +23935,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24731,8 +24001,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24799,8 +24067,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24867,8 +24133,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -24935,8 +24199,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25003,8 +24265,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25071,8 +24331,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25138,8 +24396,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25205,8 +24461,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25272,8 +24526,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25339,8 +24591,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25406,8 +24656,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25473,8 +24721,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25540,8 +24786,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25607,8 +24851,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25675,8 +24917,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25743,8 +24983,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25811,8 +25049,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25879,8 +25115,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -25947,8 +25181,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -26015,8 +25247,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -26083,8 +25313,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -26151,8 +25379,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26218,8 +25444,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26285,8 +25509,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26352,8 +25574,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26419,8 +25639,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26486,8 +25704,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26553,8 +25769,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26620,8 +25834,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26687,8 +25899,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26754,8 +25964,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26822,8 +26030,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26890,8 +26096,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -26958,8 +26162,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27026,8 +26228,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27094,8 +26294,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27162,8 +26360,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27230,8 +26426,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27298,8 +26492,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27366,8 +26558,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27433,8 +26623,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27500,8 +26688,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27567,8 +26753,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27634,8 +26818,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27701,8 +26883,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27768,8 +26948,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27835,8 +27013,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27902,8 +27078,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -27969,8 +27143,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -28037,8 +27209,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -28105,8 +27275,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -28173,8 +27341,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -28241,8 +27407,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -28309,8 +27473,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -28377,8 +27539,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -28445,8 +27605,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -28513,8 +27671,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -28580,8 +27736,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -28647,8 +27801,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -28714,8 +27866,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -28781,8 +27931,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -28848,8 +27996,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -28915,8 +28061,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -28982,8 +28126,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -29049,8 +28191,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -29116,8 +28256,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -29184,8 +28322,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -29252,8 +28388,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -29320,8 +28454,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -29388,8 +28520,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -29456,8 +28586,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -29524,8 +28652,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -29592,8 +28718,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -29661,8 +28785,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -29729,8 +28851,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -29797,8 +28917,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -29865,8 +28983,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -29933,8 +29049,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -30001,8 +29115,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -30069,8 +29181,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -30137,8 +29247,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -30205,8 +29313,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -30272,8 +29378,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -30339,8 +29443,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -30406,8 +29508,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -30473,8 +29573,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -30540,8 +29638,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -30607,8 +29703,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -30674,8 +29768,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -30741,8 +29833,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -30808,8 +29898,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -30875,8 +29963,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -30942,8 +30028,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31009,8 +30093,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31076,8 +30158,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31143,8 +30223,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31210,8 +30288,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31277,8 +30353,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31344,8 +30418,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31411,8 +30483,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31478,8 +30548,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31545,8 +30613,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31612,8 +30678,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31679,8 +30743,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31746,8 +30808,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31813,8 +30873,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31880,8 +30938,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -31947,8 +31003,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -32014,8 +31068,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -32081,8 +31133,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32148,8 +31198,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32215,8 +31263,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32282,8 +31328,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32349,8 +31393,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32416,8 +31458,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32483,8 +31523,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32550,8 +31588,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32617,8 +31653,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32684,8 +31718,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32752,8 +31784,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32820,8 +31850,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32888,8 +31916,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -32956,8 +31982,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33024,8 +32048,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33092,8 +32114,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33160,8 +32180,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33228,8 +32246,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33296,8 +32312,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33363,8 +32377,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33430,8 +32442,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33497,8 +32507,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33564,8 +32572,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33631,8 +32637,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33698,8 +32702,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33765,8 +32767,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33832,8 +32832,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33899,8 +32897,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -33967,8 +32963,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34035,8 +33029,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34103,8 +33095,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34171,8 +33161,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34239,8 +33227,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34307,8 +33293,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34375,8 +33359,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34443,8 +33425,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34511,8 +33491,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34578,8 +33556,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34645,8 +33621,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34712,8 +33686,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34779,8 +33751,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34846,8 +33816,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34913,8 +33881,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -34980,8 +33946,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35047,8 +34011,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35115,8 +34077,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35183,8 +34143,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35251,8 +34209,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35319,8 +34275,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35387,8 +34341,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35455,8 +34407,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35523,8 +34473,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35591,8 +34539,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35658,8 +34604,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35725,8 +34669,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35792,8 +34734,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35859,8 +34799,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35926,8 +34864,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -35993,8 +34929,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -36060,8 +34994,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -36127,8 +35059,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -36195,8 +35125,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -36263,8 +35191,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -36331,8 +35257,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -36399,8 +35323,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -36467,8 +35389,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -36535,8 +35455,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -36603,8 +35521,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -36671,8 +35587,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -36738,8 +35652,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -36805,8 +35717,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -36872,8 +35782,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -36939,8 +35847,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37006,8 +35912,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37073,8 +35977,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37140,8 +36042,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37207,8 +36107,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37274,8 +36172,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37342,8 +36238,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37410,8 +36304,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37478,8 +36370,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37546,8 +36436,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37614,8 +36502,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37682,8 +36568,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37750,8 +36634,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37818,8 +36700,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37886,8 +36766,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -37953,8 +36831,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38020,8 +36896,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38087,8 +36961,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38154,8 +37026,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38221,8 +37091,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38288,8 +37156,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38355,8 +37221,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38422,8 +37286,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38489,8 +37351,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38557,8 +37417,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38625,8 +37483,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38693,8 +37549,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38761,8 +37615,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38829,8 +37681,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38897,8 +37747,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -38965,8 +37813,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -39033,8 +37879,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39100,8 +37944,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39167,8 +38009,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39234,8 +38074,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39301,8 +38139,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39368,8 +38204,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39435,8 +38269,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39502,8 +38334,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39569,8 +38399,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39636,8 +38464,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39704,8 +38530,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39772,8 +38596,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39840,8 +38662,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39908,8 +38728,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -39976,8 +38794,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -40044,8 +38860,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -40112,8 +38926,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -40181,8 +38993,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -40249,8 +39059,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -40317,8 +39125,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -40385,8 +39191,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -40453,8 +39257,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -40521,8 +39323,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -40589,8 +39389,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -40657,8 +39455,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -40725,8 +39521,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -40792,8 +39586,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -40860,8 +39652,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -40928,8 +39718,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -40996,8 +39784,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41064,8 +39850,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41132,8 +39916,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41200,8 +39982,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41268,8 +40048,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41336,8 +40114,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41404,8 +40180,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41472,8 +40246,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41540,8 +40312,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41608,8 +40378,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41676,8 +40444,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41744,8 +40510,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41812,8 +40576,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41880,8 +40642,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -41948,8 +40708,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42016,8 +40774,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42084,8 +40840,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42152,8 +40906,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42220,8 +40972,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42288,8 +41038,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42356,8 +41104,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42424,8 +41170,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42492,8 +41236,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42560,8 +41302,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42628,8 +41368,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42696,8 +41434,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42764,8 +41500,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42832,8 +41566,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42900,8 +41632,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -42968,8 +41698,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43036,8 +41764,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43104,8 +41830,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43172,8 +41896,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43240,8 +41962,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43308,8 +42028,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43376,8 +42094,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43444,8 +42160,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43512,8 +42226,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43580,8 +42292,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43648,8 +42358,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43716,8 +42424,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43784,8 +42490,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43852,8 +42556,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43920,8 +42622,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -43988,8 +42688,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44056,8 +42754,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44124,8 +42820,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44192,8 +42886,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44260,8 +42952,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44328,8 +43018,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44396,8 +43084,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44464,8 +43150,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44532,8 +43216,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44600,8 +43282,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44668,8 +43348,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44736,8 +43414,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44804,8 +43480,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44872,8 +43546,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -44940,8 +43612,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45008,8 +43678,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45076,8 +43744,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45144,8 +43810,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45212,8 +43876,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45280,8 +43942,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45348,8 +44008,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45416,8 +44074,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45484,8 +44140,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45552,8 +44206,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45620,8 +44272,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45688,8 +44338,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45756,8 +44404,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45824,8 +44470,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45892,8 +44536,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -45960,8 +44602,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -46028,8 +44668,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -46096,8 +44734,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -46164,8 +44800,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -46232,8 +44866,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -46300,8 +44932,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -46368,8 +44998,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -46436,8 +45064,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -46504,8 +45130,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -46572,8 +45196,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -46640,8 +45262,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -46708,8 +45328,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -46776,8 +45394,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -46844,8 +45460,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -46912,8 +45526,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -46980,8 +45592,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -47048,8 +45658,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -47116,8 +45724,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -47184,8 +45790,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -47252,8 +45856,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -47320,8 +45922,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -47388,8 +45988,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -47456,8 +46054,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -47524,8 +46120,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -47592,8 +46186,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -47660,8 +46252,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -47728,8 +46318,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -47796,8 +46384,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -47864,8 +46450,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -47932,8 +46516,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48000,8 +46582,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48068,8 +46648,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48136,8 +46714,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48204,8 +46780,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48272,8 +46846,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48340,8 +46912,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48408,8 +46978,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48476,8 +47044,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48544,8 +47110,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48612,8 +47176,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48680,8 +47242,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48748,8 +47308,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -48817,8 +47375,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -48886,8 +47442,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -48955,8 +47509,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -49024,8 +47576,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -49093,8 +47643,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -49162,8 +47710,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -49231,8 +47777,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -49300,8 +47844,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -49369,8 +47911,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -49437,8 +47977,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -49504,8 +48042,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -49571,8 +48107,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -49638,8 +48172,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -49705,8 +48237,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -49772,8 +48302,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -49839,8 +48367,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -49906,8 +48432,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -49973,8 +48497,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50040,8 +48562,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50107,8 +48627,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50174,8 +48692,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50241,8 +48757,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50308,8 +48822,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50375,8 +48887,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50442,8 +48952,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50509,8 +49017,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50576,8 +49082,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50643,8 +49147,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50710,8 +49212,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50777,8 +49277,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50844,8 +49342,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50911,8 +49407,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -50978,8 +49472,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -51045,8 +49537,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -51112,8 +49602,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -51179,8 +49667,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -51246,8 +49732,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -51313,8 +49797,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -51380,8 +49862,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -51447,8 +49927,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -51514,8 +49992,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -51581,8 +50057,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -51648,8 +50122,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -51715,8 +50187,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -51782,8 +50252,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -51849,8 +50317,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -51917,8 +50383,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -51985,8 +50449,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52053,8 +50515,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52121,8 +50581,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52189,8 +50647,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52257,8 +50713,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52325,8 +50779,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52393,8 +50845,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52461,8 +50911,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52528,8 +50976,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52595,8 +51041,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52662,8 +51106,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52729,8 +51171,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52796,8 +51236,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52863,8 +51301,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52930,8 +51366,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -52997,8 +51431,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53064,8 +51496,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53132,8 +51562,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53200,8 +51628,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53268,8 +51694,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53336,8 +51760,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53404,8 +51826,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53472,8 +51892,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53540,8 +51958,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53608,8 +52024,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53676,8 +52090,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53743,8 +52155,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53810,8 +52220,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53877,8 +52285,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -53944,8 +52350,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54011,8 +52415,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54078,8 +52480,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54145,8 +52545,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54212,8 +52610,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54280,8 +52676,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54348,8 +52742,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54416,8 +52808,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54484,8 +52874,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54552,8 +52940,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54620,8 +53006,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54688,8 +53072,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54756,8 +53138,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54823,8 +53203,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54890,8 +53268,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -54957,8 +53333,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55024,8 +53398,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55091,8 +53463,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55158,8 +53528,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55225,8 +53593,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55292,8 +53658,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55360,8 +53724,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55428,8 +53790,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55496,8 +53856,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55564,8 +53922,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55632,8 +53988,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55700,8 +54054,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55768,8 +54120,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -55836,8 +54186,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -55903,8 +54251,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -55970,8 +54316,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56037,8 +54381,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56104,8 +54446,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56171,8 +54511,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56238,8 +54576,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56305,8 +54641,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56372,8 +54706,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56439,8 +54771,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56507,8 +54837,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56575,8 +54903,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56643,8 +54969,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56711,8 +55035,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56779,8 +55101,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56847,8 +55167,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56915,8 +55233,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -56983,8 +55299,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57051,8 +55365,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57118,8 +55430,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57185,8 +55495,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57252,8 +55560,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57319,8 +55625,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57386,8 +55690,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57453,8 +55755,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57520,8 +55820,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57587,8 +55885,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57654,8 +55950,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57722,8 +56016,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57790,8 +56082,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57858,8 +56148,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57926,8 +56214,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -57994,8 +56280,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -58062,8 +56346,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -58130,8 +56412,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -58198,8 +56478,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -58265,8 +56543,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -58332,8 +56608,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -58399,8 +56673,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -58466,8 +56738,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -58533,8 +56803,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -58600,8 +56868,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -58667,8 +56933,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -58734,8 +56998,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -58801,8 +57063,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -58869,8 +57129,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -58937,8 +57195,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -59005,8 +57261,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -59073,8 +57327,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -59141,8 +57393,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -59209,8 +57459,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -59277,8 +57525,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -59346,8 +57592,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -59414,8 +57658,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -59482,8 +57724,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -59550,8 +57790,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -59618,8 +57856,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -59686,8 +57922,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -59754,8 +57988,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -59822,8 +58054,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -59890,8 +58120,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -59957,8 +58185,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60024,8 +58250,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60091,8 +58315,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60158,8 +58380,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60225,8 +58445,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60292,8 +58510,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60359,8 +58575,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60426,8 +58640,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60493,8 +58705,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60560,8 +58770,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60627,8 +58835,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60694,8 +58900,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60761,8 +58965,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60828,8 +59030,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60895,8 +59095,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -60962,8 +59160,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61029,8 +59225,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61096,8 +59290,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61163,8 +59355,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61230,8 +59420,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61297,8 +59485,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61364,8 +59550,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61431,8 +59615,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61498,8 +59680,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61565,8 +59745,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61632,8 +59810,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61699,8 +59875,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -61766,8 +59940,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -61833,8 +60005,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -61900,8 +60070,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -61967,8 +60135,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62034,8 +60200,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62101,8 +60265,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62168,8 +60330,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62235,8 +60395,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62302,8 +60460,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62369,8 +60525,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62437,8 +60591,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62505,8 +60657,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62573,8 +60723,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62641,8 +60789,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62709,8 +60855,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62777,8 +60921,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62845,8 +60987,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62913,8 +61053,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -62981,8 +61119,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63048,8 +61184,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63115,8 +61249,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63182,8 +61314,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63249,8 +61379,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63316,8 +61444,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63383,8 +61509,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63450,8 +61574,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63517,8 +61639,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63584,8 +61704,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63652,8 +61770,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63720,8 +61836,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63788,8 +61902,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63856,8 +61968,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63924,8 +62034,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -63992,8 +62100,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64060,8 +62166,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64128,8 +62232,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64196,8 +62298,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64263,8 +62363,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64330,8 +62428,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64397,8 +62493,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64464,8 +62558,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64531,8 +62623,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64598,8 +62688,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64665,8 +62753,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64732,8 +62818,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64800,8 +62884,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64868,8 +62950,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -64936,8 +63016,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65004,8 +63082,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65072,8 +63148,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65140,8 +63214,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65208,8 +63280,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65276,8 +63346,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65343,8 +63411,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65410,8 +63476,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65477,8 +63541,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65544,8 +63606,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65611,8 +63671,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65678,8 +63736,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65745,8 +63801,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65812,8 +63866,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65880,8 +63932,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -65948,8 +63998,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -66016,8 +64064,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -66084,8 +64130,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -66152,8 +64196,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -66220,8 +64262,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -66288,8 +64328,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -66356,8 +64394,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -66423,8 +64459,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -66490,8 +64524,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -66557,8 +64589,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -66624,8 +64654,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -66691,8 +64719,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -66758,8 +64784,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -66825,8 +64849,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -66892,8 +64914,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -66959,8 +64979,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67027,8 +65045,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67095,8 +65111,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67163,8 +65177,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67231,8 +65243,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67299,8 +65309,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67367,8 +65375,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67435,8 +65441,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67503,8 +65507,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67571,8 +65573,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67638,8 +65638,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67705,8 +65703,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67772,8 +65768,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67839,8 +65833,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67906,8 +65898,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -67973,8 +65963,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -68040,8 +66028,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -68107,8 +66093,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -68174,8 +66158,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -68242,8 +66224,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -68310,8 +66290,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -68378,8 +66356,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -68446,8 +66422,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -68514,8 +66488,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -68582,8 +66554,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -68650,8 +66620,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -68718,8 +66686,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -68785,8 +66751,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -68852,8 +66816,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -68919,8 +66881,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -68986,8 +66946,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69053,8 +67011,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69120,8 +67076,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69187,8 +67141,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69254,8 +67206,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69321,8 +67271,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69389,8 +67337,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69457,8 +67403,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69525,8 +67469,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69593,8 +67535,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69661,8 +67601,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69729,8 +67667,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69797,8 +67733,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -69866,8 +67800,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -69934,8 +67866,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -70002,8 +67932,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -70070,8 +67998,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -70138,8 +68064,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -70206,8 +68130,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -70274,8 +68196,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -70342,8 +68262,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -70410,8 +68328,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -70477,8 +68393,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -70544,8 +68458,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -70611,8 +68523,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -70678,8 +68588,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -70745,8 +68653,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -70812,8 +68718,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -70879,8 +68783,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -70946,8 +68848,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71013,8 +68913,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71080,8 +68978,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71147,8 +69043,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71214,8 +69108,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71281,8 +69173,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71348,8 +69238,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71415,8 +69303,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71482,8 +69368,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71549,8 +69433,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71616,8 +69498,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71683,8 +69563,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71750,8 +69628,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71817,8 +69693,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71884,8 +69758,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -71951,8 +69823,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -72018,8 +69888,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -72085,8 +69953,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -72152,8 +70018,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -72219,8 +70083,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -72286,8 +70148,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -72353,8 +70213,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -72420,8 +70278,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -72487,8 +70343,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -72554,8 +70408,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -72621,8 +70473,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -72688,8 +70538,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -72755,8 +70603,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -72822,8 +70668,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -72889,8 +70733,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -72956,8 +70798,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73023,8 +70863,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73090,8 +70928,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73157,8 +70993,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73224,8 +71058,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73291,8 +71123,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73358,8 +71188,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73425,8 +71253,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73492,8 +71318,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73559,8 +71383,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73626,8 +71448,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73693,8 +71513,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73760,8 +71578,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73827,8 +71643,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73894,8 +71708,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -73961,8 +71773,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -74028,8 +71838,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -74095,8 +71903,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -74162,8 +71968,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -74229,8 +72033,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -74296,8 +72098,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -74363,8 +72163,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -74430,8 +72228,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -74497,8 +72293,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -74564,8 +72358,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -74631,8 +72423,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -74698,8 +72488,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -74765,8 +72553,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -74832,8 +72618,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -74899,8 +72683,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -74966,8 +72748,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75033,8 +72813,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75100,8 +72878,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75167,8 +72943,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75234,8 +73008,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75301,8 +73073,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75368,8 +73138,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75435,8 +73203,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75502,8 +73268,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75569,8 +73333,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75636,8 +73398,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75703,8 +73463,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -75770,8 +73528,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -75837,8 +73593,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -75904,8 +73658,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -75971,8 +73723,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -76038,8 +73788,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -76105,8 +73853,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -76172,8 +73918,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -76239,8 +73983,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -76306,8 +74048,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -76373,8 +74113,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -76441,8 +74179,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -76509,8 +74245,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -76577,8 +74311,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -76645,8 +74377,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -76713,8 +74443,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -76781,8 +74509,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -76849,8 +74575,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -76917,8 +74641,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -76985,8 +74707,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77053,8 +74773,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77121,8 +74839,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77189,8 +74905,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77257,8 +74971,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77325,8 +75037,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77393,8 +75103,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77461,8 +75169,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77529,8 +75235,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77597,8 +75301,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77665,8 +75367,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77733,8 +75433,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77801,8 +75499,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77869,8 +75565,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -77937,8 +75631,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -78005,8 +75697,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -78073,8 +75763,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -78141,8 +75829,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -78209,8 +75895,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -78277,8 +75961,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -78345,8 +76027,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -78413,8 +76093,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -78481,8 +76159,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -78549,8 +76225,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -78617,8 +76291,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -78685,8 +76357,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -78753,8 +76423,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -78821,8 +76489,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -78889,8 +76555,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -78957,8 +76621,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79025,8 +76687,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79093,8 +76753,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79161,8 +76819,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79229,8 +76885,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79297,8 +76951,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79365,8 +77017,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79433,8 +77083,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79501,8 +77149,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79569,8 +77215,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79637,8 +77281,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79705,8 +77347,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79773,8 +77413,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79841,8 +77479,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79909,8 +77545,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -79977,8 +77611,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80045,8 +77677,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80113,8 +77743,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80181,8 +77809,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80249,8 +77875,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80317,8 +77941,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80385,8 +78007,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80453,8 +78073,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80521,8 +78139,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80589,8 +78205,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80657,8 +78271,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80725,8 +78337,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80793,8 +78403,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80861,8 +78469,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80929,8 +78535,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -80997,8 +78601,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81065,8 +78667,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81133,8 +78733,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81201,8 +78799,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81269,8 +78865,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81337,8 +78931,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81405,8 +78997,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81473,8 +79063,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81541,8 +79129,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81609,8 +79195,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81677,8 +79261,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81745,8 +79327,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81813,8 +79393,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81881,8 +79459,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -81949,8 +79525,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82017,8 +79591,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82085,8 +79657,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82153,8 +79723,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82221,8 +79789,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82289,8 +79855,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82357,8 +79921,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82425,8 +79987,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82493,8 +80053,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82561,8 +80119,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82629,8 +80185,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82697,8 +80251,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82765,8 +80317,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -82833,8 +80383,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -82901,8 +80449,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -82969,8 +80515,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83037,8 +80581,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83105,8 +80647,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83173,8 +80713,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83241,8 +80779,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83309,8 +80845,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83377,8 +80911,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83445,8 +80977,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83513,8 +81043,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83581,8 +81109,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83649,8 +81175,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83717,8 +81241,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83785,8 +81307,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83853,8 +81373,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83921,8 +81439,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -83989,8 +81505,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84057,8 +81571,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84125,8 +81637,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84193,8 +81703,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84261,8 +81769,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84329,8 +81835,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84397,8 +81901,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84465,8 +81967,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84533,8 +82033,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84601,8 +82099,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84669,8 +82165,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84737,8 +82231,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84805,8 +82297,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84873,8 +82363,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -84941,8 +82429,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -85009,8 +82495,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -85077,8 +82561,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -85145,8 +82627,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -85213,8 +82693,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -85281,8 +82759,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -85349,8 +82825,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -85417,8 +82891,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -85485,8 +82957,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -85553,8 +83023,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -85621,8 +83089,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -85689,8 +83155,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -85757,8 +83221,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -85825,8 +83287,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -85893,8 +83353,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -85961,8 +83419,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -86029,8 +83485,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -86097,8 +83551,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -86165,8 +83617,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -86233,8 +83683,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -86301,8 +83749,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -86370,8 +83816,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -86439,8 +83883,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -86508,8 +83950,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -86577,8 +84017,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -86646,8 +84084,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -86715,8 +84151,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -86784,8 +84218,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -86853,8 +84285,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -86922,8 +84352,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -86990,8 +84418,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87057,8 +84483,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87124,8 +84548,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87191,8 +84613,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87258,8 +84678,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87325,8 +84743,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87392,8 +84808,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87459,8 +84873,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87526,8 +84938,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87593,8 +85003,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87660,8 +85068,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87727,8 +85133,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87794,8 +85198,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87861,8 +85263,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87928,8 +85328,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -87995,8 +85393,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88062,8 +85458,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88129,8 +85523,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88196,8 +85588,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88263,8 +85653,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88330,8 +85718,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88397,8 +85783,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88464,8 +85848,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88531,8 +85913,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88598,8 +85978,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88665,8 +86043,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88732,8 +86108,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -88799,8 +86173,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -88866,8 +86238,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -88933,8 +86303,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89000,8 +86368,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89067,8 +86433,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89134,8 +86498,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89201,8 +86563,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89268,8 +86628,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89335,8 +86693,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89402,8 +86758,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89470,8 +86824,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89538,8 +86890,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89606,8 +86956,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89674,8 +87022,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89742,8 +87088,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89810,8 +87154,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89878,8 +87220,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -89946,8 +87286,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90014,8 +87352,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90081,8 +87417,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90148,8 +87482,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90215,8 +87547,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90282,8 +87612,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90349,8 +87677,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90416,8 +87742,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90483,8 +87807,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90550,8 +87872,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90617,8 +87937,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90685,8 +88003,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90753,8 +88069,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90821,8 +88135,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90889,8 +88201,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -90957,8 +88267,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91025,8 +88333,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91093,8 +88399,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91161,8 +88465,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91229,8 +88531,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91296,8 +88596,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91363,8 +88661,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91430,8 +88726,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91497,8 +88791,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91564,8 +88856,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91631,8 +88921,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91698,8 +88986,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91765,8 +89051,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91833,8 +89117,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91901,8 +89183,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -91969,8 +89249,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92037,8 +89315,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92105,8 +89381,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92173,8 +89447,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92241,8 +89513,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92309,8 +89579,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92376,8 +89644,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92443,8 +89709,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92510,8 +89774,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92577,8 +89839,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92644,8 +89904,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92711,8 +89969,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92778,8 +90034,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92845,8 +90099,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92913,8 +90165,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -92981,8 +90231,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -93049,8 +90297,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -93117,8 +90363,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -93185,8 +90429,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -93253,8 +90495,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -93321,8 +90561,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -93389,8 +90627,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -93456,8 +90692,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -93523,8 +90757,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -93590,8 +90822,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -93657,8 +90887,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -93724,8 +90952,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -93791,8 +91017,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -93858,8 +91082,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -93925,8 +91147,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -93992,8 +91212,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94060,8 +91278,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94128,8 +91344,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94196,8 +91410,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94264,8 +91476,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94332,8 +91542,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94400,8 +91608,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94468,8 +91674,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94536,8 +91740,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94604,8 +91806,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94671,8 +91871,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94738,8 +91936,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94805,8 +92001,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94872,8 +92066,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -94939,8 +92131,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -95006,8 +92196,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -95073,8 +92261,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -95140,8 +92326,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -95207,8 +92391,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -95274,8 +92456,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -95341,8 +92521,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -95408,8 +92586,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -95475,8 +92651,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -95542,8 +92716,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -95609,8 +92781,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -95676,8 +92846,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -95743,8 +92911,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -95811,8 +92977,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -95879,8 +93043,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -95947,8 +93109,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -96015,8 +93175,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -96083,8 +93241,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -96151,8 +93307,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -96219,8 +93373,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -96287,8 +93439,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -96355,8 +93505,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -113,8 +113,6 @@ periodics:
           --test-package-marker=latest.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -247,8 +245,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -313,8 +309,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -379,8 +373,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -446,8 +438,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -513,8 +503,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR
@@ -579,8 +567,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -645,8 +631,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -712,8 +696,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -779,8 +761,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -845,8 +825,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -1217,8 +1195,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -1283,8 +1259,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -1351,8 +1325,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -1545,8 +1517,6 @@ periodics:
           --skip-regex="\[Feature:Volumes\]|\[Driver:.nfs\]|\[Driver:.nfs3\]|\[Driver:.local\]|\[Feature:SELinuxMountReadWriteOncePodOnly\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -1686,8 +1656,6 @@ periodics:
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]" \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -1755,8 +1723,6 @@ periodics:
           --skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]" \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -1895,8 +1861,6 @@ periodics:
           --skip-regex="\[Driver:.gcepd\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]" \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -2035,8 +1999,6 @@ periodics:
           --skip-regex="\[FOOBAR\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -2103,8 +2065,6 @@ periodics:
           --skip-regex="\[FOOBAR\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -2173,8 +2133,6 @@ periodics:
           --skip-regex="\[FOOBAR\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -2243,8 +2201,6 @@ periodics:
           --skip-regex="should.serve.endpoints.on.same.port.and.different.protocols|same.hostPort.but.different.hostIP.and.protocol" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -2383,8 +2339,6 @@ periodics:
           --skip-regex="\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -2524,8 +2478,6 @@ periodics:
           --skip-regex="\[Driver:.gcepd\]|\[Flaky\]|\[Feature:.+\]" \
           --parallel=1
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -2595,8 +2547,6 @@ periodics:
           --skip-regex="\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0" \
           --parallel=4
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -41,8 +41,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -107,8 +105,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -368,8 +364,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -563,8 +557,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -695,8 +687,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -761,8 +751,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -827,8 +815,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -1022,8 +1008,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -1088,8 +1072,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -1283,8 +1265,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-periodics-nftables.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-nftables.yaml
@@ -41,8 +41,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -107,8 +105,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -173,8 +169,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: admin
       - name: GINKGO_NO_COLOR
@@ -239,8 +233,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -305,8 +297,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -371,8 +361,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -437,8 +425,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -503,8 +489,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -569,8 +553,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -635,8 +617,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -701,8 +681,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -767,8 +745,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -833,8 +809,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -899,8 +873,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -965,8 +937,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ec2-user
       - name: GINKGO_NO_COLOR
@@ -1031,8 +1001,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -1097,8 +1065,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: rocky
       - name: GINKGO_NO_COLOR
@@ -1164,8 +1130,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: core
       - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-pipeline.yaml
@@ -46,8 +46,6 @@ periodics:
           --skip-regex="\[Slow\]|\[Serial\]" \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -116,8 +114,6 @@ periodics:
           --skip-regex="\[Slow\]|\[Serial\]" \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -186,8 +182,6 @@ periodics:
           --skip-regex="\[Slow\]|\[Serial\]" \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -256,8 +250,6 @@ periodics:
           --skip-regex="\[Slow\]|\[Serial\]" \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -43,8 +43,6 @@ periodics:
           --test-package-marker=latest.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -110,8 +108,6 @@ periodics:
           --test-package-marker=latest-1.34.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -177,8 +173,6 @@ periodics:
           --test-package-marker=latest-1.35.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR
@@ -244,8 +238,6 @@ periodics:
           --test-package-marker=latest-1.36.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/aws-ssh/aws-ssh-private
       - name: KUBE_SSH_USER
         value: ubuntu
       - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-presubmits-ai-conformance.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-ai-conformance.yaml
@@ -31,8 +31,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-presubmits-branch.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-branch.yaml
@@ -47,8 +47,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -186,8 +184,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -325,8 +321,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -464,8 +458,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -45,8 +45,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: admin
         - name: GINKGO_NO_COLOR
@@ -112,8 +110,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: admin
         - name: GINKGO_NO_COLOR
@@ -179,8 +175,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: admin
         - name: GINKGO_NO_COLOR
@@ -246,8 +240,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: admin
         - name: GINKGO_NO_COLOR
@@ -313,8 +305,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: admin
         - name: GINKGO_NO_COLOR
@@ -380,8 +370,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: admin
         - name: GINKGO_NO_COLOR
@@ -447,8 +435,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -514,8 +500,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -581,8 +565,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -649,8 +631,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -717,8 +697,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -784,8 +762,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -851,8 +827,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -919,8 +893,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -987,8 +959,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1054,8 +1024,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1121,8 +1089,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1189,8 +1155,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1257,8 +1221,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1324,8 +1286,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1391,8 +1351,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1459,8 +1417,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1527,8 +1483,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ec2-user
         - name: GINKGO_NO_COLOR
@@ -1594,8 +1548,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ec2-user
         - name: GINKGO_NO_COLOR
@@ -1661,8 +1613,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ec2-user
         - name: GINKGO_NO_COLOR
@@ -1729,8 +1679,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ec2-user
         - name: GINKGO_NO_COLOR
@@ -1797,8 +1745,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ec2-user
         - name: GINKGO_NO_COLOR
@@ -1864,8 +1810,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ec2-user
         - name: GINKGO_NO_COLOR
@@ -1931,8 +1875,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ec2-user
         - name: GINKGO_NO_COLOR
@@ -1999,8 +1941,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ec2-user
         - name: GINKGO_NO_COLOR
@@ -2067,8 +2007,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: rocky
         - name: GINKGO_NO_COLOR
@@ -2134,8 +2072,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: rocky
         - name: GINKGO_NO_COLOR
@@ -2201,8 +2137,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: rocky
         - name: GINKGO_NO_COLOR
@@ -2269,8 +2203,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: rocky
         - name: GINKGO_NO_COLOR
@@ -2337,8 +2269,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: core
         - name: GINKGO_NO_COLOR
@@ -2404,8 +2334,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: core
         - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-presubmits-dns-none.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-dns-none.yaml
@@ -45,8 +45,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -313,8 +311,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -48,8 +48,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -118,8 +116,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -186,8 +182,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -253,8 +247,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ec2-user
         - name: GINKGO_NO_COLOR
@@ -321,8 +313,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -931,8 +921,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -991,8 +979,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1046,8 +1032,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1115,8 +1099,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1183,8 +1165,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1251,8 +1231,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1321,8 +1299,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1389,8 +1365,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1457,8 +1431,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1593,8 +1565,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1661,8 +1631,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1730,8 +1698,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1799,8 +1765,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1853,8 +1817,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1908,8 +1870,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1963,8 +1923,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -2022,8 +1980,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -2092,8 +2048,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -2160,8 +2114,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -2231,8 +2183,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -46,8 +46,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -114,8 +112,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -183,8 +179,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -387,8 +381,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -456,8 +448,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -660,8 +650,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -729,8 +717,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -867,8 +853,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -936,8 +920,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1005,8 +987,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1074,8 +1054,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1278,8 +1256,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -1347,8 +1323,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -37,8 +37,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR
@@ -139,8 +137,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/kops-presubmits-upgrades-dns-none.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-upgrades-dns-none.yaml
@@ -31,8 +31,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/aws-ssh/aws-ssh-private
         - name: KUBE_SSH_USER
           value: ubuntu
         - name: GINKGO_NO_COLOR

--- a/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
@@ -120,9 +120,13 @@
           {%- endif %}
           --parallel={{test_parallelism}}
       env:
-      {%- if cloud != "azure" and cloud != "do" %}
+      {#- AWS jobs get the key from preset-aws-ssh's AWS_SSH_PRIVATE_KEY_FILE,
+          which kubetest2-kops re-exports as KUBE_SSH_KEY_PATH for the e2e framework. -#}
+      {%- if cloud != "azure" and cloud != "do" and cloud != "aws" %}
       - name: KUBE_SSH_KEY_PATH
         value: {{kops_ssh_key_path}}
+      {%- endif %}
+      {%- if cloud != "azure" and cloud != "do" %}
       - name: KUBE_SSH_USER
         value: {{kops_ssh_user}}
       {%- endif %}

--- a/config/jobs/kubernetes/kops/templates/presubmit-scenario.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit-scenario.yaml.jinja
@@ -70,9 +70,13 @@
         - name: KOPS_FEATURE_FLAGS
           value: "{{kops_feature_flags}}"
         {%- endif %}
-        {%- if cloud != "azure" %}
+        {#- AWS jobs get the key from preset-aws-ssh's AWS_SSH_PRIVATE_KEY_FILE,
+            which kubetest2-kops re-exports as KUBE_SSH_KEY_PATH for the e2e framework. -#}
+        {%- if cloud != "azure" and cloud != "aws" %}
         - name: KUBE_SSH_KEY_PATH
           value: {{kops_ssh_key_path}}
+        {%- endif %}
+        {%- if cloud != "azure" %}
         - name: KUBE_SSH_USER
           value: {{kops_ssh_user}}
         {%- endif %}

--- a/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
@@ -122,9 +122,13 @@
         securityContext:
           privileged: true
         env:
-        {%- if cloud != "azure" and cloud != "do" %}
+        {#- AWS jobs get the key from preset-aws-ssh's AWS_SSH_PRIVATE_KEY_FILE,
+            which kubetest2-kops re-exports as KUBE_SSH_KEY_PATH for the e2e framework. -#}
+        {%- if cloud != "azure" and cloud != "do" and cloud != "aws" %}
         - name: KUBE_SSH_KEY_PATH
           value: {{kops_ssh_key_path}}
+        {%- endif %}
+        {%- if cloud != "azure" and cloud != "do" %}
         - name: KUBE_SSH_USER
           value: {{kops_ssh_user}}
         {%- endif %}


### PR DESCRIPTION
Every AWS kops job already carries `preset-aws-ssh` (all four templates add it unconditionally for `cloud == "aws"`). That preset mounts the key secret and exports:

```yaml
- name: AWS_SSH_PRIVATE_KEY_FILE
  value: /etc/aws-ssh/aws-ssh-private
```

https://github.com/kubernetes/test-infra/blob/be53e5885863880b05e87ebf166957fe84ee58ee/config/prow/config.yaml#L1007-L1013

which is byte-identical to the `KUBE_SSH_KEY_PATH` the templates were *also* emitting on every AWS job. The templates render `kops_ssh_key_path = '/etc/aws-ssh/aws-ssh-private'` for AWS — the same path, from the same secret.

It is not just duplicated, it is the value the deployer never reads. On AWS, `kubetest2-kops` resolves the key from `AWS_SSH_PRIVATE_KEY_FILE` in `tests/e2e/kubetest2-kops/deployer/common.go`; `KUBE_SSH_KEY_PATH` is consulted only in the GCE branch. The deployer then re-exports `KUBE_SSH_KEY_PATH=<resolved private key>` from `deployer.env()`, with a comment citing the k/k line that consumes it, so downstream test binaries still see it.

https://github.com/kubernetes/kops/blob/889251632ef7fa4c2c661e37bd55436b93d445a4/tests/e2e/kubetest2-kops/deployer/common.go#L76-L78

This emits `KUBE_SSH_KEY_PATH` only for the clouds whose deployer path actually reads it.

## What is kept

- **GCE keeps it.** With an explicit `--gcp-project`, `common.go` uses `KUBE_SSH_KEY_PATH` as the *only* key source and has no keypair-generation fallback. All 1003 remaining entries point at `/etc/ssh-key-secret/ssh-private` from `preset-k8s-ssh`.
- **`KUBE_SSH_USER` is untouched everywhere** — 2654 entries before and after. It cannot be dropped the same way: nothing derives the SSH user from the AMI, and k/k's `test/e2e/framework/ssh/ssh.go` silently falls back to `$USER` (which `preset-aws-ssh` sets to `prow`), so removing it would produce auth failures rather than a clean error.
- Azure and DigitalOcean paths are unchanged; the aws exclusion was added to the existing conditionals rather than rewriting them.

## Testing

- `go test ./config/tests/jobs/...` passes (run with `-count=1`).
- Regenerated against the existing `pinned.list`, so no image or cron churn. The generated diff is **0 insertions, 3198 deletions**, and every changed line is either a `KUBE_SSH_KEY_PATH` name or an `/etc/aws-ssh/aws-ssh-private` value — nothing else moved.
- Parsed all generated job YAML and asserted every job still has a key source. Result: 1649 AWS jobs now sourcing it from `preset-aws-ssh`, 1003 keeping an explicit path, 27 azure/do jobs that legitimately have neither.
- No `aws-ssh-private` reference remains in the kops job configs.

## Pre-existing issue found while validating (not addressed here)

The same audit flagged `e2e-kops-gce-upgrade-dns-none`, which has an **empty `labels:` block** — no ssh preset and no `KUBE_SSH_KEY_PATH`. This is pre-existing on master and untouched by this PR: `templates/periodic-scenario.yaml.jinja` only emits preset labels for `aws` and `azure`, with no branch for `gce` or `do`. Worth a separate look.

/sig testing
/area jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)