### PR TITLE
triage: support filtering failures by date range

### DIFF
--- a/triage/README.md
+++ b/triage/README.md
@@ -37,6 +37,8 @@ The web page can be accessed at https://go.k8s.io/triage with the following opti
 - `Show clusters for SIG`: filter results by the SIG assigned to the majority of the tests; allows multi-select
 - `Include results from`: toggle between CI tests, PR tests, or both
 - `Sort by`: basic sorting
+- `Only show failures started between`: only count builds that started within the given date
+  range (inclusive); useful for hiding failures that were already fixed before a given date
 - `Include filter`/`Exclude filter`: advanced regex filtering by field
 
 Note that the clusters at the top of the web page are static, and must be added/removed manually.

--- a/triage/index.html
+++ b/triage/index.html
@@ -47,6 +47,10 @@ Sort by
 <label><input name="sort" type="radio" value="message">error message</label>
 <br>
 <label style="display:none"><input type="checkbox" id="show-normalize">Display normalized errors</label><br>
+Only show failures started between
+<input type="date" id="min-date"> and
+<input type="date" id="max-date"> (inclusive)
+<br>
 <table>
 <tr>
 <td>

--- a/triage/interactive.js
+++ b/triage/interactive.js
@@ -50,6 +50,8 @@ function readOptions() {
     date: read('date'),
     ci: read('job-ci'),
     pr: read('job-pr'),
+    minDate: read('min-date'),
+    maxDate: read('max-date'),
     reText: read('filter-include-text'),
     reJob: read('filter-include-job'),
     reTest: read('filter-include-test'),
@@ -67,6 +69,8 @@ function readOptions() {
   if (opts.date) url += '&date=' + opts.date;
   if (!opts.ci) url += '&ci=0';
   if (opts.pr) url += '&pr=1';
+  if (opts.minDate) url += '&mindate=' + opts.minDate;
+  if (opts.maxDate) url += '&maxdate=' + opts.maxDate;
   if (opts.sig.length) url += '&sig=' + opts.sig.join(',');
   for (var name of ["text", "job", "test", "repo", "xtext", "xjob", "xtest", "xrepo"]) {
     var re = (name[0] == 'x') ?
@@ -125,6 +129,8 @@ function setOptionsFromURL() {
   write('date', qs.date);
   write('job-ci', qs.ci);
   write('job-pr', qs.pr);
+  write('min-date', qs.mindate);
+  write('max-date', qs.maxdate);
   write('filter-include-text', qs.text);
   write('filter-include-job', qs.job);
   write('filter-include-test', qs.test);

--- a/triage/model.js
+++ b/triage/model.js
@@ -16,6 +16,12 @@ function tsToString(ts) {
   return new Date(ts * 1000).toLocaleString();
 }
 
+// Parse a YYYY-MM-DD date string into a timestamp (in seconds) at local midnight.
+function dateToTs(date) {
+  let [y, m, d] = date.split('-').map(Number);
+  return new Date(y, m - 1, d).getTime() / 1000;
+}
+
 // Store information about individual builds.
 class Builds {
   constructor(dict) {
@@ -209,6 +215,10 @@ class Clusters {
 
   // Return a new Clusters object, with the given filters applied.
   refilter(opts) {
+    // Restrict builds to those started within [minDate, maxDate], inclusive on both ends.
+    var filterDates = Boolean(opts.minDate || opts.maxDate);
+    var minStarted = opts.minDate ? dateToTs(opts.minDate) : 0;
+    var maxStarted = opts.maxDate ? dateToTs(opts.maxDate) + 60 * 60 * 24 : Infinity;
     var out = [];
     for (let cluster of this.data) {
       if ((opts.reText && !opts.reText.test(cluster.text)) ||
@@ -236,6 +246,16 @@ class Clusters {
                 (opts.reXRepo && opts.reXRepo.test(repo))) {
               continue;
             }
+          }
+          if (filterDates) {
+            let buildsOut = job.builds.filter(number => {
+              let build = builds.get(job.name, number);
+              return build && build.started >= minStarted && build.started < maxStarted;
+            });
+            if (buildsOut.length === 0) {
+              continue;
+            }
+            job = Object.assign({}, job, {builds: buildsOut});
           }
           if (job.name.startsWith("pr:")) {
             if (opts.pr) jobsOut.push(job);

--- a/triage/script_test.js
+++ b/triage/script_test.js
@@ -77,4 +77,73 @@ describe('Clusters', () => {
         expect('sorts results by build count', [ham, spam], [spam, ham], {ci: true, sort: 'total'});
         expect('sorts results by message', [first, ham, spam], [ham, spam, first], {ci: true, sort: 'message'});
     });
+
+    describe('refilter by date range', () => {
+        // Timestamp (in seconds) for a local-timezone date, matching dateToTs in model.js.
+        function ts(y, m, d, h, min, s) {
+            return new Date(y, m - 1, d, h || 0, min || 0, s || 0).getTime() / 1000;
+        }
+
+        let savedBuilds;
+        before(function() {
+            savedBuilds = builds;
+            builds = new model.Builds({
+                jobs: {
+                    'early-job': {1: 0, 2: 1},
+                    'late-job': {1: 2, 2: 3},
+                },
+                cols: {
+                    started: [
+                        ts(2026, 7, 10, 12),          // early-job build 1
+                        ts(2026, 7, 14, 23, 59, 59),  // early-job build 2
+                        ts(2026, 7, 15),              // late-job build 1
+                        ts(2026, 7, 20, 12),          // late-job build 2
+                    ],
+                    pr: ['', '', '', ''],
+                },
+                job_paths: {},
+            });
+        });
+        after(function() {
+            builds = savedBuilds;
+        });
+
+        function expect(name, expected, clustered, opts) {
+            it(name, function() {
+                var c = new model.Clusters(clustered);
+                assert.deepEqual(c.refilter(opts).data, expected);
+            });
+        }
+
+        let mixed = {text: 'mixed', key: 'mixed', id: 'abcd', tests: [
+            {name: 'timing', jobs: [
+                {name: 'early-job', builds: [1, 2]},
+                {name: 'late-job', builds: [1, 2]},
+            ]},
+        ]};
+
+        expect('keeps builds started at or after mindate', [
+            {text: 'mixed', key: 'mixed', id: 'abcd', tests: [
+                {name: 'timing', jobs: [{name: 'late-job', builds: [1, 2]}]},
+            ]},
+        ], [mixed], {ci: true, minDate: '2026-07-15'});
+        expect('keeps builds started during the whole maxdate day', [
+            {text: 'mixed', key: 'mixed', id: 'abcd', tests: [
+                {name: 'timing', jobs: [{name: 'early-job', builds: [1, 2]}]},
+            ]},
+        ], [mixed], {ci: true, maxDate: '2026-07-14'});
+        expect('combines mindate and maxdate', [
+            {text: 'mixed', key: 'mixed', id: 'abcd', tests: [
+                {name: 'timing', jobs: [{name: 'late-job', builds: [1]}]},
+            ]},
+        ], [mixed], {ci: true, minDate: '2026-07-15', maxDate: '2026-07-15'});
+        expect('drops clusters with no builds in range', [], [mixed], {ci: true, minDate: '2026-08-01'});
+
+        it('does not modify the original cluster data', function() {
+            var c = new model.Clusters([mixed]);
+            c.refilter({ci: true, minDate: '2026-07-15'});
+            assert.deepEqual(mixed.tests[0].jobs[0].builds, [1, 2]);
+            assert.deepEqual(mixed.tests[0].jobs[1].builds, [1, 2]);
+        });
+    });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a date-range filter to the k8s-triage web UI. Two new date inputs ("Only show failures started between ... and ...") and matching `mindate`/`maxdate` URL parameters restrict all clusters, counts, and graphs to builds whose `started` timestamp falls within the range (inclusive on both ends).

This helps when CI had a known breakage: after the fix lands you can set `mindate` to the fix date and review only the failures that happened afterwards, instead of waiting ~2 weeks for the noise to age out of the window.

Filtering happens per build inside `Clusters.refilter`, mirroring how the existing job/test/text filters rebuild the cluster hierarchy, so failure counts, sparklines and graphs stay consistent automatically. Nothing changes on the data side: the `started` column is already present in the summarizer output. Unit tests cover the range boundaries (the mocha suite in `triage/script_test.js`: 20 existing tests stay green, 5 new ones added).

Example: `?mindate=2026-07-15&job=.*cluster-api.*` shows only failures started on or after July 15.

This PR was written in part with the assistance of generative AI.

**Which issue(s) this PR fixes**:
Fixes #37560

/sig testing
/cc @sbueringer

**Release note**:

```release-note
NONE
```
