### PR TITLE
ci-kubernetes-integration-race: sync with presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -101,13 +101,14 @@ presubmits:
         - name: KUBE_RACE
           value: "-race"
         - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
-          value: "4"
+          value: "4" # Update together resources below. We need some spare CPUs to avoid starvation when each test binary itself needs more than one CPU.
         args:
         - ./hack/jenkins/test-integration-dockerized.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
+          # Update cpu together with KUBE_INTEGRATION_TEST_MAX_CONCURRENCY above.
           limits:
             cpu: 7
             memory: 25Gi
@@ -268,13 +269,16 @@ periodics:
         value: "-timeout=40m"
       - name: KUBE_RACE
         value: "-race"
+      - name: KUBE_INTEGRATION_TEST_MAX_CONCURRENCY
+        value: "4" # Update together with resources below. We need some spare CPUs to avoid starvation when each test binary itself needs more than one CPU.
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
       resources:
+        # Update cpu together with KUBE_INTEGRATION_TEST_MAX_CONCURRENCY above.
         limits:
-          cpu: 6
-          memory: 20Gi
+          cpu: 7
+          memory: 25Gi
         requests:
-          cpu: 6
-          memory: 20Gi
+          cpu: 7
+          memory: 25Gi


### PR DESCRIPTION
As tested before in the presubmit, "context deadline exceeded" errors seem to get avoided when keeping some CPUs available for situations where GOMAXPROC test binaries keep more than those CPUs busy due to internal parallelism.

See https://prow.k8s.io/pr-history/?org=kubernetes&repo=kubernetes&pr=140914 - not perfect, but much better than https://testgrid.k8s.io/sig-testing-canaries#integration-race-master.

/assign @macsko 

