### PR TITLE
k8s-infra: select medium-effort model for agentic AI

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
@@ -20,9 +20,7 @@ periodics:
             - agy
           args:
             - --model
-            - gemini-3.7-flash-latest
-            - --effort
-            - medium
+            - gemini-3.7-flash-medium
             - --print
             - Respond with exactly "k8s-infra-agentic-ai is ready".
           env:


### PR DESCRIPTION
The agentic AI canary currently selects `gemini-3.7-flash-latest` and separately requests `--effort medium`. Antigravity rejects that combination because the `-latest` alias does not expose effort capability metadata.

Select the explicit `gemini-3.7-flash-medium` model tier instead. This preserves the intended medium reasoning effort without relying on the unsupported alias/flag combination.

Failed run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-k8s-infra-agentic-ai/2091535829229899776