### PR TITLE
lws: require upgrade E2E except on docs-only PRs

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -212,8 +212,7 @@ presubmits:
     cluster: eks-prow-build-cluster
     branches:
     - ^main
-    always_run: false
-    optional: true
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
     decorate: true
     decoration_config:
       timeout: 1h


### PR DESCRIPTION
## Summary

Make `pull-lws-test-e2e-upgrade-main` required so API defaulting, ControllerRevision, CRD, and rollout changes cannot merge without upgrade coverage.

The job was added as optional and manually triggered in https://github.com/kubernetes/test-infra/pull/37476. That left a gap shown by kubernetes-sigs/lws#877: a new defaulted field could make a legacy revision look changed and trigger an unintended rollout, while required CI still passed.

This follows the same skip pattern as `pull-lws-verify-main`: skip docs-only PRs (`docs/`, `.github/`, `*.md`, README, LICENSE, OWNERS) to control CI cost; otherwise auto-run and block merge.

Fixes https://github.com/kubernetes-sigs/lws/issues/988

Related: kubernetes-sigs/lws#926, kubernetes-sigs/lws#928

## Testing

- `go test ./config/tests/jobs/...`
- `go test ./config/tests/testgrids/...`
- `yamllint -c config/jobs/.yamllint.conf config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml`