### PR TITLE
DRA aws ec2 fix qps and burst config

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
+++ b/config/jobs/kubernetes/sig-scalability/DRA/sig-scalability-ec2-dra.yaml
@@ -107,6 +107,10 @@ periodics:
         value: "gcr.io/k8s-staging-perf-tests/sleep:v0.0.3"
       - name: KOPS_CL2_TEST_CONFIG
         value: testing/dra/config.yaml
+      - name: KOPS_SCHEDULER_QPS
+        value: "500"
+      - name: KOPS_SCHEDULER_BURST
+        value: "500"
       resources:
         requests:
           cpu: 7
@@ -320,6 +324,10 @@ presubmits:
           value: "gcr.io/k8s-staging-perf-tests/sleep:v0.0.3"
         - name: KOPS_CL2_TEST_CONFIG
           value: testing/dra/config.yaml
+        - name: KOPS_SCHEDULER_QPS
+          value: "500"
+        - name: KOPS_SCHEDULER_BURST
+          value: "500"
         resources:
           requests:
             cpu: 7


### PR DESCRIPTION
The DRA tests qps and burst config needed tweaking based on the Node Count.

This fixes the https://github.com/kubernetes/kubernetes/issues/141421