### PR TITLE
node-readiness-controller: add golangci-lint presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-presubmits.yaml
@@ -81,6 +81,39 @@ presubmits:
       testgrid-dashboards: sig-node-node-readiness-controller
       testgrid-num-columns-recent: '30'
       testgrid-create-test-group: 'true'
+  - name: pull-node-readiness-controller-lint
+    cluster: eks-prow-build-cluster
+    always_run: false
+    skip_if_only_changed: "^docs/|\\.md$|^(README|LICENSE|OWNERS|SECURITY_CONTACTS)$"
+    branches:
+    - ^main$
+    - ^release-v.*$
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    decoration_config:
+      timeout: 2h
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
+          command:
+            - runner.sh
+          args:
+            - make
+            - lint
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 2
+              memory: 4Gi
+    annotations:
+      testgrid-dashboards: sig-node-node-readiness-controller
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'
   - name: pull-node-readiness-controller-scale-test-binary-1000-continuous
     cluster: eks-prow-build-cluster
     always_run: false


### PR DESCRIPTION
This PR adds a presubmit job to `kubernetes-sigs/node-readiness-controller`.

The job runs both `golangci-lint` and `kube-api-linter`.

Follow-up to https://github.com/kubernetes-sigs/node-readiness-controller/pull/210#issuecomment-4427490667