### PR TITLE
agent-sandbox: skip presubmits for OWNERS changes in subdirectories

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -7,7 +7,7 @@ presubmits:
   kubernetes-sigs/agent-sandbox:
   - name: presubmit-test-autogen-up-to-date
     cluster: eks-prow-build-cluster
-    skip_if_only_changed: "^(docs|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    skip_if_only_changed: "^(docs|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|(.*/)?OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     labels:
       preset-service-account: "true"
@@ -30,7 +30,7 @@ presubmits:
       testgrid-num-columns-recent: "30"
   - name: presubmit-agent-sandbox-test-unit
     cluster: eks-prow-build-cluster
-    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|(.*/)?OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     spec:
       containers:
@@ -87,7 +87,7 @@ presubmits:
       testgrid-tab-name: presubmit-lint-api
   - name: presubmit-agent-sandbox-test-e2e
     cluster: eks-prow-build-cluster
-    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|(.*/)?OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -112,7 +112,7 @@ presubmits:
       testgrid-tab-name: presubmit-test-e2e
   - name: presubmit-agent-sandbox-benchmarks-kops-gcp-cilium
     cluster: k8s-infra-prow-build
-    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|(.*/)?OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     optional: true
     labels:
@@ -172,7 +172,7 @@ presubmits:
       testgrid-tab-name: presubmit-benchmarks-kops-gcp-claims
   - name: presubmit-agent-sandbox-benchmarks-kops-gcp-kindnet
     cluster: k8s-infra-prow-build
-    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|(.*/)?OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     optional: true
     labels:
@@ -202,7 +202,7 @@ presubmits:
       testgrid-tab-name: presubmit-benchmarks-kops-gcp-kindnet
   - name: presubmit-agent-sandbox-test-skill-eval
     cluster: eks-prow-build-cluster
-    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|(.*/)?OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     always_run: false
     optional: true
@@ -223,7 +223,7 @@ presubmits:
       testgrid-tab-name: presubmit-test-skill-eval
   - name: presubmit-agent-sandbox-test-e2e-scalability-kwok
     cluster: eks-prow-build-cluster
-    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|(.*/)?OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     optional: true
     labels:
@@ -249,7 +249,7 @@ presubmits:
       testgrid-tab-name: presubmit-test-e2e-scalability-kwok
   - name: presubmit-agent-sandbox-lint-olm
     cluster: eks-prow-build-cluster
-    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|(.*/)?OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     optional: true
     spec:
@@ -269,7 +269,7 @@ presubmits:
       testgrid-tab-name: presubmit-lint-olm
   - name: presubmit-agent-sandbox-test-olm-unit
     cluster: eks-prow-build-cluster
-    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
+    skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|(.*/)?OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
     optional: true
     spec:

--- a/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/generate_jobs.py
@@ -42,7 +42,7 @@ import sys
 
 import yaml
 
-IMAGE = "us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260712-9b391474f6-master"  # pylint: disable=line-too-long
+IMAGE = "us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master"  # pylint: disable=line-too-long
 DASHBOARD = "sig-apps-agent-sandbox"
 REPO_ORG = "kubernetes-sigs"
 REPO_NAME = "agent-sandbox"
@@ -50,13 +50,13 @@ REPO_NAME = "agent-sandbox"
 # Skip presubmits when only docs/site/metadata changed.
 SKIP_DOCS = (
     r"^(docs|site|\.agents)/|\.md$"
-    r"|^(\.gitignore|LICENSE|netlify\.toml|OWNERS|\.coderabbit\.yaml|SECURITY_CONTACTS|cloudbuild\.yaml)$"  # pylint: disable=line-too-long
+    r"|^(\.gitignore|LICENSE|netlify\.toml|(.*/)?OWNERS|\.coderabbit\.yaml|SECURITY_CONTACTS|cloudbuild\.yaml)$"  # pylint: disable=line-too-long
     r"|^\.github/"
 )
 # Variant that still runs for site/ changes (used by the autogen check).
 SKIP_DOCS_ALLOW_SITE = (
     r"^(docs|\.agents)/|\.md$"
-    r"|^(\.gitignore|LICENSE|netlify\.toml|OWNERS|\.coderabbit\.yaml|SECURITY_CONTACTS|cloudbuild\.yaml)$"  # pylint: disable=line-too-long
+    r"|^(\.gitignore|LICENSE|netlify\.toml|(.*/)?OWNERS|\.coderabbit\.yaml|SECURITY_CONTACTS|cloudbuild\.yaml)$"  # pylint: disable=line-too-long
     r"|^\.github/"
 )
 


### PR DESCRIPTION
Currently, presubmit tests for `agent-sandbox` are only skipped when the root `OWNERS` file is changed. If an `OWNERS` file in a subdirectory (e.g., `olm/OWNERS`) is changed, all presubmits still run.

This PR updates `generate_jobs.py` to match `OWNERS` files in any directory by changing `OWNERS` to `(.*/)?OWNERS` in the `skip_if_only_changed` regex.

The job configurations have been manually updated to apply this change to existing jobs, to avoid bringing in unrelated new jobs from the `agent-sandbox` main branch.