### PR TITLE
dracpu: group-by=machine requires external allocator

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-cpu/dra-driver-cpu-presubmits-main.yaml
@@ -255,6 +255,8 @@ presubmits:
           value: "true"
         - name: DRACPU_E2E_VERBOSE
           value: "1"
+        - name: DRACPU_E2E_ALLOCATOR
+          value: "external"
         command:
         - runner.sh
         args:


### PR DESCRIPTION
This was always implied, the work we're doing in
https://github.com/kubernetes-sigs/dra-driver-cpu/issues/304 makes it explicit