### PR TITLE
update e2e tests to golang 1.27

### DIFF
--- a/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml
@@ -56,7 +56,7 @@ periodics:
     decorate: true
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.26
+      - image: public.ecr.aws/docker/library/golang:1.27
         command:
         - make
         args:
@@ -92,7 +92,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.34.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.26
+              value: public.ecr.aws/docker/library/golang:1.27
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -132,7 +132,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.35.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.26
+              value: public.ecr.aws/docker/library/golang:1.27
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -212,7 +212,7 @@ periodics:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.37.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.26
+              value: public.ecr.aws/docker/library/golang:1.27
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
+++ b/config/jobs/kubernetes-sigs/jobset/jobset-presubmit-main.yaml
@@ -47,7 +47,7 @@ presubmits:
       description: "Run jobset integration tests"
     spec:
       containers:
-      - image: public.ecr.aws/docker/library/golang:1.26
+      - image: public.ecr.aws/docker/library/golang:1.27
         command:
         - make
         args:
@@ -79,7 +79,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.34.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.26
+              value: public.ecr.aws/docker/library/golang:1.27
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -116,7 +116,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.35.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.26
+              value: public.ecr.aws/docker/library/golang:1.27
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -153,7 +153,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.36.1
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.26
+              value: public.ecr.aws/docker/library/golang:1.27
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -190,7 +190,7 @@ presubmits:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.37.0
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.26
+              value: public.ecr.aws/docker/library/golang:1.27
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -226,7 +226,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260907-7013e6a654-master
           env:
             - name: BUILDER_IMAGE
-              value: public.ecr.aws/docker/library/golang:1.26
+              value: public.ecr.aws/docker/library/golang:1.27
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh


### PR DESCRIPTION
Update jobset e2e tests to 1.27 golang.

Fixes failures in https://github.com/kubernetes-sigs/jobset/pull/1328