### PR TITLE
kops: canary SSH user discovery on two GCE jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -115,6 +115,7 @@ def build_test(cloud='aws',
                alert_email=None,
                alert_num_failures=None,
                job_queue_name=None,
+               derive_ssh_user=False,
                extra_refs=None):
     # pylint: disable=too-many-statements,too-many-arguments
     if kops_version is None:
@@ -266,6 +267,7 @@ def build_test(cloud='aws',
         instance_groups_overrides=instance_groups_overrides,
         extra_refs=extra_refs,
         job_queue_name=job_queue_name,
+        derive_ssh_user=derive_ssh_user,
     )
 
     spec = {
@@ -2041,6 +2043,12 @@ def generate_nftables():
                 extra_flags=extra_flags,
                 extra_dashboards=["kops-nftables"],
                 runs_per_day=3,
+                # Canary for kubetest2-kops determining the SSH user from the cluster
+                # (kubernetes/kops#18699). cos125 is the load-bearing case: it derives
+                # "admin", which differs from the kops fallback, so a broken lookup fails
+                # visibly. u2404 derives "ubuntu", the same as the fallback, so it is a
+                # control. Every other distro keeps KUBE_SSH_USER.
+                derive_ssh_user=(distro_short in ('u2404', 'cos125')),
             )
         )
     return results

--- a/config/jobs/kubernetes/kops/kops-periodics-nftables.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-nftables.yaml
@@ -1310,8 +1310,6 @@ periodics:
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
-      - name: KUBE_SSH_USER
-        value: prow
       - name: GINKGO_NO_COLOR
         value: "TRUE"
       image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
@@ -2036,8 +2034,6 @@ periodics:
       env:
       - name: KUBE_SSH_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
-      - name: KUBE_SSH_USER
-        value: prow
       - name: GINKGO_NO_COLOR
         value: "TRUE"
       image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master

--- a/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/periodic.yaml.jinja
@@ -124,7 +124,9 @@
       - name: KUBE_SSH_KEY_PATH
         value: {{kops_ssh_key_path}}
       {%- endif %}
-      {%- if cloud != "azure" and cloud != "do" %}
+      {#- Without KUBE_SSH_USER, kubetest2-kops asks the cluster which user kops
+          registered the SSH key for. -#}
+      {%- if cloud != "azure" and cloud != "do" and not derive_ssh_user %}
       - name: KUBE_SSH_USER
         value: {{kops_ssh_user}}
       {%- endif %}


### PR DESCRIPTION
kubernetes/kops#18699 lets `kubetest2-kops` ask the cluster which user kops registered the SSH key for — but only when the job does not set `KUBE_SSH_USER`. Every GCE job sets it to `prow`, so nothing exercises the new path yet. This opts two jobs in by dropping the variable.

| job | distro | expected derived user |
|---|---|---|
| `e2e-kops-gce-nftables-cos125` | cos125 | **`admin`** |
| `e2e-kops-gce-nftables-u2404` | u2404 | `ubuntu` |

## cos125 is the real test; u2404 is a control

kops defaults `--ssh-user` to `ubuntu` when it is not supplied (`cmd/kops/toolbox_dump.go`). A u2404 job therefore **cannot distinguish a working lookup from a broken one** — both produce `ubuntu`. cos125 derives `admin`, so if discovery silently fails it degrades to `ubuntu` and log collection breaks visibly.

Accept on:

- `Determined SSH user from the cluster: [admin]` / `[ubuntu]` in the build log — **non-empty** is the assertion, not merely that the job is green
- per-node artifact directories still populated with real content
- `[sig-node] SSH should SSH to all nodes` still passing where it runs

Both distros were verified beforehand to have that account created with sudo and holding the key kops installs in instance metadata: `google_guest_agent: Updating keys for user ubuntu.` on u2404, `check_run: Creating user admin.` + `Updating keys for user admin.` on cos125 (`google-sudoers`).

## Only the user moves

`KUBE_SSH_KEY_PATH` and `preset-k8s-ssh` stay, so these jobs keep the shared CI key. That is deliberate: kops installs whatever it is handed as `--ssh-public-key` into instance metadata under the derived username, so the existing key is already authorized for `ubuntu`/`admin` as well as `prow`. Moving the key to ephemeral is a separate later step.

The other 36 nftables jobs keep `KUBE_SSH_USER` as controls, so a regression is distinguishable from unrelated breakage.

## Why only these two

Eligibility is gated on the kops version a job runs, not just the cloud: GCE only started reporting `sshUser` in `c6e61af681` (kops 1.37), which is not in release-1.34/1.35/1.36. Both canaries are on the `master` marker, which currently resolves to `1.37.0-alpha.2+v1.37.0-alpha.1-213-gde4d11b4d6` and contains that commit. The remaining GCE jobs become eligible as those release branches age out of the matrix — by decision, the fix is not being cherry-picked.

## Testing

- `go test ./config/tests/jobs/...` passes.
- Regenerated with `make generate-jobs` against the existing `pinned.list`. The diff is **4 deleted lines** — one `KUBE_SSH_USER` pair per canary — with no image or cron churn.
- Parsed the generated YAML: exactly two jobs now lack `KUBE_SSH_USER`, both retain `KUBE_SSH_KEY_PATH` and `preset-k8s-ssh`, and 36 sibling jobs still set it.

Plan: `docs/plans/gce-ssh-cleanup-step1.md` in the kops repo.

/sig testing
/area jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)