### PR TITLE
minikube: Cut periodics to daily required jobs

### DIFF
--- a/config/jobs/kubernetes/minikube/minikube-periodics.yaml
+++ b/config/jobs/kubernetes/minikube/minikube-periodics.yaml
@@ -1,37 +1,4 @@
 periodics:
-- name: ci-minikube-integration
-  cluster: k8s-infra-prow-build
-  interval: 4h
-  decorate: true
-  labels:
-    preset-dind-enabled: "true"
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  annotations:
-    testgrid-dashboards: minikube-periodics
-  extra_refs:
-  - org: kubernetes
-    repo: minikube
-    base_ref: master
-    path_alias: k8s.io/minikube
-  spec:
-    containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
-      command:
-      - runner.sh
-      args:
-      - make
-      - integration-prow-docker-docker-linux-x86
-      resources:
-        limits:
-          cpu: 7
-          memory: 20Gi
-        requests:
-          cpu: 7
-          memory: 20Gi
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
 # name convention: integration-<driver>-<container-runtime>-<OS>-<arch>
 - name: ci-minikube-kvm-docker-linux-x86
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/minikube/minikube-periodics.yaml
+++ b/config/jobs/kubernetes/minikube/minikube-periodics.yaml
@@ -2,7 +2,7 @@ periodics:
 # name convention: integration-<driver>-<container-runtime>-<OS>-<arch>
 - name: ci-minikube-kvm-docker-linux-x86
   cluster: k8s-infra-prow-build
-  interval: 4h
+  interval: 24h
   decorate: true
   path_alias: "k8s.io/minikube"
   labels:
@@ -36,7 +36,7 @@ periodics:
           cpu: 7
 - name: ci-minikube-docker-docker-linux-arm
   cluster: k8s-infra-prow-build
-  interval: 4h
+  interval: 24h
   decorate: true
   path_alias: "k8s.io/minikube"
   labels:
@@ -71,7 +71,7 @@ periodics:
           cpu: 7
 - name: ci-minikube-kvm-containerd-linux-x86
   cluster: k8s-infra-prow-build
-  interval: 4h
+  interval: 24h
   decorate: true
   path_alias: "k8s.io/minikube"
   labels:
@@ -105,7 +105,7 @@ periodics:
           cpu: 7
 - name: ci-minikube-docker-docker-linux-x86
   cluster: k8s-infra-prow-build
-  interval: 4h
+  interval: 24h
   decorate: true
   path_alias: "k8s.io/minikube"
   labels:
@@ -139,7 +139,7 @@ periodics:
           cpu: 7
 - name: ci-minikube-docker-containerd-linux-x86
   cluster: k8s-infra-prow-build
-  interval: 4h
+  interval: 24h
   decorate: true
   path_alias: "k8s.io/minikube"
   labels:
@@ -173,7 +173,7 @@ periodics:
           cpu: 7
 - name: ci-minikube-none-docker-linux-x86
   cluster: k8s-infra-prow-build
-  interval: 4h
+  interval: 24h
   decorate: true
   path_alias: "k8s.io/minikube"
   labels:

--- a/config/jobs/kubernetes/minikube/minikube-periodics.yaml
+++ b/config/jobs/kubernetes/minikube/minikube-periodics.yaml
@@ -102,41 +102,6 @@ periodics:
         limits:
           memory: 20Gi
           cpu: 7
-- name: ci-minikube-docker-containerd-linux-arm
-  cluster: k8s-infra-prow-build
-  interval: 4h
-  decorate: true
-  path_alias: "k8s.io/minikube"
-  labels:
-    preset-dind-enabled: "true"
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  annotations:
-    testgrid-dashboards: minikube-periodics
-  extra_refs:
-  - org: kubernetes
-    repo: minikube
-    base_ref: master
-    path_alias: k8s.io/minikube
-  spec:
-    nodeSelector:
-      kubernetes.io/arch: arm64
-    containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
-      command:
-      - runner.sh
-      args:
-      - make
-      - integration-prow-docker-containerd-arm
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: 20Gi
-          cpu: 7
-        limits:
-          memory: 20Gi
-          cpu: 7
 - name: ci-minikube-kvm-containerd-linux-x86
   cluster: k8s-infra-prow-build
   interval: 4h
@@ -161,40 +126,6 @@ periodics:
       args:
       - make
       - integration-prow-kvm-containerd-linux-x86
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: 20Gi
-          cpu: 7
-        limits:
-          memory: 20Gi
-          cpu: 7
-- name: ci-minikube-kvm-crio-linux-x86
-  cluster: k8s-infra-prow-build
-  interval: 4h
-  decorate: true
-  path_alias: "k8s.io/minikube"
-  labels:
-    preset-dind-enabled: "true"
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  annotations:
-    testgrid-dashboards: minikube-periodics
-  extra_refs:
-  - org: kubernetes
-    repo: minikube
-    base_ref: master
-    path_alias: k8s.io/minikube
-  spec:
-    containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
-      command:
-      - runner.sh
-      args:
-      - make
-      - integration-prow-kvm-crio-linux-x86
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -263,74 +194,6 @@ periodics:
       args:
       - make
       - integration-prow-docker-containerd-linux-x86
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: 20Gi
-          cpu: 7
-        limits:
-          memory: 20Gi
-          cpu: 7
-- name: ci-minikube-docker-crio-linux-x86
-  cluster: k8s-infra-prow-build
-  interval: 4h
-  decorate: true
-  path_alias: "k8s.io/minikube"
-  labels:
-    preset-dind-enabled: "true"
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  annotations:
-    testgrid-dashboards: minikube-periodics
-  extra_refs:
-  - org: kubernetes
-    repo: minikube
-    base_ref: master
-    path_alias: k8s.io/minikube
-  spec:
-    containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
-      command:
-      - runner.sh
-      args:
-      - make
-      - integration-prow-docker-crio-linux-x86
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: 20Gi
-          cpu: 7
-        limits:
-          memory: 20Gi
-          cpu: 7
-- name: ci-minikube-none-containerd-linux-x86
-  cluster: k8s-infra-prow-build
-  interval: 4h
-  decorate: true
-  path_alias: "k8s.io/minikube"
-  labels:
-    preset-dind-enabled: "true"
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  annotations:
-    testgrid-dashboards: minikube-periodics
-  extra_refs:
-  - org: kubernetes
-    repo: minikube
-    base_ref: master
-    path_alias: k8s.io/minikube
-  spec:
-    containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260810-7619858115-master
-      command:
-      - runner.sh
-      args:
-      - make
-      - integration-prow-none-containerd-linux-x86
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true


### PR DESCRIPTION
Minikube periodics were running the full integration suite every 4 hours
on every driver/runtime combo, including optional and duplicate jobs.
That is more than master needs for flake history.

- Keep one periodic per required presubmit:
  - ci-minikube-kvm-docker-linux-x86
  - ci-minikube-kvm-containerd-linux-x86
  - ci-minikube-docker-docker-linux-x86
  - ci-minikube-docker-containerd-linux-x86
  - ci-minikube-docker-docker-linux-arm
  - ci-minikube-none-docker-linux-x86
- Remove optional periodics (crio, none-containerd, docker-containerd-arm)
- Remove ci-minikube-integration (duplicate of docker-docker x86)
- Change the interval from 4 hours to 24 hours