### PR TITLE
node-readiness-controller: add canary job for scalability test

### DIFF
--- a/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-canaries.yaml
@@ -1,0 +1,35 @@
+presubmits:
+  kubernetes-sigs/node-readiness-controller:
+  - name: pull-node-readiness-controller-junit-report-canary
+    cluster: eks-prow-build-cluster
+    always_run: false
+    optional: true
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    decoration_config:
+      timeout: 2h
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
+          command:
+            - runner.sh
+          env:
+          - name: JUNIT_REPORT
+            value: "true"
+          args:
+            - make
+            - test-scale
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+    annotations:
+      testgrid-dashboards: sig-node-node-readiness-controller
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'


### PR DESCRIPTION
This PR adds an experimental job for validating  the JUnit Scalability Report output by the scale test.

The metrics should be displayable in graph view in the testgrid. 

If this works, we can enable this by default in #37689. 

xref: kubernetes-sigs/node-readiness-controller#284
xref: kubernetes-sigs/node-readiness-controller#409
xref: kubernetes-sigs/node-readiness-controller#415