### PR TITLE
Move group snapshot test to regular snapshot jobs

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -103,7 +103,7 @@ presubmits:
         - --gcp-node-image=gci
         - --gcp-zone=us-central1-b
         - --provider=gce
-        - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
+        - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\]\|\[Feature:VolumeGroupSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
         - --timeout=150m
         securityContext:
           privileged: true
@@ -348,7 +348,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\]\|\[Feature:VolumeGroupSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m
       resources:
         requests:

--- a/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kind.yaml
@@ -54,47 +54,6 @@ presubmits:
             cpu: "2"
             memory: "6Gi"
 
-  - name: pull-kubernetes-e2e-storage-kind-volume-group-snapshots
-    always_run: false
-    optional: true
-    decorate: true
-    path_alias: k8s.io/kubernetes
-    cluster: eks-prow-build-cluster
-    skip_branches:
-    - release-\d+\.\d+
-    annotations:
-      testgrid-dashboards: presubmits-kubernetes-nonblocking
-      testgrid-tab-name: pull-kubernetes-e2e-storage-kind-volume-group-snapshots
-      testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-      description: Run storage tests volume group snapshots in a KIND cluster.
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20260824-a5e45c393a-master
-        command:
-        - wrapper.sh
-        - bash
-        - -c
-        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/run_group_snapshot_e2e.sh
-        env:
-        - name: RUNTIME_CONFIG
-          value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
-        - name: FOCUS
-          value: \[Feature:volumegroupsnapshot\]
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "2"
-            memory: "6Gi"
-          limits:
-            cpu: "2"
-            memory: "6Gi"
-
   - name: pull-kubernetes-e2e-storage-kind-snapshot-metadata
     always_run: false
     optional: true
@@ -125,62 +84,6 @@ presubmits:
           value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
         - name: FOCUS
           value: \[Feature:snapshotmetadata\]
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "2"
-            memory: "6Gi"
-          limits:
-            cpu: "2"
-            memory: "6Gi"
-
-  # This temporary job used for refine the vgs tests fast iterations
-  - name: pull-kubernetes-e2e-storage-kind-vgs
-    always_run: false
-    optional: true
-    decorate: true
-    path_alias: k8s.io/kubernetes
-    cluster: eks-prow-build-cluster
-    skip_branches:
-    - release-\d+\.\d+
-    annotations:
-      testgrid-dashboards: presubmits-kubernetes-nonblocking
-      testgrid-tab-name: pull-kubernetes-e2e-storage-kind-vgs
-      testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-      description: Run storage tests volume group snapshots in a KIND cluster.
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20260824-a5e45c393a-master
-        command:
-        - wrapper.sh
-        - bash
-        - -c
-        - |
-          set -ex
-          # Download prow.sh from csi-release-tools
-          # TODO: Back to use the official repo after finish fast iterations
-          curl -fsSL https://raw.githubusercontent.com/Phaow/csi-release-tools/dev/prow.sh -o prow.sh
-          chmod +x prow.sh
-          ./prow.sh
-        env:
-        - name: CSI_PROW_DRIVER_VERSION
-          value: "v1.17.0"
-        - name: CSI_PROW_DEPLOYMENT_SUFFIX
-          value: ""
-        - name: CSI_SNAPSHOTTER_VERSION
-          value: "v8.3.0"
-        - name: CSI_PROW_ENABLE_GROUP_SNAPSHOT
-          value: "true"
-        - name: CSI_PROW_E2E_FOCUS
-          value: \[Feature:volumegroupsnapshot\]
-        - name: CSI_PROW_TESTS
-          value: "serial parallel"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -377,50 +280,6 @@ periodics:
           value: \[Feature:VolumeAttributesClass\]
         - name: SKIP
           value: \[Slow\]|\[Disruptive\]|\[Flaky\]
-        - name: PARALLEL
-          value: "true"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "2"
-            memory: "6Gi"
-          limits:
-            cpu: "2"
-            memory: "6Gi"
-
-  - name: ci-kubernetes-e2e-storage-kind-volume-group-snapshots
-    interval: 12h
-    annotations:
-      testgrid-dashboards: sig-storage-kubernetes
-      testgrid-tab-name: storage-kind-volume-group-snapshots
-      testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com
-      description: Run storage tests volume group snapshots in a KIND cluster.
-    decorate: true
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: master
-      path_alias: k8s.io/kubernetes
-    cluster: eks-prow-build-cluster
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20260824-a5e45c393a-master
-        command:
-        - wrapper.sh
-        - bash
-        - -c
-        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && test/e2e/testing-manifests/storage-csi/external-snapshotter/volume-group-snapshots/run_group_snapshot_e2e.sh
-        env:
-        - name: RUNTIME_CONFIG
-          value: '{"api/ga":"true", "storage.k8s.io/v1alpha1":"true", "storage.k8s.io/v1beta1":"true"}'
-        - name: FOCUS
-          value: \[Feature:volumegroupsnapshot\]
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker


### PR DESCRIPTION
And remove the group snapshot jobs.

Volume group snapshots are GA in 1.36 and should not require any special CI job. We can test them together with regular volume snapshots.

/hold
requires https://github.com/kubernetes/kubernetes/pull/141358 to be merged first.