### PR TITLE
kops: discover the SSH user and use ephemeral keys on GCE presubmits

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -413,6 +413,8 @@ def presubmit_test(branch='master',
     marker, k8s_deploy_url, test_package_url, test_package_dir = k8s_version_info(k8s_version)
     args = create_args(kops_channel, networking, extra_flags, kops_image, distro)
 
+    derive_ssh_user = cloud == 'gce' and branch not in ('release-1.33', 'release-1.34', 'release-1.35', 'release-1.36')
+
     # Scenario-specific parameters
     if env is None:
         env = {}
@@ -460,6 +462,7 @@ def presubmit_test(branch='master',
         instance_groups_overrides=instance_groups_overrides,
         extra_refs=extra_refs,
         job_queue_name=job_queue_name,
+        derive_ssh_user=derive_ssh_user,
     )
 
     spec = {

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -2330,7 +2330,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2363,10 +2362,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2398,7 +2393,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2431,10 +2425,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2466,7 +2456,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2499,10 +2488,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2534,7 +2519,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2567,10 +2551,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2602,7 +2582,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2635,10 +2614,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2670,7 +2645,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2703,10 +2677,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2738,7 +2708,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2771,10 +2740,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2806,7 +2771,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2839,10 +2803,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2874,7 +2834,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2907,10 +2866,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2942,7 +2897,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -2975,10 +2929,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3010,7 +2960,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3043,10 +2992,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3078,7 +3023,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3111,10 +3055,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3146,7 +3086,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3179,10 +3118,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3214,7 +3149,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3247,10 +3181,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3282,7 +3212,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3315,10 +3244,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3350,7 +3275,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3383,10 +3307,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3418,7 +3338,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3451,10 +3370,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3486,7 +3401,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3519,10 +3433,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3554,7 +3464,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3587,10 +3496,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3622,7 +3527,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3655,10 +3559,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3690,7 +3590,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3723,10 +3622,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3758,7 +3653,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3791,10 +3685,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3826,7 +3716,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3859,10 +3748,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3894,7 +3779,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3927,10 +3811,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -3962,7 +3842,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -3995,10 +3874,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4030,7 +3905,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4063,10 +3937,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4098,7 +3968,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4131,10 +4000,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4166,7 +4031,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4199,10 +4063,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4234,7 +4094,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4267,10 +4126,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4302,7 +4157,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4335,10 +4189,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4370,7 +4220,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4403,10 +4252,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4438,7 +4283,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4471,10 +4315,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4506,7 +4346,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4539,10 +4378,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4574,7 +4409,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4607,10 +4441,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4642,7 +4472,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4675,10 +4504,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4710,7 +4535,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4743,10 +4567,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4778,7 +4598,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4811,10 +4630,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4846,7 +4661,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4879,10 +4693,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4914,7 +4724,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -4947,10 +4756,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -4982,7 +4787,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -5015,10 +4819,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH

--- a/config/jobs/kubernetes/kops/kops-presubmits-dns-none.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-dns-none.yaml
@@ -143,7 +143,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -176,10 +175,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -407,7 +402,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -440,10 +434,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -341,7 +341,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -374,10 +373,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -409,7 +404,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -442,10 +436,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -477,7 +467,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -510,10 +499,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -545,7 +530,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -588,10 +572,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -623,7 +603,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -656,10 +635,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -691,7 +666,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -724,10 +698,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -759,7 +729,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -792,10 +761,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -827,7 +792,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -862,10 +826,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -1450,7 +1410,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1483,10 +1442,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2191,7 +2146,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 530m
@@ -2228,10 +2182,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2263,7 +2213,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 70m
@@ -2299,10 +2248,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2334,7 +2279,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 100m
@@ -2371,10 +2315,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -276,7 +276,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -309,10 +308,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -543,7 +538,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -576,10 +570,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -744,7 +734,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -777,10 +766,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -1143,7 +1128,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     decorate: true
     decoration_config:
       timeout: 90m
@@ -1176,10 +1160,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH

--- a/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit.yaml.jinja
@@ -22,7 +22,7 @@
       preset-service-account: "true"
       preset-do-credential: "true"
       preset-do-spaces-credential: "true"
-      {%- else %}
+      {%- elif not derive_ssh_user %}
       preset-k8s-ssh: "true"
       {%- endif %}
     decorate: true
@@ -120,13 +120,13 @@
         securityContext:
           privileged: true
         env:
-        {#- AWS jobs have no key to point at: kubetest2-kops generates an ephemeral one
-            per cluster and re-exports it as KUBE_SSH_KEY_PATH for the e2e framework. -#}
-        {%- if cloud != "azure" and cloud != "do" and cloud != "aws" %}
+        {#- Jobs without a configured key get an ephemeral one per cluster from
+            kubetest2-kops, re-exported as KUBE_SSH_KEY_PATH for the e2e framework. -#}
+        {%- if cloud != "azure" and cloud != "do" and cloud != "aws" and not derive_ssh_user %}
         - name: KUBE_SSH_KEY_PATH
           value: {{kops_ssh_key_path}}
         {%- endif %}
-        {%- if cloud != "azure" and cloud != "do" %}
+        {%- if cloud != "azure" and cloud != "do" and not derive_ssh_user %}
         - name: KUBE_SSH_USER
           value: {{kops_ssh_user}}
         {%- endif %}


### PR DESCRIPTION
Applies to the GCE presubmits what #37696 and #37711 did for the periodics, in one step since the periodics have already de-risked both halves:

- drop `KUBE_SSH_USER`, so `kubetest2-kops` asks the cluster which user kops registered the key for
- drop `preset-k8s-ssh` and `KUBE_SSH_KEY_PATH`, so it generates a throwaway keypair per cluster

**58 GCE presubmits** convert; 290 lines removed, nothing added.

## Why one step here

The periodics did user-then-key across two changes to isolate the risk. That question is now answered — the most recent periodic runs use ephemeral keys and derive correctly:

| job | key | user | node dirs | tests |
|---|---|---|---|---|
| `e2e-kops-gce-nftables-cos125` | ephemeral | `admin` | 5 | 7962 / 0 fail |
| `e2e-kops-gce-nftables-cos129` | ephemeral | `admin` | 5 | — |
| `e2e-kops-gce-nftables-deb12` | ephemeral | `admin` | 5 | 7962 / 0 fail |
| `e2e-kops-gce-cni-cilium` | ephemeral | `ubuntu` | 5 | 7962 / 0 fail |
| `e2e-kops-gce-cni-calico` | ephemeral | `ubuntu` | 5 | — |

`admin` is the value that proves it: a failed lookup falls back to kops's `ubuntu` default, which would break log collection on those distros rather than passing quietly.

## Gated on the branch, not a version marker

Presubmits have no `--kops-version-marker` — they build kops *and the kubetest2-kops deployer* from the branch under test. So eligibility follows the branch:

```python
derive_ssh_user = cloud == 'gce' and branch not in ('release-1.33', 'release-1.34', 'release-1.35', 'release-1.36')
```

Those four branches carry neither `sshUser` in `kops toolbox dump` nor the deployer support, so their four GCE presubmits keep the preset, the key path and the user.

Listed as branches that *cannot* rather than branches that can, for the same reason as the periodic version list: a newly cut release branch will carry both changes and so should discover the user by default, and each entry becomes inert when that branch is dropped from the matrix — at which point the condition and the `derive_ssh_user` plumbing can be deleted outright. Gating on `branch == 'master'` would instead need editing at every release.

## Result

```
master        sets KUBE_SSH_USER=False   58   (converted)
master        sets KUBE_SSH_USER=True     7   (scenario jobs, see below)
release-1.36  sets KUBE_SSH_USER=True     1
release-1.35  sets KUBE_SSH_USER=True     1
release-1.34  sets KUBE_SSH_USER=True     1
release-1.33  sets KUBE_SSH_USER=True     1
```

The seven GCE **scenario** presubmits are untouched — they render from `presubmit-scenario.yaml.jinja` and take `KUBE_SSH_USER` from the `env` dict rather than the template, so they need separate plumbing, alongside the periodic scenario job already deferred.

`preset-k8s-ssh` itself is not deleted; it is shared with many non-kops jobs.

## Testing

- `go test ./config/tests/jobs/...` passes.
- Regenerated with `make generate-jobs` against the existing `pinned.list`: **0 insertions, 290 deletions** = 58 jobs × 5 lines, and every removed line is one of `preset-k8s-ssh`, the `KUBE_SSH_KEY_PATH` pair or the `KUBE_SSH_USER` pair — confirmed by tallying the removed lines, which yields exactly those five strings, 58 times each.
- Parsed the generated YAML and checked every GCE presubmit against its branch: zero release-branch jobs stripped, zero jobs in a mixed state.

Unlike the periodics, these gate contributors' PRs, so the failure mode is visible immediately rather than only in artifacts.

/sig testing
/area jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)