### PR TITLE
Update milestone applier for k/website dev-1.38 release branch

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -626,7 +626,7 @@ milestone_applier:
   kubernetes-sigs/boskos:
     master: v1.23
   kubernetes/website:
-    dev-1.37: 1.37
+    dev-1.38: 1.38
   kubernetes/node-problem-detector:
     main: v1.36
     release-1.35: v1.35


### PR DESCRIPTION
Update the k/website applier for the `dev-1.38` branch to automatically apply the 1.38 milestone for PRs created against `dev-1.38` branch

/hold for review from @kubernetes/sig-docs-leads