### PR TITLE
Propagate the CPU quota to the runner init cgroup

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -97,6 +97,17 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
         done
     done
     echo "cgroup: ${own_cgroup} subtree_control=[$(cat "${cg}/cgroup.subtree_control")], dind subtree_control=[$(cat "${cg}/dind/cgroup.subtree_control")]"
+    # Moving into the init leaf hides the container's CPU quota from anything
+    # that reads its own cgroup: cpu.max is not inherited, so a fresh leaf
+    # reports "max" while the kernel still throttles the whole subtree to the
+    # quota on ${own_cgroup}. Go's cgroup-aware GOMAXPROCS default reads only
+    # the leaf, so test binaries size themselves to the node's CPU count
+    # instead of the pod's quota. Copy the quota down so the leaf reports it.
+    # The parent still caps the subtree, so enforcement is unchanged.
+    if [[ -f "${cg}/cpu.max" && -f "${cg}/init/cpu.max" ]]; then
+        cat "${cg}/cpu.max" > "${cg}/init/cpu.max" || true
+        echo "cgroup: init cpu.max=[$(cat "${cg}/init/cpu.max")]"
+    fi
 
     docker_registry_mirror_url=""
     if [[ "${PROW_CLOUD_PROVIDER:-}" == "amazon" ]]; then

--- a/images/kubekins-e2e-v2/runner.sh
+++ b/images/kubekins-e2e-v2/runner.sh
@@ -92,6 +92,17 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
         done
     done
     echo "cgroup: ${own_cgroup} subtree_control=[$(cat "${cg}/cgroup.subtree_control")], dind subtree_control=[$(cat "${cg}/dind/cgroup.subtree_control")]"
+    # Moving into the init leaf hides the container's CPU quota from anything
+    # that reads its own cgroup: cpu.max is not inherited, so a fresh leaf
+    # reports "max" while the kernel still throttles the whole subtree to the
+    # quota on ${own_cgroup}. Go's cgroup-aware GOMAXPROCS default reads only
+    # the leaf, so test binaries size themselves to the node's CPU count
+    # instead of the pod's quota. Copy the quota down so the leaf reports it.
+    # The parent still caps the subtree, so enforcement is unchanged.
+    if [[ -f "${cg}/cpu.max" && -f "${cg}/init/cpu.max" ]]; then
+        cat "${cg}/cpu.max" > "${cg}/init/cpu.max" || true
+        echo "cgroup: init cpu.max=[$(cat "${cg}/init/cpu.max")]"
+    fi
 
     docker_registry_mirror_url=""
     if [[ "${PROW_CLOUD_PROVIDER:-}" == "amazon" ]]; then


### PR DESCRIPTION
The runner moves its own processes into a "<pod-cgroup>/init" leaf so the pod cgroup can be subdivided for the sibling dind subtree. That hides the pod's CPU quota from the job. Under cgroup v2, cpu.max is not inherited. A fresh leaf reports "max" while the kernel still throttles the whole subtree to the quota on the parent. Go's GOMAXPROCS default reads only the leaf cgroup that contains the process, so test binaries size themselves to the node's CPU count instead of the pod's quota. On a 2 CPU job running on an 8 CPU node, ginkgo picks GOMAXPROCS=8 and oversubscribes.

This copies the parent's cpu.max onto the init leaf, right after the controllers are delegated.

Note: processes inside the kind node containers are out of scope. They sit in per-container leaves under dind that docker creates without a CPU limit, so they still see the node's CPU count. That predates the init leaf and would need the containers created with `--cpu` to propagate.

Verified by sourcing the delegation block against a cgroup with a 2 CPU quota on a 16 CPU host, then reading runtime.GOMAXPROCS from the init leaf. It reports 2 with this change and 16 without.

Fixes: #37727