### PR TITLE
Update milestone applier for k/website dev-1.38 release branch

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -626,7 +626,7 @@ milestone_applier:
   kubernetes-sigs/boskos:
     master: v1.23
   kubernetes/website:
-    dev-1.37: 1.37
+    dev-1.38: 1.38
   kubernetes/node-problem-detector:
     main: v1.36
     release-1.35: v1.35


### PR DESCRIPTION

Update the k/website milestone applier from `dev-1.37` to `dev-1.38` so PRs against
`dev-1.38` automatically get the 1.38 milestone.

Until this lands, no docs PR for the v1.38 cycle is milestoned.

cc @kubernetes/sig-docs-leads @kubernetes/release-engineering 