### PR TITLE
sig-node/dra: fail fast when the version-skew CI build lookup fails

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -288,8 +288,12 @@ periodics:
           fi
           # Test with the most recent CI build, doesn't even need to be released yet.
           # We want to know if those are broken.
-          previous=$(curl --silent -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
-          curl --silent -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
+          previous=$(curl --fail --silent --show-error -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
+          if [[ ! "$previous" =~ ^v[0-9]+\.[0-9]+\. ]]; then
+              echo "error: unexpected CI version for $major.$previous_minor: '$previous'"
+              exit 1
+          fi
+          curl --fail --silent --show-error -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
           chmod a+rx /tmp/kubelet
           /tmp/kubelet --version
           worker_nodes=$(kind get nodes | grep worker)
@@ -415,8 +419,12 @@ periodics:
           fi
           # Test with the most recent CI build, doesn't even need to be released yet.
           # We want to know if those are broken.
-          previous=$(curl --silent -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
-          curl --silent -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
+          previous=$(curl --fail --silent --show-error -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
+          if [[ ! "$previous" =~ ^v[0-9]+\.[0-9]+\. ]]; then
+              echo "error: unexpected CI version for $major.$previous_minor: '$previous'"
+              exit 1
+          fi
+          curl --fail --silent --show-error -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
           chmod a+rx /tmp/kubelet
           /tmp/kubelet --version
           worker_nodes=$(kind get nodes | grep worker)
@@ -542,8 +550,12 @@ periodics:
           fi
           # Test with the most recent CI build, doesn't even need to be released yet.
           # We want to know if those are broken.
-          previous=$(curl --silent -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
-          curl --silent -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
+          previous=$(curl --fail --silent --show-error -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
+          if [[ ! "$previous" =~ ^v[0-9]+\.[0-9]+\. ]]; then
+              echo "error: unexpected CI version for $major.$previous_minor: '$previous'"
+              exit 1
+          fi
+          curl --fail --silent --show-error -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
           chmod a+rx /tmp/kubelet
           /tmp/kubelet --version
           worker_nodes=$(kind get nodes | grep worker)

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -242,8 +242,12 @@ presubmits:
           {%- if ci %}
           # Test with the most recent CI build, doesn't even need to be released yet.
           # We want to know if those are broken.
-          previous=$(curl --silent -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
-          curl --silent -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
+          previous=$(curl --fail --silent --show-error -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt" )
+          if [[ ! "$previous" =~ ^v[0-9]+\.[0-9]+\. ]]; then
+              echo "error: unexpected CI version for $major.$previous_minor: '$previous'"
+              exit 1
+          fi
+          curl --fail --silent --show-error -L "https://dl.k8s.io/ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar zxOf - kubernetes/server/bin/kubelet >/tmp/kubelet
           {%- else %}
           # Test with the stable release to avoid breaking presubmits because of unrelated issues in a release candidate.
           # Ask curl to append the HTTP status code after the response body (-w ' %{http_code}').


### PR DESCRIPTION
**What**

The version-skew CI jobs (`ci-kind-dra-n-1`, `-n-2`, `-n-3`) fetch the previous minor's CI build:

```
previous=$(curl --silent -L "https://dl.k8s.io/ci/latest-$major.$previous_minor.txt")
curl --silent -L ".../ci/$previous/kubernetes-server-linux-amd64.tar.gz" | tar ...
```

The first curl have no `--fail` and no validation. If that URL return a 404 (for example a missing marker gives back a `NoSuchKey` XML body), `$previous` become that XML and the second curl build a nonsense URL, so the job fail later in a confusing place instead of here.

**Change**

Add `--fail` to both curls and check that `$previous` look like a version before using it, so the job fail fast with a clear message. The release path (the `else` branch) already do a status check, so this just make the CI path match.

Only the version-skew CI jobs change. Regenerated with `make generate-jobs`.

/sig node
/sig testing
