### PR TITLE
pull-kubernetes-integration-race: increase resources

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -100,6 +100,8 @@ presubmits:
           value: "-timeout=30m"
         - name: KUBE_RACE
           value: "-race"
+        - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
+          value: "5"
         args:
         - ./hack/jenkins/test-integration-dockerized.sh
         # docker-in-docker needs privileged mode
@@ -108,10 +110,10 @@ presubmits:
         resources:
           limits:
             cpu: 7
-            memory: 20Gi
+            memory: 27Gi
           requests:
             cpu: 7
-            memory: 20Gi
+            memory: 27Gi
   - name: pull-kubernetes-integration-go-compatibility
     cluster: k8s-infra-prow-build
     always_run: true


### PR DESCRIPTION
The Grafana dashboard shows that the job is consuming all of its resources and various tests are failing with "context deadline exceeded", which might be because of CPU contention.

Let's give the job more resources and at the same time limit the max procs to leave some buffer when n test procs each need more than one CPU due to internal parallelism.

If this works out in the pre-submit, then the periodic needs to be changed accordingly.

/assign @macsko 