### PR TITLE
s390x: isolate integration test etcd data from worker root storage

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-s390x-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-ibmcloud/cloud-provider-ibmcloud-s390x-periodics.yaml
@@ -57,8 +57,13 @@ periodics:
         args:
         - ./hack/jenkins/test-integration-dockerized.sh
         env:
+        - name: ETCD_DIR
+          value: /etcd-data/data
         - name: SHORT
           value: --short=false
+        volumeMounts:
+        - name: etcd-data
+          mountPath: /etcd-data
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -69,6 +74,11 @@ periodics:
           requests:
             cpu: 6
             memory: 20Gi
+      volumes:
+      - name: etcd-data
+        emptyDir:
+          medium: Memory
+          sizeLimit: 4Gi
 
   - name: ci-kubernetes-integration-1-34-s390x
     interval: 6h # bump to 24h after initial debugging


### PR DESCRIPTION

 [s390x master integration job](https://testgrid.k8s.io/ibm-s390x-k8s#ci-kubernetes-integration-master-s390x) intermittently fails API-server readiness while its test etcd instance uses the worker's root-backed temporary storage. Captured logs show slow `fdatasync`, apply and ReadIndex operations, together with etcd request deadlines.

Set `ETCD_DIR=/etcd-data/data and mount /etcd-data` from a memory-backed emptyDir capped at 4 GiB in ci-kubernetes-integration-master-s390x

- Auth test runs 20 pairs: root disk passed 4/20; tmpfs passed 20/20.
- Captured full-suite etcd warnings (fdatasync / slow apply / ReadIndex retry): 
   -   root disk 87 / 2,839 / 211
    - tmpfs 0 / 0 / 0

Additional full-suite release coverage, with source pinned independently within each test jobs:
- release-1.34 : root disk 0/5 passes; tmpfs 5/5.
- release-1.33 : root disk 2/5 passes; tmpfs 4/5.


Related: kubernetes/kubernetes#141284
Supersedes the approach proposed in kubernetes/kubernetes#141313
Related package-timeout proposal: #37660
