### PR TITLE
sig-node/dra: complete kind cleanup and keep the real test exit code

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -70,7 +70,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -78,6 +78,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
@@ -168,7 +169,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -176,6 +177,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
@@ -275,7 +277,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -283,6 +285,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
@@ -374,7 +377,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -382,6 +385,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
@@ -514,7 +518,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -522,6 +526,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
@@ -654,7 +659,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -662,6 +667,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.

--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -72,8 +72,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -168,8 +170,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -273,8 +277,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -370,8 +376,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -508,8 +516,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -646,8 +656,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 

--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -46,8 +46,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -145,8 +145,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -253,8 +253,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -353,8 +353,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -494,8 +494,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -635,8 +635,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -75,8 +75,10 @@ periodics:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -173,8 +175,10 @@ periodics:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -274,8 +278,10 @@ periodics:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -401,8 +407,10 @@ periodics:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -528,8 +536,10 @@ periodics:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -73,7 +73,7 @@ periodics:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -81,6 +81,7 @@ periodics:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
@@ -173,7 +174,7 @@ periodics:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -181,6 +182,7 @@ periodics:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
@@ -276,7 +278,7 @@ periodics:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -284,6 +286,7 @@ periodics:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
@@ -405,7 +408,7 @@ periodics:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -413,6 +416,7 @@ periodics:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
@@ -534,7 +538,7 @@ periodics:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -542,6 +546,7 @@ periodics:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -49,8 +49,8 @@ periodics:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -150,8 +150,8 @@ periodics:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -254,8 +254,8 @@ periodics:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -384,8 +384,8 @@ periodics:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -514,8 +514,8 @@ periodics:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -72,7 +72,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -80,6 +80,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
@@ -172,7 +173,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -180,6 +181,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
@@ -280,7 +282,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -288,6 +290,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
@@ -381,7 +384,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -389,6 +392,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
@@ -523,7 +527,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -531,6 +535,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.
@@ -665,7 +670,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -673,6 +678,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1
           # and https://github.com/kubernetes/test-infra/blob/9cccc25265537e8dfa556688cf10754622014424/experiment/compatibility-versions/emulated-version-upgrade.sh#L56-L66.

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -74,8 +74,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -172,8 +174,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -278,8 +282,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -377,8 +383,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -517,8 +525,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 
@@ -657,8 +667,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
 

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -48,8 +48,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -149,8 +149,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -258,8 +258,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -360,8 +360,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -503,8 +503,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -646,8 +646,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -223,7 +223,7 @@ presubmits:
           cp /tmp/kind.yaml "${ARTIFACTS}/kind"
           cat /tmp/kind.yaml
 
-          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
+          # Install cleanup before create, so a partially created --retain cluster still gets its logs.
           atexit () {
               rc=$?
               kind export logs "${ARTIFACTS}/kind" || true
@@ -231,6 +231,7 @@ presubmits:
               exit "${rc}"
           }
           trap atexit EXIT
+          kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           {%- if kubelet_skew|int > 0 %}
 
           # Replace the kubelet binary and restart it, as in https://gist.github.com/aojea/2c94034f8e86d08842e5916231eb3fe1

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -225,8 +225,10 @@ presubmits:
 
           kind create cluster --retain --config /tmp/kind.yaml --image dra/node:latest
           atexit () {
-              kind export logs "${ARTIFACTS}/kind"
-              kind delete cluster
+              rc=$?
+              kind export logs "${ARTIFACTS}/kind" || true
+              kind delete cluster || true
+              exit "${rc}"
           }
           trap atexit EXIT
           {%- if kubelet_skew|int > 0 %}

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -199,8 +199,8 @@ presubmits:
           curl --fail --silent --show-error --location https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" kind
           kind build node-image --image=dra/node:latest "${kind_node_source}"
           GINKGO_E2E_PID=
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
-          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}" || true; fi' TERM
+          trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}" || true; fi' INT
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (


### PR DESCRIPTION
/kind bug
/sig node

The DRA e2e script runs with `bash -xce`, so errexit is on. Its EXIT trap is:

```bash
atexit () {
    kind export logs "${ARTIFACTS}/kind"
    kind delete cluster
}
```

If `kind export logs` returns non-zero, errexit stops the trap right there, so `kind delete cluster` never runs and the kind cluster is left behind. The failing command also overwrites the shell exit status, so a real test failure ends up reported as the cleanup failure instead of the actual one.

I checked this in a small script: with the export failing, the delete line does not run, and an `exit 7` comes out as `exit 1`.

The fix captures the exit code first, runs both cleanup steps best-effort, then exits with the captured code:

```bash
atexit () {
    rc=$?
    kind export logs "${ARTIFACTS}/kind" || true
    kind delete cluster || true
    exit "${rc}"
}
```

A failing log export no longer stops the delete from being attempted, and a cleanup failure no longer replaces the test's own exit code. I kept the cleanup best-effort on purpose, so a log-export hiccup does not turn a passing test red. Regenerated `dra-*.yaml` with `hack/generate-jobs.py`.


I folded in a second, related fix: install the trap before `kind create --retain`. Today the trap is set after create, so if create fails partway it leaves the partial cluster with no log export and no delete. With the trap first, a partial cluster still gets its logs and gets deleted. Same complete-cleanup goal, and it touches the same block, so it is here rather than a separate PR.

A third commit closes the same two failures reached a different way. The TERM and INT handlers forward the signal to Ginkgo. Once Ginkgo has exited and been reaped, `GINKGO_E2E_PID` still holds its number and the kill fails, which under errexit ends the EXIT handler where it stands. So a signal arriving during log export skipped the delete and returned 1 anyway. Both forwarding calls are best-effort now.

I pulled the traps and the `atexit` body out of the three generated configs and drove them with a stubbed `kind`. A signal during export leaves the cluster undeleted and returns 1 on all 17 jobs before that commit, and deletes the cluster and returns the test's own status on all 17 after. That is a shell-level check, not a real cluster run.

