### PR TITLE
Cleanup remove the E2E_K8S_VERSION field

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -1041,7 +1041,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1088,7 +1088,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1135,7 +1135,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1182,7 +1182,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1229,7 +1229,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1276,7 +1276,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1323,7 +1323,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1370,7 +1370,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1559,7 +1559,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1606,7 +1606,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1653,7 +1653,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1700,7 +1700,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1747,7 +1747,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1794,7 +1794,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1841,7 +1841,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1888,7 +1888,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1978,7 +1978,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -1040,8 +1040,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1087,8 +1085,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1134,8 +1130,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1181,8 +1175,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1228,8 +1220,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1275,8 +1265,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1322,8 +1310,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1369,8 +1355,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1416,8 +1400,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1463,8 +1445,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1510,8 +1490,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1558,8 +1536,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1605,8 +1581,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1652,8 +1626,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1699,8 +1671,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1746,8 +1716,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1793,8 +1761,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1840,8 +1806,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1887,8 +1851,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1977,8 +1939,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -965,7 +965,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1012,7 +1012,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1059,7 +1059,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1106,7 +1106,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1153,7 +1153,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1200,7 +1200,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1247,7 +1247,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1294,7 +1294,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1341,7 +1341,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1388,7 +1388,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1435,7 +1435,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1482,7 +1482,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1529,7 +1529,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1576,7 +1576,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1623,7 +1623,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1670,7 +1670,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1760,7 +1760,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -964,8 +964,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1011,8 +1009,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1058,8 +1054,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1105,8 +1099,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1152,8 +1144,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1199,8 +1189,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1246,8 +1234,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1293,8 +1279,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1340,8 +1324,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1387,8 +1369,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1434,8 +1414,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1481,8 +1459,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1528,8 +1504,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1575,8 +1549,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1622,8 +1594,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1669,8 +1639,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1759,8 +1727,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
@@ -1005,7 +1005,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1052,7 +1052,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1099,7 +1099,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1146,7 +1146,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1193,7 +1193,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1240,7 +1240,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1287,7 +1287,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1334,7 +1334,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1522,7 +1522,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1569,7 +1569,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1616,7 +1616,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1663,7 +1663,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1710,7 +1710,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1757,7 +1757,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1804,7 +1804,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1851,7 +1851,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1941,7 +1941,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
@@ -1004,8 +1004,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1051,8 +1049,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1098,8 +1094,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1145,8 +1139,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1192,8 +1184,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1239,8 +1229,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1286,8 +1274,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1333,8 +1319,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1380,8 +1364,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1427,8 +1409,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1474,8 +1454,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1521,8 +1499,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1568,8 +1544,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1615,8 +1589,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1662,8 +1634,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1709,8 +1679,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1756,8 +1724,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1803,8 +1769,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1850,8 +1814,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:
@@ -1940,8 +1902,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-main.yaml
@@ -25,8 +25,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-main.yaml
@@ -26,7 +26,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.18.yaml
@@ -25,8 +25,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.18.yaml
@@ -26,7 +26,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.19.yaml
@@ -25,8 +25,6 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
-            - name: E2E_K8S_VERSION
-              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-s390x-ppc64le-release-0.19.yaml
@@ -26,7 +26,7 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
           env:
             - name: E2E_K8S_VERSION
-              value: "1.35"
+              value: "1.36"
             - name: BASE_BUILDER_IMAGE
               value: public.ecr.aws/docker/library/golang
           command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -754,8 +754,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -795,8 +793,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -836,8 +832,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -877,8 +871,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -918,8 +910,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -959,8 +949,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1000,8 +988,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1041,8 +1027,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1082,8 +1066,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1123,8 +1105,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1164,8 +1144,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1205,8 +1183,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1246,8 +1222,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1288,8 +1262,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1329,8 +1301,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1370,8 +1340,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1411,8 +1379,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1452,8 +1418,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1493,8 +1457,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1534,8 +1496,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1815,8 +1775,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -755,7 +755,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -796,7 +796,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -837,7 +837,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -878,7 +878,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -919,7 +919,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -960,7 +960,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1001,7 +1001,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1042,7 +1042,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1206,7 +1206,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1247,7 +1247,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1289,7 +1289,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1330,7 +1330,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1371,7 +1371,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1412,7 +1412,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1453,7 +1453,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1494,7 +1494,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1535,7 +1535,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1816,7 +1816,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -723,7 +723,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -764,7 +764,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -805,7 +805,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -846,7 +846,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -887,7 +887,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -928,7 +928,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -969,7 +969,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1010,7 +1010,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1051,7 +1051,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1092,7 +1092,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1133,7 +1133,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1174,7 +1174,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1215,7 +1215,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1256,7 +1256,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1297,7 +1297,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1338,7 +1338,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1379,7 +1379,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1420,7 +1420,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1461,7 +1461,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1742,7 +1742,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -722,8 +722,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -763,8 +761,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -804,8 +800,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -845,8 +839,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -886,8 +878,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -927,8 +917,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -968,8 +956,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1009,8 +995,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1050,8 +1034,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1091,8 +1073,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1132,8 +1112,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1173,8 +1151,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1214,8 +1190,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1255,8 +1229,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1296,8 +1268,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1337,8 +1307,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1378,8 +1346,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1419,8 +1385,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1460,8 +1424,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1741,8 +1703,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
@@ -723,7 +723,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -764,7 +764,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -805,7 +805,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -846,7 +846,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -887,7 +887,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -928,7 +928,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -969,7 +969,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1010,7 +1010,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1174,7 +1174,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1215,7 +1215,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1256,7 +1256,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1297,7 +1297,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1338,7 +1338,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1379,7 +1379,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1420,7 +1420,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1461,7 +1461,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1502,7 +1502,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1543,7 +1543,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1584,7 +1584,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1865,7 +1865,7 @@ presubmits:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
               - name: E2E_K8S_VERSION
-                value: "1.35"
+                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
@@ -722,8 +722,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -763,8 +761,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -804,8 +800,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -845,8 +839,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -886,8 +878,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -927,8 +917,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -968,8 +956,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1009,8 +995,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1050,8 +1034,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1091,8 +1073,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1132,8 +1112,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1173,8 +1151,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1214,8 +1190,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1255,8 +1229,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1296,8 +1268,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1337,8 +1307,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1378,8 +1346,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1419,8 +1385,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1460,8 +1424,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1501,8 +1463,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1542,8 +1502,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1583,8 +1541,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:
@@ -1864,8 +1820,6 @@ presubmits:
         containers:
           - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
             env:
-              - name: E2E_K8S_VERSION
-                value: "1.36"
               - name: BASE_BUILDER_IMAGE
                 value: public.ecr.aws/docker/library/golang
             command:


### PR DESCRIPTION
## Summary
Updates the default (unversioned) E2E test jobs across main, release-0.19, and release-0.18 from Kubernetes 1.35 to 1.36.

## Fix
Fix for [kubernetes-sigs/kueue#14581](https://github.com/kubernetes-sigs/kueue/issues/14581)

