### PR TITLE
k8s-infra: fix ci-k8s-infra-agentic-ai project targeting

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
@@ -21,6 +21,8 @@ periodics:
           args:
             - --model
             - gemini-3.7-flash-medium
+            - --project
+            - k8s-infra-agentic-ai
             - --print
             - Respond with exactly "k8s-infra-agentic-ai is ready".
           env:
@@ -29,6 +31,8 @@ periodics:
             - name: GOOGLE_GENAI_USE_VERTEXAI
               value: "true"
             - name: GOOGLE_CLOUD_PROJECT
+              value: "k8s-infra-agentic-ai"
+            - name: GOOGLE_CLOUD_QUOTA_PROJECT
               value: "k8s-infra-agentic-ai"
             - name: GOOGLE_CLOUD_LOCATION
               value: "us-central1"


### PR DESCRIPTION
The agy CLI defaults its session/quota project to the GKE cluster project instead of the intended k8s-infra-agentic-ai project, where aiplatform.googleapis.com is enabled and the agy-agent workload identity has roles/aiplatform.user.

Pass --project k8s-infra-agentic-ai to agy and set GOOGLE_CLOUD_QUOTA_PROJECT so both the resource project and the ADC quota/billing project point at k8s-infra-agentic-ai.