### PR TITLE
pull-kubernetes-integration-race: reduce parallelism to 4 out of 7 CPUs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -101,7 +101,7 @@ presubmits:
         - name: KUBE_RACE
           value: "-race"
         - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
-          value: "5"
+          value: "4"
         args:
         - ./hack/jenkins/test-integration-dockerized.sh
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
The random "context deadline exceeded" still occurred when using 5 out of 7 CPUs. Let's reduce further.

/assign @macsko 