### PR TITLE
RFC node: add new flaky test labeller 

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -100,6 +100,109 @@ presubmits:
               requests:
                 cpu: "4"
                 memory: "6Gi"
+    - name: pull-kubernetes-node-e2e-containerd-flaky-canary
+      skip_branches:
+        - release-\d+\.\d+ # per-release image
+      annotations:
+        fork-per-release: "true"
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: sig-node-presubmits
+        testgrid-tab-name: pull-kubernetes-node-e2e-containerd-flaky-canary
+        description: "Runs configured flaky node-e2e tests with containerd"
+      always_run: false
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 90m
+      path_alias: k8s.io/kubernetes
+      extra_refs:
+        - org: kubernetes
+          repo: test-infra
+          base_ref: master
+          path_alias: k8s.io/test-infra
+      cluster: k8s-infra-prow-build
+      max_concurrency: 12
+      labels:
+        preset-service-account: "true"
+        preset-k8s-ssh: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+            command:
+              - runner.sh
+              - /home/prow/go/src/k8s.io/test-infra/hack/signode-flaky-tests/flaky-test-filter.sh
+            args:
+              - --mode=focus-regex
+              - --job-name=pull-kubernetes-node-e2e-containerd
+              - --suite=node_e2e
+              - --
+              - /workspace/scenarios/kubernetes_e2e.py
+              - --deployment=node
+              - --gcp-zone=us-central1-b
+              - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              - --node-tests=true
+              - --provider=gce
+              - --test_args=--nodes=8 --focus= --skip=
+              - --timeout=80m
+              - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
+            resources:
+              limits:
+                cpu: "4"
+                memory: "6Gi"
+              requests:
+                cpu: "4"
+                memory: "6Gi"
+    - name: pull-kubernetes-node-e2e-containerd-flaky-skip-canary
+      skip_branches:
+        - release-\d+\.\d+ # per-release image
+      annotations:
+        fork-per-release: "true"
+        testgrid-create-test-group: "true"
+        testgrid-dashboards: sig-node-presubmits
+        testgrid-tab-name: pull-kubernetes-node-e2e-containerd-flaky-skip-canary
+        description: "Skips configured flaky node-e2e tests with containerd"
+      always_run: false
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 90m
+      path_alias: k8s.io/kubernetes
+      extra_refs:
+        - org: kubernetes
+          repo: test-infra
+          base_ref: master
+          path_alias: k8s.io/test-infra
+      cluster: k8s-infra-prow-build
+      max_concurrency: 12
+      labels:
+        preset-service-account: "true"
+        preset-k8s-ssh: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+            command:
+              - runner.sh
+              - /home/prow/go/src/k8s.io/test-infra/hack/signode-flaky-tests/flaky-test-filter.sh
+            args:
+              - --job-name=pull-kubernetes-node-e2e-containerd
+              - --suite=node_e2e
+              - --
+              - /workspace/scenarios/kubernetes_e2e.py
+              - --deployment=node
+              - --gcp-zone=us-central1-b
+              - '--node-test-args=--container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd*\"]}"'
+              - --node-tests=true
+              - --provider=gce
+              - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
+              - --timeout=80m
+              - --node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/image-config-systemd.yaml
+            resources:
+              limits:
+                cpu: "4"
+                memory: "6Gi"
+              requests:
+                cpu: "4"
+                memory: "6Gi"
     - name: pull-kubernetes-node-e2e-containerd-slow
       skip_branches:
         - release-\d+\.\d+ # per-release image
@@ -1812,6 +1915,126 @@ presubmits:
             command:
               - runner.sh
             args:
+              - kubetest2
+              - noop
+              - --test=node
+              - --
+              - --repo-root=.
+              - --gcp-zone=us-central1-b
+              - --parallelism=8
+              - --focus-regex=\[NodeConformance\]|\[Feature:.+\]|\[Feature\]
+              - --skip-regex=\[Flaky\]|\[Slow\]|\[Serial\]|\[Feature:InPlacePodVerticalScaling\]|\[Feature:UserNamespacesSupport]|\[Feature:UserNamespacesPodSecurityStandards\]|\[Feature:KubeletCredentialProviders\]|\[Feature:LockContention\]|\[Feature:SCTPConnectivity\]|\[Feature:PodLevelResources\]|\[Alpha\]
+              - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+              - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-canary.yaml
+    - name: pull-node-crio-e2e-flaky-canary
+      cluster: k8s-infra-prow-build
+      # explicitly needs /test pull-node-crio-e2e-flaky-canary to run
+      always_run: false
+      optional: true
+      branches:
+        # TODO(releng): Remove once repo default branch has been renamed
+        - master
+        - main
+      decorate: true
+      path_alias: k8s.io/kubernetes
+      extra_refs:
+        - org: kubernetes
+          repo: test-infra
+          base_ref: master
+          path_alias: k8s.io/test-infra
+      decoration_config:
+        timeout: 180m
+      labels:
+        preset-service-account: "true"
+        preset-k8s-ssh: "true"
+        preset-pull-kubernetes-e2e: "true"
+        preset-pull-kubernetes-e2e-gce: "true"
+      annotations:
+        testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
+        testgrid-tab-name: pull-node-crio-e2e-flaky-canary
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+            resources:
+              limits:
+                cpu: 4
+                memory: 6Gi
+              requests:
+                cpu: 4
+                memory: 6Gi
+            env:
+              - name: KUBE_SSH_USER
+                value: core
+              - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+                value: "1"
+            command:
+              - runner.sh
+              - /home/prow/go/src/k8s.io/test-infra/hack/signode-flaky-tests/flaky-test-filter.sh
+            args:
+              - --mode=focus-regex
+              - --job-name=pull-node-crio-e2e-canary
+              - --suite=node_e2e
+              - --
+              - kubetest2
+              - noop
+              - --test=node
+              - --
+              - --repo-root=.
+              - --gcp-zone=us-central1-b
+              - --parallelism=8
+              - --focus-regex=
+              - --skip-regex=
+              - '--test-args=--container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
+              - --image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/crio/latest/image-config-canary.yaml
+    - name: pull-node-crio-e2e-flaky-skip-canary
+      cluster: k8s-infra-prow-build
+      # explicitly needs /test pull-node-crio-e2e-flaky-skip-canary to run
+      always_run: false
+      optional: true
+      branches:
+        # TODO(releng): Remove once repo default branch has been renamed
+        - master
+        - main
+      decorate: true
+      path_alias: k8s.io/kubernetes
+      extra_refs:
+        - org: kubernetes
+          repo: test-infra
+          base_ref: master
+          path_alias: k8s.io/test-infra
+      decoration_config:
+        timeout: 180m
+      labels:
+        preset-service-account: "true"
+        preset-k8s-ssh: "true"
+        preset-pull-kubernetes-e2e: "true"
+        preset-pull-kubernetes-e2e-gce: "true"
+      annotations:
+        testgrid-dashboards: sig-node-cri-o, sig-node-presubmits
+        testgrid-tab-name: pull-node-crio-e2e-flaky-skip-canary
+        description: "Skips configured flaky node-e2e tests with CRI-O"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260810-7619858115-master
+            resources:
+              limits:
+                cpu: 4
+                memory: 6Gi
+              requests:
+                cpu: 4
+                memory: 6Gi
+            env:
+              - name: KUBE_SSH_USER
+                value: core
+              - name: IGNITION_INJECT_GCE_SSH_PUBLIC_KEY_FILE
+                value: "1"
+            command:
+              - runner.sh
+              - /home/prow/go/src/k8s.io/test-infra/hack/signode-flaky-tests/flaky-test-filter.sh
+            args:
+              - --job-name=pull-node-crio-e2e-canary
+              - --suite=node_e2e
+              - --
               - kubetest2
               - noop
               - --test=node

--- a/hack/signode-flaky-tests/OWNERS
+++ b/hack/signode-flaky-tests/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- sig-node-test-reviewers
+approvers:
+- sig-node-leads
+- sig-node-test-approvers
+labels:
+- sig/node

--- a/hack/signode-flaky-tests/flaky-test-filter.sh
+++ b/hack/signode-flaky-tests/flaky-test-filter.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wrapper script for e2e jobs that injects flaky test skip or focus patterns.
+#
+# Usage in a job command:
+#   command:
+#     - runner.sh
+#     - /home/prow/go/src/k8s.io/test-infra/hack/signode-flaky-tests/flaky-test-filter.sh
+#   args:
+#     - --job-name=ci-cos-containerd-node-e2e-serial
+#     - --suite=node_e2e
+#     - --
+#     - kubetest2
+#     - noop
+#     - --test=node
+#     - --
+#     - --skip-regex=\[Flaky\]|\[Slow\]
+#     - ...remaining kubetest2 args...
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG="${SCRIPT_DIR}/flaky-tests.yaml"
+
+JOB_NAME=""
+SUITE=""
+MODE="skip-regex"
+
+# Parse wrapper-specific flags before the -- separator.
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --job-name=*)
+            JOB_NAME="${1#*=}"
+            shift
+            ;;
+        --suite=*)
+            SUITE="${1#*=}"
+            shift
+            ;;
+        --mode=skip-regex|--mode=focus-regex)
+            MODE="${1#*=}"
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# Both modes need the generated regex. Focus jobs start with an empty focus filter,
+# so they must fail closed if the tool cannot produce one.
+# Build the flaky test tool from its own module.
+SKIP_TOOL="$(mktemp /tmp/signode-flaky-tests.XXXXXX)"
+trap 'rm -f "${SKIP_TOOL}"' EXIT
+
+if ! (cd "${SCRIPT_DIR}" && go build -o "${SKIP_TOOL}" .); then
+    if [[ "${MODE}" == "focus-regex" ]]; then
+        echo "ERROR: failed to build signode-flaky-tests tool" >&2
+        exit 1
+    fi
+    echo "WARNING: failed to build signode-flaky-tests tool, running without flaky skip" >&2
+    rm -f "${SKIP_TOOL}"
+    exec "$@"
+fi
+
+# Generate the requested regex.
+TOOL_ARGS=(--config="${CONFIG}" --mode="${MODE}")
+if [[ -n "${JOB_NAME}" ]]; then
+    TOOL_ARGS+=(--job="${JOB_NAME}")
+fi
+if [[ -n "${SUITE}" ]]; then
+    TOOL_ARGS+=(--suite="${SUITE}")
+fi
+
+FLAKY_REGEX=$("${SKIP_TOOL}" "${TOOL_ARGS[@]}")
+rm -f "${SKIP_TOOL}"
+
+if [[ -z "${FLAKY_REGEX}" ]]; then
+    if [[ "${MODE}" == "focus-regex" ]]; then
+        echo "ERROR: no flaky tests configured for focused run" >&2
+        exit 1
+    fi
+    echo "signode-flaky-tests: no flaky tests configured, running as-is" >&2
+    exec "$@"
+fi
+
+echo "signode-flaky-tests: applying flaky tests matching: ${FLAKY_REGEX}" >&2
+
+if [[ "${MODE}" == "skip-regex" ]]; then
+    REGEX_FLAGS=(--skip-regex --skip --ginkgo.skip)
+else
+    REGEX_FLAGS=(--focus-regex --focus --ginkgo.focus)
+fi
+
+shell_quote() {
+    local escaped="${1//\'/\'\\\'\'}"
+    printf "'%s'" "${escaped}"
+}
+
+ARGS=()
+INJECTED=false
+for arg in "$@"; do
+    nested_test_args=false
+    [[ "${arg}" == --test_args=* ]] && nested_test_args=true
+    for regex_flag in "${REGEX_FLAGS[@]}"; do
+        if [[ "${arg}" =~ (^|[[:space:]=])(${regex_flag//./[.]})=([^[:space:]]*) ]]; then
+            match="${BASH_REMATCH[0]}"
+            separator="${BASH_REMATCH[1]}"
+            flag="${BASH_REMATCH[2]}"
+            value="${BASH_REMATCH[3]}"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            regex="${value:+${value}|}${FLAKY_REGEX}"
+            if [[ "${nested_test_args}" == "true" && "${flag}" != --ginkgo.* ]]; then
+                regex="$(shell_quote "${regex}")"
+            elif [[ "${nested_test_args}" == "true" ]]; then
+                regex="${regex// /\\x20}"
+            fi
+            arg="${arg/"${match}"/"${separator}${flag}=${regex}"}"
+            INJECTED=true
+            break
+        fi
+    done
+    ARGS+=("${arg}")
+done
+
+# Legacy test-e2e-node.sh jobs use SKIP instead of --skip-regex.
+if [[ "${MODE}" == "skip-regex" && "${INJECTED}" == "false" && -n "${SKIP:-}" ]]; then
+    export SKIP="${SKIP}|${FLAKY_REGEX}"
+    INJECTED=true
+fi
+
+if [[ "${INJECTED}" == "false" ]]; then
+    if [[ "${MODE}" == "focus-regex" ]]; then
+        echo "ERROR: could not find a ${MODE} argument to inject flaky patterns" >&2
+        exit 1
+    fi
+    echo "WARNING: could not find a ${MODE} argument to inject flaky patterns" >&2
+fi
+
+exec "${ARGS[@]}"

--- a/hack/signode-flaky-tests/flaky-tests.yaml
+++ b/hack/signode-flaky-tests/flaky-tests.yaml
@@ -1,0 +1,42 @@
+# SIG Node Flaky Test Configuration
+#
+# Tests listed here are known to be flaky and will be skipped in CI jobs
+# that opt into this configuration. This allows SIG Node maintainers to
+# quickly quarantine flaky tests without modifying kubernetes/kubernetes.
+#
+# Each entry requires:
+#   - name:       Ginkgo test name substring or regex to match (required)
+#   - issue:      Link to a tracking issue (required)
+#   - dateAdded:  Date the entry was added, YYYY-MM-DD (required)
+#
+# Optional fields:
+#   - suite:      Limit to "node_e2e" or "e2e" tests (default: both)
+#   - feature:    Feature gate name if test covers a non-GA feature (omit for conformance)
+#   - jobs:       Limit to specific job names (default: all sig-node jobs)
+#   - reason:     Brief explanation of the flake
+#
+# To add a flaky test, open a PR adding an entry below.
+#
+# Integration: jobs append the generated pattern to their focus or skip argument.
+#
+# Example:
+#   - name: "should not allow privilege escalation when false"
+#     issue: "https://github.com/kubernetes/kubernetes/issues/12345"
+#     dateAdded: "2026-08-26"
+#     suite: "node_e2e"
+#     reason: "Flakes on COS with containerd 2.0"
+#     jobs:
+#       - ci-cos-containerd-node-e2e-serial
+
+flakyTests:
+  - name: "Probing container should \\*not\\* be restarted with a non-local redirect http liveness probe"
+    issue: "https://github.com/kubernetes/kubernetes/issues/116123"
+    dateAdded: "2026-08-26"
+    suite: "node_e2e"
+    reason: "30 failures in 14 days across pull-kubernetes-node-e2e-containerd, ci-cos-containerd-node-e2e, ci-kubernetes-node-e2e-containerd"
+
+  - name: "Probing restartable init container should \\*not\\* be restarted with a non-local redirect http liveness probe"
+    issue: "https://github.com/kubernetes/kubernetes/issues/116123"
+    dateAdded: "2026-08-26"
+    suite: "node_e2e"
+    reason: "23 failures in 14 days across ci-cos-containerd-node-e2e, pull-kubernetes-node-e2e-containerd, ci-kubernetes-node-e2e-containerd"

--- a/hack/signode-flaky-tests/main.go
+++ b/hack/signode-flaky-tests/main.go
@@ -1,0 +1,161 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/yaml"
+)
+
+type FlakyTest struct {
+	Name      string   `json:"name"`
+	Issue     string   `json:"issue"`
+	DateAdded string   `json:"dateAdded"`
+	Suite     string   `json:"suite,omitempty"`
+	Feature   string   `json:"feature,omitempty"`
+	Reason    string   `json:"reason,omitempty"`
+	Jobs      []string `json:"jobs,omitempty"`
+}
+
+type FlakyTestConfig struct {
+	FlakyTests []FlakyTest `json:"flakyTests"`
+}
+
+func main() {
+	os.Exit(run(os.Stdout, os.Stderr, os.Args[1:]))
+}
+
+func run(stdout, stderr io.Writer, args []string) int {
+	fs := flag.NewFlagSet("signode-flaky-tests", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	configPath := fs.String("config", "", "Path to flaky-tests.yaml")
+	mode := fs.String("mode", "validate", "Mode: validate, skip-regex, focus-regex")
+	suite := fs.String("suite", "", "Filter by test suite: node_e2e, e2e")
+	job := fs.String("job", "", "Filter by job name")
+
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	if *configPath == "" {
+		fmt.Fprintln(stderr, "error: --config is required")
+		return 1
+	}
+
+	config, err := loadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	switch *mode {
+	case "validate":
+		errs := validate(config)
+		if len(errs) > 0 {
+			for _, e := range errs {
+				fmt.Fprintf(stderr, "error: %s\n", e)
+			}
+			return 1
+		}
+		fmt.Fprintf(stdout, "ok: %d flaky test entries validated\n", len(config.FlakyTests))
+
+	case "skip-regex", "focus-regex":
+		regex := generateSkipRegex(config, *suite, *job)
+		if regex != "" {
+			fmt.Fprint(stdout, regex)
+		}
+
+	default:
+		fmt.Fprintf(stderr, "error: unknown mode %q (use validate, skip-regex, or focus-regex)\n", *mode)
+		return 1
+	}
+
+	return 0
+}
+
+func loadConfig(path string) (*FlakyTestConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+	var config FlakyTestConfig
+	if err := yaml.UnmarshalStrict(data, &config); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+	return &config, nil
+}
+
+func validate(config *FlakyTestConfig) []string {
+	var errors []string
+	seen := make(map[string]bool)
+
+	for i, t := range config.FlakyTests {
+		prefix := fmt.Sprintf("flakyTests[%d]", i)
+
+		if t.Name == "" {
+			errors = append(errors, fmt.Sprintf("%s: name is required", prefix))
+		} else {
+			if _, err := regexp.Compile(t.Name); err != nil {
+				errors = append(errors, fmt.Sprintf("%s: name is not a valid regex: %v", prefix, err))
+			}
+			if seen[t.Name] {
+				errors = append(errors, fmt.Sprintf("%s: duplicate name %q", prefix, t.Name))
+			}
+			seen[t.Name] = true
+		}
+
+		if t.Issue == "" {
+			errors = append(errors, fmt.Sprintf("%s: issue is required", prefix))
+		} else if !strings.HasPrefix(t.Issue, "https://github.com/") {
+			errors = append(errors, fmt.Sprintf("%s: issue must be a GitHub URL, got %q", prefix, t.Issue))
+		}
+
+		if t.DateAdded == "" {
+			errors = append(errors, fmt.Sprintf("%s: dateAdded is required", prefix))
+		} else if _, err := time.Parse("2006-01-02", t.DateAdded); err != nil {
+			errors = append(errors, fmt.Sprintf("%s: dateAdded must be YYYY-MM-DD, got %q", prefix, t.DateAdded))
+		}
+
+		if t.Suite != "" && t.Suite != "node_e2e" && t.Suite != "e2e" {
+			errors = append(errors, fmt.Sprintf("%s: suite must be \"node_e2e\" or \"e2e\", got %q", prefix, t.Suite))
+		}
+	}
+
+	return errors
+}
+
+func generateSkipRegex(config *FlakyTestConfig, suite string, job string) string {
+	var patterns []string
+	for _, t := range config.FlakyTests {
+		if suite != "" && t.Suite != "" && t.Suite != suite {
+			continue
+		}
+		if job != "" && len(t.Jobs) > 0 && !slices.Contains(t.Jobs, job) {
+			continue
+		}
+		patterns = append(patterns, t.Name)
+	}
+	return strings.Join(patterns, "|")
+}

--- a/hack/signode-flaky-tests/main_test.go
+++ b/hack/signode-flaky-tests/main_test.go
@@ -1,0 +1,658 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     FlakyTestConfig
+		wantErrors int
+		wantSubstr []string
+	}{
+		{
+			name:       "empty config is valid",
+			config:     FlakyTestConfig{},
+			wantErrors: 0,
+		},
+		{
+			name: "valid entry with required fields only",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Name:      "should do something",
+					Issue:     "https://github.com/kubernetes/kubernetes/issues/12345",
+					DateAdded: "2026-08-26",
+				}},
+			},
+			wantErrors: 0,
+		},
+		{
+			name: "valid entry with all fields",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Name:      "should do something",
+					Issue:     "https://github.com/kubernetes/kubernetes/issues/12345",
+					DateAdded: "2026-08-26",
+					Suite:     "node_e2e",
+					Feature:   "SidecarContainers",
+					Reason:    "Flakes on COS",
+					Jobs:      []string{"ci-cos-containerd-node-e2e-serial"},
+				}},
+			},
+			wantErrors: 0,
+		},
+		{
+			name: "valid regex pattern as name",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Name:      `should (create|delete) pods in \d+ seconds`,
+					Issue:     "https://github.com/kubernetes/kubernetes/issues/12345",
+					DateAdded: "2026-08-26",
+				}},
+			},
+			wantErrors: 0,
+		},
+		{
+			name: "valid issue from non-k/k repo",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Name:      "should work",
+					Issue:     "https://github.com/kubernetes/test-infra/issues/99999",
+					DateAdded: "2026-08-26",
+				}},
+			},
+			wantErrors: 0,
+		},
+		{
+			name: "missing name",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Issue:     "https://github.com/kubernetes/kubernetes/issues/12345",
+					DateAdded: "2026-08-26",
+				}},
+			},
+			wantErrors: 1,
+			wantSubstr: []string{"name is required"},
+		},
+		{
+			name: "missing issue",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Name:      "should do something",
+					DateAdded: "2026-08-26",
+				}},
+			},
+			wantErrors: 1,
+			wantSubstr: []string{"issue is required"},
+		},
+		{
+			name: "missing dateAdded",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Name:  "should do something",
+					Issue: "https://github.com/kubernetes/kubernetes/issues/12345",
+				}},
+			},
+			wantErrors: 1,
+			wantSubstr: []string{"dateAdded is required"},
+		},
+		{
+			name: "all required fields missing",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{}},
+			},
+			wantErrors: 3,
+			wantSubstr: []string{"name is required", "issue is required", "dateAdded is required"},
+		},
+		{
+			name: "invalid issue URL",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Name:      "should do something",
+					Issue:     "not-a-github-url",
+					DateAdded: "2026-08-26",
+				}},
+			},
+			wantErrors: 1,
+			wantSubstr: []string{"must be a GitHub URL"},
+		},
+		{
+			name: "invalid dateAdded format",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Name:      "should do something",
+					Issue:     "https://github.com/kubernetes/kubernetes/issues/12345",
+					DateAdded: "yesterday",
+				}},
+			},
+			wantErrors: 1,
+			wantSubstr: []string{"dateAdded must be YYYY-MM-DD"},
+		},
+		{
+			name: "invalid suite value",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Name:      "should do something",
+					Issue:     "https://github.com/kubernetes/kubernetes/issues/12345",
+					DateAdded: "2026-08-26",
+					Suite:     "integration",
+				}},
+			},
+			wantErrors: 1,
+			wantSubstr: []string{`suite must be`},
+		},
+		{
+			name: "valid with feature gate",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Name:      "should do something",
+					Issue:     "https://github.com/kubernetes/kubernetes/issues/12345",
+					DateAdded: "2026-08-26",
+					Feature:   "SidecarContainers",
+				}},
+			},
+			wantErrors: 0,
+		},
+		{
+			name: "invalid regex in name",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{{
+					Name:      "[invalid",
+					Issue:     "https://github.com/kubernetes/kubernetes/issues/12345",
+					DateAdded: "2026-08-26",
+				}},
+			},
+			wantErrors: 1,
+			wantSubstr: []string{"not a valid regex"},
+		},
+		{
+			name: "duplicate names",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{
+					{Name: "same name", Issue: "https://github.com/kubernetes/kubernetes/issues/1", DateAdded: "2026-08-26"},
+					{Name: "same name", Issue: "https://github.com/kubernetes/kubernetes/issues/2", DateAdded: "2026-08-26"},
+				},
+			},
+			wantErrors: 1,
+			wantSubstr: []string{"duplicate name"},
+		},
+		{
+			name: "errors in multiple entries are all reported",
+			config: FlakyTestConfig{
+				FlakyTests: []FlakyTest{
+					{Name: "valid", Issue: "https://github.com/kubernetes/kubernetes/issues/1", DateAdded: "2026-08-26"},
+					{Name: "", Issue: "https://github.com/kubernetes/kubernetes/issues/2", DateAdded: "2026-08-26"},
+					{Name: "also valid", Issue: "", DateAdded: "2026-08-26"},
+				},
+			},
+			wantErrors: 2,
+			wantSubstr: []string{"flakyTests[1]", "flakyTests[2]"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validate(&tt.config)
+			if len(errs) != tt.wantErrors {
+				t.Errorf("got %d errors, want %d: %v", len(errs), tt.wantErrors, errs)
+			}
+			for _, substr := range tt.wantSubstr {
+				found := false
+				for _, e := range errs {
+					if strings.Contains(e, substr) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected error containing %q, got: %v", substr, errs)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateSkipRegex(t *testing.T) {
+	config := &FlakyTestConfig{
+		FlakyTests: []FlakyTest{
+			{Name: "unscoped", Issue: "https://github.com/kubernetes/kubernetes/issues/1", DateAdded: "2026-08-26"},
+			{Name: "node only", Issue: "https://github.com/kubernetes/kubernetes/issues/2", DateAdded: "2026-08-26", Suite: "node_e2e"},
+			{Name: "job scoped", Issue: "https://github.com/kubernetes/kubernetes/issues/3", DateAdded: "2026-08-26", Jobs: []string{"job-A"}},
+			{Name: "e2e only", Issue: "https://github.com/kubernetes/kubernetes/issues/4", DateAdded: "2026-08-26", Suite: "e2e"},
+			{Name: "node+job", Issue: "https://github.com/kubernetes/kubernetes/issues/5", DateAdded: "2026-08-26", Suite: "node_e2e", Jobs: []string{"job-A", "job-B"}},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		suite     string
+		job       string
+		wantParts []string
+	}{
+		{"no filters", "", "", []string{"unscoped", "node only", "job scoped", "e2e only", "node+job"}},
+		{"suite=e2e", "e2e", "", []string{"unscoped", "job scoped", "e2e only"}},
+		{"suite=node_e2e", "node_e2e", "", []string{"unscoped", "node only", "job scoped", "node+job"}},
+		{"matching job", "", "job-A", []string{"unscoped", "node only", "job scoped", "e2e only", "node+job"}},
+		{"non-matching job", "", "job-X", []string{"unscoped", "node only", "e2e only"}},
+		{"second of multi-job", "", "job-B", []string{"unscoped", "node only", "e2e only", "node+job"}},
+		{"suite+job combined", "node_e2e", "job-A", []string{"unscoped", "node only", "job scoped", "node+job"}},
+		{"all filtered out", "e2e", "job-X", []string{"unscoped", "e2e only"}},
+		{"empty config", "", "", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config
+			if tt.name == "empty config" {
+				cfg = &FlakyTestConfig{}
+			}
+			got := generateSkipRegex(cfg, tt.suite, tt.job)
+			gotParts := splitNonEmpty(got)
+
+			if len(gotParts) != len(tt.wantParts) {
+				t.Fatalf("got %d patterns %v, want %d patterns %v", len(gotParts), gotParts, len(tt.wantParts), tt.wantParts)
+			}
+			for i, want := range tt.wantParts {
+				if gotParts[i] != want {
+					t.Errorf("pattern[%d] = %q, want %q", i, gotParts[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateSkipRegex_OutputIsValidRegex(t *testing.T) {
+	config := &FlakyTestConfig{
+		FlakyTests: []FlakyTest{
+			{Name: "should handle pod (creation|deletion)", Issue: "https://github.com/kubernetes/kubernetes/issues/1", DateAdded: "2026-08-26"},
+			{Name: `should timeout after \d+ seconds`, Issue: "https://github.com/kubernetes/kubernetes/issues/2", DateAdded: "2026-08-26"},
+		},
+	}
+	got := generateSkipRegex(config, "", "")
+	if _, err := regexp.Compile(got); err != nil {
+		t.Errorf("generated regex %q is not valid: %v", got, err)
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	config := loadConfigFromString(t, `
+flakyTests:
+  - name: "should do something"
+    issue: "https://github.com/kubernetes/kubernetes/issues/12345"
+    dateAdded: "2026-08-26"
+    suite: "node_e2e"
+    reason: "Flakes on COS"
+    jobs:
+      - ci-cos-containerd-node-e2e-serial
+`)
+	if len(config.FlakyTests) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(config.FlakyTests))
+	}
+
+	e := config.FlakyTests[0]
+	if e.Name != "should do something" {
+		t.Errorf("name = %q", e.Name)
+	}
+	if e.Issue != "https://github.com/kubernetes/kubernetes/issues/12345" {
+		t.Errorf("issue = %q", e.Issue)
+	}
+	if e.DateAdded != "2026-08-26" {
+		t.Errorf("dateAdded = %q", e.DateAdded)
+	}
+	if e.Suite != "node_e2e" {
+		t.Errorf("suite = %q", e.Suite)
+	}
+	if e.Reason != "Flakes on COS" {
+		t.Errorf("reason = %q", e.Reason)
+	}
+	if len(e.Jobs) != 1 || e.Jobs[0] != "ci-cos-containerd-node-e2e-serial" {
+		t.Errorf("jobs = %v", e.Jobs)
+	}
+}
+
+func TestLoadConfig_Errors(t *testing.T) {
+	if _, err := loadConfig("/nonexistent/path/flaky-tests.yaml"); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+
+	dir := t.TempDir()
+	badPath := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(badPath, []byte("not: valid: yaml: [[["), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadConfig(badPath); err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+
+	for name, content := range map[string]string{
+		"unknown field": `
+flakyTests:
+  - name: "test"
+    issue: "https://github.com/kubernetes/kubernetes/issues/1"
+    dateAdded: "2026-08-26"
+    jbos:
+      - pull-node-e2e
+`,
+		"duplicate field": `
+flakyTests:
+  - name: "first"
+    name: "second"
+    issue: "https://github.com/kubernetes/kubernetes/issues/1"
+    dateAdded: "2026-08-26"
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := writeTestConfig(t, content)
+			if _, err := loadConfig(path); err == nil {
+				t.Fatal("expected strict YAML error")
+			}
+		})
+	}
+
+	emptyPath := filepath.Join(dir, "empty.yaml")
+	if err := os.WriteFile(emptyPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	config, err := loadConfig(emptyPath)
+	if err != nil {
+		t.Fatalf("empty file should parse without error: %v", err)
+	}
+	if len(config.FlakyTests) != 0 {
+		t.Errorf("expected 0 entries from empty file, got %d", len(config.FlakyTests))
+	}
+}
+
+func TestGenerateSkipRegex_MatchesRealTestNames(t *testing.T) {
+	config := &FlakyTestConfig{
+		FlakyTests: []FlakyTest{
+			{Name: "should not allow privilege escalation when false", Issue: "https://github.com/kubernetes/kubernetes/issues/1", DateAdded: "2026-08-26"},
+			{Name: "should support pod level resources", Issue: "https://github.com/kubernetes/kubernetes/issues/2", DateAdded: "2026-08-26"},
+		},
+	}
+
+	re := regexp.MustCompile(generateSkipRegex(config, "", ""))
+
+	for _, name := range []string{
+		"[sig-node] Security Context should not allow privilege escalation when false [NodeConformance]",
+		"[sig-node] Pods should support pod level resources [Feature:PodLevelResources]",
+	} {
+		if !re.MatchString(name) {
+			t.Errorf("should match %q", name)
+		}
+	}
+	for _, name := range []string{
+		"[sig-node] Security Context should allow privilege escalation when true [NodeConformance]",
+		"[sig-node] Pods should create a pod",
+	} {
+		if re.MatchString(name) {
+			t.Errorf("should NOT match %q", name)
+		}
+	}
+}
+
+func TestGenerateSkipRegex_CombinedWithExistingSkip(t *testing.T) {
+	config := &FlakyTestConfig{
+		FlakyTests: []FlakyTest{{
+			Name: "should handle eviction", Issue: "https://github.com/kubernetes/kubernetes/issues/1", DateAdded: "2026-08-26",
+		}},
+	}
+
+	combined := `\[Flaky\]|\[Slow\]` + "|" + generateSkipRegex(config, "", "")
+	re := regexp.MustCompile(combined)
+
+	if !re.MatchString("[Flaky] some test") {
+		t.Error("should match [Flaky]")
+	}
+	if !re.MatchString("kubelet should handle eviction properly") {
+		t.Error("should match flaky test")
+	}
+	if re.MatchString("should create pods normally") {
+		t.Error("should not match unrelated test")
+	}
+}
+
+func TestValidateRealConfig(t *testing.T) {
+	configPath := filepath.Join("flaky-tests.yaml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Skip("flaky-tests.yaml not found")
+	}
+
+	config, err := loadConfig(configPath)
+	if err != nil {
+		t.Fatalf("failed to load real config: %v", err)
+	}
+	for _, e := range validate(config) {
+		t.Errorf("validation error: %s", e)
+	}
+}
+
+func TestRun_Validate(t *testing.T) {
+	validPath := writeTestConfig(t, `
+flakyTests:
+  - name: "test one"
+    issue: "https://github.com/kubernetes/kubernetes/issues/1"
+    dateAdded: "2026-08-26"
+  - name: "test two"
+    issue: "https://github.com/kubernetes/kubernetes/issues/2"
+    dateAdded: "2026-08-26"
+`)
+	invalidPath := writeTestConfig(t, `
+flakyTests:
+  - name: ""
+    issue: ""
+    dateAdded: ""
+`)
+
+	t.Run("success", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		if code := run(&stdout, &stderr, []string{"--config=" + validPath, "--mode=validate"}); code != 0 {
+			t.Fatalf("exit %d; stderr: %s", code, stderr.String())
+		}
+		if got := stdout.String(); got != "ok: 2 flaky test entries validated\n" {
+			t.Errorf("stdout = %q", got)
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		if code := run(&stdout, &stderr, []string{"--config=" + invalidPath, "--mode=validate"}); code != 1 {
+			t.Fatalf("expected exit 1, got %d", code)
+		}
+		if stdout.Len() != 0 {
+			t.Errorf("expected no stdout, got: %s", stdout.String())
+		}
+		for _, want := range []string{"name is required", "issue is required", "dateAdded is required"} {
+			if !strings.Contains(stderr.String(), want) {
+				t.Errorf("stderr missing %q", want)
+			}
+		}
+	})
+
+	t.Run("default mode is validate", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		if code := run(&stdout, &stderr, []string{"--config=" + validPath}); code != 0 {
+			t.Fatalf("exit %d; stderr: %s", code, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "ok: 2 flaky test entries validated") {
+			t.Errorf("stdout = %q", stdout.String())
+		}
+	})
+}
+
+func TestRun_SkipAndFocusRegex(t *testing.T) {
+	path := writeTestConfig(t, `
+flakyTests:
+  - name: "job-scoped"
+    issue: "https://github.com/kubernetes/kubernetes/issues/1"
+    dateAdded: "2026-08-26"
+    jobs:
+      - job-A
+  - name: "node only"
+    issue: "https://github.com/kubernetes/kubernetes/issues/2"
+    dateAdded: "2026-08-26"
+    suite: "node_e2e"
+  - name: "e2e only"
+    issue: "https://github.com/kubernetes/kubernetes/issues/3"
+    dateAdded: "2026-08-26"
+    suite: "e2e"
+`)
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"unfiltered", nil, "job-scoped|node only|e2e only"},
+		{"suite=e2e", []string{"--suite=e2e"}, "job-scoped|e2e only"},
+		{"suite=node_e2e", []string{"--suite=node_e2e"}, "job-scoped|node only"},
+		{"matching job", []string{"--job=job-A"}, "job-scoped|node only|e2e only"},
+		{"non-matching job", []string{"--job=job-X"}, "node only|e2e only"},
+		{"all filtered out", []string{"--suite=e2e", "--job=job-X"}, "e2e only"},
+	}
+
+	for _, mode := range []string{"skip-regex", "focus-regex"} {
+		t.Run(mode, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					var stdout, stderr bytes.Buffer
+					args := append([]string{"--config=" + path, "--mode=" + mode}, tt.args...)
+					if code := run(&stdout, &stderr, args); code != 0 {
+						t.Fatalf("exit %d; stderr: %s", code, stderr.String())
+					}
+					if got := stdout.String(); got != tt.want {
+						t.Errorf("stdout = %q, want %q", got, tt.want)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestFlakyTestFilter(t *testing.T) {
+	const flakyRegex = `Probing container should \*not\* be restarted with a non-local redirect http liveness probe|Probing restartable init container should \*not\* be restarted with a non-local redirect http liveness probe`
+
+	script, err := filepath.Abs("flaky-test-filter.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) (string, error) {
+		cmd := exec.Command(script, args...)
+		cmd.Dir = t.TempDir() // Verify the helper builds outside its own Go module.
+		output, err := cmd.CombinedOutput()
+		return string(output), err
+	}
+
+	t.Run("quotes nested node regex", func(t *testing.T) {
+		output, err := run(
+			"--mode=focus-regex", "--suite=node_e2e", "--",
+			"bash", "-c", `args="${1#--test_args=}"; eval "set -- ${args}"; printf '%s\n' "$@"`, "_",
+			"--test_args=--nodes=8 --focus= --skip=",
+		)
+		if err != nil {
+			t.Fatalf("filter failed: %v\n%s", err, output)
+		}
+		want := "--nodes=8\n--focus=" + flakyRegex + "\n--skip=\n"
+		if !strings.Contains(output, want) {
+			t.Fatalf("focused args = %q, want substring %q", output, want)
+		}
+	})
+
+	t.Run("encodes nested ginkgo regex", func(t *testing.T) {
+		output, err := run(
+			"--suite=node_e2e", "--", "printf", "%s\\n",
+			"--test_args=--ginkgo.skip=\\[Flaky\\]",
+		)
+		if err != nil {
+			t.Fatalf("filter failed: %v\n%s", err, output)
+		}
+		want := `--test_args=--ginkgo.skip=\[Flaky\]|` + strings.ReplaceAll(flakyRegex, " ", `\x20`) + "\n"
+		if !strings.Contains(output, want) {
+			t.Fatalf("nested ginkgo args = %q, want substring %q", output, want)
+		}
+	})
+
+	t.Run("empty focus does not run the command", func(t *testing.T) {
+		output, err := run("--mode=focus-regex", "--suite=e2e", "--", "false")
+		if err == nil || !strings.Contains(output, "no flaky tests configured") {
+			t.Fatalf("focus run unexpectedly proceeded: err=%v output=%s", err, output)
+		}
+	})
+}
+
+func TestRun_Errors(t *testing.T) {
+	validPath := writeTestConfig(t, `flakyTests: []`)
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{"missing config", []string{"--mode=validate"}, "--config is required"},
+		{"nonexistent config", []string{"--config=/nonexistent.yaml"}, "reading config"},
+		{"unknown mode", []string{"--config=" + validPath, "--mode=bad"}, "unknown mode"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if code := run(&stdout, &stderr, tt.args); code != 1 {
+				t.Fatalf("expected exit 1, got %d", code)
+			}
+			if !strings.Contains(stderr.String(), tt.wantStderr) {
+				t.Errorf("stderr = %q, want substring %q", stderr.String(), tt.wantStderr)
+			}
+		})
+	}
+}
+
+// helpers
+
+func writeTestConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flaky-tests.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func loadConfigFromString(t *testing.T, content string) *FlakyTestConfig {
+	t.Helper()
+	path := writeTestConfig(t, content)
+	config, err := loadConfig(path)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	return config
+}
+
+func splitNonEmpty(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "|")
+}


### PR DESCRIPTION
As SIG-Node works to cut down on flaky test suites, a new catagorization and labeling mechanism is needed. Now, we can label directly from here in test-infra, and also keep together a list of flaky tests. that'll let us do more analytics on them, and also allow more people to mark a test as flaky

co-authored by claude 4.6