### PR TITLE
Kops - Disable kindnet DNS caching on all kindnet jobs

### DIFF
--- a/config/jobs/kubernetes/kops/helpers.py
+++ b/config/jobs/kubernetes/kops/helpers.py
@@ -112,6 +112,13 @@ def create_args(kops_channel, networking, extra_flags, kops_image, distro):
         args += " --set=cluster.spec.containerd.version=2.0.7"
         args += " --set=cluster.spec.containerd.runc.version=1.3.4"
 
+    if networking == 'kindnet':
+        # kindnet is the only CNI in the grid that intercepts cluster DNS on the
+        # node, and it is the only one whose failures are Service-name resolution
+        # (`getaddrinfo ... Name does not resolve`). Turn the interception off to
+        # confirm or clear it as the cause.
+        args += " --set=cluster.spec.networking.kindnet.dnsCaching=false"
+
     image_overridden = False
     if extra_flags:
         for arg in extra_flags:

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -56129,7 +56129,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4" \
+          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -56193,7 +56193,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4" \
+          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -56257,7 +56257,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4" \
+          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -56321,7 +56321,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4" \
+          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -56385,7 +56385,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4" \
+          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -56449,7 +56449,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4" \
+          --create-args="--image='136693071363/debian-11-amd64-20260805-2561' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=1.7.29 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -56513,7 +56513,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -56577,7 +56577,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -56641,7 +56641,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -56705,7 +56705,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -56769,7 +56769,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -56833,7 +56833,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -56897,7 +56897,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -56961,7 +56961,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -57025,7 +57025,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -57089,7 +57089,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -57153,7 +57153,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -57217,7 +57217,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -57281,7 +57281,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -57345,7 +57345,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -57409,7 +57409,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -57473,7 +57473,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -57537,7 +57537,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -57601,7 +57601,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet" \
+          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -57665,7 +57665,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -57729,7 +57729,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -57793,7 +57793,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -57857,7 +57857,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -57921,7 +57921,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -57985,7 +57985,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -58049,7 +58049,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -58113,7 +58113,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -58177,7 +58177,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -58241,7 +58241,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -58306,7 +58306,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -58371,7 +58371,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -58436,7 +58436,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -58501,7 +58501,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -58566,7 +58566,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -58631,7 +58631,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -58696,7 +58696,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -58761,7 +58761,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -58826,7 +58826,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -58890,7 +58890,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -58954,7 +58954,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -59018,7 +59018,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -59082,7 +59082,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -59146,7 +59146,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -59210,7 +59210,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -59274,7 +59274,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -59338,7 +59338,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -59402,7 +59402,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -59467,7 +59467,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -59532,7 +59532,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -59597,7 +59597,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -59662,7 +59662,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -59727,7 +59727,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -59792,7 +59792,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -59857,7 +59857,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -59922,7 +59922,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -59987,7 +59987,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -60051,7 +60051,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -60115,7 +60115,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -60179,7 +60179,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -60243,7 +60243,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -60307,7 +60307,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -60371,7 +60371,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -60435,7 +60435,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -60499,7 +60499,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -60564,7 +60564,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -60629,7 +60629,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -60694,7 +60694,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -60759,7 +60759,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -60824,7 +60824,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -60889,7 +60889,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -60954,7 +60954,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -61019,7 +61019,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -61083,7 +61083,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -61147,7 +61147,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -61211,7 +61211,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -61275,7 +61275,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -61339,7 +61339,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -61403,7 +61403,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -61467,7 +61467,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -61531,7 +61531,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -61596,7 +61596,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -61661,7 +61661,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -61726,7 +61726,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -61791,7 +61791,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -61856,7 +61856,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -61921,7 +61921,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -61986,7 +61986,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -62051,7 +62051,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -62115,7 +62115,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -62179,7 +62179,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -62243,7 +62243,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -62307,7 +62307,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -62371,7 +62371,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -62435,7 +62435,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -62499,7 +62499,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -62563,7 +62563,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -62627,7 +62627,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -62692,7 +62692,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -62757,7 +62757,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -62822,7 +62822,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -62887,7 +62887,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -62952,7 +62952,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -63017,7 +63017,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -63082,7 +63082,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -63147,7 +63147,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -63212,7 +63212,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet" \
+          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -63276,7 +63276,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet" \
+          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -63340,7 +63340,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet" \
+          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -63404,7 +63404,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet" \
+          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -63468,7 +63468,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet" \
+          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -63532,7 +63532,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet" \
+          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -63596,7 +63596,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet" \
+          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -63660,7 +63660,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet" \
+          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -63724,7 +63724,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet" \
+          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -63788,7 +63788,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -63853,7 +63853,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -63918,7 +63918,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -63983,7 +63983,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -64048,7 +64048,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -64113,7 +64113,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -64178,7 +64178,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -64243,7 +64243,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -64308,7 +64308,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -64372,7 +64372,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -64436,7 +64436,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -64500,7 +64500,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -64564,7 +64564,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -64628,7 +64628,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -64692,7 +64692,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -64756,7 +64756,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -64820,7 +64820,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet" \
+          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -64884,7 +64884,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -64949,7 +64949,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -65014,7 +65014,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -65079,7 +65079,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -65144,7 +65144,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -65209,7 +65209,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -65274,7 +65274,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -65339,7 +65339,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -65404,7 +65404,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet" \
+          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --validation-wait=20m \
@@ -65469,7 +65469,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet" \
+          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --validation-wait=20m \
@@ -65534,7 +65534,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet" \
+          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --validation-wait=20m \
@@ -65599,7 +65599,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet" \
+          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --validation-wait=20m \
@@ -65664,7 +65664,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet" \
+          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --validation-wait=20m \
@@ -65729,7 +65729,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet" \
+          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --validation-wait=20m \
@@ -65794,7 +65794,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet" \
+          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --validation-wait=20m \
@@ -65859,7 +65859,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet" \
+          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --validation-wait=20m \
@@ -65924,7 +65924,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet" \
+          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --validation-wait=20m \
@@ -126171,7 +126171,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -126239,7 +126239,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -126307,7 +126307,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -126375,7 +126375,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -126443,7 +126443,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -126511,7 +126511,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-121-18867-528-43' --channel=alpha --networking=kindnet --set=cluster.spec.containerd.version=2.0.7 --set=cluster.spec.containerd.runc.version=1.3.4 --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -126578,7 +126578,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -126642,7 +126642,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -126710,7 +126710,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -126778,7 +126778,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -126845,7 +126845,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -126909,7 +126909,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -126977,7 +126977,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -127044,7 +127044,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -127108,7 +127108,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -127175,7 +127175,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -127239,7 +127239,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -127307,7 +127307,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -127375,7 +127375,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -127442,7 +127442,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -127506,7 +127506,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -127574,7 +127574,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -127641,7 +127641,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -127705,7 +127705,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -127772,7 +127772,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -127836,7 +127836,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -127903,7 +127903,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -127967,7 +127967,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -128034,7 +128034,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -128098,7 +128098,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -128165,7 +128165,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -128229,7 +128229,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -128296,7 +128296,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -128360,7 +128360,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -128427,7 +128427,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -128491,7 +128491,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -128558,7 +128558,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -128622,7 +128622,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -128690,7 +128690,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -128758,7 +128758,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -128825,7 +128825,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -128889,7 +128889,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -128957,7 +128957,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -129024,7 +129024,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -129088,7 +129088,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -129155,7 +129155,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -129219,7 +129219,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -129287,7 +129287,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -129355,7 +129355,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -129422,7 +129422,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -129486,7 +129486,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -129554,7 +129554,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -129621,7 +129621,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -129685,7 +129685,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -129752,7 +129752,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -129816,7 +129816,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -129884,7 +129884,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -129952,7 +129952,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -130019,7 +130019,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -130083,7 +130083,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -130151,7 +130151,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -130218,7 +130218,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -130282,7 +130282,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -130349,7 +130349,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -130413,7 +130413,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -130481,7 +130481,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -130549,7 +130549,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -130616,7 +130616,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -130680,7 +130680,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -130748,7 +130748,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -130815,7 +130815,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -130879,7 +130879,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -130946,7 +130946,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -131010,7 +131010,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -131078,7 +131078,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -131146,7 +131146,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -131213,7 +131213,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -131277,7 +131277,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -131345,7 +131345,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -131412,7 +131412,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -131476,7 +131476,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -131543,7 +131543,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -131607,7 +131607,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -131675,7 +131675,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -131743,7 +131743,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -131810,7 +131810,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -131874,7 +131874,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -131942,7 +131942,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -132009,7 +132009,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -132073,7 +132073,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -132140,7 +132140,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -132204,7 +132204,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -132272,7 +132272,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -132340,7 +132340,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -132407,7 +132407,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -132471,7 +132471,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -132539,7 +132539,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -132606,7 +132606,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -132670,7 +132670,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -132737,7 +132737,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -132801,7 +132801,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -132869,7 +132869,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -132937,7 +132937,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -133004,7 +133004,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -133068,7 +133068,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -133136,7 +133136,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -133203,7 +133203,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -133267,7 +133267,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -133334,7 +133334,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -133398,7 +133398,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -133466,7 +133466,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -133534,7 +133534,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -133601,7 +133601,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -133665,7 +133665,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -133733,7 +133733,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -133800,7 +133800,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -133864,7 +133864,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -133931,7 +133931,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -133995,7 +133995,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -134063,7 +134063,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -134131,7 +134131,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -134198,7 +134198,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -134262,7 +134262,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -134330,7 +134330,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -134397,7 +134397,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -134461,7 +134461,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -134528,7 +134528,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -134592,7 +134592,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.34/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -134660,7 +134660,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -134728,7 +134728,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -134795,7 +134795,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -134859,7 +134859,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -134927,7 +134927,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -134994,7 +134994,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -135058,7 +135058,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -135125,7 +135125,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -135189,7 +135189,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -135257,7 +135257,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -135324,7 +135324,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -135388,7 +135388,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -135456,7 +135456,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -135523,7 +135523,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -135587,7 +135587,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -135654,7 +135654,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -135718,7 +135718,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -135786,7 +135786,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -135853,7 +135853,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -135917,7 +135917,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -135985,7 +135985,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -136052,7 +136052,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -136116,7 +136116,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -136183,7 +136183,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -136247,7 +136247,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -136315,7 +136315,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.34.txt \
           --test=kops \
@@ -136382,7 +136382,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -136446,7 +136446,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.35/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -136514,7 +136514,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.35.txt \
           --test=kops \
@@ -136581,7 +136581,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \
@@ -136645,7 +136645,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.36/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest-1.36.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -354,7 +354,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --ipv6 --topology=private --dns=public --bastion" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --ipv6 --topology=private --dns=public --bastion" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1546,7 +1546,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=spec.nodeProblemDetector.enabled=true --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=spec.nodeProblemDetector.enabled=true --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
           --test=kops \
@@ -1742,7 +1742,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=spec.networking.networkID=default --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=spec.networking.networkID=default --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
           --test=kops \
@@ -1874,7 +1874,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
           --test=kops \
@@ -2205,7 +2205,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --node-count=3 --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-count=3 --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
           --test=kops \
@@ -2338,7 +2338,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.cloudConfig.manageStorageClasses=false --node-volume-size=100 --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.cloudConfig.manageStorageClasses=false --node-volume-size=100 --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
           --test=kops \
@@ -2538,7 +2538,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --set=spec.kubeAPIServer.runtimeConfig=api/all=true --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log --set=spec.kubeAPIServer.runtimeConfig=api/all=true --gce-service-account=default" \
           --kubernetes-feature-gates=AllAlpha,AllBeta,-EventedPLEG \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -779,7 +779,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --node-size=t3.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=t3.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -843,7 +843,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=azure \
-          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=kindnet" \
+          --create-args="--image='Canonical:ubuntu-24_04-lts:server:24.04.202606060' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
           --env=KOPS_FEATURE_FLAGS=Azure \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
@@ -905,7 +905,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-periodics-nftables.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-nftables.yaml
@@ -31,7 +31,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -94,7 +94,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -157,7 +157,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -220,7 +220,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -283,7 +283,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -346,7 +346,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -409,7 +409,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -472,7 +472,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -535,7 +535,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -598,7 +598,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -661,7 +661,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -724,7 +724,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -787,7 +787,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -850,7 +850,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -913,7 +913,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -976,7 +976,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
+          --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --node-size=m6g.large --control-plane-size=m6g.large" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1039,7 +1039,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables" \
+          --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --validation-wait=20m \
@@ -1103,7 +1103,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1164,7 +1164,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1225,7 +1225,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1286,7 +1286,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-129-19506-299-116' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1347,7 +1347,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
+          --create-args="--image='cos-cloud/cos-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1408,7 +1408,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='cos-cloud/cos-arm64-dev-138-20012-0-0' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1469,7 +1469,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1530,7 +1530,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1591,7 +1591,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1652,7 +1652,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='debian-cloud/debian-13-trixie-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1713,7 +1713,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2204-jammy-v20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1774,7 +1774,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1835,7 +1835,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-arm64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1896,7 +1896,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-amd64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -1957,7 +1957,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+          --create-args="--image='ubuntu-os-cloud/ubuntu-minimal-2404-noble-arm64-v20260730' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -2018,7 +2018,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='rhel-cloud/rhel-10-v20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -2079,7 +2079,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-arm64-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \
@@ -2140,7 +2140,7 @@ periodics:
           --up --down \
           --cloud-provider=gce \
           --admin-access=0.0.0.0/0 \
-          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
+          --create-args="--image='rocky-linux-cloud/rocky-linux-10-optimized-gcp-v20260720' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --set=cluster.spec.kubeProxy.proxyMode=nftables --gce-service-account=default --set=cluster.spec.cloudProvider.gce.useStartupScript=true" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/release/stable.txt \
           --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-distros.yaml
@@ -97,7 +97,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet" \
+            --create-args="--image='136693071363/debian-12-amd64-20260806-2562' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -225,7 +225,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet" \
+            --create-args="--image='136693071363/debian-13-amd64-20260803-2559' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -353,7 +353,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -482,7 +482,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20260731' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -611,7 +611,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -740,7 +740,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -869,7 +869,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-amd64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -998,7 +998,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-questing-25.10-arm64-server-20260626' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1127,7 +1127,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1256,7 +1256,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-arm64-server-20260806' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1385,7 +1385,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet" \
+            --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1514,7 +1514,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-arm64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1643,7 +1643,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet" \
+            --create-args="--image='309956199498/RHEL-9.8.0_HVM-20260728-x86_64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1772,7 +1772,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='309956199498/RHEL-10.2.0_HVM-20260728-arm64-0-Hourly2-GP3' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1901,7 +1901,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet" \
+            --create-args="--image='792107900819/Rocky-9-EC2-Base-9.7-20251123.2.x86_64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -2030,7 +2030,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --node-size=m6g.large --control-plane-size=m6g.large" \
+            --create-args="--image='792107900819/Rocky-10-EC2-Base-10.2-20260525.0.aarch64' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-size=m6g.large --control-plane-size=m6g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -2159,7 +2159,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet" \
+            --create-args="--image='075585003325/Flatcar-alpha-4757.0.0-hvm' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-e2e.yaml
@@ -362,7 +362,7 @@ presubmits:
             --up --build --down \
             --cloud-provider=gce \
             --admin-access=0.0.0.0/0 \
-            --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
+            --create-args="--image='debian-cloud/debian-12-bookworm-arm64-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default --node-size=t2a-standard-2 --control-plane-size=t2a-standard-2 --zones=us-central1-a" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -425,7 +425,7 @@ presubmits:
             --up --build --down \
             --cloud-provider=gce \
             --admin-access=0.0.0.0/0 \
-            --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --gce-service-account=default" \
+            --create-args="--image='debian-cloud/debian-13-trixie-v20260804' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -551,7 +551,7 @@ presubmits:
             --up --build --down \
             --cloud-provider=gce \
             --admin-access=0.0.0.0/0 \
-            --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --zones=us-east1-b --node-size=c4-standard-4 --control-plane-size=c4-standard-2 --set spec.cloudProvider.gce.pdCSIDriver.defaultStorageClassName=balanced-storage --set spec.etcdClusters[*].etcdMembers[*].volumeIOPS=10000 --set spec.etcdClusters[*].etcdMembers[*].volumeThroughput=1000 --set spec.etcdClusters[*].etcdMembers[*].volumeSize=60 --set spec.etcdClusters[*].etcdMembers[*].volumeType=hyperdisk-balanced --gce-service-account=default" \
+            --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --zones=us-east1-b --node-size=c4-standard-4 --control-plane-size=c4-standard-2 --set spec.cloudProvider.gce.pdCSIDriver.defaultStorageClassName=balanced-storage --set spec.etcdClusters[*].etcdMembers[*].volumeIOPS=10000 --set spec.etcdClusters[*].etcdMembers[*].volumeThroughput=1000 --set spec.etcdClusters[*].etcdMembers[*].volumeSize=60 --set spec.etcdClusters[*].etcdMembers[*].volumeType=hyperdisk-balanced --gce-service-account=default" \
             --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --control-plane-instance-group-overrides=spec.rootVolume.type=hyperdisk-balanced \
@@ -2167,7 +2167,7 @@ presubmits:
             --up --build --down \
             --cloud-provider=gce \
             --admin-access=0.0.0.0/0 \
-            --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --node-volume-size=100 --gce-service-account=default" \
+            --create-args="--image='cos-cloud/cos-125-19216-532-62' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --node-volume-size=100 --gce-service-account=default" \
             --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \

--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -1017,7 +1017,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --control-plane-size=c6g.large --node-size=t4g.large" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --control-plane-size=c6g.large --node-size=t4g.large" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1084,7 +1084,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=azure \
-            --create-args="--channel=alpha --networking=kindnet" \
+            --create-args="--channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false" \
             --env=KOPS_FEATURE_FLAGS=Azure \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
@@ -1149,7 +1149,7 @@ presubmits:
             --up --build --down \
             --cloud-provider=gce \
             --admin-access=0.0.0.0/0 \
-            --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --gce-service-account=default" \
+            --create-args="--image='ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20260807' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --gce-service-account=default" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \
@@ -1213,7 +1213,7 @@ presubmits:
             -v 2 \
             --up --build --down \
             --cloud-provider=aws \
-            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --ipv6 --topology=private --bastion --dns=public" \
+            --create-args="--image='099720109477/ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-20260714' --channel=alpha --networking=kindnet --set=cluster.spec.networking.kindnet.dnsCaching=false --ipv6 --topology=private --bastion --dns=public" \
             --kubernetes-version=https://dl.k8s.io/release/stable.txt \
             --kops-binary-path=/home/prow/go/src/k8s.io/kops/.build/dist/linux/amd64/kops \
             --test=kops \


### PR DESCRIPTION
Sets `--set=cluster.spec.networking.kindnet.dnsCaching=false` on every kindnet job. **382 jobs** change; no job is added or removed and nothing non-kindnet is touched.

### The failure

A `[sig-network] Services` spec fails with `service is not reachable within 2m0s timeout on endpoint <svc>:80 over TCP protocol`. The underlying per-retry error, repeated ~120 times per build, is:

```
+ echo hostName
+ nc -v -t -w 2 externalname-service 80
nc: getaddrinfo for host "externalname-service" port 80: Name does not resolve
command terminated with exit code 1
```

`nc` never gets past `getaddrinfo` — this is name resolution, not connectivity. CoreDNS is healthy and the other ~1038 specs in the same run pass.

### Currently failing jobs

Scanning the **latest build of all 312 kindnet grid periodics** just now: 25 have a red latest build, and **16 of those 25 carry this exact signature**. Every one of these links is a current, red, latest build:

| Job | Build | `Name does not resolve` hits | Failing spec |
|---|---|---|---|
| `e2e-kops-grid-kindnet-rhel9-k35-ko35` | [2089182802904879104](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-kindnet-rhel9-k35-ko35/2089182802904879104) | 318 | `should be able to create a functioning NodePort service` |
| `e2e-kops-grid-kindnet-u2204-k34-ko35` | [2088911508598689792](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-kindnet-u2204-k34-ko35/2088911508598689792) | 146 | `should be able to update service type to NodePort ... different protocols` |
| `e2e-kops-grid-gce-kindnet-deb12arm64-k34-ko36` | [2090014286884638720](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kindnet-deb12arm64-k34-ko36/2090014286884638720) | 117 | `should be able to change the type from ExternalName to NodePort` |
| `e2e-kops-grid-kindnet-al2023arm64-k34-ko35` | [2090290611134402560](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-kindnet-al2023arm64-k34-ko35/2090290611134402560) | 117 | `should be able to create a functioning NodePort service` |
| `e2e-kops-grid-gce-kindnet-rocky10arm64-k36-ko36` | [2090010763736387584](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kindnet-rocky10arm64-k36-ko36/2090010763736387584) | 117 | `should be possible to connect to a service via ExternalIP ...` |
| `e2e-kops-grid-kindnet-rocky9-k34-ko34` | [2089740983343255552](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-kindnet-rocky9-k34-ko34/2089740983343255552) | 117 | `[sig-network] Services` |
| `e2e-kops-grid-kindnet-rocky9-k36-ko36` | [2089032559072645120](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-kindnet-rocky9-k36-ko36/2089032559072645120) | 117 | `[sig-network] Services` |
| `e2e-kops-grid-kindnet-u2604-k35-ko36` | [2088908488842416128](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-kindnet-u2604-k35-ko36/2088908488842416128) | 117 | `[sig-network] Services` |
| `e2e-kops-grid-gce-kindnet-deb12arm64-k36-ko36` | [2088689795797618688](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kindnet-deb12arm64-k36-ko36/2088689795797618688) | 117 | `[sig-network] Services` |
| `e2e-kops-grid-gce-kindnet-deb12arm64-k35-ko36` | [2089809686516731904](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kindnet-deb12arm64-k35-ko36/2089809686516731904) | 117 | `[sig-network] Services` |
| `e2e-kops-grid-gce-kindnet-deb12arm64-k35-ko35` | [2090320558813089792](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kindnet-deb12arm64-k35-ko35/2090320558813089792) | 117 | `[sig-network] Services` |
| `e2e-kops-grid-gce-kindnet-deb12arm64-k34-ko35` | [2089794335691247616](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kindnet-deb12arm64-k34-ko35/2089794335691247616) | 117 | `[sig-network] Services` |
| `e2e-kops-grid-gce-kindnet-deb12-k35-ko35` | [2088331682846347264](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kindnet-deb12-k35-ko35/2088331682846347264) | 117 | `[sig-network] Services` |
| `e2e-kops-grid-gce-kindnet-deb12-k34-ko34` | [2089769424461500416](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kindnet-deb12-k34-ko34/2089769424461500416) | 117 | `[sig-network] Services` |
| `e2e-kops-grid-gce-kindnet-u2404-k34-ko36` | [2089098998487977984](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kindnet-u2404-k34-ko36/2089098998487977984) | 112 | `[sig-network] Services` |
| `e2e-kops-grid-kindnet-rocky9-k35-ko36` | [2088396866277347328](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/e2e-kops-grid-kindnet-rocky9-k35-ko36/2088396866277347328) | 105 | `[sig-network] Services` |

Raw build logs, if you want to grep them directly — e.g. the first and third rows:

- https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-grid-kindnet-rhel9-k35-ko35/2089182802904879104/build-log.txt
- https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kindnet-deb12arm64-k34-ko36/2090014286884638720/build-log.txt

Note the spread: both clouds, 9 distros (rhel9, rocky9, u2204, u2404, u2604, al2023arm64, rocky10arm64, deb12, deb12arm64), amd64 and arm64, and all of ko34/ko35/ko36. The only thing they share is the CNI.

### Why kindnet's DNS caching is the suspect

It is uniquely kindnet. Over all 315 kindnet grid jobs plus a 400-job sample of other CNIs:

| | failures | with a `[sig-network] Services` FAIL |
|---|---|---|
| kindnet | 30 | **18** |
| every other CNI | 59 | **0** |

Flat across every other dimension — kops ko34 7% / ko35 11% / ko36 13% / latest 6%; k8s 1.34 10% / 1.35 9% / 1.36 10%. (kindnet's overall failure rate of 9.6% is actually *better* than the grid average; it just fails its own way.)

kops defaults kindnet's node-local DNS interception **on**:

```
--dns-caching={{ WithDefaultBool .Networking.Kindnet.DNSCaching true }}
```

(`upup/models/cloudup/resources/addons/networking.kindnet/k8s-1.32.yaml.template:125`)

Confirmed live in the artifacts of the failing run above — [kindnet-cni.log](https://storage.googleapis.com/kubernetes-ci-logs/logs/e2e-kops-grid-gce-kindnet-deb12arm64-k34-ko36/2090014286884638720/artifacts/cluster-info/kube-system/kindnet-24dtl/kindnet-cni.log):

```
I0819 10:01:02.929702  1 main.go:130] FLAG: --dns-caching="true"
I0819 10:01:02.953713  1 main.go:281] caching DNS cluster traffic
I0819 10:01:02.953889  1 shared_informer.go:349] "Waiting for caches to sync" controller="kindnet-dnscache"
I0819 10:01:03.054764  1 shared_informer.go:356] "Caches are synced" controller="kindnet-dnscache"
```

No other CNI in the grid has this mechanism, and it sits exactly in the failing path.

### Scope

Set in `create_args` rather than at the ~15 call sites, so it reaches every kindnet job — including the 44 that don't have "kindnet" in the name because they're named for a feature or scenario instead (the `e2e-kops-{aws,gce}-nftables-*` periodics and the `e2e-ci-kubernetes-kops-cos-gce-*` canaries all run `--networking=kindnet`).

Deliberately **not** covered: `pull-kops-gce-master-scale-kindnet-performance-100`, which selects kindnet through the `CNI_PLUGIN` env var in the scalability scenario rather than `--networking`, and does not run the e2e specs in question.

`cluster.spec.networking.kindnet.dnsCaching` has existed since the original kindnet support commit (`f2c239dd81`) and is present on release-1.32 through master, so every kops version in the grid accepts the `--set`.

### This is diagnostic, not a proposed default

Draft on purpose. The intent is to confirm or clear the hypothesis across a full weekly grid cycle. If it clears the signature, the real fix belongs in kops (change the default) or upstream in kubernetes-sigs/kindnet — not in the job config, and this should then be reverted in favour of that.

If it does **not** clear it, that is also worth knowing: it rules out the one mechanism unique to kindnet and sends the investigation elsewhere.

### Verification

- Regenerated with `PYTHONPATH=. python3 build_jobs.py`
- Job-by-job diff across all kops YAML: **0 added, 0 removed, 382 changed**
- Two-way completeness check: 382 jobs have `--networking=kindnet`, all 382 carry the flag, 0 kindnet jobs missing it, 0 non-kindnet jobs carrying it
- `go test ./config/tests/...` passes; pylint 10.00/10

Context: this is cause #6 from the kOps periodic failure triage; #37732 and kubernetes/kops#18724 covered causes #1 and #2.

/cc @hakman @aojea

🤖 Generated with [Claude Code](https://claude.com/claude-code)
