### PR TITLE
Run scheduler-library integration tests in presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-library/scheduler-library-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-library/scheduler-library-presubmits-main.yaml
@@ -26,3 +26,28 @@ presubmits:
         args:
         - make
         - verify
+  - name: pull-scheduler-library-test-integration-main
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-library
+    cluster: eks-prow-build-cluster
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-scheduler-library-test-integration-main
+    branches:
+    - ^main$
+    always_run: true
+    spec:
+      containers:
+      - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "2"
+          limits:
+            memory: "4Gi"
+            cpu: "2"
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-integration


### PR DESCRIPTION
https://github.com/kubernetes-sigs/scheduler-library/pull/2 added test-integration target and excluded integration tests from the verify target: https://github.com/kubernetes-sigs/scheduler-library/blob/f2da79874789a8ab14ad41d2d425bcf046a4ca1e/Makefile#L25-L31

Having integration tests as a separate presubmit allows us to define different requirements (timeouts, resource requests) and potentially give feedback to the user faster.

/sig scheduling