### PR TITLE
sig-node/dra: restore 1Gi memory for package-based node jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -687,10 +687,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: ci-node-crio-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -746,10 +746,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: ci-node-e2e-containerd-1-7-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -801,10 +801,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: ci-node-e2e-containerd-1-7-cos-dra
     cluster: k8s-infra-prow-build
@@ -856,10 +856,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: ci-node-e2e-containerd-2-0-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -914,10 +914,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: ci-node-e2e-containerd-2-0-cos-dra
     cluster: k8s-infra-prow-build
@@ -972,10 +972,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: ci-node-e2e-containerd-1-7-ubuntu-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1024,10 +1024,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: ci-node-e2e-containerd-1-7-cos-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1076,10 +1076,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: ci-node-e2e-containerd-2-0-ubuntu-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1131,10 +1131,10 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: ci-node-e2e-containerd-2-0-cos-dra-alpha-beta-features
     cluster: k8s-infra-prow-build
@@ -1186,7 +1186,7 @@ periodics:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi

--- a/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-testinfra.yaml
@@ -58,10 +58,10 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: pull-test-infra-node-e2e-containerd-1-7-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -111,10 +111,10 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: pull-test-infra-node-e2e-containerd-1-7-cos-dra
     cluster: k8s-infra-prow-build
@@ -164,10 +164,10 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: pull-test-infra-node-e2e-containerd-2-0-ubuntu-dra
     cluster: k8s-infra-prow-build
@@ -220,10 +220,10 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
 
   - name: pull-test-infra-node-e2e-containerd-2-0-cos-dra
     cluster: k8s-infra-prow-build
@@ -276,7 +276,7 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -323,10 +323,10 @@ presubmits:
           # need few resources, but only when using release packages.
           limits:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           requests:
             cpu: 0.5
-            memory: 2Gi
+            memory: 1Gi
           {%- else %}
           limits:
             cpu: 2


### PR DESCRIPTION
#37491 raised the package-based DRA node jobs from 1Gi to 2Gi as a temporary mitigation while the Ubuntu-only host-side OOM was investigated.

kubernetes/kubernetes#141590 fixed the cause. The GCE runner now filters the image list by family before it buffers and unmarshals it. For `ubuntu-os-gke-cloud` the runner peak dropped from 1067MiB to 103MiB and the lookup from 44.6s to 5.8s, and the selected image did not change. The Prow build dashboard now shows the affected Ubuntu job's pod working set around 200MiB.

This sets the shared package-based node-job template back to 1Gi. It is just the reverse of #37491, so it needs no per-job memory parameter.

The regenerated diff covers 10 DRA node CI periodics and 5 test-infra image-config presubmits. It does not touch the Kubernetes presubmits that build binaries, the kind and integration jobs, or the already generated release-branch job files. The existing release-1.37 jobs stay at 2Gi, because that branch does not have the family-filtering fix yet.

Part of kubernetes/kubernetes#141434.

/kind cleanup
/sig node
/sig testing
