### PR TITLE
Update Kueue unit test shard jobs cpu reqs and GOMAXPROCS

### DIFF
--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-main.yaml
@@ -39,10 +39,10 @@ periodics:
             - test
           resources:
             requests:
-              cpu: "2800m"
+              cpu: "3400m"
               memory: "6Gi"
             limits:
-              cpu: "2800m"
+              cpu: "3400m"
               memory: "6Gi"
   - interval: 12h
     name: periodic-kueue-test-unit-shard-1-main
@@ -73,7 +73,7 @@ periodics:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
             - name: GOMAXPROCS
-              value: "2"
+              value: "4"
             - name: UNIT_SHARD_INDEX
               value: "1"
             - name: UNIT_TOTAL_SHARDS
@@ -84,10 +84,10 @@ periodics:
             - test
           resources:
             requests:
-              cpu: "1600m"
+              cpu: "3400m"
               memory: "6Gi"
             limits:
-              cpu: "1600m"
+              cpu: "3400m"
               memory: "6Gi"
   - interval: 24h
     name: periodic-kueue-test-fuzz-main

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-18.yaml
@@ -39,10 +39,10 @@ periodics:
             - test
           resources:
             requests:
-              cpu: "4000m"
+              cpu: "3400m"
               memory: "6Gi"
             limits:
-              cpu: "4000m"
+              cpu: "3400m"
               memory: "6Gi"
   - interval: 12h
     name: periodic-kueue-test-unit-shard-1-release-0-18
@@ -73,7 +73,7 @@ periodics:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
             - name: GOMAXPROCS
-              value: "2"
+              value: "4"
             - name: UNIT_SHARD_INDEX
               value: "1"
             - name: UNIT_TOTAL_SHARDS
@@ -84,10 +84,10 @@ periodics:
             - test
           resources:
             requests:
-              cpu: "1800m"
+              cpu: "3400m"
               memory: "6Gi"
             limits:
-              cpu: "1800m"
+              cpu: "3400m"
               memory: "6Gi"
   - interval: 12h
     name: periodic-kueue-test-integration-shard-0-release-0-18

--- a/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-periodics-release-0-19.yaml
@@ -39,10 +39,10 @@ periodics:
             - test
           resources:
             requests:
-              cpu: "4000m"
+              cpu: "3400m"
               memory: "6Gi"
             limits:
-              cpu: "4000m"
+              cpu: "3400m"
               memory: "6Gi"
   - interval: 12h
     name: periodic-kueue-test-unit-shard-1-release-0-19
@@ -73,7 +73,7 @@ periodics:
             - name: GO_TEST_FLAGS
               value: "-race -count 3"
             - name: GOMAXPROCS
-              value: "2"
+              value: "4"
             - name: UNIT_SHARD_INDEX
               value: "1"
             - name: UNIT_TOTAL_SHARDS
@@ -84,10 +84,10 @@ periodics:
             - test
           resources:
             requests:
-              cpu: "1800m"
+              cpu: "3400m"
               memory: "6Gi"
             limits:
-              cpu: "1800m"
+              cpu: "3400m"
               memory: "6Gi"
   - interval: 24h
     name: periodic-kueue-verify-website-links-release-0-19

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-main.yaml
@@ -32,10 +32,10 @@ presubmits:
               - test
             resources:
               requests:
-                cpu: "4000m"
+                cpu: "3400m"
                 memory: "6Gi"
               limits:
-                cpu: "4000m"
+                cpu: "3400m"
                 memory: "6Gi"
     - name: pull-kueue-test-unit-shard-1-main
       cluster: eks-prow-build-cluster
@@ -58,7 +58,7 @@ presubmits:
               - name: GO_TEST_FLAGS
                 value: "-race -count 3"
               - name: GOMAXPROCS
-                value: "2"
+                value: "4"
               - name: UNIT_SHARD_INDEX
                 value: "1"
               - name: UNIT_TOTAL_SHARDS
@@ -69,10 +69,10 @@ presubmits:
               - test
             resources:
               requests:
-                cpu: "1800m"
+                cpu: "3400m"
                 memory: "6Gi"
               limits:
-                cpu: "1800m"
+                cpu: "3400m"
                 memory: "6Gi"
     - name: pull-kueue-test-fuzz-main
       cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-18.yaml
@@ -32,10 +32,10 @@ presubmits:
               - test
             resources:
               requests:
-                cpu: "4000m"
+                cpu: "3400m"
                 memory: "6Gi"
               limits:
-                cpu: "4000m"
+                cpu: "3400m"
                 memory: "6Gi"
     - name: pull-kueue-test-unit-shard-1-release-0-18
       cluster: eks-prow-build-cluster
@@ -58,7 +58,7 @@ presubmits:
               - name: GO_TEST_FLAGS
                 value: "-race -count 3"
               - name: GOMAXPROCS
-                value: "2"
+                value: "4"
               - name: UNIT_SHARD_INDEX
                 value: "1"
               - name: UNIT_TOTAL_SHARDS
@@ -69,10 +69,10 @@ presubmits:
               - test
             resources:
               requests:
-                cpu: "1800m"
+                cpu: "3400m"
                 memory: "6Gi"
               limits:
-                cpu: "1800m"
+                cpu: "3400m"
                 memory: "6Gi"
     - name: pull-kueue-test-integration-shard-0-release-0-18
       cluster: eks-prow-build-cluster

--- a/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
+++ b/config/jobs/kubernetes-sigs/kueue/kueue-presubmits-release-0-19.yaml
@@ -32,10 +32,10 @@ presubmits:
               - test
             resources:
               requests:
-                cpu: "4000m"
+                cpu: "3400m"
                 memory: "6Gi"
               limits:
-                cpu: "4000m"
+                cpu: "3400m"
                 memory: "6Gi"
     - name: pull-kueue-test-unit-shard-1-release-0-19
       cluster: eks-prow-build-cluster
@@ -58,7 +58,7 @@ presubmits:
               - name: GO_TEST_FLAGS
                 value: "-race -count 3"
               - name: GOMAXPROCS
-                value: "2"
+                value: "4"
               - name: UNIT_SHARD_INDEX
                 value: "1"
               - name: UNIT_TOTAL_SHARDS
@@ -69,10 +69,10 @@ presubmits:
               - test
             resources:
               requests:
-                cpu: "1800m"
+                cpu: "3400m"
                 memory: "6Gi"
               limits:
-                cpu: "1800m"
+                cpu: "3400m"
                 memory: "6Gi"
     - name: pull-kueue-test-integration-shard-0-release-0-19
       cluster: eks-prow-build-cluster


### PR DESCRIPTION
Increase CPU for unit test shard 1 which is now getting long - 15min.

Reduce CPU for shard 0 to align it, but this one is below 10min for now

Fixes https://github.com/kubernetes-sigs/kueue/issues/15498