### PR TITLE
sig-node/dra: snapshot the CPU cgroup state before the DRA suite

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -48,6 +48,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -77,6 +121,7 @@ presubmits:
           }
           trap atexit EXIT
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -144,6 +189,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -173,6 +262,7 @@ presubmits:
           }
           trap atexit EXIT
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -249,6 +339,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -278,6 +412,7 @@ presubmits:
           }
           trap atexit EXIT
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -346,6 +481,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -425,6 +604,7 @@ presubmits:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation }$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -484,6 +664,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -563,6 +787,7 @@ presubmits:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation }$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -622,6 +847,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -701,6 +970,7 @@ presubmits:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation }$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -51,6 +51,50 @@ periodics:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -80,6 +124,7 @@ periodics:
           }
           trap atexit EXIT
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -149,6 +194,50 @@ periodics:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -178,6 +267,7 @@ periodics:
           }
           trap atexit EXIT
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -250,6 +340,50 @@ periodics:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -314,6 +448,7 @@ periodics:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation }$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -377,6 +512,50 @@ periodics:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -441,6 +620,7 @@ periodics:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation }$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -504,6 +684,50 @@ periodics:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -568,6 +792,7 @@ periodics:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation }$kubelet_label_filter && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -50,6 +50,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -79,6 +123,7 @@ presubmits:
           }
           trap atexit EXIT
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation } && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -148,6 +193,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -177,6 +266,7 @@ presubmits:
           }
           trap atexit EXIT
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -254,6 +344,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -283,6 +417,7 @@ presubmits:
           }
           trap atexit EXIT
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit -logcheck-data-races &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -353,6 +488,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -432,6 +611,7 @@ presubmits:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation }$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -493,6 +673,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -572,6 +796,7 @@ presubmits:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation }$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"
@@ -633,6 +858,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -712,6 +981,7 @@ presubmits:
           # only those cover kubelet behavior.
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --sem-ver-filter=kubelet=1.$previous_minor --label-filter="DRA && Feature: isSubsetOf { DynamicResourceAllocation }$kubelet_label_filter && !Flaky && !Slow" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -201,6 +201,50 @@ presubmits:
           GINKGO_E2E_PID=
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -TERM "${GINKGO_E2E_PID}"; fi' TERM
           trap 'if [ "${GINKGO_E2E_PID}" ]; then kill -INT "${GINKGO_E2E_PID}"; fi' INT
+
+          # Snapshot the CPU cgroup layout for kubernetes/kubernetes#141435: the runner moves the
+          # job into a leaf whose cpu.max is unset, so Go can size GOMAXPROCS to the whole node
+          # instead of the pod quota. Best-effort, never fails the job.
+          collect_cpu_state () {
+              local when="$1"
+              local rel dir leafdir parent
+              # A subshell with tracing off keeps the job's set -x out of the artifact; the
+              # redirect on the toggle hides the trace of the toggle itself.
+              ( { set +x; } 2>/dev/null
+                  echo "### cpu-state (${when})"
+                  echo "## Go sizes GOMAXPROCS to the CPU affinity, not the cgroup quota:"
+                  echo "   Cpus_allowed_list=[$(awk '/^Cpus_allowed_list/{print $2}' /proc/self/status 2>/dev/null)]"
+                  echo "## cgroup chain leaf -> root (Go reads the leaf cpu.max, not the ancestor quota):"
+                  rel=$(awk -F: '$1 == "0" { print $3 }' /proc/self/cgroup 2>/dev/null)
+                  leafdir="/sys/fs/cgroup${rel}"
+                  while [ -n "${rel}" ]; do
+                      dir="/sys/fs/cgroup${rel}"
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s] throttled_usec=[%s]\n' \
+                          "${rel}" \
+                          "$(cat "${dir}/cpu.max" 2>/dev/null || echo n/a)" \
+                          "$(awk '/^nr_throttled/{print $2}' "${dir}/cpu.stat" 2>/dev/null)" \
+                          "$(awk '/^throttled_usec/{print $2}' "${dir}/cpu.stat" 2>/dev/null)"
+                      [ "${rel}" = "/" ] && break
+                      rel="${rel%/*}"; [ -z "${rel}" ] && rel="/"
+                  done
+                  echo "## init vs dind cpu.weight (the runner and the kind cluster share the parent):"
+                  parent=${leafdir%/init}
+                  printf '  init cpu.weight=[%s]  dind cpu.weight=[%s] nr_throttled=[%s]\n' \
+                      "$(cat "${parent}/init/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(cat "${parent}/dind/cpu.weight" 2>/dev/null || echo n/a)" \
+                      "$(awk '/^nr_throttled/{print $2}' "${parent}/dind/cpu.stat" 2>/dev/null)"
+                  echo "## leaf cpu.pressure:"
+                  sed 's/^/  /' "${leafdir}/cpu.pressure" 2>/dev/null || echo "  n/a"
+                  echo "## e2e.test baked GODEBUG:"
+                  go version -m "${e2e_test}" 2>/dev/null | awk '/DefaultGODEBUG/{print "  "$0}' || echo "  n/a"
+                  echo "## kind node cpu.max + throttle:"
+                  for node in $(kind get nodes 2>/dev/null); do
+                      printf '  %s cpu.max=[%s] nr_throttled=[%s]\n' "${node}" \
+                          "$(docker exec "${node}" cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a)" \
+                          "$(docker exec "${node}" awk '/^nr_throttled/{print $2}' /sys/fs/cgroup/cpu.stat 2>/dev/null)"
+                  done
+              ) >"${ARTIFACTS}/cpu-state-${when}.txt" 2>&1 || true
+          }
           # The final kind.yaml the result of getting the original kind.yaml, manipulating it with sed,
           # and adding something at the end.
           (
@@ -290,6 +334,7 @@ presubmits:
           kubelet_label_filter+=" && Feature: containsAny DynamicResourceAllocation"
           {%- endif %}
 
+          collect_cpu_state before-ginkgo
           KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color {%- if kubelet_skew|int > 0 %} --sem-ver-filter=kubelet=1.$previous_minor {%- endif %} --label-filter="DRA && Feature: isSubsetOf { {% if all_features %}OffByDefault, {% endif -%} DynamicResourceAllocation } {%- if kubelet_skew|int > 0 %}$kubelet_label_filter{%- endif %} && !Flaky {%- if not ci and not allow_slow %} && !Slow {%- endif %}" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit {%- if all_features %} -logcheck-data-races{%endif%} &
           GINKGO_E2E_PID=$!
           wait "${GINKGO_E2E_PID}"


### PR DESCRIPTION
## What this adds

A small `collect_cpu_state` helper in the DRA e2e jobs that writes a snapshot of the CPU cgroup layout to `${ARTIFACTS}/cpu-state-before-ginkgo.txt` just before the suite starts.

## Why

`ci-kind-dra-1-34` has been timing out, and the investigation in kubernetes/kubernetes#141435 keeps hitting the same wall: the kind control plane runs out of CPU, but nothing in the artifacts shows the actual cgroup layout, so we have been reasoning from the runner source instead of from a real run.

The bootstrap runner moves the job into a `<pod>/init` leaf whose `cpu.max` is left unset and nests the kind cluster under a sibling `dind` cgroup. Two consequences follow and both are invisible today. A Go program in the `init` leaf reads its own `cpu.max` (unset) rather than the pod's 2-CPU quota on the ancestor, so it can size `GOMAXPROCS` to the whole node and oversubscribe. And `init` and `dind` split the parent CPU by `cpu.weight`, so the control plane may only get its weighted share. The only honest way to settle either is to print it from inside a job.

## What it captures

Into `${ARTIFACTS}/cpu-state-before-ginkgo.txt`:

- the process CPU affinity (`Cpus_allowed_list`), which is what Go's `NumCPU` and default `GOMAXPROCS` count;
- `cpu.max`, `nr_throttled` and `throttled_usec` at each cgroup from the leaf up to the quota-bearing ancestor;
- the `init` and `dind` `cpu.weight` and the `dind` throttle counters;
- the leaf `cpu.pressure`;
- the `e2e.test` binary's baked GODEBUG;
- each kind node's `cpu.max` and throttle.

It runs in a subshell with tracing off so the job's `set -x` stays out of the artifact, every read is guarded, and the whole thing is wrapped so it can never fail the job.

## How I checked

Regenerated with `make generate-jobs` (`--verify` is clean, the YAML still parses). I ran the helper the way the job does, under `set -e -o pipefail` and `set -x` in a reproduced `init`/`dind` cgroup capped at 2 CPU: the affinity came out as the full host, the `cpu.max` chain as leaf `max` and ancestor 2 CPU with the throttling on the ancestor, and the `init:dind` weights as 100:100, with no trace pollution in the artifact. I also confirmed it does not truncate under `errexit`, returns cleanly on an unwritable artifact path, and does not choke when run outside an `init` leaf.

## Scope

Only the snapshot; no resource, timeout, parallelism or test-code changes. It lands on the ci, canary and presubmit DRA jobs from the shared template on purpose, since comparing a failing 1.34 run against a green 1.35 run is the point. I kept it to the pre-suite snapshot so it stays independent of the cleanup change in #37723; a matching teardown capture can follow once that lands.

/sig node
/cc @pohly
