### PR TITLE
kops: drop preset-do-ssh from DigitalOcean jobs

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-dns-none.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-dns-none.yaml
@@ -202,7 +202,6 @@ periodics:
     preset-service-account: "true"
     preset-do-credential: "true"
     preset-do-spaces-credential: "true"
-    preset-do-ssh: "true"
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
@@ -459,7 +458,6 @@ periodics:
     preset-service-account: "true"
     preset-do-credential: "true"
     preset-do-spaces-credential: "true"
-    preset-do-ssh: "true"
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -5,7 +5,6 @@ periodics:
     preset-service-account: "true"
     preset-do-credential: "true"
     preset-do-spaces-credential: "true"
-    preset-do-ssh: "true"
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
@@ -62,7 +61,6 @@ periodics:
     preset-service-account: "true"
     preset-do-credential: "true"
     preset-do-spaces-credential: "true"
-    preset-do-ssh: "true"
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/kops/kops-presets-do.yaml
+++ b/config/jobs/kubernetes/kops/kops-presets-do.yaml
@@ -13,19 +13,3 @@ presets:
       secretKeyRef:
         name: spaces-digitalocean-s3
         key: secret-key
-- labels:
-    preset-do-ssh: "true"
-  env:
-  - name: DO_SSH_PUBLIC_KEY_FILE
-    value: /etc/do-ssh/public-ssh-key
-  - name: DO_SSH_PRIVATE_KEY_FILE
-    value: /etc/do-ssh/private-ssh-key
-  volumes:
-  - name: do-ssh
-    secret:
-      defaultMode: 0400
-      secretName: kops-e2e-do-ssh-key
-  volumeMounts:
-  - name: do-ssh
-    mountPath: /etc/do-ssh
-    readOnly: true

--- a/config/jobs/kubernetes/kops/kops-presubmits-dns-none.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-dns-none.yaml
@@ -214,7 +214,6 @@ presubmits:
       preset-service-account: "true"
       preset-do-credential: "true"
       preset-do-spaces-credential: "true"
-      preset-do-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -479,7 +478,6 @@ presubmits:
       preset-service-account: "true"
       preset-do-credential: "true"
       preset-do-spaces-credential: "true"
-      preset-do-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -64,7 +64,6 @@ presubmits:
       preset-service-account: "true"
       preset-do-credential: "true"
       preset-do-spaces-credential: "true"
-      preset-do-ssh: "true"
     cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:
@@ -116,7 +115,6 @@ presubmits:
       preset-service-account: "true"
       preset-do-credential: "true"
       preset-do-spaces-credential: "true"
-      preset-do-ssh: "true"
     cluster: k8s-infra-prow-build
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
@@ -14,7 +14,6 @@
     preset-service-account: "true"
     preset-do-credential: "true"
     preset-do-spaces-credential: "true"
-    preset-do-ssh: "true"
     {%- else %}
     preset-k8s-ssh: "true"
     {%- endif %}

--- a/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
@@ -22,7 +22,6 @@
       preset-service-account: "true"
       preset-do-credential: "true"
       preset-do-spaces-credential: "true"
-      preset-do-ssh: "true"
       {%- else %}
       preset-k8s-ssh: "true"
       {%- endif %}


### PR DESCRIPTION
Follows the AWS switch in #37687. With `DO_SSH_PRIVATE_KEY_FILE` / `DO_SSH_PUBLIC_KEY_FILE` unset, `kubetest2-kops` generates a throwaway keypair per cluster, kops uploads it to the DigitalOcean account (`dotasks/sshkey.go` `createKeypair` → `KeysService().Create`) and attaches it to each droplet by ID, and the deployer exports the key plus its internally-assigned `root` user for the e2e framework.

Removes the label from all 8 DO jobs and deletes the now-unreferenced preset definition, which was used only by these jobs.

## Prerequisite (now merged)

kops names the DO key `<cluster>-<fingerprint>` (`pkg/model/domodel/droplets.go`). With the shared preset key the fingerprint never changes, so the same key was found and reused every run. An ephemeral key makes every cluster create a **new** DO SSH key — and `pkg/resources/digitalocean/resources.go` had no SSH-key deleter, unlike AWS (`pkg/resources/aws/aws.go` `DeleteKeypair`) and OpenStack. Without cleanup this would have leaked one key per run into the shared account.

kubernetes/kops#18697 added that deleter and merged as `09f1844063`. It was validated on a real cluster by temporarily forcing an ephemeral key in that PR's own `pull-kops-do-dns-none` run, which showed the key being created and then removed at teardown:

```
ssh-key    kubernetes.pr18697-kops-do-dns-none.k8s.local-37:66:4f:...:3b:fa    58516648
ssh-key:58516648   ok
```

That run also collected per-node logs from five droplets, confirming a generated key reaches the droplets and DigitalOcean works end to end on ephemeral keys.

### Rollout check (satisfied)

The four DO **presubmits** build kops from the PR under test. The four **periodics** run marker builds, and both markers have now advanced to the merge commit of kubernetes/kops#18697 itself:

```
latest-ci               -> 1.37.0-alpha.2+v1.37.0-alpha.1-209-g09f1844063
latest-ci-updown-green  -> 1.37.0-alpha.2+v1.37.0-alpha.1-209-g09f1844063
```

So every DO job now runs a kops that deletes its SSH key on teardown, and nothing here leaks.

## Current state, for the record

DO jobs SSH successfully today and collect per-node logs, so there is a real baseline to regress against:

```
e2e-kops-do-dns-none:     Using SSH keypair: [/etc/do-ssh/private-ssh-key ...]
                          Using SSH user: [root]
                          node dirs: 5 (IP-named, populated)
```

## Testing so far

- `go test ./config/tests/jobs/...` passes.
- Regenerated against the existing `pinned.list`; the diff is 26 deletions and nothing else.
- Parsed the generated YAML: all 8 DO jobs retain `preset-do-credential` and `preset-do-spaces-credential`, and none carries any `KUBE_SSH_*` variable (DO never set them — the user is assigned internally by the deployer).

Note four of the eight jobs live in `kops-periodics-misc.yaml` and `kops-presubmits.yaml`, which are hand-maintained rather than generated, so those labels were edited directly; re-running `build_jobs.py` does not revert them.

/sig testing
/area jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

