### PR TITLE
dra-driver-cpu: cover node allocatable mappings enabled and disabled cases in e2e lanes.

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
@@ -36,7 +36,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-node-dra-driver-cpu
       testgrid-tab-name: e2e-test-master-individual
-      description: "Build image and run e2e-tests in individual mode"
+      description: "Build image and run e2e-tests in individual mode with node allocatable mappings enabled"
     spec:
       nodeSelector:
         kubernetes.io/arch: amd64
@@ -45,6 +45,8 @@ presubmits:
         env:
         - name: DRACPU_E2E_CPU_DEVICE_MODE
           value: "individual"
+        - name: DRACPU_E2E_NODE_ALLOCATABLE_MAPPING
+          value: "true"
         - name: DRACPU_E2E_VERBOSE
           value: "1"
         command:
@@ -74,7 +76,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-node-dra-driver-cpu
       testgrid-tab-name: e2e-test-master-individual-arm
-      description: "Build image and run e2e-tests in individual mode"
+      description: "Build image and run e2e-tests in individual mode with node allocatable mappings disabled"
     spec:
       nodeSelector:
         kubernetes.io/arch: arm64
@@ -83,6 +85,8 @@ presubmits:
         env:
         - name: DRACPU_E2E_CPU_DEVICE_MODE
           value: "individual"
+        - name: DRACPU_E2E_NODE_ALLOCATABLE_MAPPING
+          value: "false"
         - name: DRACPU_E2E_VERBOSE
           value: "1"
         command:
@@ -112,7 +116,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-node-dra-driver-cpu
       testgrid-tab-name: e2e-test-master-grouped
-      description: "Build image and run e2e-tests in grouped mode"
+      description: "Build image and run e2e-tests in grouped mode with node allocatable mappings enabled"
     spec:
       nodeSelector:
         kubernetes.io/arch: amd64
@@ -123,6 +127,8 @@ presubmits:
           value: "grouped"
         - name: DRACPU_E2E_CPU_GROUP_BY
           value: "numanode"
+        - name: DRACPU_E2E_NODE_ALLOCATABLE_MAPPING
+          value: "true"
         - name: DRACPU_E2E_VERBOSE
           value: "1"
         command:
@@ -152,7 +158,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-node-dra-driver-cpu
       testgrid-tab-name: e2e-test-master-grouped-arm
-      description: "Build image and run e2e-tests in grouped mode"
+      description: "Build image and run e2e-tests in grouped mode with node allocatable mappings disabled"
     spec:
       nodeSelector:
         kubernetes.io/arch: arm64
@@ -163,6 +169,8 @@ presubmits:
           value: "grouped"
         - name: DRACPU_E2E_CPU_GROUP_BY
           value: "numanode"
+        - name: DRACPU_E2E_NODE_ALLOCATABLE_MAPPING
+          value: "false"
         - name: DRACPU_E2E_VERBOSE
           value: "1"
         command:
@@ -192,7 +200,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-node-dra-driver-cpu
       testgrid-tab-name: e2e-test-master-grouped-socket
-      description: "Build image and run e2e-tests in grouped socket mode"
+      description: "Build image and run e2e-tests in grouped socket mode with node allocatable mappings enabled"
     spec:
       nodeSelector:
         kubernetes.io/arch: amd64
@@ -203,6 +211,8 @@ presubmits:
           value: "grouped"
         - name: DRACPU_E2E_CPU_GROUP_BY
           value: "socket"
+        - name: DRACPU_E2E_NODE_ALLOCATABLE_MAPPING
+          value: "true"
         - name: DRACPU_E2E_VERBOSE
           value: "1"
         command:
@@ -230,7 +240,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-node-dra-driver-cpu
       testgrid-tab-name: e2e-test-master-grouped-machine
-      description: "Build image and run e2e-tests in grouped machine mode"
+      description: "Build image and run e2e-tests in grouped machine mode with node allocatable mappings enabled"
     spec:
       nodeSelector:
         kubernetes.io/arch: amd64
@@ -241,6 +251,8 @@ presubmits:
           value: "grouped"
         - name: DRACPU_E2E_CPU_GROUP_BY
           value: "machine"
+        - name: DRACPU_E2E_NODE_ALLOCATABLE_MAPPING
+          value: "true"
         - name: DRACPU_E2E_VERBOSE
           value: "1"
         command:


### PR DESCRIPTION
Pin DRACPU_E2E_NODE_ALLOCATABLE_MAPPING explicitly in every e2e presubmit: enabled on the amd64 lanes, disabled on the arm64 lanes. The feature itself is not architecture dependent, but enabling in some lanes so that we have both configs covered without adding new lanes.