### PR TITLE
pull-kubernetes-integration-race: reduce memory, II

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -110,10 +110,10 @@ presubmits:
         resources:
           limits:
             cpu: 7
-            memory: 26Gi
+            memory: 25Gi
           requests:
             cpu: 7
-            memory: 26Gi
+            memory: 25Gi
   - name: pull-kubernetes-integration-go-compatibility
     cluster: k8s-infra-prow-build
     always_run: true


### PR DESCRIPTION
Next attempt to find the actual limit. 20Gi works, 26Gi doesn't.

/assign @upodroid 