### PR TITLE
jobs(kind): remove dead DOCKER_IN_DOCKER_IPV6_ENABLED config

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -144,9 +144,6 @@ presubmits:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
           value: "true"
-        # enable IPV6 in bootstrap image
-        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-          value: "true"
         # tell kind CI script to use ipv6
         - name: "IP_FAMILY"
           value: "ipv6"
@@ -199,9 +196,6 @@ presubmits:
           value: "true"
         - name: IP_FAMILY
           value: dual
-        # enable IPV6 in bootstrap image
-        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-          value: "true"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -98,9 +98,6 @@ periodics:
         - -c
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
-      # enable IPV6 in bootstrap image
-      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-        value: "true"
       # tell kind CI script to use ipv6
       - name: "IP_FAMILY"
         value: "ipv6"
@@ -181,9 +178,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-test-infra/krte:v20260831-6ed6668adc-master
       env:
-      # enable IPV6 in bootstrap image
-      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-        value: "true"
       # tell kind CI script to use ipv6
       - name: "IP_FAMILY"
         value: "ipv6"


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes 4 unused `DOCKER_IN_DOCKER_IPV6_ENABLED: "true"` environment variable settings from `kind` presubmit and periodic jobs.

Since commit [9def578ff8](https://github.com/kubernetes/test-infra/commit/9def578ff8569455fcff838e70b3efd0a1a71d82) (July 2024), runner images (`krte`, `bootstrap`, `kubekins-e2e-v2`) unconditionally configure IPv6 kernel sysctls and ip6tables whenever DinD is active. No images or test scripts consume this variable anymore, leaving it as dead configuration.

**Which issue(s) this PR fixes**:
Fixes part of #37796 (Phase 1: `kind` jobs)

**Special notes for your reviewer**:
- Category 1 of remediation plan outlined in #37796.
- Job behavior is unchanged; all affected jobs retain their functional IPv6 test configurations (`IP_FAMILY: "ipv6"` / `"dual"`).
