### PR TITLE
Remove agent-sandbox migration-test periodic

### DIFF
--- a/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/agent-sandbox/agent-sandbox-periodics-main.yaml
@@ -32,36 +32,6 @@ periodics:
         limits:
           cpu: 7
           memory: 14Gi
-- name: periodic-agent-sandbox-migration-test
-  cluster: eks-prow-build-cluster
-  interval: 1h
-  decorate: true
-  decoration_config:
-    timeout: 30m
-  annotations:
-    testgrid-dashboards: sig-apps-agent-sandbox
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: agent-sandbox
-    base_ref: main
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  spec:
-    containers:
-    - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20260824-a5e45c393a-master
-      command:
-      - runner.sh
-      - dev/ci/periodics/test-migration
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          cpu: 7
-          memory: 14Gi
-        limits:
-          cpu: 7
-          memory: 14Gi
 - name: periodic-benchmarks-kops-gcp-cilium
   cluster: k8s-infra-prow-build
   interval: 24h


### PR DESCRIPTION
Removes `periodic-agent-sandbox-migration-test`.
kubernetes-sigs/agent-sandbox#1470 merged `feature/drop-v1alpha1` into main,
dropping `api/v1alpha1` along with the migration harness this job ran:

- `dev/ci/periodics/test-migration` (the script the job invokes)
- `dev/tools/migrate.sh`
- `dev/tools/test-migration.py`
- `test/migration/`

The job upgraded a v1alpha1 install to a controller built from the checkout and
blocked on the conversion webhook. With v1alpha1 gone from main there is nothing
left for it to test, and the script it runs no longer exists, so it would fail on
every trigger.

Generated with `generate_jobs.py` against agent-sandbox main. Only the periodics
output is included -- the same run also picks up the new `dev/ci/presubmits`
scripts, which are already covered by #37536, so I left the presubmits YAML
untouched to avoid conflicting with it.

Part of the v1alpha1 removal tracked in kubernetes-sigs/agent-sandbox#1265.

/sig apps
/area jobs