### PR TITLE
enforce AIL labels on Gateway API repo

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -736,6 +736,8 @@ tide:
     # repos with custom tide queries below
     - kubernetes-sigs/cloud-provider-azure
     - kubernetes-sigs/cluster-api
+    - kubernetes-sigs/gateway-api
+    - kubernetes-sigs/gateway-api-conformance-images
     - kubernetes/autoscaler
     labels:
     - lgtm
@@ -864,6 +866,23 @@ tide:
     - do-not-merge/release-note-label-needed
     - do-not-merge/work-in-progress
     - do-not-merge/needs-area
+  - repos:
+    - kubernetes-sigs/gateway-api
+    - kubernetes-sigs/gateway-api-conformance-images
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-ail
   merge_method:
     kubernetes-client/csharp: squash
     kubernetes-client/gen: squash

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1176,6 +1176,17 @@ require_matching_label:
   issues: true
   prs: true
   regexp: ^priority/
+- missing_label: needs-ail
+  org: kubernetes-sigs
+  repo: gateway-api
+  issues: true
+  prs: true
+  regexp: ^ail/[0-5]$
+  missing_comment: |
+    Gateway API requires that contributors are explicit about AI usage
+
+    Please define your AI usage level for this Pull Request, following the guidelines on AI-POLICY.md
+    and setting the proper AI level usage with the command `/label ail/<level>` (from 0 to 5)
 - missing_label: needs-triage
   org: kubernetes-sigs
   repo: metrics-server


### PR DESCRIPTION
Gateway API is enforcing the disclosure of AI level usage on PRs.

This means that members of the org must use the command "/label ail/<level>" to add a proper label, while non-members must disclose on their PR so reviewers can add the label.

This PR initially enforces this behavior on k-sigs/gateway-api and we will be adding it to other child repositories later.