### PR TITLE
config/jobs/kubernetes/sig-testing: add OWNERS file

### DIFF
--- a/config/jobs/kubernetes/sig-testing/OWNERS
+++ b/config/jobs/kubernetes/sig-testing/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- sig-testing-leads
+approvers:
+- sig-testing-leads
+labels:
+- sig/testing


### PR DESCRIPTION
Although some of the jobs are "shared" among all SIGs, in practice they are managed and often also monitored by SIG Testing, so the leads of that SIG should have approval rights.