### PR TITLE
k8s-infra: use global endpoint for agentic AI

### DIFF
--- a/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/agentic-ai.yaml
@@ -35,7 +35,7 @@ periodics:
             - name: GOOGLE_CLOUD_QUOTA_PROJECT
               value: "k8s-infra-agentic-ai"
             - name: GOOGLE_CLOUD_LOCATION
-              value: "us-central1"
+              value: "global"
           resources:
             limits:
               cpu: "1"


### PR DESCRIPTION
The `ci-k8s-infra-agentic-ai` canary fails before running its prompt because Gemini 3.7 Flash is not supported by Antigravity in `us-central1`.

Use the `global` endpoint, which supports the selected model and provides the highest availability for this connectivity canary.

Failing job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-k8s-infra-agentic-ai/2091948931628929024

Tested with:

```console
go test ./config/tests/jobs
```