### PR TITLE
release-branch-jobs: raise the 1.34/1.35 kind-dra, -all and -all-slow jobs to 12Gi

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.34.yaml
@@ -215,10 +215,10 @@ periodics:
       resources:
         limits:
           cpu: "2"
-          memory: 6Gi
+          memory: 12Gi
         requests:
           cpu: "2"
-          memory: 6Gi
+          memory: 12Gi
       securityContext:
         privileged: true
 - annotations:
@@ -2009,10 +2009,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -2092,10 +2092,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -2174,10 +2174,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: false

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.35.yaml
@@ -225,10 +225,10 @@ periodics:
       resources:
         limits:
           cpu: "2"
-          memory: 6Gi
+          memory: 12Gi
         requests:
           cpu: "2"
-          memory: 6Gi
+          memory: 12Gi
       securityContext:
         privileged: true
 - annotations:
@@ -2140,10 +2140,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -2224,10 +2224,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -2307,10 +2307,10 @@ presubmits:
         resources:
           limits:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
           requests:
             cpu: "2"
-            memory: 6Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: false


### PR DESCRIPTION
The release-1.34 and release-1.35 forks of the DRA kind jobs run with 6Gi, and since the 07-13 kubekins image (#37421 and #37440 moved dind under the pod cgroup) that limit covers the nested kind nodes as well. The first run prow labeled `Job pod was OOM killed by the cluster.` is 07-14, the first on that image, and 13 of the 18 July runs from that day on got the same label. Of the 40 `ci-kind-dra-1-34` runs from 08-03 to 09-11, 22 got it (prowjob status of each run), 21 of them after running into the 90 minute timeout, and 8 passed. `ci-kind-dra-1-35` was labeled the same way on 09-11, and so were 3 of the 4 `pull-kubernetes-kind-dra-all` runs on kubernetes/kubernetes#141924 (release-1.35), one of them a timeout. Healthy runs of the periodic take 8 to 10 minutes.

Most of the difference to the 1.36 and 1.37 jobs comes from one test. `ResourceSlice Controller creates slices` on these two branches publishes 100 ResourceSlices of the maximum size (128 devices with 32 maximum-length attributes each); kube-apiserver RSS peaks at 1.8 GiB with 100 slices against 0.6 GiB with 10, and the e2e.test worker that runs the test holds its own copy (worker cgroup peak 2.3 GiB against 1.4 GiB). Master reduced the test to 10 slices in kubernetes/kubernetes#136156 (commit 1847d5b1a), and together with the removal of the scheduler log line in kubernetes/kubernetes#136588 that is why the 1.36 and 1.37 periodics and plain presubmit run the same shape at 6Gi and stay green. I proposed the same reduction for release-1.35 in kubernetes/kubernetes#142083; it was closed because it does not meet the cherry-pick guidelines, so this PR is about the jobs as they are today.

I measured the jobs with the real kubekins image (`v20260907-7013e6a654-1.3x`) and runner.sh with docker-in-docker, at 2 CPUs and 6Gi or 12Gi for the whole container, no swap, the job scripts with only the revision pinned, on 8 of the 20 cores of a workstation (the same visible CPU count as the prow nodes). 1 to 3 runs per condition, so treat them as examples, not rates. Non-reclaimable below means anon plus shmem plus non-reclaimable kernel memory of the container cgroup, sampled every 5 s; whole-pod peaks are the cgroup's `memory.peak`. The 6Gi rows are limit-bound, so their percentages are of the limit while the page cache was being reclaimed.

| job replica, 100 slices as on the branch today | 6Gi | 12Gi |
|---|---|---|
| release-1.34 (periodic 66 specs; presubmit variants 76) | did not finish clean in any of five runs (periodic twice; periodic with `GOMAXPROCS=2` as in #37731; the `-all` gate set; the presubmit built from source): four pinned at the limit with 0.4 to 3.6 million page-cache reclaim events, kind-node pods OOM-killed in two, 7 to 12 failed specs, kube-scheduler restarted in each; the fifth, with the runner at the oom_score_adj prow gives the test container, lost one e2e.test worker to the OOM killer and hung to the 90 minute timeout without junit, as the real runs do | completed 66/66 twice with page-cache reclaim; non-reclaimable 6798 and 6288 MiB |
| release-1.35 periodic (71 specs) | completed twice, non-reclaimable at 87% and 94% of the limit with 6k and 18k reclaim events | completed with a total peak at 84% of the limit, no reclaim; non-reclaimable 5667 MiB |
| release-1.35 `pull-kubernetes-kind-dra-all` (87 specs) | reached the limit in all four runs (two with the gate set from the CI tarball, two built from source). Two hung to the 90 minute timeout with no junit, both after the OOM killer took an e2e.test worker, which is what the OOM-labeled real runs look like. The other two were killed outright at 23 and 36 minutes under a whole-container OOM setting that prow does not use (it was also on in one of the hung runs and never fired there) | completed 87/87 (built from source) with page-cache reclaim; non-reclaimable 7066 MiB |

`-all-slow` runs the same gate set on the slower specs and was not measured separately. With 10 slices the same replicas complete at 6Gi on both branches with 3410 to 3934 MiB non-reclaimable (56 to 64% of the limit). Uncapped and with a fixed seed, the 100-slice suites peak at 6609 to 7036 MiB (release-1.34) and 7088 to 7200 MiB (release-1.35) of cgroup memory including page cache, three runs each. With random seeds, as prow uses, three release-1.34 runs peaked at 8210, 8996 and 11373 MiB (non-reclaimable 6630 to 7141 MiB): pods got scheduled while the 100 slices existed, and the scheduler on that branch logs the whole slice list at V(5) once per node it evaluates, 0.2 to 5.9 GB of scheduler log per run (kubernetes/kubernetes#142082 proposed deleting the statement on release-1.35 and was closed for the same reason); three release-1.35 runs with random seeds stayed at 6986 to 7412 MiB, because with the default gates its scheduler uses an allocator without that line. Both 12Gi replicas of the 1.34 periodic caught that mode (1.2 GB and at least 3.2 GB of scheduler log) and still completed 66/66 with page-cache reclaim and 6798 and 6288 MiB non-reclaimable.

First prow runs on the two kubernetes/kubernetes PRs (09-14, release-1.35 presubmits at 6Gi): with the log line deleted but 100 slices kept (kubernetes/kubernetes#142082) `pull-kubernetes-kind-dra-all` failed twice without an OOM kill (the apiserver stalling under the 100-slice burst in the first run) and passed on the third run with kube-scheduler and kube-controller-manager restarted once each; with 10 slices (kubernetes/kubernetes#142083) all three kind-dra presubmits passed the first time.

The bump goes to the jobs that run this workload on the two branches: the periodic `ci-kind-dra-1-3x`, the plain `pull-kubernetes-kind-dra` (same default cluster and nearly the same suite; it was OOM-labeled once on kubernetes/kubernetes#142025), and `pull-kubernetes-kind-dra-all` / `-all-slow` (all DRA gates on). 12Gi is what master gives `pull-kubernetes-kind-dra-all` (raised there together with race detection). Every 100-slice replica above completed at 12Gi, the heavier ones with page-cache reclaim and 5.1 to 5.9 GiB between their non-reclaimable peak and the limit; whether the jobs stay green at 12Gi is what this change will show. The n-1/n-2 jobs stay at 6Gi. The CPU quota is unchanged.

This PR was written in part with the assistance of generative AI.