### PR TITLE
feat: bump Tempelis image to include `--validate-only` feature

### DIFF
--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -35,7 +35,7 @@ presubmits:
       testgrid-dashboards: sig-contribex-slack-infra
     spec:
       containers:
-      - image: gcr.io/k8s-staging-slack-infra/tempelis:v20260505-4a08de2
+      - image: gcr.io/k8s-staging-slack-infra/tempelis:v20260903-13b20a9
         command:
         - /tempelis
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-tempelis.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-tempelis.yaml
@@ -13,7 +13,7 @@ postsubmits:
       testgrid-dashboards: sig-contribex-slack-infra
     spec:
       containers:
-      - image: gcr.io/k8s-staging-slack-infra/tempelis:v20260505-4a08de2
+      - image: gcr.io/k8s-staging-slack-infra/tempelis:v20260903-13b20a9
         command:
         - /tempelis
         args:


### PR DESCRIPTION
Bumps the `tempelis` image to pick up kubernetes-sigs/slack-infra#85, which adds usergroup member validation to `--validate-only` mode.

/cc @xmudrii @Priyankasaggu11929 