### PR TITLE
Bump tempelis image to v20260903-13b20a9

### DIFF
--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -35,7 +35,7 @@ presubmits:
       testgrid-dashboards: sig-contribex-slack-infra
     spec:
       containers:
-      - image: gcr.io/k8s-staging-slack-infra/tempelis:v20260505-4a08de2
+      - image: gcr.io/k8s-staging-slack-infra/tempelis:v20260903-13b20a9
         command:
         - /tempelis
         args:

--- a/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-tempelis.yaml
+++ b/config/jobs/kubernetes/sig-k8s-infra/trusted/sig-contribex-tempelis.yaml
@@ -13,7 +13,7 @@ postsubmits:
       testgrid-dashboards: sig-contribex-slack-infra
     spec:
       containers:
-      - image: gcr.io/k8s-staging-slack-infra/tempelis:v20260505-4a08de2
+      - image: gcr.io/k8s-staging-slack-infra/tempelis:v20260903-13b20a9
         command:
         - /tempelis
         args:


### PR DESCRIPTION
Bumps `tempelis` in `pull-community-tempelis-check` and `post-community-tempelis-apply` from `v20260505-4a08de2` to `v20260903-13b20a9`.

The current tag predates kubernetes-sigs/slack-infra#85 (member name validation in `--validate-only`), so kubernetes/community#9083 passed presubmit with an unknown user and failed post-merge. A further bump will follow once kubernetes-sigs/slack-infra#86 (description length and handle/channel collision checks) merges and publishes an image.

/sig contributor-experience
/cc @palnabarun @Priyankasaggu11929 @MadhavJivrajani @kaslin

### AI Disclosure

This PR was written in part with the assistance of generative AI.
