### PR TITLE
node-readiness-controller: add periodic govulncheck job

### DIFF
--- a/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/node-readiness-controller/node-readiness-controller-periodics.yaml
@@ -159,3 +159,38 @@ periodics:
             requests:
               cpu: 3
               memory: 10Gi
+  - interval: 24h
+    name: periodic-node-readiness-controller-govulncheck
+    cluster: eks-prow-build-cluster
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: node-readiness-controller
+        base_ref: main
+        path_alias: sigs.k8s.io/node-readiness-controller
+    annotations:
+      testgrid-dashboards: sig-node-node-readiness-controller
+      testgrid-num-failures-to-alert: '1'
+      testgrid-alert-email: ajaysundar.k@gmail.com
+      description: "Run periodic vulnerability check using govulncheck against the main branch"
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'
+    decorate: true
+    decoration_config:
+      timeout: 2h
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-1.36
+          command:
+            - runner.sh
+          args:
+            - make
+            - verify-govulncheck
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 2
+              memory: 4Gi


### PR DESCRIPTION
Govulncheck should run daily against the main branch.

/hold until kubernetes-sigs/node-readiness-controller#434 gets merged.