### PR TITLE
Remove customized-controller branch from etcd-operator jobs

### DIFF
--- a/config/jobs/etcd/etcd-operator-postsubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-postsubmits.yaml
@@ -5,7 +5,6 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
-    - customized-controller
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-operator-postsubmits
@@ -32,7 +31,6 @@ postsubmits:
     cluster: k8s-infra-prow-build
     branches:
     - main
-    - customized-controller
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -64,7 +62,6 @@ postsubmits:
     cluster: eks-prow-build-cluster
     branches:
     - main
-    - customized-controller
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-operator-postsubmits

--- a/config/jobs/etcd/etcd-operator-presubmits.yaml
+++ b/config/jobs/etcd/etcd-operator-presubmits.yaml
@@ -6,7 +6,6 @@ presubmits:
     always_run: true
     branches:
     - main
-    - customized-controller
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-operator-presubmits
@@ -34,7 +33,6 @@ presubmits:
     always_run: true
     branches:
     - main
-    - customized-controller
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -66,7 +64,6 @@ presubmits:
     always_run: true
     branches:
     - main
-    - customized-controller
     decorate: true
     annotations:
       testgrid-dashboards: sig-etcd-operator-presubmits


### PR DESCRIPTION
This PR will remove `customized-controller` from the branches list in all presubmit and postsubmit jobs for etcd-io/etcd-operator.
- config/jobs/etcd/etcd-operator-presubmits.yaml
- config/jobs/etcd/etcd-operator-postsubmits.yaml

The `customized-controller` integration branch  has been merged back into main via [etcd-io/etcd-operator#464](https://github.com/etcd-io/etcd-operator/pull/464), so it no longer needs separate CI coverage.


cc @ahrtr @ivanvc 