### PR TITLE
Add tas was e2e jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -1421,11 +1421,13 @@ periodics:
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
           args:
             - make
             - kind-image-build
             - test-tas-was-e2e-baseline
+          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -1466,11 +1468,13 @@ periodics:
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
           args:
             - make
             - kind-image-build
             - test-tas-was-e2e-extended-shard-0
+          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -1511,11 +1515,13 @@ periodics:
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
           args:
             - make
             - kind-image-build
             - test-tas-was-e2e-extended-shard-1
+          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -1391,6 +1391,142 @@ periodics:
               cpu: "4800m"
               memory: "10Gi"
   - interval: 12h
+    name: periodic-kueue-test-e2e-tas-was-baseline-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-was-baseline-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic tas was baseline end to end tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      pod_unscheduled_timeout: 14m
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-tas-was-e2e-baseline
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "4000m"
+              memory: "10Gi"
+            limits:
+              cpu: "4000m"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-tas-was-extended-shard-0-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-was-extended-shard-0-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic tas was extended end to end tests shard 0"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      pod_unscheduled_timeout: 14m
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-tas-was-e2e-extended-shard-0
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "3700m"
+              memory: "10Gi"
+            limits:
+              cpu: "3700m"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-tas-was-extended-shard-1-main
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-was-extended-shard-1-main
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic tas was extended end to end tests shard 1"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: main
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      pod_unscheduled_timeout: 14m
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-tas-was-e2e-extended-shard-1
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "4800m"
+              memory: "10Gi"
+            limits:
+              cpu: "4800m"
+              memory: "10Gi"
+
+  - interval: 12h
     name: periodic-kueue-test-e2e-sequential-baseline-shard-0-main
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -1417,7 +1417,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1464,7 +1464,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1511,7 +1511,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
@@ -1381,7 +1381,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1428,7 +1428,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1475,7 +1475,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
@@ -1391,7 +1391,7 @@ periodics:
             - make
             - kind-image-build
             - test-tas-was-e2e-baseline
-            # docker-in-docker needs privileged mode
+          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -1438,7 +1438,7 @@ periodics:
             - make
             - kind-image-build
             - test-tas-was-e2e-extended-shard-0
-            # docker-in-docker needs privileged mode
+          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -1485,7 +1485,7 @@ periodics:
             - make
             - kind-image-build
             - test-tas-was-e2e-extended-shard-1
-            # docker-in-docker needs privileged mode
+          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
@@ -1355,6 +1355,147 @@ periodics:
               cpu: "6500m"
               memory: "10Gi"
   - interval: 12h
+    name: periodic-kueue-test-e2e-tas-was-baseline-release-0-19
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-was-baseline-release-0-19
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic tas was baseline end to end tests"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.19
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      pod_unscheduled_timeout: 14m
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-tas-was-e2e-baseline
+            # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "6000m"
+              memory: "10Gi"
+            limits:
+              cpu: "6000m"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-tas-was-extended-shard-0-release-0-19
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-was-extended-shard-0-release-0-19
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic tas was extended end to end tests shard 0"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.19
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      pod_unscheduled_timeout: 14m
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-tas-was-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "4100m"
+              memory: "10Gi"
+            limits:
+              cpu: "4100m"
+              memory: "10Gi"
+  - interval: 12h
+    name: periodic-kueue-test-e2e-tas-was-extended-shard-1-release-0-19
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: periodic-kueue-test-e2e-tas-was-extended-shard-1-release-0-19
+      testgrid-alert-email: kueue-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+      description: "Run periodic tas was extended end to end tests shard 1"
+      testgrid-num-columns-recent: '30'
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: kueue
+        base_ref: release-0.19
+        path_alias: kubernetes-sigs/kueue
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      pod_unscheduled_timeout: 14m
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+          env:
+            - name: E2E_K8S_VERSION
+              value: "1.35"
+            - name: BASE_BUILDER_IMAGE
+              value: public.ecr.aws/docker/library/golang
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          args:
+            - make
+            - kind-image-build
+            - test-tas-was-e2e-extended-shard-1
+            # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "6500m"
+              memory: "10Gi"
+            limits:
+              cpu: "6500m"
+              memory: "10Gi"
+  - interval: 12h
     name: periodic-kueue-test-e2e-sequential-baseline-shard-0-release-0-19
     cluster: eks-prow-build-cluster
     annotations:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -1083,7 +1083,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1124,7 +1124,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1165,7 +1165,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -1062,6 +1062,129 @@ presubmits:
               limits:
                 cpu: "6500m"
                 memory: "10Gi"
+    - name: pull-kueue-test-e2e-tas-was-baseline-main
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        pod_unscheduled_timeout: 14m
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-tas-was-baseline-main
+        description: "Run tas was baseline end to end tests"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-tas-was-e2e-baseline
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "6000m"
+                memory: "10Gi"
+              limits:
+                cpu: "6000m"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-tas-was-extended-shard-0-main
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        pod_unscheduled_timeout: 14m
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-tas-was-extended-shard-0-main
+        description: "Run tas was extended end to end tests shard 0"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-tas-was-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "4100m"
+                memory: "10Gi"
+              limits:
+                cpu: "4100m"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-tas-was-extended-shard-1-main
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^main
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        pod_unscheduled_timeout: 14m
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-tas-was-extended-shard-1-main
+        description: "Run tas was extended end to end tests shard 1"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-tas-was-e2e-extended-shard-1
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "6500m"
+                memory: "10Gi"
+              limits:
+                cpu: "6500m"
+                memory: "10Gi"
     - name: pull-kueue-test-e2e-sequential-baseline-shard-0-main
       cluster: eks-prow-build-cluster
       branches:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
@@ -1055,11 +1055,13 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
               - test-tas-was-e2e-baseline
+            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -1094,11 +1096,13 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
               - test-tas-was-e2e-extended-shard-0
+            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -1133,11 +1137,13 @@ presubmits:
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
+              # generic runner script, handles DIND, bazelrc for caching, etc.
               - runner.sh
             args:
               - make
               - kind-image-build
               - test-tas-was-e2e-extended-shard-1
+            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
@@ -1051,7 +1051,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1092,7 +1092,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1133,7 +1133,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
@@ -1030,6 +1030,123 @@ presubmits:
               limits:
                 cpu: "6500m"
                 memory: "10Gi"
+    - name: pull-kueue-test-e2e-tas-was-baseline-release-0-19
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.19
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        pod_unscheduled_timeout: 14m
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-tas-was-baseline-release-0-19
+        description: "Run tas was baseline end to end tests"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-tas-was-e2e-baseline
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "6000m"
+                memory: "10Gi"
+              limits:
+                cpu: "6000m"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-tas-was-extended-shard-0-release-0-19
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.19
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        pod_unscheduled_timeout: 14m
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-tas-was-extended-shard-0-release-0-19
+        description: "Run tas was extended end to end tests shard 0"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-tas-was-e2e-extended-shard-0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "4100m"
+                memory: "10Gi"
+              limits:
+                cpu: "4100m"
+                memory: "10Gi"
+    - name: pull-kueue-test-e2e-tas-was-extended-shard-1-release-0-19
+      cluster: eks-prow-build-cluster
+      branches:
+        - ^release-0.19
+      skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$|^(keps|site|charts)/"
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        pod_unscheduled_timeout: 14m
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-tas-was-extended-shard-1-release-0-19
+        description: "Run tas was extended end to end tests shard 1"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.35"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-tas-was-e2e-extended-shard-1
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "6500m"
+                memory: "10Gi"
+              limits:
+                cpu: "6500m"
+                memory: "10Gi"
     - name: pull-kueue-test-e2e-sequential-baseline-shard-0-release-0-19
       cluster: eks-prow-build-cluster
       branches:


### PR DESCRIPTION
## Summary
Adds the new scheduler-library (WAS) TAS e2e tests (baseline + sharded extended) to presubmits and periodics for both main and release-0.19.
This will help catch regressions with scheduler-library integration.

## Fix
Fix for [kubernetes-sigs/kueue#14391](https://github.com/kubernetes-sigs/kueue/issues/14391)
