### PR TITLE
Add kubelet to KUBE_CGO_OVERRIDES in source-built race jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -183,7 +183,7 @@ presubmits:
         # Normally control plane components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -288,7 +288,7 @@ presubmits:
         # Normally control plane components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -187,7 +187,7 @@ presubmits:
         # Normally control plane components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -293,7 +293,7 @@ presubmits:
         # Normally control plane components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -404,7 +404,7 @@ periodics:
       # Normally control plane components are linked statically, which does not work with -race (needs CGO).
       # We need to override the default for components of interest.
       - name: KUBE_CGO_OVERRIDES
-        value: kube-apiserver kube-controller-manager kube-scheduler
+        value: kube-apiserver kube-controller-manager kube-scheduler kubelet
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -684,7 +684,7 @@ presubmits:
         # Normally control plane components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
Addresses kubernetes/kubernetes issue 141942

kubernetes/kubernetes PR 135870 makes kubelet a static binary, so
`-race` can't instrument it there anymore. Add `kubelet` to
`KUBE_CGO_OVERRIDES` in the jobs that build it from source:
dra-presubmit, dra-canary, kind CI, kind presubmits.

`dra-ci` and the release-branch version-skew jobs are unaffected
(they run a downloaded kubelet), so left as is.

Test plan:
- `go test ./config/tests/jobs/...` and `./config/tests/lint/...` pass

/sig node
/sig testing
/kind cleanup