### PR TITLE
scheduler-plugins: bump go version to 1.26

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits-master.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         command:
         - make
         args:
@@ -31,7 +31,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         command:
         - make
         args:
@@ -52,7 +52,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         command:
         - make
         args:
@@ -73,7 +73,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.25
+      - image: public.ecr.aws/docker/library/golang:1.26
         command:
         - make
         args:


### PR DESCRIPTION
Bump go version to 1.26 to align with k8s 1.35+.

/cc @tenzen-y could you help /lgtm?