### PR TITLE
add stage to kueue

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1635,6 +1635,7 @@ plugins:
     - milestone
     - milestonestatus
     - release-note
+    - stage
 
   kubernetes-sigs/kustomize:
     plugins:


### PR DESCRIPTION
For Kueue, following https://github.com/kubernetes-sigs/kueue/issues/14716, we want to start having enhancements issues that can have a stage of alpha, beta or stable. 

We need to enable the prow plugin in kueue to add stage labels.