### PR TITLE
node-readiness-controller: add scale test as presubmit job

### DIFF
--- a/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-presubmits.yaml
@@ -81,3 +81,45 @@ presubmits:
       testgrid-dashboards: sig-node-node-readiness-controller
       testgrid-num-columns-recent: '30'
       testgrid-create-test-group: 'true'
+  - name: pull-node-readiness-controller-scale-test-binary-1000-continuous
+    cluster: eks-prow-build-cluster
+    always_run: false
+    skip_if_only_changed: "^docs/|\\.md$|^(README|LICENSE|OWNERS|SECURITY_CONTACTS)$"
+    branches:
+    - ^main$
+    - ^release-v.*$
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    decoration_config:
+      timeout: 2h
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
+          command:
+            - runner.sh
+          env:
+          - name: NODE_COUNT
+            value: "1000"
+          - name: KWOK_RUNTIME
+            value: "binary"
+          - name: ENFORCEMENT_MODE
+            value: "continuous"
+          - name: JUNIT_REPORT
+            value: "true"
+          args:
+            - make
+            - test-scale
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+    annotations:
+      testgrid-dashboards: sig-node-node-readiness-controller
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'


### PR DESCRIPTION
This PR adds the scalability test merged in kubernetes-sigs/node-readiness-controller#284 as a presubmit job.

The following configuration is used:

KWOK_RUNTIME="binary"
NODE_COUNT=1000
ENFORCEMENT_MODE="continuous"

xref: kubernetes-sigs/node-readiness-controller#409