### PR TITLE
Disable gpu presubmits for dra-driver-nvidia-gpu

### DIFF
--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/OWNERS
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/OWNERS
@@ -1,0 +1,19 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+# Synced to the OWNERS file in sigs.k8s.io/dra-driver-nvidia-gpu as of 08/31/26
+
+reviewers:
+  - klueska
+  - shivamerla
+  - dims
+  - cdesiniotis
+  - guptaNswati
+  - tariq1890
+  - varunrsekar
+  - shengnuo
+  - visheshtanksale
+
+approvers:
+  - dims
+  - shivamerla
+  - varunrsekar
+  - klueska

--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-gcp-nvkind.yaml
@@ -13,7 +13,9 @@ presubmits:
     job_queue_name: gce-gpu-test
     optional: true
     always_run: false
-    run_if_changed: '^(api/|cmd/|deployments/|hack/|scripts/|internal/|pkg/|templates/|test/|tests/|vendor/|.*\.go$|go\.mod$|go\.sum$|Makefile$|common\.mk$|versions\.mk$|VERSION$)'
+# Disable `run_if_changed` trigger so that this only runs on demand.
+# This is done temporarily to address the increased CI pressure by high volume of PRs.
+#   run_if_changed: '^(api/|cmd/|deployments/|hack/|scripts/|internal/|pkg/|templates/|test/|tests/|vendor/|.*\.go$|go\.mod$|go\.sum$|Makefile$|common\.mk$|versions\.mk$|VERSION$)'
     max_concurrency: 1
     branches:
     - ^main$

--- a/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
+++ b/config/jobs/kubernetes-sigs/dra-driver-nvidia-gpu/dra-driver-nvidia-gpu-lambda.yaml
@@ -19,7 +19,9 @@ presubmits:
     cluster: k8s-infra-prow-build
     optional: true
     always_run: false
-    run_if_changed: '^(api/|cmd/|deployments/|hack/|scripts/|internal/|pkg/|templates/|test/|tests/|vendor/|.*\.go$|go\.mod$|go\.sum$|Makefile$|common\.mk$|versions\.mk$|VERSION$)'
+# Disable `run_if_changed` trigger so that this only runs on demand.
+# This is done temporarily to address the increased CI pressure by high volume of PRs.
+#   run_if_changed: '^(api/|cmd/|deployments/|hack/|scripts/|internal/|pkg/|templates/|test/|tests/|vendor/|.*\.go$|go\.mod$|go\.sum$|Makefile$|common\.mk$|versions\.mk$|VERSION$)'
     max_concurrency: 1
     branches:
     - ^main$


### PR DESCRIPTION
* Added OWNERS file
* Commented out the `run_if_changed` trigger so that the job doesnt run automatically (both `always_run` and `run_before_merge` are already `false`)
  * We're doing this temporarily to address the increased CI pressure due to a high volume of PRs.
  * We'll revisit this setting next year when the GCP budget is renewed.