### PR TITLE
Update SPO CI image to golang 1.27

### DIFF
--- a/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/security-profiles-operator/security-profiles-operator-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.26
+      - image: public.ecr.aws/docker/library/golang:1.27
         command:
         - hack/pull-security-profiles-operator-build
         resources:
@@ -29,7 +29,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.26
+      - image: public.ecr.aws/docker/library/golang:1.27
         command:
         - hack/pull-security-profiles-operator-verify
         resources:
@@ -49,7 +49,7 @@ presubmits:
       testgrid-create-test-group: 'true'
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.26
+      - image: public.ecr.aws/docker/library/golang:1.27
         command:
         - hack/pull-security-profiles-operator-test-unit
         resources:


### PR DESCRIPTION
Bump the Go container image for all security-profiles-operator presubmit jobs from 1.26 to 1.27:
- `pull-security-profiles-operator-build`
- `pull-security-profiles-operator-verify`
- `pull-security-profiles-operator-test-unit`