### PR TITLE
robots/commenter: allow authentication as GitHub App, maintaining backwards compatibilty

### DIFF
--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -78,6 +78,7 @@ func flagOptions() options {
 	flag.Var(&o.endpoint, "endpoint", "Deprecated: prefer --github-endpoint. GitHub's API endpoint.")
 	flag.StringVar(&o.graphqlEndpoint, "graphql-endpoint", github.DefaultGraphQLEndpoint, "Deprecated: prefer --github-graphql-endpoint. GitHub's GraphQL API endpoint.")
 	flag.StringVar(&o.token, "token", "", "Deprecated: prefer --github-token-path or --github-app-id/--github-app-private-key-path. Path to github token.")
+	flag.StringVar(&o.githubOrg, "github-org", "", "GitHub org for search-API routing. Required when --github-app-id is used, ignored when using --token / --github-token-path.")
 	flag.BoolVar(&o.random, "random", false, "Choose random issues to comment on from the query")
 
 	o.ghOpts.AddFlags(flag.CommandLine)
@@ -103,6 +104,7 @@ type options struct {
 	endpoint        flagutil.Strings
 	graphqlEndpoint string
 	token           string
+	githubOrg       string
 	updated         time.Duration
 	confirm         bool
 	random          bool
@@ -163,7 +165,7 @@ func makeQuery(query string, includeArchived, includeClosed, includeLocked bool,
 
 type client interface {
 	CreateComment(owner, repo string, number int, comment string) error
-	FindIssues(query, sort string, asc bool) ([]github.Issue, error)
+	FindIssuesWithOrg(org, query, sort string, asc bool) ([]github.Issue, error)
 	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
 }
 
@@ -200,6 +202,11 @@ func main() {
 		err error
 	)
 	if useGHOpts {
+		if o.ghOpts.AppID != "" || o.ghOpts.AppPrivateKeyPath != "" {
+			if o.githubOrg == "" {
+				log.Fatal("--github-org is required when authenticating as a GitHub App")
+			}
+		}
 		if err := o.ghOpts.Validate(!o.confirm); err != nil {
 			log.Fatalf("Invalid --github-* flags: %v", err)
 		}
@@ -239,7 +246,7 @@ func main() {
 		asc = true
 	}
 	commenter := makeCommenter(o.comment, o.useTemplate)
-	if err := run(c, query, sort, asc, o.random, commenter, o.ceiling); err != nil {
+	if err := run(c, o.githubOrg, query, sort, asc, o.random, commenter, o.ceiling); err != nil {
 		log.Fatalf("Failed run: %v", err)
 	}
 }
@@ -258,9 +265,11 @@ func makeCommenter(comment string, useTemplate bool) func(meta) (string, error) 
 	}
 }
 
-func run(c client, query, sort string, asc, random bool, commenter func(meta) (string, error), ceiling int) error {
+func run(c client, org, query, sort string, asc, random bool, commenter func(meta) (string, error), ceiling int) error {
 	log.Printf("Searching: %s", query)
-	issues, err := c.FindIssues(query, sort, asc)
+	// org="" preserves FindIssues(WithoutOrg) behavior. When using GitHub Apps
+	// org is required so the search hits the correct installation.
+	issues, err := c.FindIssuesWithOrg(org, query, sort, asc)
 	if err != nil {
 		return fmt.Errorf("search failed: %w", err)
 	}

--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -75,10 +75,12 @@ func flagOptions() options {
 	flag.StringVar(&o.comment, "comment", "", "Append the following comment to matching issues")
 	flag.BoolVar(&o.useTemplate, "template", false, templateHelp)
 	flag.IntVar(&o.ceiling, "ceiling", 3, "Maximum number of issues to modify, 0 for infinite")
-	flag.Var(&o.endpoint, "endpoint", "GitHub's API endpoint")
-	flag.StringVar(&o.graphqlEndpoint, "graphql-endpoint", github.DefaultGraphQLEndpoint, "GitHub's GraphQL API Endpoint")
-	flag.StringVar(&o.token, "token", "", "Path to github token")
+	flag.Var(&o.endpoint, "endpoint", "Deprecated: prefer --github-endpoint. GitHub's API endpoint.")
+	flag.StringVar(&o.graphqlEndpoint, "graphql-endpoint", github.DefaultGraphQLEndpoint, "Deprecated: prefer --github-graphql-endpoint. GitHub's GraphQL API endpoint.")
+	flag.StringVar(&o.token, "token", "", "Deprecated: prefer --github-token-path or --github-app-id/--github-app-private-key-path. Path to github token.")
 	flag.BoolVar(&o.random, "random", false, "Choose random issues to comment on from the query")
+
+	o.ghOpts.AddFlags(flag.CommandLine)
 	flag.Parse()
 	return o
 }
@@ -104,6 +106,10 @@ type options struct {
 	updated         time.Duration
 	confirm         bool
 	random          bool
+
+	// ghOpts enables GitHub App auth (and the standard --github-* flags)
+	// alongside the legacy --token flow. Either --token OR the ghOpts can be set, not both.
+	ghOpts flagutil.GitHubOptions
 }
 
 func parseHTMLURL(url string) (string, string, int, error) {
@@ -174,33 +180,52 @@ func main() {
 	if o.query == "" {
 		log.Fatal("empty --query")
 	}
-	if o.token == "" {
-		log.Fatal("empty --token")
-	}
 	if o.comment == "" {
 		log.Fatal("empty --comment")
 	}
 
-	if err := secret.Add(o.token); err != nil {
-		log.Fatalf("Error starting secrets agent: %v", err)
+	// Detect whether the caller uses GitHubOptions path by
+	// setting any --github-* auth flag. If not, and --token is also unset,
+	// there is no credential to use.
+	useGHOpts := o.ghOpts.TokenPath != "" || o.ghOpts.AppID != "" || o.ghOpts.AppPrivateKeyPath != ""
+	if o.token == "" && !useGHOpts {
+		log.Fatal("no GitHub credentials: set --token, --github-token-path, or --github-app-id/--github-app-private-key-path")
+	}
+	if o.token != "" && useGHOpts {
+		log.Fatal("either use --token OR --github-token-path / --github-app-* flags, not both at the same time")
 	}
 
-	var err error
-	for _, ep := range o.endpoint.Strings() {
-		_, err = url.ParseRequestURI(ep)
-		if err != nil {
-			log.Fatalf("Invalid --endpoint URL %q: %v.", ep, err)
+	var (
+		c   client
+		err error
+	)
+	if useGHOpts {
+		if err := o.ghOpts.Validate(!o.confirm); err != nil {
+			log.Fatalf("Invalid --github-* flags: %v", err)
 		}
-	}
-
-	var c client
-	if o.confirm {
-		c, err = github.NewClient(secret.GetTokenGenerator(o.token), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
+		c, err = o.ghOpts.GitHubClient(!o.confirm)
+		if err != nil {
+			log.Fatalf("Failed to construct GitHub client: %v", err)
+		}
 	} else {
-		c, err = github.NewDryRunClient(secret.GetTokenGenerator(o.token), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
-	}
-	if err != nil {
-		log.Fatalf("Failed to construct GitHub client: %v", err)
+		if err := secret.Add(o.token); err != nil {
+			log.Fatalf("Error starting secrets agent: %v", err)
+		}
+
+		for _, ep := range o.endpoint.Strings() {
+			if _, err := url.ParseRequestURI(ep); err != nil {
+				log.Fatalf("Invalid --endpoint URL %q: %v.", ep, err)
+			}
+		}
+
+		if o.confirm {
+			c, err = github.NewClient(secret.GetTokenGenerator(o.token), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
+		} else {
+			c, err = github.NewDryRunClient(secret.GetTokenGenerator(o.token), secret.Censor, o.graphqlEndpoint, o.endpoint.Strings()...)
+		}
+		if err != nil {
+			log.Fatalf("Failed to construct GitHub client: %v", err)
+		}
 	}
 
 	query, err := makeQuery(o.query, o.includeArchived, o.includeClosed, o.includeLocked, o.updated)

--- a/robots/commenter/main.go
+++ b/robots/commenter/main.go
@@ -109,8 +109,6 @@ type options struct {
 	confirm         bool
 	random          bool
 
-	// ghOpts enables GitHub App auth (and the standard --github-* flags)
-	// alongside the legacy --token flow. Either --token OR the ghOpts can be set, not both.
 	ghOpts flagutil.GitHubOptions
 }
 
@@ -169,6 +167,30 @@ type client interface {
 	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
 }
 
+type authMode int
+
+const (
+	authLegacyToken authMode = iota
+	authGitHubOptions
+)
+
+func selectAuthMode(o options) (authMode, error) {
+	useGHOpts := o.ghOpts.TokenPath != "" || o.ghOpts.AppID != "" || o.ghOpts.AppPrivateKeyPath != ""
+	switch {
+	case o.token == "" && !useGHOpts:
+		return 0, errors.New("no GitHub credentials: set --token, --github-token-path, or --github-app-id/--github-app-private-key-path")
+	case o.token != "" && useGHOpts:
+		return 0, errors.New("--token is mutually exclusive with --github-token-path / --github-app-* flags")
+	case useGHOpts:
+		if (o.ghOpts.AppID != "" || o.ghOpts.AppPrivateKeyPath != "") && o.githubOrg == "" {
+			return 0, errors.New("--github-org is required when authenticating as a GitHub App")
+		}
+		return authGitHubOptions, nil
+	default:
+		return authLegacyToken, nil
+	}
+}
+
 // normalizeComment makes comment bodies comparable across GitHub round-trips,
 // which can differ in line endings and surrounding whitespace.
 func normalizeComment(s string) string {
@@ -186,27 +208,14 @@ func main() {
 		log.Fatal("empty --comment")
 	}
 
-	// Detect whether the caller uses GitHubOptions path by
-	// setting any --github-* auth flag. If not, and --token is also unset,
-	// there is no credential to use.
-	useGHOpts := o.ghOpts.TokenPath != "" || o.ghOpts.AppID != "" || o.ghOpts.AppPrivateKeyPath != ""
-	if o.token == "" && !useGHOpts {
-		log.Fatal("no GitHub credentials: set --token, --github-token-path, or --github-app-id/--github-app-private-key-path")
-	}
-	if o.token != "" && useGHOpts {
-		log.Fatal("either use --token OR --github-token-path / --github-app-* flags, not both at the same time")
+	mode, err := selectAuthMode(o)
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	var (
-		c   client
-		err error
-	)
-	if useGHOpts {
-		if o.ghOpts.AppID != "" || o.ghOpts.AppPrivateKeyPath != "" {
-			if o.githubOrg == "" {
-				log.Fatal("--github-org is required when authenticating as a GitHub App")
-			}
-		}
+	var c client
+	switch mode {
+	case authGitHubOptions:
 		if err := o.ghOpts.Validate(!o.confirm); err != nil {
 			log.Fatalf("Invalid --github-* flags: %v", err)
 		}
@@ -214,7 +223,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to construct GitHub client: %v", err)
 		}
-	} else {
+	case authLegacyToken:
 		if err := secret.Add(o.token); err != nil {
 			log.Fatalf("Error starting secrets agent: %v", err)
 		}
@@ -267,8 +276,6 @@ func makeCommenter(comment string, useTemplate bool) func(meta) (string, error) 
 
 func run(c client, org, query, sort string, asc, random bool, commenter func(meta) (string, error), ceiling int) error {
 	log.Printf("Searching: %s", query)
-	// org="" preserves FindIssues(WithoutOrg) behavior. When using GitHub Apps
-	// org is required so the search hits the correct installation.
 	issues, err := c.FindIssuesWithOrg(org, query, sort, asc)
 	if err != nil {
 		return fmt.Errorf("search failed: %w", err)

--- a/robots/commenter/main_test.go
+++ b/robots/commenter/main_test.go
@@ -232,7 +232,7 @@ func (c *fakeClient) ListIssueComments(owner, repo string, number int) ([]github
 }
 
 // Fakes searching for issues, using the same signature as github.Client
-func (c *fakeClient) FindIssues(query, sort string, asc bool) ([]github.Issue, error) {
+func (c *fakeClient) FindIssuesWithOrg(org, query, sort string, asc bool) ([]github.Issue, error) {
 	if strings.Contains(query, "error") {
 		return nil, errors.New(query)
 	}
@@ -355,7 +355,7 @@ func TestRun(t *testing.T) {
 	for _, tc := range cases {
 		ignoreSorting := ""
 		ignoreOrder := false
-		err := run(&tc.client, tc.query, ignoreSorting, ignoreOrder, false, makeCommenter(tc.comment, tc.template), tc.ceiling)
+		err := run(&tc.client, "", tc.query, ignoreSorting, ignoreOrder, false, makeCommenter(tc.comment, tc.template), tc.ceiling)
 		if tc.err && err == nil {
 			t.Errorf("%s: failed to received an error", tc.name)
 			continue

--- a/robots/commenter/main_test.go
+++ b/robots/commenter/main_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"sigs.k8s.io/prow/pkg/flagutil"
 	"sigs.k8s.io/prow/pkg/github"
 )
 
@@ -212,6 +213,8 @@ type fakeClient struct {
 	issues   []github.Issue
 	// existingComments maps an issue number to the comments already on it.
 	existingComments map[int][]github.IssueComment
+	// orgSeen captures the org argument passed to FindIssuesWithOrg.
+	orgSeen string
 }
 
 // Fakes Creating a client, using the same signature as github.Client
@@ -233,6 +236,7 @@ func (c *fakeClient) ListIssueComments(owner, repo string, number int) ([]github
 
 // Fakes searching for issues, using the same signature as github.Client
 func (c *fakeClient) FindIssuesWithOrg(org, query, sort string, asc bool) ([]github.Issue, error) {
+	c.orgSeen = org
 	if strings.Contains(query, "error") {
 		return nil, errors.New(query)
 	}
@@ -437,5 +441,87 @@ func TestMakeCommenter(t *testing.T) {
 		if err == nil && tc.err {
 			t.Errorf("%s: failed to raise an exception", tc.name)
 		}
+	}
+}
+
+func TestSelectAuthMode(t *testing.T) {
+	cases := []struct {
+		name     string
+		opts     options
+		expected authMode
+		err      bool
+	}{
+		{
+			name:     "legacy --token",
+			opts:     options{token: "/etc/token"},
+			expected: authLegacyToken,
+		},
+		{
+			name:     "ghOpts token-path",
+			opts:     options{ghOpts: flagutil.GitHubOptions{TokenPath: "/etc/gh-token"}},
+			expected: authGitHubOptions,
+		},
+		{
+			name: "ghOpts app auth with --github-org",
+			opts: options{
+				githubOrg: "kubernetes",
+				ghOpts:    flagutil.GitHubOptions{AppID: "42", AppPrivateKeyPath: "/etc/key"},
+			},
+			expected: authGitHubOptions,
+		},
+		{
+			name: "no credentials errors",
+			opts: options{},
+			err:  true,
+		},
+		{
+			name: "--token with --github-token-path errors",
+			opts: options{
+				token:  "/etc/token",
+				ghOpts: flagutil.GitHubOptions{TokenPath: "/etc/gh-token"},
+			},
+			err: true,
+		},
+		{
+			name: "--token with --github-app-id errors",
+			opts: options{
+				token:     "/etc/token",
+				githubOrg: "kubernetes",
+				ghOpts:    flagutil.GitHubOptions{AppID: "42", AppPrivateKeyPath: "/etc/key"},
+			},
+			err: true,
+		},
+		{
+			name: "app auth without --github-org errors",
+			opts: options{ghOpts: flagutil.GitHubOptions{AppID: "42", AppPrivateKeyPath: "/etc/key"}},
+			err:  true,
+		},
+		{
+			name: "app private-key-path without --github-org errors",
+			opts: options{ghOpts: flagutil.GitHubOptions{AppPrivateKeyPath: "/etc/key"}},
+			err:  true,
+		},
+	}
+	for _, tc := range cases {
+		got, err := selectAuthMode(tc.opts)
+		if err != nil && !tc.err {
+			t.Errorf("%s: unexpected err: %v", tc.name, err)
+		}
+		if err == nil && tc.err {
+			t.Errorf("%s: failed to raise an exception", tc.name)
+		}
+		if err == nil && got != tc.expected {
+			t.Errorf("%s: mode = %v, want %v", tc.name, got, tc.expected)
+		}
+	}
+}
+
+func TestRunPassesOrg(t *testing.T) {
+	fc := &fakeClient{}
+	if err := run(fc, "kubernetes", "hello", "", false, false, makeCommenter("x", false), 0); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if fc.orgSeen != "kubernetes" {
+		t.Errorf("FindIssuesWithOrg received org=%q, want %q", fc.orgSeen, "kubernetes")
 	}
 }


### PR DESCRIPTION
This PR is related to #32805, which is closed as not-planned by prow. Nevertheless I think it would be beneficial.

This PR,
- uses flagutil.GitHubOptions, primarly to provide authentication via GitHub Apps.
- maintains backwards compatibility, no existing setups will break (correct me if im wrong).
- marks the args that are now redundant through GitHubOptions as deprecated (--token, etc. )
- adds some test relating the new behaviour

(AI was used to generate test cases and strings)