### PR TITLE
Add periodic ChangeContainerStatusOnKubeletRestart job

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -1079,6 +1079,57 @@ periodics:
     testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
     description: "Runs kubelet in standalone mode"
 
+# This test job takes about 30 minutes to run and will be removed after the ChangeContainerStatusOnKubeletRestart feature gate is removed.
+- name: ci-kubernetes-node-kubelet-serial-change-container-status-on-kubelet-restart
+  interval: 24h
+  cluster: k8s-infra-prow-build
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    testgrid-tab-name: kubelet-serial-change-container-status-on-kubelet-restart
+    testgrid-alert-email: sig-node-ci+testgrid@kubernetes.io
+    description: "Runs node e2e tests for ChangeContainerStatusOnKubeletRestart"
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  spec:
+    containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --deployment=node
+          - --gcp-zone=us-central1-b
+          - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-serial.yaml
+          - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}" --feature-gates="ChangeContainerStatusOnKubeletRestart=false"'
+          - --node-tests=true
+          - --provider=gce
+          - '--test_args=--nodes=1 --label-filter="FeatureGate:ChangeContainerStatusOnKubeletRestart"'
+          - --timeout=65m
+        env:
+          - name: GOPATH
+            value: /go
+        resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
+          requests:
+            cpu: 4
+            memory: 6Gi
+
 - name: ci-kubernetes-node-kubelet-serial-topology-manager
   interval: 24h
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
Adds a periodic node e2e job for tests labeled with`FeatureGate:ChangeContainerStatusOnKubeletRestart`.