### PR TITLE
Simplify SSH key environment variables

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -275,7 +275,7 @@ presubmits:
         - -c
         - >-
           ./test/build.sh install-lib &&
-          SSH_USER=${USER} SSH_KEY=${JENKINS_GCE_SSH_PRIVATE_KEY_FILE} make e2e-test
+          SSH_USER=${KUBE_SSH_USER} SSH_KEY=${KUBE_SSH_PRIVATE_KEY_PATH} make e2e-test
         resources:
           limits:
             cpu: 2

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -556,8 +556,8 @@ periodics:
         # (k8s-infra-prow-build lacks cgroup v2, and the kubekins-e2e container lacks systemd)
         (cd ; GO111MODULE=on go install github.com/rootless-containers/kubetest2-kindinv@master)
         mkdir -p -m 0700 ~/.ssh
-        cp -f "${GCE_SSH_PRIVATE_KEY_FILE}" ~/.ssh/google_compute_engine
-        cp -f "${GCE_SSH_PUBLIC_KEY_FILE}" ~/.ssh/google_compute_engine.pub
+        cp -f "${KUBE_SSH_PRIVATE_KEY_PATH}" ~/.ssh/google_compute_engine
+        cp -f "${KUBE_SSH_PUBLIC_KEY_PATH}" ~/.ssh/google_compute_engine.pub
         exec kubetest2 kindinv \
           --boskos-location=http://boskos.test-pods.svc.cluster.local \
           --gcp-zone=us-central1-b \

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -989,15 +989,11 @@ presets:
 - labels:
     preset-k8s-ssh: "true"
   env:
-  - name: USER
+  - name: KUBE_SSH_USER
     value: prow
-  - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+  - name: KUBE_SSH_PRIVATE_KEY_PATH
     value: /etc/ssh-key-secret/ssh-private
-  - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-    value: /etc/ssh-key-secret/ssh-public
-  - name: GCE_SSH_PRIVATE_KEY_FILE
-    value: /etc/ssh-key-secret/ssh-private
-  - name: GCE_SSH_PUBLIC_KEY_FILE
+  - name: KUBE_SSH_PUBLIC_KEY_PATH
     value: /etc/ssh-key-secret/ssh-public
   volumes:
   - name: ssh
@@ -1011,12 +1007,14 @@ presets:
 - labels:
     preset-aws-ssh: "true"
   env:
-  - name: USER
+  - name: KUBE_SSH_USER
     value: prow
-  - name: AWS_SSH_PRIVATE_KEY_FILE
+  - name: KUBE_SSH_PRIVATE_KEY_PATH
     value: /etc/aws-ssh/aws-ssh-private
-  - name: AWS_SSH_PUBLIC_KEY_FILE
+  - name: KUBE_SSH_PUBLIC_KEY_PATH
     value: /etc/aws-ssh/aws-ssh-public
+  - name: KUBE_SSH_KEY_PATH
+    value: /etc/aws-ssh/aws-ssh-private
   volumes:
   - name: aws-ssh
     secret:

--- a/experiment/pod.yaml
+++ b/experiment/pod.yaml
@@ -28,10 +28,10 @@ spec:
         value: k8s-jkns-e2e-prow-canary
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+      - name: KUBE_SSH_PRIVATE_KEY_PATH
         value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public       
+      - name: KUBE_SSH_PUBLIC_KEY_PATH
+        value: /etc/ssh-key-secret/ssh-public
     volumeMounts:
     - mountPath: /etc/service-account
       name: service

--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -713,7 +713,7 @@ def pr_paths(base, repos, job, build):
 BUILD_ENV = 'BUILD_ID'
 BOOTSTRAP_ENV = 'BOOTSTRAP_MIGRATION'
 CLOUDSDK_ENV = 'CLOUDSDK_CONFIG'
-GCE_KEY_ENV = 'JENKINS_GCE_SSH_PRIVATE_KEY_FILE'
+GCE_KEY_ENV = 'KUBE_SSH_PRIVATE_KEY_PATH'
 GUBERNATOR = 'https://gubernator.k8s.io/build'
 HOME_ENV = 'HOME'
 JENKINS_HOME_ENV = 'JENKINS_HOME'
@@ -729,7 +729,7 @@ GIT_AUTHOR_DATE_ENV = 'GIT_AUTHOR_DATE'
 GIT_COMMITTER_DATE_ENV = 'GIT_COMMITTER_DATE'
 SOURCE_DATE_EPOCH_ENV = 'SOURCE_DATE_EPOCH'
 JOB_ARTIFACTS_ENV = 'ARTIFACTS'
-
+SSH_PUBLIC_KEY_ENV = 'KUBE_SSH_PUBLIC_KEY_PATH'
 
 def build_name(started):
     """Return the unique(ish) string representing this build."""
@@ -827,15 +827,15 @@ def setup_magic_environment(job, call):
         os.path.join(home, '.ssh/google_compute_engine'),
     )
     os.environ.setdefault(
-        'JENKINS_GCE_SSH_PUBLIC_KEY_FILE',
+           SSH_PUBLIC_KEY_ENV,
         os.path.join(home, '.ssh/google_compute_engine.pub'),
     )
     os.environ.setdefault(
-        'AWS_SSH_PRIVATE_KEY_FILE',
+        'KUBE_SSH_PRIVATE_KEY_PATH',
         os.path.join(home, '.ssh/kube_aws_rsa'),
     )
     os.environ.setdefault(
-        'AWS_SSH_PUBLIC_KEY_FILE',
+        'KUBE_SSH_PUBLIC_KEY_PATH',
         os.path.join(home, '.ssh/kube_aws_rsa.pub'),
     )
 

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -588,7 +588,7 @@ func nodeTest(nodeArgs []string, testArgs, nodeTestArgs, project, zone, runtimeC
 		log.Printf("cwd : %s", wd)
 	}
 
-	sshKeyPath := os.Getenv("JENKINS_GCE_SSH_PRIVATE_KEY_FILE")
+	sshKeyPath := os.Getenv("KUBE_SSH_PRIVATE_KEY_PATH")
 	if _, err := os.Stat(sshKeyPath); err != nil {
 		return fmt.Errorf("Cannot find ssh key from: %v, err : %w", sshKeyPath, err)
 	}

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -113,8 +113,8 @@ class LocalMode(object):
         shutil.copy(priv, gce_ssh)
         shutil.copy(pub, gce_pub)
         self.add_environment(
-            'JENKINS_GCE_SSH_PRIVATE_KEY_FILE=%s' % gce_ssh,
-            'JENKINS_GCE_SSH_PUBLIC_KEY_FILE=%s' % gce_pub,
+              'KUBE_SSH_PRIVATE_KEY_PATH=%s' % gce_ssh,
+              'KUBE_SSH_PUBLIC_KEY_PATH=%s' % gce_pub,
         )
 
     @staticmethod
@@ -319,11 +319,11 @@ def create_parser():
         '(usage: "--env=VAR=SETTING" will set VAR to SETTING).')
     parser.add_argument(
         '--gce-ssh',
-        default=os.environ.get('JENKINS_GCE_SSH_PRIVATE_KEY_FILE'),
+        default=os.environ.get('KUBE_SSH_PRIVATE_KEY_PATH'),
         help='Path to .ssh/google_compute_engine keys')
     parser.add_argument(
         '--gce-pub',
-        default=os.environ.get('JENKINS_GCE_SSH_PUBLIC_KEY_FILE'),
+        default=os.environ.get('KUBE_SSH_PUBLIC_KEY_PATH'),
         help='Path to pub gce ssh key')
     parser.add_argument(
         '--service-account',


### PR DESCRIPTION
Fixes #37561

Simplifies SSH key environment variables by standardizing their names and paths.