### PR TITLE
Remove PARALLEL from snapshot-metadata prow jobs

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
@@ -125,8 +125,6 @@ presubmits:
           value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
         - name: FOCUS
           value: \[Feature:snapshotmetadata\]
-        - name: PARALLEL
-          value: "true"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -467,8 +465,6 @@ periodics:
           value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
         - name: FOCUS
           value: \[Feature:snapshotmetadata\]
-        - name: PARALLEL
-          value: "true"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
PARALLEL=true causes run_snapshot_metadata_e2e.sh to add SKIP=\[Serial\] which silently skips all [Serial] tagged tests. This prevents the new snapshot-metadata-stress suite (tagged [Serial], [Slow]) from running.

No other comparable stress suite prow job sets PARALLEL:
- pull-kubernetes-e2e-storage-kind-volume-group-snapshots
- ci-kubernetes-e2e-snapshot

The snapshot-metadata suite currently has only 2 non-stress tests - parallelism provides negligible benefit while excluding serial stress tests.

required for: https://github.com/kubernetes/kubernetes/pull/141372