### PR TITLE
Remove bom embedded data check

### DIFF
--- a/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/bom/bom-presubmits.yaml
@@ -54,30 +54,3 @@ presubmits:
       testgrid-tab-name: bom-verify
       testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
-  - name: pull-bom-check-embedded-data
-    always_run: true
-    decorate: true
-    path_alias: "sigs.k8s.io/bom"
-    cluster: eks-prow-build-cluster
-    spec:
-      containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci:latest-go1.25-trixie
-        imagePullPolicy: Always
-        command:
-        - go
-        args:
-        - run
-        - mage.go
-        - CheckEmbeddedData
-        resources:
-          requests:
-            cpu: 2
-            memory: 2Gi
-          limits:
-            cpu: 2
-            memory: 2Gi
-    annotations:
-      testgrid-dashboards: sig-release-releng-presubmits
-      testgrid-tab-name: bom-check-embedded-data
-      testgrid-alert-email: release-managers+alerts@kubernetes.io
-      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Starting in v0.8 bom no longer embeds the SPDX license list. This PR removes the presubmit that ensured the licenses were up to date.