### PR TITLE
kubernetes-sigs/kubernetes-mixin: use squash merge method

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -883,6 +883,7 @@ tide:
     kubernetes-sigs/kro: rebase
     kubernetes-sigs/kube-agentic-networking: squash
     kubernetes-sigs/kube-agents: squash
+    kubernetes-sigs/kubernetes-mixin: squash
     kubernetes-sigs/kubespray: squash
     kubernetes-sigs/kueue: squash
     kubernetes-sigs/lws: squash


### PR DESCRIPTION
Fixes failing CI check: `tide — Not mergeable. Merge type "merge" disallowed by repo settings`, for example:

- https://github.com/kubernetes-sigs/kubernetes-mixin/pull/1286