### PR TITLE
sig-node/dra: set GOMAXPROCS=2 in ci-kind-dra-1-34 to match the 2 CPU quota

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -205,7 +205,7 @@ periodics:
         }
         trap atexit EXIT
 
-        KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Alpha && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+        KUBECONFIG=${HOME}/.kube/config GOMAXPROCS=2 ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Alpha && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
         GINKGO_E2E_PID=$!
         wait "${GINKGO_E2E_PID}"
       command:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -205,11 +205,14 @@ periodics:
         }
         trap atexit EXIT
 
-        KUBECONFIG=${HOME}/.kube/config GOMAXPROCS=2 ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Alpha && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
+        KUBECONFIG=${HOME}/.kube/config ${ginkgo} run --nodes=8 --timeout=24h --silence-skips --force-newlines --no-color --label-filter="DRA && Feature: isSubsetOf { OffByDefault, DynamicResourceAllocation } && !FeatureGate:ResourceHealthStatus && !Alpha && !Flaky" ${e2e_test} -- -provider=local -report-dir="${ARTIFACTS}" -report-complete-ginkgo -report-complete-junit &
         GINKGO_E2E_PID=$!
         wait "${GINKGO_E2E_PID}"
       command:
       - runner.sh
+      env:
+      - name: GOMAXPROCS
+        value: "2"
       image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260907-7013e6a654-1.34
       name: ""
       resources:


### PR DESCRIPTION
## Status (2026-09-14)

#37733 has been in the job image since 09-07 and ci-kind-dra-1-34 kept failing. Those failures are memory: prow reports `Job pod was OOM killed by the cluster.` for 22 of the 40 runs from 08-03 to 09-11, and in replicas of the job the whole pod (four kind nodes, dockerd, ginkgo and its workers) goes over 6Gi with the 100 slice ResourceSlice test on this branch. Measurements, and the two kubernetes/kubernetes changes for the test and the scheduler log line, are in #37865 and kubernetes/kubernetes#141435.

This PR only caps GOMAXPROCS for ginkgo and e2e.test in the runner. The 1.34 CI binaries have `containermaxprocs=0` and size themselves to the node even with #37733, so the cap is real, but with it my replica of the job still ran into the 6Gi limit and did not finish clean (one run each way), and it does not reach the kind control plane. It does not fix the OOM failures. I have put it on hold and will close it unless a job owner wants the cap anyway.

---

The job was timing out (kubernetes/kubernetes#141435). The runner put it in an `init` cgroup leaf with no `cpu.max`, so Go sized GOMAXPROCS to the whole node instead of the 2 CPU pod quota. I confirmed this on a real presubmit (kubernetes/kubernetes#141492): the ginkgo binary printed `GOMAXPROCS=8 NumCPU=8` on an 8 CPU node, with the process in `.../cri-containerd-<hash>.scope/init` (`cpu.max=max`) under a `.../scope` with `cpu.max=200000 100000` (2 CPU). So the eight ginkgo workers each oversubscribed. That probe ran in a master presubmit; the release jobs were not measured one by one.

`GOMAXPROCS=2` makes each worker match the 2 CPU quota~~, which targets the root cause more directly than adding CPU~~. It supersedes the CPU-only #37717 per @pohly's suggestion there.

Only `ci-kind-dra-1-34` changes.

/sig node
/sig testing
/cc @pohly