### PR TITLE
Fix --focus of group snapshot tests

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -103,7 +103,7 @@ presubmits:
         - --gcp-node-image=gci
         - --gcp-zone=us-central1-b
         - --provider=gce
-        - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\]\|\[Feature:VolumeGroupSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
+        - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\]|\[Feature:VolumeGroupSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
         - --timeout=150m
         securityContext:
           privileged: true
@@ -348,7 +348,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-central1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\]\|\[Feature:VolumeGroupSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\]|\[Feature:VolumeGroupSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m
       resources:
         requests:


### PR DESCRIPTION
Do not escape `|` in a `--focus`.

See [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/141738/pull-kubernetes-e2e-gce-storage-snapshot/2094690657095389184), no tests actually ran with `\|`. 

Broken by https://github.com/kubernetes/test-infra/pull/37700