### PR TITLE
kops: finish the GCE SSH migration, except the upgrade jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -125,8 +125,6 @@ def build_test(cloud='aws',
     else:
         kops_deploy_url = marker_updown_green(kops_version)
 
-    derive_ssh_user = cloud == 'gce' and kops_version not in ('1.34', '1.35', '1.36')
-
     if should_skip_newer_k8s(k8s_version, kops_version):
         return None
     if networking == 'kopeio' and distro in ('flatcar', 'flatcararm64'):
@@ -209,6 +207,10 @@ def build_test(cloud='aws',
     if env is None:
         env = {}
 
+    derive_ssh_user = (cloud == 'gce'
+                       and kops_version not in ('1.34', '1.35', '1.36')
+                       and env.get('KOPS_VERSION_A') not in ('1.34', '1.35', '1.36'))
+
     tmpl_file = "periodic.yaml.jinja"
     if scenario is not None:
         tmpl_file = "periodic-scenario.yaml.jinja"
@@ -217,7 +219,8 @@ def build_test(cloud='aws',
             if 'KOPS_DNS_DOMAIN' not in env:
                 env['KOPS_DNS_DOMAIN'] = "tests-kops-aws.k8s.io"
         env['CLOUD_PROVIDER'] = cloud
-        env['KUBE_SSH_USER'] = kops_ssh_user
+        if not derive_ssh_user:
+            env['KUBE_SSH_USER'] = kops_ssh_user
         if not cluster_name:
             # scenario scripts often need to reference the cluster name outside of kubetest2-kops.
             # Since kubetest2-kops defaults to generating one automatically, the easiest way to
@@ -413,11 +416,13 @@ def presubmit_test(branch='master',
     marker, k8s_deploy_url, test_package_url, test_package_dir = k8s_version_info(k8s_version)
     args = create_args(kops_channel, networking, extra_flags, kops_image, distro)
 
-    derive_ssh_user = cloud == 'gce' and branch not in ('release-1.33', 'release-1.34', 'release-1.35', 'release-1.36')
-
     # Scenario-specific parameters
     if env is None:
         env = {}
+
+    derive_ssh_user = (cloud == 'gce'
+                       and branch not in ('release-1.33', 'release-1.34', 'release-1.35', 'release-1.36')
+                       and env.get('KOPS_VERSION_A') not in ('1.34', '1.35', '1.36'))
 
     tmpl_file = "presubmit.yaml.jinja"
     if scenario is not None:

--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -2,7 +2,6 @@ periodics:
 # Runs e2e on the cluster built with latest released kops and latest released k/k
 - cron: '3 1-23/3 * * *'
   labels:
-    preset-k8s-ssh: "true"
   cluster: k8s-infra-prow-build
   name: e2e-kops-gce-stable
   decorate: true
@@ -38,10 +37,6 @@ periodics:
           --test-package-marker=stable.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/ssh-key-secret/ssh-private
-      - name: KUBE_SSH_USER
-        value: prow
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
       imagePullPolicy: Always
       resources:
@@ -67,7 +62,6 @@ periodics:
 # Runs e2e on the cluster built with latest released kops and k/k master branch
 - cron: '48 1-23/3 * * *'
   labels:
-    preset-k8s-ssh: "true"
   cluster: k8s-infra-prow-build
   name: e2e-kops-gce-latest
   decorate: true
@@ -105,10 +99,6 @@ periodics:
           --test-package-marker=latest.txt \
           --parallel=25
       env:
-      - name: KUBE_SSH_KEY_PATH
-        value: /etc/ssh-key-secret/ssh-private
-      - name: KUBE_SSH_USER
-        value: prow
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
       imagePullPolicy: Always
       resources:

--- a/config/jobs/kubernetes/kops/kops-periodics-upgrades-dns-none.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-upgrades-dns-none.yaml
@@ -154,6 +154,7 @@ periodics:
   cluster: k8s-infra-prow-build
   cron: '41 3-23/8 * * *'
   labels:
+    preset-k8s-ssh: "true"
   max_concurrency: 1
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -2346,7 +2346,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -2364,10 +2363,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -2400,7 +2395,6 @@ presubmits:
     optional: true
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -2420,10 +2414,6 @@ presubmits:
         env:
         - name: KOPS_FEATURE_FLAGS
           value: "APIServerNodes,ExperimentalRoles"
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH

--- a/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-scale.yaml
@@ -210,7 +210,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -233,10 +232,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -316,7 +311,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -339,10 +333,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH
@@ -419,7 +409,6 @@ presubmits:
     optional: false
     skip_report: false
     labels:
-      preset-k8s-ssh: "true"
     max_concurrency: 1
     decorate: true
     decoration_config:
@@ -442,10 +431,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         - name: GINKGO_NO_COLOR
           value: "TRUE"
         - name: GOPATH

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -393,7 +393,6 @@ presubmits:
     run_if_changed: 'tests/e2e'
     optional: true
     labels:
-      preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     decorate: true
     extra_refs:
@@ -416,10 +415,6 @@ presubmits:
         securityContext:
           privileged: true
         env:
-        - name: KUBE_SSH_KEY_PATH
-          value: /etc/ssh-key-secret/ssh-private
-        - name: KUBE_SSH_USER
-          value: prow
         resources:
           limits:
             cpu: "4"

--- a/config/jobs/kubernetes/kops/templates/periodic-scenario.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/periodic-scenario.yaml.jinja
@@ -11,6 +11,8 @@
     {%- elif cloud == "azure" %}
     preset-service-account: "true"
     preset-kops-azure-cred-wi: "true"
+    {%- elif not derive_ssh_user %}
+    preset-k8s-ssh: "true"
     {%- endif %}
   max_concurrency: 1
   decorate: true

--- a/config/jobs/kubernetes/kops/templates/presubmit-scenario.yaml.jinja
+++ b/config/jobs/kubernetes/kops/templates/presubmit-scenario.yaml.jinja
@@ -23,7 +23,7 @@
       {%- elif cloud == "azure" %}
       preset-service-account: "true"
       preset-kops-azure-cred-wi: "true"
-      {%- else %}
+      {%- elif not derive_ssh_user %}
       preset-k8s-ssh: "true"
       {%- endif %}
     max_concurrency: 1
@@ -69,13 +69,13 @@
         - name: KOPS_FEATURE_FLAGS
           value: "{{kops_feature_flags}}"
         {%- endif %}
-        {#- AWS jobs have no key to point at: kubetest2-kops generates an ephemeral one
-            per cluster and re-exports it as KUBE_SSH_KEY_PATH for the e2e framework. -#}
-        {%- if cloud != "azure" and cloud != "aws" %}
+        {#- Jobs without a configured key get an ephemeral one per cluster from
+            kubetest2-kops, re-exported as KUBE_SSH_KEY_PATH for the e2e framework. -#}
+        {%- if cloud != "azure" and cloud != "aws" and not derive_ssh_user %}
         - name: KUBE_SSH_KEY_PATH
           value: {{kops_ssh_key_path}}
         {%- endif %}
-        {%- if cloud != "azure" %}
+        {%- if cloud != "azure" and not derive_ssh_user %}
         - name: KUBE_SSH_USER
           value: {{kops_ssh_user}}
         {%- endif %}


### PR DESCRIPTION
Picks up the GCE jobs #37696, #37711 and #37718 could not reach, so they discover the SSH user and use an ephemeral key like the rest. **8 jobs convert**, 40 lines removed and 1 added.

| job | why it was missed |
|---|---|
| `e2e-kops-gce-stable`, `e2e-kops-gce-latest` | hand-maintained `kops-periodics-gce.yaml`, not generated |
| `pull-kops-kubernetes-e2e-ubuntu-gce-build` | hand-maintained `kops-presubmits.yaml` |
| `pull-kops-scenario-clusterapi-gcp` | scenario template |
| `pull-kops-scenario-splitkcp-gcp` | scenario template |
| `pull-kops-gce-master-scale-performance-100` | scenario template |
| `pull-kops-gce-master-scale-performance-5000` | scenario template |
| `pull-kops-gce-master-scale-kindnet-performance-100` | scenario template |

Both scenario templates gained the gate the others already have. For **periodic** scenarios the `KUBE_SSH_USER` entry in the `env` dict is gated as well, since those jobs take it from there rather than from the template.

## The upgrade jobs are deliberately excluded

`e2e-kops-gce-upgrade-dns-none` and `pull-kops-gce-upgrade-dns-none` run `KOPS_VERSION_A=1.35` for the A-side of the upgrade. `lib/upgrade.sh` brings that cluster up with the downloaded 1.35 binary, whose `kops toolbox dump` does not report `sshUser` for GCE — so discovery would find nothing and the deployer would omit `--ssh-user`, leaving kops to apply its own `ubuntu` default.

Both jobs run u2404, where `ubuntu` is the correct answer. They would pass while proving nothing, which is precisely the false green this migration has been avoiding. The condition therefore also excludes jobs whose `KOPS_VERSION_A` is a release that cannot answer:

```python
derive_ssh_user = (cloud == 'gce'
                   and kops_version not in ('1.34', '1.35', '1.36')
                   and env.get('KOPS_VERSION_A') not in ('1.34', '1.35', '1.36'))
```

Same skip-list shape as the rest, so it ages out when those versions leave the matrix.

## A long-standing bug fixed on the way

Keeping those two jobs on the old path exposed why `periodic-scenario.yaml.jinja` needed fixing regardless: its label block had branches for `aws` and `azure` and **no `else`**, so GCE and DO scenario periodics rendered an empty `labels:`. `e2e-kops-gce-upgrade-dns-none` therefore had no `preset-k8s-ssh`, and so no key for the `prow` user it authenticates as — it has never collected node logs. Its most recent runs show the symptom: SSH authentication failures and only `cluster-info` in the artifacts, no per-node directories.

Adding the missing branch gives it `GCE_SSH_PRIVATE_KEY_FILE`, which `resolveSSHKeys` reads through the legacy per-cloud map. That is the single added line in the generated diff.

## Result

```
GCE jobs on a current kops line, discovering the user   425
GCE jobs on a current kops line, still configured         2   (the upgrade jobs)
GCE jobs on a release kops line, still configured       583   (age out on their own)
```

## Testing

- `go test ./config/tests/jobs/...` passes.
- Regenerated with `make generate-jobs` against the existing `pinned.list`: **1 insertion, 40 deletions**. Every removed line is one of `preset-k8s-ssh`, the `KUBE_SSH_KEY_PATH` pair or the `KUBE_SSH_USER` pair — 8 of each, i.e. 8 jobs × 5 lines — and the single insertion is the `preset-k8s-ssh` label restored to `e2e-kops-gce-upgrade-dns-none`.
- Re-running `build_jobs.py` does not revert the two hand-maintained files.
- Parsed the generated YAML: exactly the two upgrade jobs remain configured outside the release lines, and both now carry a preset.

## Note on the scale jobs

`pull-kops-gce-master-scale-*` are `always_run: false` and run rarely, so they will not produce signal on their own. clusterloader2 reads `KUBE_SSH_KEY_PATH` to scrape metrics over SSH; it runs as a kubetest2 tester and so inherits the value the deployer exports from the ephemeral key, the same way it already does on AWS. Worth a manual run before relying on them.

/sig testing
/area jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)