### PR TITLE
kubespray: use default image-builder target

### DIFF
--- a/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
@@ -53,7 +53,7 @@ presubmits:
           apt-get install -y --no-install-recommends qemu-utils
           python3 -m pip install --no-cache-dir --break-system-packages ansible-core
           ansible-galaxy collection install community.general -p /usr/share/ansible/collections
-          make -C test-infra/image-builder validate-single-docker image_name=ubuntu-2404
+          make -C test-infra/image-builder validate-single-docker
 
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
/kind cleanup

## What this PR does / why we need it

The Kubespray `validate-single-docker` target now defaults to `ubuntu-2404`.
Remove the redundant `image_name=ubuntu-2404` argument from the Prow job.

Depends on kubernetes-sigs/kubespray#13445.
Related issue: kubernetes-sigs/kubespray#13444.

## Test

- `go test ./config/tests/jobs`
- `make verify-yamllint`

## Special notes for your reviewer

This PR was written in part with the assistance of generative AI.
