### PR TITLE
Add Kueue WAS e2e presubmit for Kubernetes 1.37

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -2059,6 +2059,46 @@ presubmits:
               limits:
                 cpu: "7"
                 memory: "10Gi"
+    - name: pull-kueue-test-e2e-was-main-1-37
+      cluster: eks-prow-build-cluster
+      optional: true
+      always_run: false
+      branches:
+        - ^main
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        pod_unscheduled_timeout: 10m
+      path_alias: sigs.k8s.io/kueue
+      annotations:
+        testgrid-dashboards: sig-scheduling
+        testgrid-tab-name: pull-kueue-test-e2e-was-main-1-37
+        description: "Run kueue WAS end to end tests for Kubernetes 1.37"
+      labels:
+        preset-dind-enabled: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260622-537e33cc05-master
+            env:
+              - name: E2E_K8S_VERSION
+                value: "1.37"
+              - name: BASE_BUILDER_IMAGE
+                value: public.ecr.aws/docker/library/golang
+            command:
+              - runner.sh
+            args:
+              - make
+              - kind-image-build
+              - test-e2e-was
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "7"
+                memory: "10Gi"
+              limits:
+                cpu: "7"
+                memory: "10Gi"
     - name: pull-kueue-test-large-scale-scheduling-perf-main
       cluster: eks-prow-build-cluster
       optional: true


### PR DESCRIPTION
Adds an optional presubmit that runs Kueue's pinned WAS e2e lane against Kubernetes 1.37 via `make test-e2e-was` (kubernetes-sigs/kueue#14910).

It mirrors the existing k/k-main WAS presubmit, with the new make target and `E2E_K8S_VERSION=1.37`.

Part of kubernetes-sigs/kueue#13728.