### PR TITLE
Add lws Helm-based upgrade E2E presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -245,6 +245,42 @@ presubmits:
             requests:
               cpu: 3
               memory: 10Gi
+  - name: pull-lws-test-e2e-upgrade-helm-main
+    cluster: eks-prow-build-cluster
+    branches:
+    - ^main
+    skip_if_only_changed: "^docs/|^\\.github/|\\.(md)$|^(README|LICENSE|OWNERS)$"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      pod_unscheduled_timeout: 10m
+    path_alias: sigs.k8s.io/lws
+    annotations:
+      testgrid-dashboards: sig-apps-lws-presubmits
+      testgrid-tab-name: pull-lws-test-e2e-upgrade-helm-main
+      description: "Run lws Helm-based upgrade end to end tests"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260729-f0c41ad0b9-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.36.1
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e-upgrade-helm
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
   - name: pull-lws-test-e2e-main-gang-scheduling
     cluster: eks-prow-build-cluster
     always_run: true


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Adds an optional presubmit for lws that runs the Helm-based upgrade E2E test added in kubernetes-sigs/lws#1003.

Helm upgrades behave differently from the kustomize path already covered by the existing upgrade job. Most importantly, Helm never touches the `crds/` directory, so CRDs must be reconciled by hand. Nothing in CI exercises that path today.

The new job `pull-lws-test-e2e-upgrade-helm-main` runs `make test-e2e-upgrade-helm` on the `eks-prow-build-cluster`. It is `optional` and does not run by default (`always_run: false`), matching the existing `pull-lws-test-e2e-upgrade-main` job.

#### Which issue(s) this PR fixes

Refs kubernetes-sigs/lws#962

#### Special notes for your reviewer

Companion to kubernetes-sigs/lws#1003, which adds the make target and shell path this job invokes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
