### PR TITLE
Add yankay to LWS job OWNERS

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/OWNERS
+++ b/config/jobs/kubernetes-sigs/lws/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - ahg-g
 - Edwinhr716
 - kerthcet
+- yankay
 
 emeritus_approvers:
 - liurupeng


### PR DESCRIPTION
Add `yankay` as an approver for LWS Prow job configs, matching the approver role in the [upstream LWS OWNERS file](https://github.com/kubernetes-sigs/lws/blob/main/OWNERS).

/sig apps

## Testing

- `yamllint -c config/jobs/.yamllint.conf config/jobs/kubernetes-sigs/lws/OWNERS`

## Special notes for your reviewer

This PR was written in part with the assistance of generative AI.