### PR TITLE
kubernetes-sigs/agent-sandbox: make the olm tests required

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-presubmits-main.yaml
@@ -251,7 +251,6 @@ presubmits:
     cluster: eks-prow-build-cluster
     skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|(.*/)?OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
-    optional: true
     spec:
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
@@ -271,7 +270,6 @@ presubmits:
     cluster: eks-prow-build-cluster
     skip_if_only_changed: "^(docs|site|\\.agents)/|\\.md$|^(\\.gitignore|LICENSE|netlify\\.toml|(.*/)?OWNERS|\\.coderabbit\\.yaml|SECURITY_CONTACTS|cloudbuild\\.yaml)$|^\\.github/"
     decorate: true
-    optional: true
     spec:
       containers:
       - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master


### PR DESCRIPTION
As they are now stable in the agent-sandbox CI