### PR TITLE
kops: canary ephemeral SSH keys on two AWS jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -115,6 +115,7 @@ def build_test(cloud='aws',
                alert_email=None,
                alert_num_failures=None,
                job_queue_name=None,
+               ephemeral_ssh_key=False,
                extra_refs=None):
     # pylint: disable=too-many-statements,too-many-arguments
     if kops_version is None:
@@ -267,6 +268,7 @@ def build_test(cloud='aws',
         instance_groups_overrides=instance_groups_overrides,
         extra_refs=extra_refs,
         job_queue_name=job_queue_name,
+        ephemeral_ssh_key=ephemeral_ssh_key,
     )
 
     spec = {
@@ -1409,6 +1411,10 @@ def generate_distros():
                        extra_dashboards=['kops-distros'],
                        extra_flags=extra_flags,
                        runs_per_day=3,
+                       # Canary for kubetest2-kops' ephemeral SSH keys. al2023 covers a
+                       # non-ubuntu default user (ec2-user); the other distros keep the
+                       # shared CI key as a control.
+                       ephemeral_ssh_key=(distro_short == 'al2023'),
                        )
         )
     return results
@@ -2062,6 +2068,10 @@ def generate_versions():
                 networking='calico',
                 extra_dashboards=['kops-versions'],
                 runs_per_day=8,
+                # Canary for kubetest2-kops' ephemeral SSH keys. 1.36 covers the ubuntu
+                # default user at 8 runs/day; the other versions keep the shared CI key
+                # as a control.
+                ephemeral_ssh_key=(version == '1.36'),
             )
         )
     return results

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -704,7 +704,6 @@ periodics:
   cron: '17 1-23/8 * * *'
   labels:
     preset-service-account: "true"
-    preset-aws-ssh: "true"
     preset-k8s-kops-aws-credential: "true"
   cluster: k8s-infra-kops-prow-build
   decorate: true

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -202,7 +202,6 @@ periodics:
   cron: '35 1-23/3 * * *'
   labels:
     preset-service-account: "true"
-    preset-aws-ssh: "true"
     preset-k8s-kops-aws-credential: "true"
   cluster: k8s-infra-kops-prow-build
   decorate: true

--- a/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
@@ -4,7 +4,11 @@
   labels:
     {%- if cloud == "aws" %}
     preset-service-account: "true"
+    {#- Without preset-aws-ssh there is no AWS_SSH_PRIVATE_KEY_FILE, so kubetest2-kops
+        generates a throwaway keypair for the cluster instead of using the shared CI key. -#}
+    {%- if not ephemeral_ssh_key %}
     preset-aws-ssh: "true"
+    {%- endif %}
     {%- if not boskos_resource_type %}
     preset-k8s-kops-aws-credential: "true"
     {%- endif %}


### PR DESCRIPTION
kubernetes/kops#18686 gave `kubetest2-kops` a single SSH key resolution path ending in "generate a throwaway keypair for this cluster", and kops registers whatever public key it is handed with the cloud provider itself — on AWS as an EC2 key pair, which cloud-init installs for the AMI's default user.

That fallback has only ever executed on **azure**, where no key was ever configured. Every AWS job still supplies the shared CI key through `preset-aws-ssh`, so the AWS generation path has never actually run in CI. This canaries it on two jobs before the fleet-wide switch.

## The canaries

| job | runs/day | distro | `KUBE_SSH_USER` |
|---|---|---|---|
| `e2e-kops-aws-k8s-1-36` | 8 | u2404 | `ubuntu` |
| `e2e-kops-aws-distro-al2023` | 3 | al2023 | `ec2-user` |

Chosen so that:

- **Failure is loud.** Both already run `[sig-node] SSH should SSH to all nodes and run commands`, and I confirmed it currently **passes** on the latest build of each. A bad key or a key/user mismatch fails a test outright, rather than quietly degrading log collection into an empty node directory.
- **Two different default users are covered** — `ubuntu` and `ec2-user` — which is the axis most likely to break, since the generated key is installed for whichever user the AMI defaults to.
- **Controls remain.** The sibling jobs in both families (`kops-aws-k8s-master/1-35/1-34`, and every other `kops-aws-distro-*`) keep `preset-aws-ssh`, so a regression is distinguishable from unrelated breakage.
- **Blast radius is limited.** Both report only to kops-owned dashboards. I deliberately avoided `e2e-kops-pipeline-updown-*` despite 24 runs/day, since those publish `latest-ci-updown-green.txt` and gate the rest of the kops pipeline, and the `*-canary` jobs on `sig-cluster-lifecycle-kubeup-to-kops` / `amazon-ec2-kops`, which other teams watch.

## Mechanism

`ephemeral_ssh_key=True` omits `preset-aws-ssh` from the job. With no `AWS_SSH_PRIVATE_KEY_FILE` / `AWS_SSH_PUBLIC_KEY_FILE`, `resolveSSHKeys()` falls through to `util.CreateSSHKeyPair()`. `KUBE_SSH_USER` is untouched on both jobs — only the key source moves — and `kubetest2-kops` re-exports `KUBE_SSH_KEY_PATH` from the resolved key so ginkgo still finds it.

Dropping the preset also drops its `USER=prow`. Nothing in kops reads `$USER` except the e2e framework's fallback, which is bypassed whenever `KUBE_SSH_USER` is set — and it is, on both jobs.

## Testing

- `go test ./config/tests/jobs/...` passes.
- Regenerated against the existing `pinned.list`: the diff is exactly **two deleted lines**, one `preset-aws-ssh` on each canary, with no image or cron churn.
- Parsed the regenerated YAML to confirm both canaries retain `KUBE_SSH_USER` (`ubuntu` / `ec2-user`), have no `KUBE_SSH_KEY_PATH`, and keep `preset-k8s-kops-aws-credential`; and that the control jobs still carry `preset-aws-ssh`.

## What to watch

Give it a day (roughly 11 runs). Green on both, plus non-empty per-node artifact directories, clears the way to drop `preset-aws-ssh` from all 1,649 AWS jobs. GCE stays blocked separately: its jobs SSH as `prow` using a key registered in GCP *project* metadata, so the key and the user have to change together there.

/sig testing
/area jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)