### PR TITLE
Update LWS E2E matrix for Kubernetes 1.37

### DIFF
--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -53,37 +53,6 @@ presubmits:
           requests:
             cpu: 3
             memory: 10Gi
-  - name: pull-lws-test-e2e-main-1-33
-    cluster: eks-prow-build-cluster
-    always_run: true
-    decorate: true
-    path_alias: sigs.k8s.io/lws
-    annotations:
-      testgrid-dashboards: sig-apps-lws-presubmits
-      testgrid-tab-name: pull-lws-test-e2e-main-1-33
-      description: "Run lws end to end tests for Kubernetes 1.33"
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260907-7013e6a654-master
-          env:
-            - name: E2E_KIND_VERSION
-              value: kindest/node:v1.33.12
-          command:
-            - runner.sh
-          args:
-            - make
-            - test-e2e
-          securityContext:
-            privileged: true
-          resources:
-            limits:
-              cpu: 3
-              memory: 10Gi
-            requests:
-              cpu: 3
-              memory: 10Gi
   - name: pull-lws-test-e2e-main-1-34
     cluster: eks-prow-build-cluster
     always_run: true
@@ -163,6 +132,37 @@ presubmits:
           env:
             - name: E2E_KIND_VERSION
               value: kindest/node:v1.36.1
+          command:
+            - runner.sh
+          args:
+            - make
+            - test-e2e
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 3
+              memory: 10Gi
+            requests:
+              cpu: 3
+              memory: 10Gi
+  - name: pull-lws-test-e2e-main-1-37
+    cluster: eks-prow-build-cluster
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/lws
+    annotations:
+      testgrid-dashboards: sig-apps-lws-presubmits
+      testgrid-tab-name: pull-lws-test-e2e-main-1-37
+      description: "Run lws end to end tests for Kubernetes 1.37"
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260907-7013e6a654-master
+          env:
+            - name: E2E_KIND_VERSION
+              value: kindest/node:v1.37.0
           command:
             - runner.sh
           args:

--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -131,7 +131,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260907-7013e6a654-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.36.1
+              value: kindest/node:v1.37.0
           command:
             - runner.sh
           args:
@@ -193,7 +193,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260907-7013e6a654-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.36.1
+              value: kindest/node:v1.37.0
           command:
             - runner.sh
           args:
@@ -229,7 +229,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260907-7013e6a654-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.36.1
+              value: kindest/node:v1.37.0
           command:
             - runner.sh
           args:
@@ -265,7 +265,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260907-7013e6a654-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.36.1
+              value: kindest/node:v1.37.0
           command:
             - runner.sh
           args:
@@ -296,7 +296,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260907-7013e6a654-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.36.1
+              value: kindest/node:v1.37.0
           command:
             - runner.sh
           args:

--- a/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml
@@ -131,7 +131,7 @@ presubmits:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20260907-7013e6a654-master
           env:
             - name: E2E_KIND_VERSION
-              value: kindest/node:v1.37.0
+              value: kindest/node:v1.36.1
           command:
             - runner.sh
           args:


### PR DESCRIPTION
## Description

Update the LWS E2E presubmit test matrix for Kubernetes 1.37.

- Remove Kubernetes 1.33 from the E2E matrix.
- Add Kubernetes 1.37 using `kindest/node:v1.37.0`.
- Keep E2E coverage for Kubernetes 1.34 through 1.37.

Related to kubernetes-sigs/lws#1038