### PR TITLE
Keep kubelet race instrumentation once kubelet builds static

### DIFF
--- a/config/jobs/kubernetes/sig-node/dra-canary.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-canary.yaml
@@ -180,10 +180,10 @@ presubmits:
         # -race gets injected into the build of dynamically linked binaries during "kind build node-image" and "make e2e.test".
         - name: KUBE_RACE
           value: -race
-        # Normally control plane components are linked statically, which does not work with -race (needs CGO).
+        # Normally these components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -285,10 +285,10 @@ presubmits:
         # -race gets injected into the build of dynamically linked binaries during "kind build node-image" and "make e2e.test".
         - name: KUBE_RACE
           value: -race
-        # Normally control plane components are linked statically, which does not work with -race (needs CGO).
+        # Normally these components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-node/dra-ci.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-ci.yaml
@@ -185,10 +185,10 @@ periodics:
         # -race gets injected into the build of dynamically linked binaries during "kind build node-image" and "make e2e.test".
         - name: KUBE_RACE
           value: -race
-        # Normally control plane components are linked statically, which does not work with -race (needs CGO).
+        # Normally these components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/dra-presubmit.yaml
@@ -184,10 +184,10 @@ presubmits:
         # -race gets injected into the build of dynamically linked binaries during "kind build node-image" and "make e2e.test".
         - name: KUBE_RACE
           value: -race
-        # Normally control plane components are linked statically, which does not work with -race (needs CGO).
+        # Normally these components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -290,10 +290,10 @@ presubmits:
         # -race gets injected into the build of dynamically linked binaries during "kind build node-image" and "make e2e.test".
         - name: KUBE_RACE
           value: -race
-        # Normally control plane components are linked statically, which does not work with -race (needs CGO).
+        # Normally these components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-node/dra.jinja
+++ b/config/jobs/kubernetes/sig-node/dra.jinja
@@ -298,10 +298,10 @@ presubmits:
         # -race gets injected into the build of dynamically linked binaries during "kind build node-image" and "make e2e.test".
         - name: KUBE_RACE
           value: -race
-        # Normally control plane components are linked statically, which does not work with -race (needs CGO).
+        # Normally these components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         {%- endif %}
         {%- endif %}
         {%- if use_dind %}

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-ci.yaml
@@ -401,10 +401,10 @@ periodics:
       # -race gets injected into the build of dynamically linked binaries during "kind build node-image".
       - name: KUBE_RACE
         value: -race
-      # Normally control plane components are linked statically, which does not work with -race (needs CGO).
+      # Normally these components are linked statically, which does not work with -race (needs CGO).
       # We need to override the default for components of interest.
       - name: KUBE_CGO_OVERRIDES
-        value: kube-apiserver kube-controller-manager kube-scheduler
+        value: kube-apiserver kube-controller-manager kube-scheduler kubelet
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -681,10 +681,10 @@ presubmits:
         # -race gets injected into the build of dynamically linked binaries during "kind build node-image".
         - name: KUBE_RACE
           value: -race
-        # Normally control plane components are linked statically, which does not work with -race (needs CGO).
+        # Normally these components are linked statically, which does not work with -race (needs CGO).
         # We need to override the default for components of interest.
         - name: KUBE_CGO_OVERRIDES
-          value: kube-apiserver kube-controller-manager kube-scheduler
+          value: kube-apiserver kube-controller-manager kube-scheduler kubelet
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
`hack/lib/golang.sh` appends `KUBE_RACE` only to the non-static and `.test` groups, and `-race` needs cgo, so a kubelet in `KUBE_STATIC_BINARIES` cannot carry race instrumentation at all. kubernetes/kubernetes#135870 adds kubelet to that list.

These jobs already override the components they care about for that exact reason. kubelet was absent only because it was still dynamically linked, so the current value works right up until that PR merges and then stops covering the component the DRA jobs are testing. `e2e.test` keeps its instrumentation either way, so nothing fails to signal the gap.

Exercising `kube::golang::is_statically_linked` with #135870 applied and the value these jobs set today:

```
KUBE_CGO_OVERRIDES='kube-apiserver kube-controller-manager kube-scheduler'
  cmd/kubelet         -> static     (CGO=0, no -race)
  cmd/kube-apiserver  -> non-static (CGO=1, gets -race)
```

Adding `kubelet` puts it back in the non-static group. The override is a no-op until #135870 merges, since kubelet is built non-static today either way.

On scope: the jobs that build kubelet from source are `dra-presubmit` and `dra-canary`, which set `kind_node_source=.`, plus the kind CI and presubmit jobs going through `e2e-k8s.sh`. `dra-ci` points `kind_node_source` at a `dl.k8s.io` tarball and downloads `e2e.test`, so its `KUBE_RACE` and `KUBE_CGO_OVERRIDES` have nothing to act on. It changes here only because it shares the template. Version-skew jobs swap in a downloaded kubelet after the build and are unaffected.

The comment above each override said "control plane components", which stopped being accurate once kubelet joined the list, so it now reads "these components".

`make generate-jobs` regenerated the three DRA files and `--verify` passes.

Ref: kubernetes/kubernetes#141942

/cc @pohly @bart0sh
/sig node
/sig testing
