### PR TITLE
Install crictl on the al2023 AWS disruptive canary

### DIFF
--- a/config/jobs/kubernetes/kops/build_jobs.py
+++ b/config/jobs/kubernetes/kops/build_jobs.py
@@ -1212,6 +1212,7 @@ def generate_misc():
                        "--node-size=r5d.xlarge",
                        "--control-plane-size=r5d.xlarge",
                        *AMAZON_VPC_ENV_FLAGS,
+                       "--set=cluster.spec.containerd.installCriCtl=true",
                        "--set=spec.kubeAPIServer.logLevel=4",
                        "--set=spec.kubeAPIServer.auditLogMaxSize=2000000000",
                        "--set=spec.kubeAPIServer.enableAggregatorRouting=true",

--- a/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc2.yaml
@@ -2241,7 +2241,7 @@ periodics:
     testgrid-days-of-results: '90'
     testgrid-tab-name: ci-kubernetes-kops-cos-gce-disruptive-canary
 
-# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=r5d.xlarge --control-plane-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "amazonvpc"}
+# {"cloud": "aws", "distro": "al2023", "extra_flags": "--node-size=r5d.xlarge --control-plane-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=cluster.spec.containerd.installCriCtl=true --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log", "k8s_version": "ci", "kops_channel": "alpha", "kops_version": "latest", "networking": "amazonvpc"}
 - name: e2e-ci-kubernetes-kops-al2023-aws-disruptive-canary
   cron: '10 4-23/8 * * *'
   labels:
@@ -2270,7 +2270,7 @@ periodics:
           -v 2 \
           --up --down \
           --cloud-provider=aws \
-          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=amazonvpc --node-size=r5d.xlarge --control-plane-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log" \
+          --create-args="--image='137112412989/al2023-ami-2023.12.20260803.3-kernel-6.12-x86_64' --channel=alpha --networking=amazonvpc --node-size=r5d.xlarge --control-plane-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=cluster.spec.containerd.installCriCtl=true --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log" \
           --kops-version-marker=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt \
           --kubernetes-version=https://dl.k8s.io/ci/latest.txt \
           --test=kops \
@@ -2299,7 +2299,7 @@ periodics:
   annotations:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/distro: al2023
-    test.kops.k8s.io/extra_flags: --node-size=r5d.xlarge --control-plane-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log
+    test.kops.k8s.io/extra_flags: --node-size=r5d.xlarge --control-plane-size=r5d.xlarge --set=cluster.spec.networking.amazonVPC.env=ENABLE_PREFIX_DELEGATION=true --set=cluster.spec.networking.amazonVPC.env=MINIMUM_IP_TARGET=80 --set=cluster.spec.networking.amazonVPC.env=WARM_IP_TARGET=10 --set=cluster.spec.containerd.installCriCtl=true --set=spec.kubeAPIServer.logLevel=4 --set=spec.kubeAPIServer.auditLogMaxSize=2000000000 --set=spec.kubeAPIServer.enableAggregatorRouting=true --set=spec.kubeAPIServer.auditLogPath=/var/log/kube-apiserver-audit.log
     test.kops.k8s.io/k8s_version: ci
     test.kops.k8s.io/kops_channel: alpha
     test.kops.k8s.io/kops_version: latest


### PR DESCRIPTION
`e2e-ci-kubernetes-kops-al2023-aws-disruptive-canary` has failed every run since 2026-06-23, always with exactly 12 failed specs out of the 85 that run. All 12 are instances of the upstream test `subPath should remount stale subpath bind mount after network filesystem disruption` (kubernetes/kubernetes#139275), which landed in the commit window between the last passing build (`v1.37.0-alpha.1.356`) and the first failing one (`v1.37.0-alpha.1.373`).

That test shells out to `crictl` on the node hosting the test pod:

```
cid=$(crictl ps --label io.kubernetes.pod.uid=... --name ... -q 2>/dev/null | head -1)
[ -z "$cid" ] && { echo "container not found"; exit 1; }
crictl stop "$cid"
```

kops has not installed `crictl` by default since 1.34 (kubernetes/kops#17604 made it opt-in), so nodeup logs:

```
assetstore.go:109] Matching assets for "^crictl$":
W crictl.go:43] unable to find any crictl binaries in assets
```

and the command above finds nothing. The test's `2>/dev/null` swallows the shell's own "not found" message, which is why the failure surfaces as `container not found` rather than anything mentioning `crictl`. The preceding steps of the same spec — locating and lazy-unmounting the subPath bind mount over the same hostexec pod — succeed, so only the `crictl` step is broken.

`e2e-ci-kubernetes-kops-cos-gce-disruptive-canary` runs the same 12 instances and passes them, so the test itself is fine on kops clusters; COS provides a `crictl` on `PATH` and AL2023 does not.

Setting `spec.containerd.installCriCtl=true` makes kops stage the asset and install it to `/usr/local/bin/crictl`, which is on the `PATH` the hostexec pod uses. `/etc/crictl.yaml` is already written by kops unconditionally, so no other configuration is needed.

The job runs 3x/day, so this should show a result within about 8 hours of merging. Opened as a draft until then.

/sig cluster-lifecycle
