### PR TITLE
Raise ci-kind-dra-1-34 CPU request/limit from 2 to 4

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -214,10 +214,10 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: "2"
+          cpu: "4"
           memory: 6Gi
         requests:
-          cpu: "2"
+          cpu: "4"
           memory: 6Gi
       securityContext:
         privileged: true


### PR DESCRIPTION
## What is happening

`ci-kind-dra-1-34` keeps running out of wall-clock before the DRA suite finishes, tracked in kubernetes/kubernetes#141435. In the failing run's artifacts the kind control plane was missing its own health probes rather than hitting OOM: kube-apiserver readiness went to a TLS handshake timeout and then a context deadline, etcd and kube-controller-manager liveness went to context-deadline and then connection-refused, and both kube-apiserver and kube-controller-manager restarted a few times. While the controller-manager is down its ServiceAccount controller can't create a namespace's default ServiceAccount, and that is the roughly 847s `BeforeEach` wait that eventually trips the 90 minute Prow timeout.

## Why this is a useful canary

The artifacts line up with CPU starvation: the control-plane components fall behind their probes while the job runs eight Ginkgo processes and a four-node kind cluster inside a 2-CPU pod. How much of that pressure comes from the test processes versus the nested control plane is still being worked out in kubernetes/kubernetes#141435 (the short version is that the bootstrap runner moves the job into a cgroup leaf where Go can't see the pod's CPU quota, so the processes size themselves to the whole node and oversubscribe). This PR changes only the overall CPU envelope, so the next periodics can tell us whether more CPU on its own is enough to keep the control plane healthy.

## What this changes

It raises the CPU request and limit for `ci-kind-dra-1-34` from 2 to 4. Nothing else changes. The main test container keeps equal CPU request and limit and a hard 4-CPU ceiling. (The Pod as a whole is Burstable: the Prow-injected utility containers do not all set matching CPU and memory requests and limits, so it is not Guaranteed at the Pod level.)

An alternative is to cut test-side concurrency, either the Ginkgo process count or an explicit `GOMAXPROCS`. That works the demand side rather than the CPU budget, and it is better tested on its own rather than folded in here, so this PR stays CPU-only.

## Scope

This touches `ci-kind-dra-1-34` only, since that is the job with the confirmed failure. The 1.35 and 1.36 jobs carry the same definition and are currently green, so I have left them alone rather than change jobs that are not failing.

## How I checked

Because this is a resource change rather than a logic fix, I did not want to land it blind. In an isolated four-node kind v1.34.0 cluster I capped the control-plane node's CPU and measured how long a fresh namespace takes to get its default ServiceAccount under API load, which is the exact wait the suite dies on. The median was about 0.08s at 4 CPU, 0.22s at 2 CPU, and 0.58s at 1 CPU, and it came back to 0.08s once I restored 4 CPU. That confirms the direction between available CPU and the ServiceAccount wait, not the exact Prow numbers, since my box is faster and does not reproduce the nested DinD cgroup layout. The periodic job itself is the real canary for this change.
