### PR TITLE
images/krte: add an optional cgroup contract probe

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -217,3 +217,35 @@ presubmits:
             limits:
               cpu: "1"
               memory: 2Gi
+  - name: pull-test-infra-krte-cgroup-snapshot
+    cluster: k8s-infra-prow-build
+    decorate: true
+    optional: true
+    run_if_changed: '^experiment/krte-cgroup-contract/'
+    decoration_config:
+      timeout: 30m
+      grace_period: 2m
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20260824-a5e45c393a-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - cd ./experiment/krte-cgroup-contract && ./verify.sh
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "2"
+            memory: 4Gi
+          limits:
+            cpu: "2"
+            memory: 4Gi
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: krte-cgroup-snapshot
+      description: one-shot KRTE outer/dockerd/Docker-child/kind cgroup topology snapshot for kubernetes/test-infra#37775

--- a/experiment/krte-cgroup-contract/main.go
+++ b/experiment/krte-cgroup-contract/main.go
@@ -1,0 +1,505 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command krte-cgroup-contract records the CPU cgroup topology a process sees.
+// It collects best-effort: parse problems become entries in "errors" and the
+// snapshot is still written, so the most interesting cases (a hidden ancestor,
+// a virtualized mount root, an unexpected placement) leave evidence instead of
+// an empty artifact. Assertions belong to the caller, not here.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type cgroupMount struct {
+	version int
+	root    string
+	point   string
+	options []string // super options; v1 controllers appear here
+}
+
+type cpuLevel struct {
+	Path                string `json:"path"`
+	Type                string `json:"type,omitempty"`
+	CPUMax              string `json:"cpu_max,omitempty"`
+	CPUStat             string `json:"cpu_stat,omitempty"`
+	CPUSetCPUsEffective string `json:"cpuset_cpus_effective,omitempty"`
+}
+
+type snapshot struct {
+	Label             string            `json:"label"`
+	PID               int               `json:"pid"`
+	Runtime           string            `json:"runtime"`
+	NumCPU            int               `json:"num_cpu"`
+	GOMAXPROCS        int               `json:"gomaxprocs"`
+	GODEBUG           string            `json:"godebug,omitempty"`
+	GOMAXPROCSEnv     string            `json:"gomaxprocs_env,omitempty"`
+	CgroupMode        string            `json:"cgroup_mode"` // unified|hybrid|legacy|unknown
+	UnsupportedReason string            `json:"unsupported_reason,omitempty"`
+	RawCgroup         string            `json:"raw_cgroup,omitempty"`
+	CgroupV2Path      string            `json:"cgroup_v2_path,omitempty"`
+	MountRoot         string            `json:"mount_root,omitempty"`
+	MountPoint        string            `json:"mount_point,omitempty"`
+	NamespaceLinks    map[string]string `json:"namespace_links,omitempty"`
+	// MinimumVisibleCPUQuota is the smallest quota/period found in the visible
+	// chain. It is a quota, not an effective core count: it ignores affinity,
+	// cpuset.cpus.effective, NumCPU, and Go's rounding.
+	MinimumVisibleCPUQuota float64    `json:"minimum_visible_cpu_quota,omitempty"`
+	HasVisibleCPULimit     bool       `json:"has_visible_cpu_limit"`
+	Levels                 []cpuLevel `json:"levels,omitempty"`
+	Errors                 []string   `json:"errors,omitempty"`
+}
+
+func (s *snapshot) addErr(format string, a ...any) {
+	s.Errors = append(s.Errors, fmt.Sprintf(format, a...))
+}
+
+func main() {
+	label := flag.String("label", "process", "snapshot label")
+	output := flag.String("output", "", "also write JSON to this file")
+	hold := flag.Duration("hold", 0, "stay alive after writing the snapshot")
+	summarize := flag.String("summarize", "", "read outer.json and docker-child.json from this directory and write summary.json")
+	flag.Parse()
+
+	if *summarize != "" {
+		if err := writeSummary(*summarize); err != nil {
+			fmt.Fprintf(os.Stderr, "cgroup contract: summarize: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	s := takeSnapshot(*label)
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cgroup contract: encode snapshot: %v\n", err)
+		os.Exit(1)
+	}
+	data = append(data, '\n')
+
+	// Write the artifact before stdout so a broken pipe cannot lose it.
+	if *output != "" {
+		if err := os.WriteFile(*output, data, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "cgroup contract: write %s: %v\n", *output, err)
+			os.Exit(1)
+		}
+	}
+	os.Stdout.Write(data)
+	if *hold > 0 {
+		time.Sleep(*hold)
+	}
+}
+
+func takeSnapshot(label string) snapshot {
+	s := snapshot{
+		Label:         label,
+		PID:           os.Getpid(),
+		Runtime:       runtime.Version(),
+		NumCPU:        runtime.NumCPU(),
+		GOMAXPROCS:    runtime.GOMAXPROCS(0),
+		GODEBUG:       os.Getenv("GODEBUG"),
+		GOMAXPROCSEnv: os.Getenv("GOMAXPROCS"),
+		CgroupMode:    "unknown",
+	}
+	s.readNamespaceLinks()
+
+	raw, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		s.addErr("read /proc/self/cgroup: %v", err)
+		return s
+	}
+	s.RawCgroup = strings.TrimSpace(string(raw))
+	v2path, v1, err := parseProcCgroup(strings.NewReader(s.RawCgroup))
+	if err != nil {
+		s.addErr("parse /proc/self/cgroup: %v", err)
+	}
+	_, cpuOnV1 := v1["cpu"]
+	switch {
+	case v2path != "" && len(v1) == 0:
+		s.CgroupMode = "unified"
+	case v2path != "" && len(v1) > 0:
+		s.CgroupMode = "hybrid"
+	case v2path == "" && len(v1) > 0:
+		s.CgroupMode = "legacy"
+	}
+
+	mountData, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		s.addErr("read /proc/self/mountinfo: %v", err)
+		return s
+	}
+	mounts, err := parseMounts(strings.NewReader(string(mountData)))
+	if err != nil {
+		s.addErr("parse mountinfo: %v", err)
+	}
+
+	if cpuOnV1 || v2path == "" {
+		s.readV1CPU(v1["cpu"], mounts)
+		return s
+	}
+	s.CgroupV2Path = v2path
+	s.readV2Chain(v2path, mounts)
+	return s
+}
+
+func (s *snapshot) readNamespaceLinks() {
+	links := map[string]string{}
+	for _, ns := range []string{"cgroup", "mnt", "pid"} {
+		link, err := os.Readlink("/proc/self/ns/" + ns)
+		if err != nil {
+			s.addErr("readlink ns/%s: %v", ns, err)
+			continue
+		}
+		links[ns] = link
+	}
+	if len(links) > 0 {
+		s.NamespaceLinks = links
+	}
+}
+
+// readV2Chain walks the unified leaf up to the mount point, reading cpu.max at
+// each level, and records the smallest quota it can see.
+func (s *snapshot) readV2Chain(v2path string, mounts []cgroupMount) {
+	m, ok := pickVisibleV2Mount(v2path, mounts)
+	if !ok {
+		s.UnsupportedReason = "no visible cgroup2 mount contains the current path"
+		return
+	}
+	s.MountRoot, s.MountPoint = m.root, m.point
+	leaf, err := fullLeaf(v2path, m)
+	if err != nil {
+		s.addErr("resolve leaf: %v", err)
+		return
+	}
+
+	var limits []float64
+	for path := leaf; ; path = filepath.Dir(path) {
+		l := cpuLevel{
+			Path:                path,
+			Type:                readOptional(filepath.Join(path, "cgroup.type")),
+			CPUMax:              readOptional(filepath.Join(path, "cpu.max")),
+			CPUStat:             readOptional(filepath.Join(path, "cpu.stat")),
+			CPUSetCPUsEffective: readOptional(filepath.Join(path, "cpuset.cpus.effective")),
+		}
+		s.Levels = append(s.Levels, l)
+		if value, ok, err := parseCPUMax(l.CPUMax); err != nil {
+			s.addErr("parse %s/cpu.max: %v", path, err)
+		} else if ok {
+			limits = append(limits, value)
+		}
+		if path == m.point {
+			break
+		}
+		if parent := filepath.Dir(path); parent == path || !within(parent, m.point) {
+			s.addErr("cgroup walk escaped mount point %q at %q", m.point, path)
+			break
+		}
+	}
+	if len(limits) > 0 {
+		s.HasVisibleCPULimit = true
+		s.MinimumVisibleCPUQuota = slices.Min(limits)
+	}
+}
+
+// readV1CPU reads cpu.cfs_quota_us / cpu.cfs_period_us for the v1 cpu hierarchy.
+func (s *snapshot) readV1CPU(cpuPath string, mounts []cgroupMount) {
+	if cpuPath == "" {
+		s.UnsupportedReason = "cpu controller not found in /proc/self/cgroup"
+		return
+	}
+	var mount *cgroupMount
+	for i := range mounts {
+		if mounts[i].version == 1 && slices.Contains(mounts[i].options, "cpu") {
+			mount = &mounts[i]
+			break
+		}
+	}
+	if mount == nil {
+		s.UnsupportedReason = "cpu controller is on cgroup v1 but no v1 cpu mount is visible"
+		return
+	}
+	s.MountRoot, s.MountPoint = mount.root, mount.point
+	leaf, err := fullLeaf(cpuPath, *mount)
+	if err != nil {
+		s.addErr("resolve v1 cpu leaf: %v", err)
+		return
+	}
+	quotaRaw := readOptional(filepath.Join(leaf, "cpu.cfs_quota_us"))
+	periodRaw := readOptional(filepath.Join(leaf, "cpu.cfs_period_us"))
+	s.Levels = append(s.Levels, cpuLevel{Path: leaf, CPUMax: quotaRaw + " " + periodRaw})
+	quota, err := strconv.ParseFloat(quotaRaw, 64)
+	if err != nil || quota < 0 {
+		return // -1 means unlimited; anything unparsable is left as no limit
+	}
+	period, err := strconv.ParseFloat(periodRaw, 64)
+	if err != nil || period <= 0 {
+		s.addErr("invalid v1 cpu.cfs_period_us %q", periodRaw)
+		return
+	}
+	s.HasVisibleCPULimit = true
+	s.MinimumVisibleCPUQuota = quota / period
+	// v1 here reads only the leaf, unlike the v2 chain that walks to the mount
+	// point, so this value is not the visible-ancestor minimum the field name
+	// implies on v2. Flag the gap rather than let it read as the same guarantee.
+	s.UnsupportedReason = "v1 cpu quota is read leaf-only; the visible-ancestor minimum is not computed"
+}
+
+// parseProcCgroup returns the unified v2 path (hierarchy 0) and a
+// controller->path map for any v1 hierarchies.
+func parseProcCgroup(r io.Reader) (v2path string, v1 map[string]string, err error) {
+	v1 = map[string]string{}
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		fields := strings.SplitN(scanner.Text(), ":", 3)
+		if len(fields) != 3 {
+			continue
+		}
+		switch {
+		case fields[0] == "0" && fields[1] == "":
+			if !strings.HasPrefix(fields[2], "/") {
+				return "", nil, fmt.Errorf("malformed cgroup v2 path %q", fields[2])
+			}
+			v2path = filepath.Clean(fields[2])
+		case fields[1] != "":
+			for _, c := range strings.Split(fields[1], ",") {
+				v1[c] = fields[2]
+			}
+		}
+	}
+	return v2path, v1, scanner.Err()
+}
+
+// parseMounts returns every cgroup and cgroup2 mount from a mountinfo stream.
+func parseMounts(r io.Reader) ([]cgroupMount, error) {
+	var mounts []cgroupMount
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		sep := slices.Index(fields, "-")
+		// after "-": fstype (sep+1), source (sep+2), super options (sep+3)
+		if sep < 5 || sep+3 >= len(fields) {
+			continue
+		}
+		var m cgroupMount
+		switch fields[sep+1] {
+		case "cgroup2":
+			m.version = 2
+		case "cgroup":
+			m.version = 1
+		default:
+			continue
+		}
+		m.root = filepath.Clean(unescapeMount(fields[3]))
+		m.point = filepath.Clean(unescapeMount(fields[4]))
+		m.options = strings.Split(fields[sep+3], ",")
+		mounts = append(mounts, m)
+	}
+	return mounts, scanner.Err()
+}
+
+// pickVisibleV2Mount returns the cgroup2 mount whose root is the longest prefix
+// of cgroup, i.e. the one that actually contains it.
+func pickVisibleV2Mount(cgroup string, mounts []cgroupMount) (cgroupMount, bool) {
+	best := cgroupMount{}
+	bestLen := -1
+	for _, m := range mounts {
+		if m.version != 2 {
+			continue
+		}
+		if m.root != "/" && cgroup != m.root && !strings.HasPrefix(cgroup, m.root+"/") {
+			continue
+		}
+		if len(m.root) > bestLen {
+			best, bestLen = m, len(m.root)
+		}
+	}
+	return best, bestLen >= 0
+}
+
+func fullLeaf(cgroup string, m cgroupMount) (string, error) {
+	var relative string
+	switch {
+	case m.root == "/":
+		relative = cgroup
+	case cgroup == m.root:
+		relative = "/"
+	default:
+		rest, ok := strings.CutPrefix(cgroup, m.root+"/")
+		if !ok {
+			return "", fmt.Errorf("cgroup %q is outside mount root %q", cgroup, m.root)
+		}
+		relative = "/" + rest
+	}
+	return filepath.Join(m.point, relative), nil
+}
+
+func within(path, point string) bool {
+	rel, err := filepath.Rel(point, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, "../")
+}
+
+func parseCPUMax(raw string) (float64, bool, error) {
+	if raw == "" || raw == "<absent>" {
+		return 0, false, nil
+	}
+	quotaStr, periodStr, ok := strings.Cut(raw, " ")
+	if !ok {
+		return 0, false, fmt.Errorf("malformed value %q", raw)
+	}
+	if quotaStr == "max" {
+		return 0, false, nil
+	}
+	quota, err := strconv.ParseFloat(quotaStr, 64)
+	if err != nil {
+		return 0, false, err
+	}
+	period, err := strconv.ParseFloat(periodStr, 64)
+	if err != nil || period <= 0 {
+		return 0, false, fmt.Errorf("invalid period %q", periodStr)
+	}
+	return quota / period, true, nil
+}
+
+func readOptional(path string) string {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "<absent>"
+	}
+	if err != nil {
+		return "<error: " + err.Error() + ">"
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func unescapeMount(s string) string {
+	return strings.NewReplacer(`\040`, " ", `\011`, "\t", `\012`, "\n", `\134`, `\`).Replace(s)
+}
+
+type summaryEntry struct {
+	CgroupMode             string  `json:"cgroup_mode,omitempty"`
+	CgroupV2Path           string  `json:"cgroup_v2_path,omitempty"`
+	MinimumVisibleCPUQuota float64 `json:"minimum_visible_cpu_quota,omitempty"`
+	HasVisibleCPULimit     bool    `json:"has_visible_cpu_limit"`
+	GOMAXPROCS             int     `json:"gomaxprocs"`
+	OuterNamespaceCgroup   string  `json:"outer_namespace_cgroup,omitempty"`
+	UnsupportedReason      string  `json:"unsupported_reason,omitempty"`
+	Errors                 int     `json:"errors,omitempty"`
+}
+
+type summaryDoc struct {
+	Provenance         map[string]string `json:"provenance,omitempty"`
+	OuterDefault       *summaryEntry     `json:"outer_default,omitempty"`
+	OuterForced        *summaryEntry     `json:"outer_forced,omitempty"`
+	DockerChildDefault *summaryEntry     `json:"docker_child_default,omitempty"`
+	DockerChildForced  *summaryEntry     `json:"docker_child_forced,omitempty"`
+	KindNode           *summaryEntry     `json:"kind_node,omitempty"`
+}
+
+// writeSummary reduces every layer that produced a snapshot to the compared
+// fields, alongside the run's provenance. A layer that did not run is omitted,
+// so the summary reports the layers that actually ran rather than implying all
+// of them did.
+func writeSummary(dir string) error {
+	hostCgroup := ""
+	if data, err := os.ReadFile(filepath.Join(dir, "docker-child-from-outer.cgroup")); err == nil {
+		hostCgroup = strings.TrimSpace(string(data))
+	}
+	doc := summaryDoc{
+		Provenance:         readProvenance(dir),
+		OuterDefault:       entryFromFile(dir, "outer-default.json", ""),
+		OuterForced:        entryFromFile(dir, "outer.json", ""),
+		DockerChildDefault: entryFromFile(dir, "docker-child-default.json", ""),
+		DockerChildForced:  entryFromFile(dir, "docker-child.json", hostCgroup),
+		KindNode:           entryFromFile(dir, "kind-node-go.json", ""),
+	}
+	if doc.OuterForced == nil {
+		return fmt.Errorf("outer snapshot missing; nothing to summarize")
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filepath.Join(dir, "summary.json"), data, 0o644); err != nil {
+		return err
+	}
+	os.Stdout.Write(data)
+	return nil
+}
+
+// entryFromFile reads one snapshot file into a summaryEntry, returning nil when
+// the file is absent so a layer that did not run is left out of the summary.
+func entryFromFile(dir, name, hostCgroup string) *summaryEntry {
+	var s snapshot
+	if err := readSnapshot(filepath.Join(dir, name), &s); err != nil {
+		return nil
+	}
+	e := entryOf(s, hostCgroup)
+	return &e
+}
+
+// readProvenance parses the key=value lines verify.sh writes to provenance.txt.
+func readProvenance(dir string) map[string]string {
+	data, err := os.ReadFile(filepath.Join(dir, "provenance.txt"))
+	if err != nil {
+		return nil
+	}
+	out := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if k, v, ok := strings.Cut(line, "="); ok {
+			out[strings.TrimSpace(k)] = strings.TrimSpace(v)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func entryOf(s snapshot, hostCgroup string) summaryEntry {
+	return summaryEntry{
+		CgroupMode:             s.CgroupMode,
+		CgroupV2Path:           s.CgroupV2Path,
+		MinimumVisibleCPUQuota: s.MinimumVisibleCPUQuota,
+		HasVisibleCPULimit:     s.HasVisibleCPULimit,
+		GOMAXPROCS:             s.GOMAXPROCS,
+		OuterNamespaceCgroup:   hostCgroup,
+		UnsupportedReason:      s.UnsupportedReason,
+		Errors:                 len(s.Errors),
+	}
+}
+
+func readSnapshot(path string, s *snapshot) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, s)
+}

--- a/experiment/krte-cgroup-contract/main_test.go
+++ b/experiment/krte-cgroup-contract/main_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseProcCgroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantV2  string
+		wantCPU string // v1 cpu path, "" if none
+		isErr   bool
+	}{
+		{"unified", "0::/a/b\n", "/a/b", "", false},
+		{"legacy v1", "4:cpu,cpuacct:/x\n3:memory:/x\n", "", "/x", false},
+		{"hybrid cpu on v1", "0::/only/v2\n4:cpu,cpuacct:/y\n", "/only/v2", "/y", false},
+		{"malformed v2 path", "0::relative\n", "", "", true},
+		{"blank lines ignored", "\n0::/z\n\n", "/z", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v2, v1, err := parseProcCgroup(strings.NewReader(tc.in))
+			if (err != nil) != tc.isErr {
+				t.Fatalf("err = %v, want error %v", err, tc.isErr)
+			}
+			if err != nil {
+				return
+			}
+			if v2 != tc.wantV2 {
+				t.Errorf("v2 = %q, want %q", v2, tc.wantV2)
+			}
+			if got := v1["cpu"]; got != tc.wantCPU {
+				t.Errorf("v1[cpu] = %q, want %q", got, tc.wantCPU)
+			}
+		})
+	}
+}
+
+func TestParseMounts(t *testing.T) {
+	// 3 4 0:5 / /sys/fs/cgroup ro - cgroup2 cgroup2 rw
+	mi := strings.Join([]string{
+		`31 23 0:26 / /sys/fs/cgroup rw shared:9 - cgroup2 cgroup2 rw`,
+		`40 31 0:35 /x /sys/fs/cgroup/x rw - cgroup2 cgroup2 rw`,
+		`50 23 0:60 / /sys/fs/cgroup/cpu rw - cgroup cgroup rw,cpu,cpuacct`,
+		`60 23 0:61 / /mnt/notcgroup rw - tmpfs tmpfs rw`,
+		`70 23 0:70 /a\040b /sys/fs/cgroup/esc rw - cgroup2 cgroup2 rw`,
+	}, "\n") + "\n"
+	mounts, err := parseMounts(strings.NewReader(mi))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mounts) != 4 {
+		t.Fatalf("got %d cgroup mounts, want 4 (tmpfs excluded)", len(mounts))
+	}
+	var v1cpu, escaped bool
+	for _, m := range mounts {
+		if m.version == 1 && contains(m.options, "cpu") {
+			v1cpu = true
+		}
+		if m.root == "/a b" {
+			escaped = true
+		}
+	}
+	if !v1cpu {
+		t.Error("did not detect the v1 cpu mount")
+	}
+	if !escaped {
+		t.Error("did not unescape the mount root")
+	}
+}
+
+func TestPickVisibleV2Mount(t *testing.T) {
+	mounts := []cgroupMount{
+		{version: 2, root: "/", point: "/sys/fs/cgroup"},
+		{version: 2, root: "/x", point: "/sys/fs/cgroup"},
+		{version: 1, root: "/", point: "/sys/fs/cgroup/cpu", options: []string{"cpu"}},
+	}
+	tests := []struct {
+		name      string
+		cgroup    string
+		wantRoot  string
+		wantFound bool
+	}{
+		{"longest prefix wins", "/x/y", "/x", true},
+		{"root fallback", "/other", "/", true},
+		{"exact root match", "/x", "/x", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, ok := pickVisibleV2Mount(tc.cgroup, mounts)
+			if ok != tc.wantFound {
+				t.Fatalf("found = %v, want %v", ok, tc.wantFound)
+			}
+			if ok && m.root != tc.wantRoot {
+				t.Errorf("root = %q, want %q", m.root, tc.wantRoot)
+			}
+		})
+	}
+
+	if _, ok := pickVisibleV2Mount("/a", []cgroupMount{{version: 2, root: "/b", point: "/p"}}); ok {
+		t.Error("expected no visible mount when nothing contains the cgroup")
+	}
+}
+
+func TestParseCPUMax(t *testing.T) {
+	tests := []struct {
+		name  string
+		raw   string
+		want  float64
+		ok    bool
+		isErr bool
+	}{
+		{"unlimited", "max 100000", 0, false, false},
+		{"two cpus", "200000 100000", 2, true, false},
+		{"fractional", "50000 100000", 0.5, true, false},
+		{"empty", "", 0, false, false},
+		{"absent", "<absent>", 0, false, false},
+		{"missing period", "200000", 0, false, true},
+		{"bad quota", "abc 100000", 0, false, true},
+		{"zero period", "200000 0", 0, false, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok, err := parseCPUMax(tc.raw)
+			if (err != nil) != tc.isErr {
+				t.Fatalf("err = %v, want error %v", err, tc.isErr)
+			}
+			if err == nil && (got != tc.want || ok != tc.ok) {
+				t.Errorf("got (%v, %v), want (%v, %v)", got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestFullLeaf(t *testing.T) {
+	tests := []struct {
+		name   string
+		cgroup string
+		mount  cgroupMount
+		want   string
+		isErr  bool
+	}{
+		{"root mount", "/a/b", cgroupMount{root: "/", point: "/sys/fs/cgroup"}, "/sys/fs/cgroup/a/b", false},
+		{"namespaced at root", "/x", cgroupMount{root: "/x", point: "/sys/fs/cgroup"}, "/sys/fs/cgroup", false},
+		{"namespaced child", "/x/y", cgroupMount{root: "/x", point: "/sys/fs/cgroup"}, "/sys/fs/cgroup/y", false},
+		{"outside root", "/z", cgroupMount{root: "/x", point: "/sys/fs/cgroup"}, "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := fullLeaf(tc.cgroup, tc.mount)
+			if (err != nil) != tc.isErr {
+				t.Fatalf("err = %v, want error %v", err, tc.isErr)
+			}
+			if err == nil && got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUnescapeMount(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{`plain`, `plain`},
+		{`a\040b`, "a b"},
+		{`tab\011here`, "tab\there"},
+		{`back\134slash`, `back\slash`},
+	}
+	for _, tc := range tests {
+		if got := unescapeMount(tc.in); got != tc.want {
+			t.Errorf("unescapeMount(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// writeSummary must not lose the child entry when the optional host-side cgroup
+// file is missing.
+func TestWriteSummaryMissingHostCgroup(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string, s snapshot) {
+		data, err := json.Marshal(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("outer.json", snapshot{Label: "outer", CgroupMode: "unified", GOMAXPROCS: 2, HasVisibleCPULimit: true, MinimumVisibleCPUQuota: 2})
+	write("docker-child.json", snapshot{Label: "child", CgroupMode: "unified", GOMAXPROCS: 20, Errors: []string{"x"}})
+
+	if err := writeSummary(dir); err != nil {
+		t.Fatalf("writeSummary: %v", err)
+	}
+	var doc summaryDoc
+	data, err := os.ReadFile(filepath.Join(dir, "summary.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.OuterForced == nil || doc.DockerChildForced == nil {
+		t.Fatalf("outer/child summary entries missing: %+v", doc)
+	}
+	if doc.OuterForced.GOMAXPROCS != 2 || doc.DockerChildForced.GOMAXPROCS != 20 {
+		t.Errorf("gomaxprocs outer=%d child=%d, want 2/20", doc.OuterForced.GOMAXPROCS, doc.DockerChildForced.GOMAXPROCS)
+	}
+	if doc.DockerChildForced.Errors != 1 {
+		t.Errorf("child errors = %d, want 1", doc.DockerChildForced.Errors)
+	}
+	if doc.DockerChildForced.OuterNamespaceCgroup != "" {
+		t.Errorf("host cgroup should be empty when the file is missing, got %q", doc.DockerChildForced.OuterNamespaceCgroup)
+	}
+}
+
+func TestWithin(t *testing.T) {
+	cases := []struct {
+		path, point string
+		want        bool
+	}{
+		{"/a", "/", true}, // root mount point: the case the old prefix check missed
+		{"/", "/", true},
+		{"/a/b", "/a", true},
+		{"/a", "/a", true},
+		{"/ab", "/a", false},  // shared prefix but not a subpath
+		{"/a", "/a/b", false}, // path is above the point
+	}
+	for _, c := range cases {
+		if got := within(c.path, c.point); got != c.want {
+			t.Errorf("within(%q, %q) = %v, want %v", c.path, c.point, got, c.want)
+		}
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/experiment/krte-cgroup-contract/verify.sh
+++ b/experiment/krte-cgroup-contract/verify.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# One-shot KRTE cgroup topology snapshot. Records four layers (outer wrapper,
+# dockerd, an ordinary Docker child, and a kind node with a control-plane
+# process) so #37775 can decide the fix. It is a collector, not a contract:
+# it fails closed if a promised layer cannot run, but it does not assert a
+# topology, because the expected topology is exactly what this run establishes.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+artifacts="${ARTIFACTS:-/tmp/krte-cgroup-contract}"
+mkdir -p "${artifacts}"
+tmp="$(mktemp -d)"
+probe="${tmp}/probe"
+container="krte-cgroup-contract-${RANDOM}-$$"
+kind_name="krte-contract"
+forced="GODEBUG=containermaxprocs=1,updatemaxprocs=1"
+
+cleanup() {
+  kind delete cluster --name "${kind_name}" >/dev/null 2>&1 || true
+  docker rm -f "${container}" >/dev/null 2>&1 || true
+  rm -rf "${tmp}"
+}
+trap cleanup EXIT
+
+log() { echo "[krte-cgroup-contract] $*"; }
+
+# --- provenance: what image and toolchain actually ran -----------------------
+{
+  printf 'krte_image=%s\n' "${KRTE_IMAGE:-unknown}"
+  printf 'kind_version=%s\n' "$(kind version 2>/dev/null || echo unavailable)"
+  printf 'go_version=%s\n' "$(go version 2>/dev/null || echo unavailable)"
+} >"${artifacts}/provenance.txt"
+
+# --- build the probe ---------------------------------------------------------
+CGO_ENABLED=0 go build -trimpath -o "${probe}" .
+
+# --- layer 1: outer wrapper command, default and forced ----------------------
+"${probe}" -label=outer-default -output="${artifacts}/outer-default.json"
+env "${forced}" "${probe}" -label=outer -output="${artifacts}/outer.json"
+cat /proc/self/cgroup >"${artifacts}/outer.cgroup"
+cat /proc/self/mountinfo >"${artifacts}/outer.mountinfo"
+
+# --- layer 2: dockerd's own cgroup (why children land where they do) ---------
+if dockerd_pid="$(pidof dockerd | awk '{print $1}')" && [[ -n "${dockerd_pid}" ]]; then
+  cat "/proc/${dockerd_pid}/cgroup" >"${artifacts}/dockerd-from-outer.cgroup" 2>/dev/null || true
+  for ns in cgroup mnt pid; do
+    printf '%s=%s\n' "${ns}" "$(readlink "/proc/${dockerd_pid}/ns/${ns}" 2>/dev/null || echo unknown)"
+  done >"${artifacts}/dockerd.ns"
+else
+  log "dockerd pid not found; skipping dockerd cgroup capture"
+fi
+
+# --- layer 3: an ordinary nested Docker child, fail closed -------------------
+# The probe was built to ${tmp}/probe, which is the build context, so the
+# scratch image can COPY it directly.
+cat >"${tmp}/Dockerfile" <<'DOCKERFILE'
+FROM scratch
+COPY probe /probe
+ENTRYPOINT ["/probe"]
+DOCKERFILE
+timeout 3m docker build --pull=false -t krte-cgroup-contract:local "${tmp}"
+
+# Detached, no --rm: the cleanup trap removes it, and keeping it lets us read
+# the exit code and logs when the probe fails.
+cid="$(docker run --detach \
+  --name "${container}" \
+  --volume "${artifacts}:/artifacts" \
+  --env "${forced}" \
+  krte-cgroup-contract:local \
+  -label=docker-child -output=/artifacts/docker-child.json -hold=30s)"
+
+for _ in $(seq 1 100); do
+  [[ -s "${artifacts}/docker-child.json" ]] && break
+  if [[ "$(docker inspect --format '{{.State.Running}}' "${cid}")" != "true" ]]; then
+    break
+  fi
+  sleep 0.1
+done
+
+docker logs "${cid}" >"${artifacts}/docker-child.log" 2>&1 || true
+if [[ ! -s "${artifacts}/docker-child.json" ]]; then
+  child_rc="$(docker inspect --format '{{.State.ExitCode}}' "${cid}" 2>/dev/null || echo unknown)"
+  log "docker child produced no snapshot (exit ${child_rc}); see docker-child.log"
+  exit 1
+fi
+
+# A second child with no forced GODEBUG shows the default runtime behavior.
+docker run --rm --volume "${artifacts}:/artifacts" \
+  krte-cgroup-contract:local \
+  -label=docker-child-default -output=/artifacts/docker-child-default.json >/dev/null
+
+# host-side view of the child cgroup, and only the Docker fields we compare
+pid="$(docker inspect --format '{{.State.Pid}}' "${cid}")"
+cat "/proc/${pid}/cgroup" >"${artifacts}/docker-child-from-outer.cgroup"
+{
+  printf 'server_version=%s\n' "$(timeout 30s docker info --format '{{.ServerVersion}}')"
+  printf 'cgroup_driver=%s\n' "$(timeout 30s docker info --format '{{.CgroupDriver}}')"
+  printf 'cgroup_version=%s\n' "$(timeout 30s docker info --format '{{.CgroupVersion}}')"
+} >"${artifacts}/docker-info.txt"
+docker inspect --format '{{json .State}}' "${cid}" >"${artifacts}/docker-child-state.json"
+docker inspect --format '{{.HostConfig.CgroupParent}}' "${cid}" >"${artifacts}/docker-child-cgroup-parent.txt"
+docker inspect --format '{{.HostConfig.CgroupnsMode}}' "${cid}" >"${artifacts}/docker-child-cgroupns-mode.txt"
+
+child_rc="$(docker wait "${cid}")"
+if [[ "${child_rc}" != "0" ]]; then
+  log "docker child probe exited ${child_rc}; see docker-child.log"
+  exit 1
+fi
+
+# --- layer 4: a kind node and one Go control-plane process -------------------
+# In a real KRTE presubmit dockerd is already up. A missing or unhealthy kind
+# means this layer did not run, so capture the log and then fail rather than
+# report a green run that skipped it.
+command -v kind >/dev/null || { log "kind binary is required for the kind-node layer"; exit 1; }
+if timeout 10m kind create cluster --name "${kind_name}" --wait 3m >"${artifacts}/kind-create.log" 2>&1; then
+  node="$(docker ps --filter "name=${kind_name}-control-plane" --format '{{.ID}}' | head -1)"
+  if [[ -n "${node}" ]]; then
+    docker cp "${probe}" "${node}:/probe"
+    # A Go process in the node: what GOMAXPROCS it is handed. This is the
+    # environmental default the probe observes, not a running component's value.
+    docker exec "${node}" /probe -label=kind-node-go >"${artifacts}/kind-node-go.json" 2>&1 || true
+    if [[ ! -s "${artifacts}/kind-node-go.json" ]]; then
+      log "kind node probe produced no snapshot; see kind-node-go.json"
+      exit 1
+    fi
+    docker exec "${node}" sh -c 'c=$(awk -F: "\$1==0{print \$3}" /proc/1/cgroup); \
+      printf "pid1_comm=%s\npid1_cgroup=%s\npid1_cpu_max=%s\n" \
+      "$(cat /proc/1/comm)" "${c}" "$(cat /sys/fs/cgroup${c}/cpu.max 2>/dev/null || echo absent)"' \
+      >"${artifacts}/kind-node-pid1.txt" 2>&1 || true
+    api="$(docker exec "${node}" sh -c 'pidof kube-apiserver 2>/dev/null | tr " " "\n" | head -1' || true)"
+    if [[ -n "${api}" ]]; then
+      docker exec "${node}" sh -c "c=\$(awk -F: '\$1==0{print \$3}' /proc/${api}/cgroup); \
+        printf 'apiserver_cgroup=%s\napiserver_leaf_cpu_max=%s\n' \
+        \"\${c}\" \"\$(cat /sys/fs/cgroup\${c}/cpu.max 2>/dev/null || echo absent)\"" \
+        >"${artifacts}/kind-apiserver.txt" 2>&1 || true
+    else
+      log "no kube-apiserver process found in the node"
+    fi
+  else
+    log "kind reported success but no control-plane node was found"
+    exit 1
+  fi
+else
+  log "kind cluster did not come up; see kind-create.log"
+  exit 1
+fi
+
+# --- summary of the two directly comparable snapshots ------------------------
+"${probe}" -summarize "${artifacts}"
+log "artifacts in ${artifacts}"


### PR DESCRIPTION
#37733 fixed the CPU quota visibility bug in the bootstrap/kubekins init leaf. KRTE uses a different wrapper, so this measures its real Prow topology before any behavior change.

The optional presubmit runs a small Go probe as the outer wrapper.sh command and again in a nested Docker container, and records the visible cgroup chain, cpu.max, effective cpuset, NumCPU/GOMAXPROCS, the child's host-side cgroup, and docker info. It changes no cgroup placement or Docker config; the output decides whether KRTE needs the init/dind delegation, a per-container CPU limit, or no change.

xref #37775

/sig testing
/kind cleanup
/cc @aojea @BenTheElder
