### PR TITLE
pull-kubernetes-integration-race: reduce memory

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -110,10 +110,10 @@ presubmits:
         resources:
           limits:
             cpu: 7
-            memory: 27Gi
+            memory: 26Gi
           requests:
             cpu: 7
-            memory: 27Gi
+            memory: 26Gi
   - name: pull-kubernetes-integration-go-compatibility
     cluster: k8s-infra-prow-build
     always_run: true


### PR DESCRIPTION
Despite passing the test-infra test ("resources.limits[memory] (40Gi) must be at most 27Gi"), actually scheduling the pod failed when. On Slack, 26Gi was suggested instead.

/assign @upodroid 