### PR TITLE
test-infra-e2e-k8s.sh: preserve PARALLEL

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -771,7 +771,7 @@ presubmits:
         - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && ../test-infra/hack/ci/test-infra-e2e-k8s.sh
         env:
         - name: LABEL_FILTER
-          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky"
+          value: "Feature: isEmpty && !Slow && !Disruptive && !Flaky && !Serial"
         - name: PARALLEL
           value: "true"
         # we need privileged mode in order to do docker in docker

--- a/hack/ci/test-infra-e2e-k8s.sh
+++ b/hack/ci/test-infra-e2e-k8s.sh
@@ -222,6 +222,12 @@ run_tests() {
   LABEL_FILTER="${LABEL_FILTER:-}"
   FOCUS="${FOCUS:-}"
 
+  # Jobs could also set GINKGO_PARALLEL directly,
+  # but let's preserve compatibility with the original e2e-k8s.sh script.
+  if [ "${PARALLEL:-false}" = "true" ]; then
+    export GINKGO_PARALLEL=y
+  fi
+
   # setting this env prevents ginkgo e2e from trying to run provider setup
   export KUBERNETES_CONFORMANCE_TEST='y'
   # ginkgo can take forever to exit, so we run it in the background and save the


### PR DESCRIPTION
Setting GINKGO_PARALLEL=y was was accidentally removed; only adding the SKIP was meant to be gone.